### PR TITLE
fix: allow time_series aggregations for logs

### DIFF
--- a/pkg/types/querybuilder_test.go
+++ b/pkg/types/querybuilder_test.go
@@ -1,0 +1,87 @@
+package types
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func int64ptr(v int64) *int64 { return &v }
+
+func TestQueryPayloadValidate_AllowsLogsTimeSeries(t *testing.T) {
+	q := &QueryPayload{
+		SchemaVersion: "v1",
+		Start:         1,
+		End:           2,
+		RequestType:   "time_series",
+		CompositeQuery: CompositeQuery{
+			Queries: []Query{
+				{
+					Type: "builder_query",
+					Spec: QuerySpec{
+						Name:         "A",
+						Signal:       "logs",
+						Disabled:     false,
+						StepInterval: int64ptr(60),
+						Aggregations: []any{map[string]any{"expression": "count()"}},
+					},
+				},
+			},
+		},
+	}
+
+	require.NoError(t, q.Validate())
+	require.Equal(t, "time_series", q.RequestType)
+	require.NotNil(t, q.CompositeQuery.Queries[0].Spec.StepInterval)
+}
+
+func TestQueryPayloadValidate_LogsRawClearsStepInterval(t *testing.T) {
+	q := &QueryPayload{
+		SchemaVersion: "v1",
+		Start:         1,
+		End:           2,
+		RequestType:   "raw",
+		CompositeQuery: CompositeQuery{
+			Queries: []Query{
+				{
+					Type: "builder_query",
+					Spec: QuerySpec{
+						Name:         "A",
+						Signal:       "logs",
+						Disabled:     false,
+						StepInterval: int64ptr(60),
+					},
+				},
+			},
+		},
+	}
+
+	require.NoError(t, q.Validate())
+	require.Nil(t, q.CompositeQuery.Queries[0].Spec.StepInterval)
+}
+
+func TestQueryPayloadValidate_LogsTimeSeriesRequiresAggregations(t *testing.T) {
+	q := &QueryPayload{
+		SchemaVersion: "v1",
+		Start:         1,
+		End:           2,
+		RequestType:   "time_series",
+		CompositeQuery: CompositeQuery{
+			Queries: []Query{
+				{
+					Type: "builder_query",
+					Spec: QuerySpec{
+						Name:         "A",
+						Signal:       "logs",
+						Disabled:     false,
+						StepInterval: int64ptr(60),
+						Aggregations: nil,
+					},
+				},
+			},
+		},
+	}
+
+	require.Error(t, q.Validate())
+}
+


### PR DESCRIPTION
Problem
- Query Builder v5 payload validation was forcing logs (and traces) queries to requestType=raw.
- This makes count()/groupBy aggregation queries return raw rows (or fail validation paths) even when the caller requested requestType=time_series.

Fix
- In pkg/types/querybuilder.go, stop downgrading logs/traces queries to raw.
- For logs/traces requestType=time_series, require aggregations and default stepInterval=60 if missing.
- Added a small unit test in pkg/types/querybuilder_test.go.

Smoke test (real SigNoz)
- Gist: https://gist.github.com/rgarcia/115321e4d70138304e94497daeed9ae8
- Ran against SIGNOZ_URL=https://tough-gecko.us.signoz.cloud using tool signoz_execute_builder_query with:
  - signal=logs
  - requestType=time_series
  - aggregations=[{expression: "count()"}]
  - stepInterval=60
  - filter=service.name in ['vm-logs']
- Observed real time series values returned (counts per 60s bucket). Example output snippet:

  PASS
  - tool status: success
  - detected type: time_series


Made with [Cursor](https://cursor.com)