### PR TITLE
docs: update SIGNOZ_URL example in README for clarity

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,7 +219,7 @@ export SIGNOZ_API_KEY="your-api-key-here"
 export LOG_LEVEL="info"  # Optional: debug, info, error (default: info)
 ```
 
-In SigNoz Cloud, SIGNOZ_URL is typically - https://ingest.<region>.signoz.cloud
+In SigNoz Cloud, SIGNOZ_URL is typically - https://tenant-slug.<region>.signoz.cloud for example main-dinosaur.us.signoz.cloud
 
 You can access API Key by going to Settings -> Workspace Settings -> API Key in SigNoz UI
 


### PR DESCRIPTION
This pull request updates the documentation to clarify the format of the `SIGNOZ_URL` for SigNoz Cloud, providing a more accurate example for users.

Documentation update:

* Updated the `README.md` to specify that the `SIGNOZ_URL` should use the tenant slug format (e.g., `main-dinosaur.us.signoz.cloud`) instead of the previous ingest-based format.