### PR TITLE
feat: add alert management tools (create, list rules, list channels)

### DIFF
--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -988,6 +988,94 @@ func (s *SigNoz) CreateDashboard(ctx context.Context, dashboard types.Dashboard)
 	return body, nil
 }
 
+// ListAlertRules lists all configured alert rules in SigNoz.
+func (s *SigNoz) ListAlertRules(ctx context.Context) (json.RawMessage, error) {
+	url := fmt.Sprintf("%s/api/v1/rules", s.baseURL)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	req.Header.Set(ContentType, "application/json")
+	req.Header.Set(SignozApiKey, s.apiKey)
+
+	ctx, cancel := context.WithTimeout(ctx, 600*time.Second)
+	defer cancel()
+	req = req.WithContext(ctx)
+
+	s.logger.Debug("Fetching alert rules from SigNoz")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		s.logger.Error("HTTP request failed", zap.String("url", url), zap.Error(err))
+		return nil, fmt.Errorf("failed to do request: %w", err)
+	}
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			s.logger.Warn("Failed to close response body", zap.Error(err))
+		}
+	}()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		s.logger.Error("Failed to read response body", zap.String("url", url), zap.Error(err))
+		return nil, fmt.Errorf("failed to read response body: %w", err)
+	}
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		s.logger.Error("API request failed", zap.String("url", url), zap.Int("status", resp.StatusCode), zap.String("response", string(body)))
+		return nil, fmt.Errorf("unexpected status %d: %s", resp.StatusCode, string(body))
+	}
+
+	s.logger.Debug("Successfully retrieved alert rules", zap.Int("status", resp.StatusCode))
+	return body, nil
+}
+
+// ListChannels lists available notification channels in SigNoz.
+func (s *SigNoz) ListChannels(ctx context.Context) (json.RawMessage, error) {
+	url := fmt.Sprintf("%s/api/v1/channels", s.baseURL)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	req.Header.Set(ContentType, "application/json")
+	req.Header.Set(SignozApiKey, s.apiKey)
+
+	ctx, cancel := context.WithTimeout(ctx, 600*time.Second)
+	defer cancel()
+	req = req.WithContext(ctx)
+
+	s.logger.Debug("Fetching notification channels from SigNoz")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		s.logger.Error("HTTP request failed", zap.String("url", url), zap.Error(err))
+		return nil, fmt.Errorf("failed to do request: %w", err)
+	}
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			s.logger.Warn("Failed to close response body", zap.Error(err))
+		}
+	}()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		s.logger.Error("Failed to read response body", zap.String("url", url), zap.Error(err))
+		return nil, fmt.Errorf("failed to read response body: %w", err)
+	}
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		s.logger.Error("API request failed", zap.String("url", url), zap.Int("status", resp.StatusCode), zap.String("response", string(body)))
+		return nil, fmt.Errorf("unexpected status %d: %s", resp.StatusCode, string(body))
+	}
+
+	s.logger.Debug("Successfully retrieved notification channels", zap.Int("status", resp.StatusCode))
+	return body, nil
+}
+
 // CreateAlert creates a new alert rule in SigNoz.
 func (s *SigNoz) CreateAlert(ctx context.Context, alertRule types.CreateAlertRuleRequest) (json.RawMessage, error) {
 	url := fmt.Sprintf("%s/api/v1/rules", s.baseURL)

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -988,6 +988,54 @@ func (s *SigNoz) CreateDashboard(ctx context.Context, dashboard types.Dashboard)
 	return body, nil
 }
 
+// CreateAlert creates a new alert rule in SigNoz.
+func (s *SigNoz) CreateAlert(ctx context.Context, alertRule types.CreateAlertRuleRequest) (json.RawMessage, error) {
+	url := fmt.Sprintf("%s/api/v1/rules", s.baseURL)
+
+	alertJSON, err := json.Marshal(alertRule)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal alert rule: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewBuffer(alertJSON))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	req.Header.Set(SignozApiKey, s.apiKey)
+	req.Header.Set(ContentType, "application/json")
+
+	timeoutCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+
+	s.logger.Debug("Creating alert rule in SigNoz", zap.String("alert", alertRule.Alert))
+
+	resp, err := http.DefaultClient.Do(req.WithContext(timeoutCtx))
+	if err != nil {
+		s.logger.Error("HTTP request failed", zap.String("url", url), zap.Error(err))
+		return nil, fmt.Errorf("failed to do request: %w", err)
+	}
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			s.logger.Warn("Failed to close response body", zap.Error(err))
+		}
+	}()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		s.logger.Error("Failed to read response body", zap.String("url", url), zap.Error(err))
+		return nil, fmt.Errorf("failed to read response body: %w", err)
+	}
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		s.logger.Error("API request failed", zap.String("url", url), zap.Int("status", resp.StatusCode), zap.String("response", string(body)))
+		return nil, fmt.Errorf("unexpected status %d: %s", resp.StatusCode, string(body))
+	}
+
+	s.logger.Debug("Successfully created alert rule", zap.String("alert", alertRule.Alert), zap.Int("status", resp.StatusCode))
+	return body, nil
+}
+
 func (s *SigNoz) UpdateDashboard(ctx context.Context, id string, dashboard types.Dashboard) error {
 	url := fmt.Sprintf("%s/api/v1/dashboards/%s", s.baseURL, id)
 

--- a/pkg/types/alerts.go
+++ b/pkg/types/alerts.go
@@ -47,3 +47,96 @@ type APIAlertsResponse struct {
 	Status string     `json:"status"`
 	Data   []APIAlert `json:"data"`
 }
+
+// CreateAlertRuleRequest is the payload for creating a new alert rule.
+type CreateAlertRuleRequest struct {
+	Alert           string            `json:"alert"`
+	AlertType       string            `json:"alertType"`
+	RuleType        string            `json:"ruleType"`
+	Condition       AlertCondition    `json:"condition"`
+	Labels          map[string]string `json:"labels,omitempty"`
+	Annotations     map[string]string `json:"annotations,omitempty"`
+	EvalWindow      string            `json:"evalWindow"`
+	Source          string            `json:"source"`
+	Disabled        bool              `json:"disabled"`
+	BroadcastToAll  bool              `json:"broadcastToAll"`
+	PreferredChannels []string        `json:"preferredChannels,omitempty"`
+}
+
+// AlertCondition defines the threshold condition for an alert.
+type AlertCondition struct {
+	CompositeQuery CompositeAlertQuery `json:"compositeQuery"`
+	Op             string              `json:"op"`
+	Target         float64             `json:"target"`
+	MatchType      string              `json:"matchType"`
+	TargetUnit     string              `json:"targetUnit,omitempty"`
+	SelectedQueryName string           `json:"selectedQueryName,omitempty"`
+}
+
+// CompositeAlertQuery defines the query structure for alert rules.
+type CompositeAlertQuery struct {
+	BuilderQueries map[string]AlertBuilderQuery `json:"builderQueries"`
+	QueryType      string                       `json:"queryType"`
+	PanelType      string                       `json:"panelType"`
+	Unit           string                       `json:"unit,omitempty"`
+}
+
+// AlertBuilderQuery is a single query within a composite alert query.
+type AlertBuilderQuery struct {
+	QueryName          string                 `json:"queryName"`
+	StepInterval       int                    `json:"stepInterval"`
+	DataSource         string                 `json:"dataSource"`
+	AggregateOperator  string                 `json:"aggregateOperator"`
+	AggregateAttribute AggregateAttribute     `json:"aggregateAttribute"`
+	Filters            AlertFilters           `json:"filters"`
+	Expression         string                 `json:"expression"`
+	Disabled           bool                   `json:"disabled"`
+	Having             []interface{}          `json:"having"`
+	Legend             string                 `json:"legend"`
+	Limit              int                    `json:"limit,omitempty"`
+	Offset             int                    `json:"offset,omitempty"`
+	PageSize           int                    `json:"pageSize,omitempty"`
+	OrderBy            []OrderByItem          `json:"orderBy,omitempty"`
+	ReduceTo           string                 `json:"reduceTo,omitempty"`
+	SpaceAggregation   string                 `json:"spaceAggregation,omitempty"`
+	TimeAggregation    string                 `json:"timeAggregation,omitempty"`
+	ShiftBy            int                    `json:"ShiftBy,omitempty"`
+	Functions          []interface{}          `json:"functions,omitempty"`
+}
+
+// AggregateAttribute defines the attribute to aggregate on.
+type AggregateAttribute struct {
+	Key      string `json:"key"`
+	DataType string `json:"dataType"`
+	Type     string `json:"type"`
+	IsColumn bool   `json:"isColumn"`
+	IsJSON   bool   `json:"isJSON"`
+}
+
+// AlertFilters contains filter items for alert queries.
+type AlertFilters struct {
+	Items []AlertFilterItem `json:"items"`
+	Op    string            `json:"op"`
+}
+
+// AlertFilterItem is a single filter condition.
+type AlertFilterItem struct {
+	Key   FilterKey   `json:"key"`
+	Op    string      `json:"op"`
+	Value interface{} `json:"value"`
+}
+
+// FilterKey defines the key for a filter item.
+type FilterKey struct {
+	Key      string `json:"key"`
+	DataType string `json:"dataType"`
+	Type     string `json:"type"`
+	IsColumn bool   `json:"isColumn"`
+	IsJSON   bool   `json:"isJSON"`
+}
+
+// OrderByItem defines ordering for query results.
+type OrderByItem struct {
+	ColumnName string `json:"columnName"`
+	Order      string `json:"order"`
+}


### PR DESCRIPTION
## Summary
- **signoz_create_alert**: Create new alert rules with full configuration (threshold, conditions, notification channels)
- **signoz_list_alert_rules**: List all configured alert rules (not just currently firing alerts)
- **signoz_list_channels**: List available notification channels for alert routing

These tools enable AI agents to programmatically manage SigNoz alerts.

## Test plan
- [x] Build and run locally
- [x] Test `signoz_list_channels` returns configured channels
- [x] Test `signoz_list_alert_rules` returns all alert rules
- [x] Test `signoz_create_alert` creates alert with preferred channels