### PR TITLE
fix: trim trailing slashes from SIGNOZ_URL to prevent double-slash issues

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -3,6 +3,7 @@ package config
 import (
 	"fmt"
 	"os"
+	"strings"
 )
 
 type Config struct {
@@ -22,8 +23,10 @@ const (
 )
 
 func LoadConfig() (*Config, error) {
+	// Trim trailing slash from URL to prevent double-slash issues in API paths
+	url := strings.TrimSuffix(getEnv(SignozURL, ""), "/")
 	return &Config{
-		URL:           getEnv(SignozURL, ""),
+		URL:           url,
 		APIKey:        getEnv(SignozApiKey, ""),
 		LogLevel:      getEnv(LogLevel, "info"),
 		TransportMode: getEnv(TransportMode, "stdio"),


### PR DESCRIPTION
## Summary

This PR makes the config more resilient to trailing slashes in the `SIGNOZ_URL` environment variable.

## Problem

When users configure `SIGNOZ_URL` with a trailing slash (e.g., `https://signoz.example.com/`), API calls could end up with double slashes in the path (e.g., `https://signoz.example.com//api/v1/...`), which may cause issues with some servers.

## Solution

Use `strings.TrimSuffix` to remove any trailing slash from the URL when loading the config. This ensures consistent URL formatting regardless of how the user provides the URL.