### PR TITLE
feat: add signoz_execute_clickhouse_query MCP tool via v3 API

### DIFF
--- a/internal/mcp-server/server.go
+++ b/internal/mcp-server/server.go
@@ -36,6 +36,7 @@ func (m *MCPServer) Start() error {
 	m.handler.RegisterDashboardHandlers(s)
 	m.handler.RegisterServiceHandlers(s)
 	m.handler.RegisterQueryBuilderV5Handlers(s)
+	m.handler.RegisterClickHouseSQLHandlers(s)
 	m.handler.RegisterLogsHandlers(s)
 	m.handler.RegisterTracesHandlers(s)
 

--- a/pkg/types/querybuilder_test.go
+++ b/pkg/types/querybuilder_test.go
@@ -84,4 +84,3 @@ func TestQueryPayloadValidate_LogsTimeSeriesRequiresAggregations(t *testing.T) {
 
 	require.Error(t, q.Validate())
 }
-


### PR DESCRIPTION
Adds a new MCP tool `signoz_execute_clickhouse_query` that runs raw ClickHouse SQL against SigNoz's /api/v3/query_range endpoint.

Supports template variables auto-substituted from the time range:
  - {{.start_timestamp}} / {{.end_timestamp}} (Unix seconds)
  - {{.start_datetime}} / {{.end_datetime}} (UTC datetime string)

Defaults to last 1 day if no time range is specified.