### PR TITLE
enables http transport for signoz-mcp-server

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,50 @@
+# Build stage
+FROM golang:1.25-alpine AS builder
+
+# Install git and ca-certificates for dependencies
+RUN apk --no-cache add git ca-certificates tzdata
+
+WORKDIR /app
+
+# Copy go mod files first for better caching
+COPY go.mod go.sum ./
+
+# Download dependencies
+RUN go mod download
+
+# Copy source code
+COPY . .
+
+# Build the application with optimizations
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build \
+    -ldflags='-w -s -extldflags "-static"' \
+    -a -installsuffix cgo \
+    -o signoz-mcp-server \
+    ./cmd/server/
+
+# Final stage
+FROM alpine:latest
+
+# Install ca-certificates
+RUN apk --no-cache add ca-certificates
+
+# Create non-root user for security
+RUN addgroup -g 1001 -S appgroup && \
+    adduser -u 1001 -S appuser -G appgroup
+
+WORKDIR /app
+
+# Copy the binary from builder stage
+COPY --from=builder /app/signoz-mcp-server .
+
+# Change ownership to non-root user
+RUN chown -R appuser:appgroup /app
+
+# Switch to non-root user
+USER appuser
+
+# Expose port
+EXPOSE 8000
+
+# Run the application
+CMD ["./signoz-mcp-server"]

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -20,18 +20,25 @@ func main() {
 		os.Exit(1)
 	}
 
+	if err := cfg.ValidateConfig(); err != nil {
+		fmt.Fprintln(os.Stderr, fmt.Sprintf("Configuration validation failed: %v", err))
+		os.Exit(1)
+	}
+
 	log, err := logger.NewLogger(logger.LogLevel(cfg.LogLevel))
 	if err != nil {
 		fmt.Fprintln(os.Stderr, fmt.Sprintf("Failed to initialize logger: %v", err))
 		os.Exit(1)
 	}
 
-	log.Info("Starting SigNoz MCP Server", zap.String("log_level", cfg.LogLevel))
+	log.Info("Starting SigNoz MCP Server",
+		zap.String("log_level", cfg.LogLevel),
+		zap.String("deployment_mode", cfg.DeploymentMode))
 
 	sigNozClient := client.NewClient(log, cfg.URL, cfg.APIKey)
 	handler := tools.NewHandler(log, sigNozClient)
 
-	if err := mcpserver.NewMCPServer(log, handler).Start(); err != nil {
+	if err := mcpserver.NewMCPServer(log, handler, cfg).Start(); err != nil {
 		log.Fatal(fmt.Sprintf("Failed to start server: %v", err))
 	}
 }

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -33,7 +33,7 @@ func main() {
 
 	log.Info("Starting SigNoz MCP Server",
 		zap.String("log_level", cfg.LogLevel),
-		zap.String("deployment_mode", cfg.DeploymentMode))
+		zap.String("transport_mode", cfg.TransportMode))
 
 	sigNozClient := client.NewClient(log, cfg.URL, cfg.APIKey)
 	handler := tools.NewHandler(log, sigNozClient)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,24 @@
+services:
+  signoz-mcp-server:
+    build: 
+      context: .
+      dockerfile: Dockerfile
+    container_name: signoz-mcp-server
+    ports:
+      - "${MCP_SERVER_PORT:-8000}:8000"
+    environment:
+      - SIGNOZ_URL=${SIGNOZ_URL}
+      - SIGNOZ_API_KEY=${SIGNOZ_API_KEY}
+      - DEPLOYMENT_MODE=cloud
+      - MCP_SERVER_PORT=8000
+      - LOG_LEVEL=${LOG_LEVEL:-info}
+    restart: unless-stopped
+    networks:
+      - signoz-mcp-network
+    labels:
+      - "com.signoz.service=signoz-mcp-server"
+      - "com.signoz.description=SigNoz MCP Server for AI assistants"
+
+networks:
+  signoz-mcp-network:
+    driver: bridge

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
     environment:
       - SIGNOZ_URL=${SIGNOZ_URL}
       - SIGNOZ_API_KEY=${SIGNOZ_API_KEY}
-      - DEPLOYMENT_MODE=cloud
+      - TRANSPORT_MODE=http
       - MCP_SERVER_PORT=8000
       - LOG_LEVEL=${LOG_LEVEL:-info}
     restart: unless-stopped

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,26 +1,33 @@
 package config
 
 import (
+	"fmt"
 	"os"
 )
 
 type Config struct {
-	URL      string
-	APIKey   string
-	LogLevel string
+	URL            string
+	APIKey         string
+	LogLevel       string
+	DeploymentMode string
+	Port           string
 }
 
 const (
-	SignozURL    = "SIGNOZ_URL"
-	SignozApiKey = "SIGNOZ_API_KEY"
-	LogLevel     = "LOG_LEVEL"
+	SignozURL      = "SIGNOZ_URL"
+	SignozApiKey   = "SIGNOZ_API_KEY"
+	LogLevel       = "LOG_LEVEL"
+	DeploymentMode = "DEPLOYMENT_MODE"
+	MCPPort        = "MCP_SERVER_PORT"
 )
 
 func LoadConfig() (*Config, error) {
 	return &Config{
-		URL:      getEnv(SignozURL, ""),
-		APIKey:   getEnv(SignozApiKey, ""),
-		LogLevel: getEnv(LogLevel, "info"),
+		URL:            getEnv(SignozURL, ""),
+		APIKey:         getEnv(SignozApiKey, ""),
+		LogLevel:       getEnv(LogLevel, "info"),
+		DeploymentMode: getEnv(DeploymentMode, "local"),
+		Port:           getEnv(MCPPort, "8000"),
 	}, nil
 }
 
@@ -29,4 +36,20 @@ func getEnv(key, defaultValue string) string {
 		return value
 	}
 	return defaultValue
+}
+
+func (c *Config) ValidateConfig() error {
+	if c.URL == "" {
+		return fmt.Errorf("SIGNOZ_URL is required")
+	}
+	if c.APIKey == "" {
+		return fmt.Errorf("SIGNOZ_API_KEY is required")
+	}
+
+	if c.DeploymentMode == "cloud" {
+		if c.Port == "" {
+			return fmt.Errorf("MCP_SERVER_PORT is required for cloud deployment")
+		}
+	}
+	return nil
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -6,28 +6,28 @@ import (
 )
 
 type Config struct {
-	URL            string
-	APIKey         string
-	LogLevel       string
-	DeploymentMode string
-	Port           string
+	URL           string
+	APIKey        string
+	LogLevel      string
+	TransportMode string
+	Port          string
 }
 
 const (
-	SignozURL      = "SIGNOZ_URL"
-	SignozApiKey   = "SIGNOZ_API_KEY"
-	LogLevel       = "LOG_LEVEL"
-	DeploymentMode = "DEPLOYMENT_MODE"
-	MCPPort        = "MCP_SERVER_PORT"
+	SignozURL     = "SIGNOZ_URL"
+	SignozApiKey  = "SIGNOZ_API_KEY"
+	LogLevel      = "LOG_LEVEL"
+	TransportMode = "TRANSPORT_MODE"
+	MCPPort       = "MCP_SERVER_PORT"
 )
 
 func LoadConfig() (*Config, error) {
 	return &Config{
-		URL:            getEnv(SignozURL, ""),
-		APIKey:         getEnv(SignozApiKey, ""),
-		LogLevel:       getEnv(LogLevel, "info"),
-		DeploymentMode: getEnv(DeploymentMode, "local"),
-		Port:           getEnv(MCPPort, "8000"),
+		URL:           getEnv(SignozURL, ""),
+		APIKey:        getEnv(SignozApiKey, ""),
+		LogLevel:      getEnv(LogLevel, "info"),
+		TransportMode: getEnv(TransportMode, "stdio"),
+		Port:          getEnv(MCPPort, "8000"),
 	}, nil
 }
 
@@ -46,9 +46,9 @@ func (c *Config) ValidateConfig() error {
 		return fmt.Errorf("SIGNOZ_API_KEY is required")
 	}
 
-	if c.DeploymentMode == "cloud" {
+	if c.TransportMode == "http" {
 		if c.Port == "" {
-			return fmt.Errorf("MCP_SERVER_PORT is required for cloud deployment")
+			return fmt.Errorf("MCP_SERVER_PORT is required for HTTP transport mode")
 		}
 	}
 	return nil

--- a/internal/mcp-server/server.go
+++ b/internal/mcp-server/server.go
@@ -26,7 +26,7 @@ func (m *MCPServer) Start() error {
 
 	m.logger.Info("Starting SigNoz MCP Server",
 		zap.String("server_name", "SigNozMCPServer"),
-		zap.String("deployment_mode", m.config.DeploymentMode))
+		zap.String("transport_mode", m.config.TransportMode))
 
 	// Register all handlers
 	m.handler.RegisterMetricsHandlers(s)
@@ -38,19 +38,19 @@ func (m *MCPServer) Start() error {
 
 	m.logger.Info("All handlers registered successfully")
 
-	if m.config.DeploymentMode == "cloud" {
-		return m.startCloud(s)
+	if m.config.TransportMode == "http" {
+		return m.startHTTP(s)
 	}
-	return m.startLocal(s)
+	return m.startStdio(s)
 }
 
-func (m *MCPServer) startLocal(s *server.MCPServer) error {
-	m.logger.Info("MCP Server running in LOCAL mode (stdio)")
+func (m *MCPServer) startStdio(s *server.MCPServer) error {
+	m.logger.Info("MCP Server running in stdio mode")
 	return server.ServeStdio(s)
 }
 
-func (m *MCPServer) startCloud(s *server.MCPServer) error {
-	m.logger.Info("MCP Server running in cloud hosted mode")
+func (m *MCPServer) startHTTP(s *server.MCPServer) error {
+	m.logger.Info("MCP Server running in HTTP mode")
 
 	addr := fmt.Sprintf(":%s", m.config.Port)
 

--- a/internal/mcp-server/server.go
+++ b/internal/mcp-server/server.go
@@ -1,25 +1,32 @@
 package mcp_server
 
 import (
+	"fmt"
+	"net/http"
+
 	"github.com/mark3labs/mcp-go/server"
 	"go.uber.org/zap"
 
+	"github.com/SigNoz/signoz-mcp-server/internal/config"
 	"github.com/SigNoz/signoz-mcp-server/internal/handler/tools"
 )
 
 type MCPServer struct {
 	logger  *zap.Logger
 	handler *tools.Handler
+	config  *config.Config
 }
 
-func NewMCPServer(log *zap.Logger, handler *tools.Handler) *MCPServer {
-	return &MCPServer{logger: log, handler: handler}
+func NewMCPServer(log *zap.Logger, handler *tools.Handler, cfg *config.Config) *MCPServer {
+	return &MCPServer{logger: log, handler: handler, config: cfg}
 }
 
 func (m *MCPServer) Start() error {
 	s := server.NewMCPServer("SigNozMCP", "0.0.1", server.WithLogging(), server.WithToolCapabilities(false))
 
-	m.logger.Info("Starting SigNoz MCP Server", zap.String("server_name", "SigNozMCPServer"))
+	m.logger.Info("Starting SigNoz MCP Server",
+		zap.String("server_name", "SigNozMCPServer"),
+		zap.String("deployment_mode", m.config.DeploymentMode))
 
 	// Register all handlers
 	m.handler.RegisterMetricsHandlers(s)
@@ -30,7 +37,31 @@ func (m *MCPServer) Start() error {
 	m.handler.RegisterLogsHandlers(s)
 
 	m.logger.Info("All handlers registered successfully")
-	m.logger.Info("MCP Server ready, serving on stdio")
 
+	if m.config.DeploymentMode == "cloud" {
+		return m.startCloud(s)
+	}
+	return m.startLocal(s)
+}
+
+func (m *MCPServer) startLocal(s *server.MCPServer) error {
+	m.logger.Info("MCP Server running in LOCAL mode (stdio)")
 	return server.ServeStdio(s)
+}
+
+func (m *MCPServer) startCloud(s *server.MCPServer) error {
+	m.logger.Info("MCP Server running in cloud hosted mode")
+
+	addr := fmt.Sprintf(":%s", m.config.Port)
+
+	mux := http.NewServeMux()
+
+	httpServer := server.NewStreamableHTTPServer(s)
+	mux.Handle("/mcp", httpServer)
+
+	m.logger.Info("Listening for MCP clients",
+		zap.String("addr", addr),
+		zap.String("mcp_endpoint", "/mcp"))
+
+	return http.ListenAndServe(addr, mux)
 }


### PR DESCRIPTION
this adds environment variables to enalbe local and cloud hosted mcp-server integration, currently only working with cursor. TRANSPORT_MODE :<http/stdio>, MCP_SERVER_PORT

Currently it uses API Key, need to change it to OAuth/or similar