### PR TITLE
feat: be able to pass api key over authorization header

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,11 +114,18 @@ Once added, restart Cursor to use the SigNoz tools.
 {
   "mcpServers": {
     "signoz": {
-      "url": <hosted-mcp-server-url/mcp> "http://localhost:8000/mcp",
+      "url": "http://localhost:8000/mcp",
+      "headers": {
+        "Authorization": "Bearer your-api-key-here"
+      }
     }
   }
 }
 ```
+
+**Note:** You can pass the SigNoz API key either as:
+- An environment variable (`SIGNOZ_API_KEY`) when starting the server, or
+- Via the `Authorization` header in the client configuration as shown above
 
 4. Restart Claude Desktop. You should see the `signoz` server load in the developer console and its tools become available.
 
@@ -139,11 +146,18 @@ For Both options use same json struct
 {
   "mcpServers": {
     "signoz": {
-      "url": <hosted-mcp-server-url/mcp> "http://localhost:8000/mcp",
+      "url": "http://localhost:8000/mcp",
+      "headers": {
+        "Authorization": "Bearer signoz-api-key-here"
       }
     }
   }
+}
 ```
+
+**Note:** You can pass the SigNoz API key either as:
+- An environment variable (`SIGNOZ_API_KEY`) when starting the server, or
+- Via the `Authorization` header in the client configuration as shown above
 
 
 **Note:** By default, the server logs at `info` level. If you need detailed debugging information, set `LOG_LEVEL=debug` in your environment. For production use, consider using `LOG_LEVEL=warn` to reduce log verbosity.

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -36,7 +36,7 @@ func main() {
 		zap.String("transport_mode", cfg.TransportMode))
 
 	sigNozClient := client.NewClient(log, cfg.URL, cfg.APIKey)
-	handler := tools.NewHandler(log, sigNozClient)
+	handler := tools.NewHandlerWithURL(log, sigNozClient, cfg.URL)
 
 	if err := mcpserver.NewMCPServer(log, handler, cfg).Start(); err != nil {
 		log.Fatal(fmt.Sprintf("Failed to start server: %v", err))

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -42,8 +42,11 @@ func (c *Config) ValidateConfig() error {
 	if c.URL == "" {
 		return fmt.Errorf("SIGNOZ_URL is required")
 	}
-	if c.APIKey == "" {
-		return fmt.Errorf("SIGNOZ_API_KEY is required")
+
+	// In HTTP mode, API key can come from Authorization header, so it's optional
+	// In stdio mode, API key must be provided via environment variable
+	if c.TransportMode != "http" && c.APIKey == "" {
+		return fmt.Errorf("SIGNOZ_API_KEY is required for stdio mode")
 	}
 
 	if c.TransportMode == "http" {

--- a/internal/contextutil/context.go
+++ b/internal/contextutil/context.go
@@ -1,0 +1,18 @@
+package contextutil
+
+import "context"
+
+type contextKey string
+
+const apiKeyContextKey contextKey = "api_key"
+
+// SetAPIKey stores the API key in the context
+func SetAPIKey(ctx context.Context, apiKey string) context.Context {
+	return context.WithValue(ctx, apiKeyContextKey, apiKey)
+}
+
+// GetAPIKey retrieves the API key from the context
+func GetAPIKey(ctx context.Context) (string, bool) {
+	apiKey, ok := ctx.Value(apiKeyContextKey).(string)
+	return apiKey, ok
+}


### PR DESCRIPTION
## Before

it needs `SIGNOZ_API_KEY` as env variable when running the mcp server

## After

it could pass `SIGNOZ_API_KEY` over the `Authorization` header so that it could manage access to this mcp server at application level.