### PR TITLE
adds logs tool

### DIFF
--- a/internal/mcp-server/server.go
+++ b/internal/mcp-server/server.go
@@ -27,6 +27,7 @@ func (m *MCPServer) Start() error {
 	m.handler.RegisterDashboardHandlers(s)
 	m.handler.RegisterServiceHandlers(s)
 	m.handler.RegisterQueryBuilderV5Handlers(s)
+	m.handler.RegisterLogsHandlers(s)
 
 	m.logger.Info("All handlers registered successfully")
 	m.logger.Info("MCP Server ready, serving on stdio")


### PR DESCRIPTION
this pr adds log tools in this mcp server.
this helps to get logs related to alerts, service, errors diff log views.

a little refactor to old code.
reuse querybuilder featrue.
Try to add as logs as possible as that gives LLMs capability to fix request.

todo : we can do more refactor