### PR TITLE
fix: flatten dashboard tool schemas to avoid OpenAI API nesting depth limit

### DIFF
--- a/internal/handler/tools/handler.go
+++ b/internal/handler/tools/handler.go
@@ -454,7 +454,18 @@ func (h *Handler) RegisterDashboardHandlers(s *server.MCPServer) {
 				"IMPORTANT: The widgets-examples resource contains complete, working widget configurations. "+
 				"You must consult it to ensure all required fields (id, panelTypes, title, query, selectedLogFields, selectedTracesFields, thresholds, contextLinks) are properly populated.",
 		),
-		mcp.WithInputSchema[types.Dashboard](),
+		mcp.WithRawInputSchema(json.RawMessage(`{
+			"type": "object",
+			"properties": {
+				"title": {"type": "string", "description": "The display name of the dashboard."},
+				"description": {"type": "string", "description": "A brief explanation of what the dashboard shows."},
+				"tags": {"type": "array", "items": {"type": "string"}, "description": "Keywords for categorization e.g performance latency."},
+				"layout": {"type": "array", "items": {"type": "object"}, "description": "Defines the grid positioning and size for each widget."},
+				"variables": {"type": "object", "description": "Key-value map of template variables available for queries."},
+				"widgets": {"type": "array", "items": {"type": "object"}, "description": "The list of all graphical components displayed on the dashboard."}
+			},
+			"required": ["title", "tags", "layout", "widgets"]
+		}`)),
 	)
 
 	s.AddTool(createDashboardTool, func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
@@ -511,7 +522,21 @@ func (h *Handler) RegisterDashboardHandlers(s *server.MCPServer) {
 				"WARNING: Failing to consult widgets-examples will result in incomplete widget configurations missing required fields "+
 				"(id, panelTypes, title, query, selectedLogFields, selectedTracesFields, thresholds, contextLinks).",
 		),
-		mcp.WithInputSchema[types.UpdateDashboardInput](),
+		mcp.WithRawInputSchema(json.RawMessage(`{
+			"type": "object",
+			"properties": {
+				"uuid": {"type": "string", "description": "Dashboard UUID to update."},
+				"dashboard": {"type": "object", "description": "Full dashboard configuration representing the complete post-update state.", "properties": {
+					"title": {"type": "string", "description": "The display name of the dashboard."},
+					"description": {"type": "string", "description": "A brief explanation of what the dashboard shows."},
+					"tags": {"type": "array", "items": {"type": "string"}, "description": "Keywords for categorization e.g performance latency."},
+					"layout": {"type": "array", "items": {"type": "object"}, "description": "Defines the grid positioning and size for each widget."},
+					"variables": {"type": "object", "description": "Key-value map of template variables available for queries."},
+					"widgets": {"type": "array", "items": {"type": "object"}, "description": "The list of all graphical components displayed on the dashboard."}
+				}, "required": ["title", "tags", "layout", "widgets"]}
+			},
+			"required": ["uuid", "dashboard"]
+		}`)),
 	)
 
 	s.AddTool(updateDashboardTool, func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {

--- a/internal/handler/tools/handler.go
+++ b/internal/handler/tools/handler.go
@@ -20,6 +20,17 @@ import (
 	"github.com/SigNoz/signoz-mcp-server/pkg/util"
 )
 
+// withFlatInputSchema replaces the auto-generated InputSchema with a
+// hand-written JSON schema. mcp.NewTool sets InputSchema.Type = "object"
+// by default; we must clear it so MarshalJSON doesn't see both InputSchema
+// and RawInputSchema as populated (mcp-go v0.38 treats that as an error).
+func withFlatInputSchema(schema json.RawMessage) mcp.ToolOption {
+	return func(t *mcp.Tool) {
+		t.InputSchema.Type = ""
+		t.RawInputSchema = schema
+	}
+}
+
 type Handler struct {
 	client      *signozclient.SigNoz
 	logger      *zap.Logger
@@ -454,7 +465,7 @@ func (h *Handler) RegisterDashboardHandlers(s *server.MCPServer) {
 				"IMPORTANT: The widgets-examples resource contains complete, working widget configurations. "+
 				"You must consult it to ensure all required fields (id, panelTypes, title, query, selectedLogFields, selectedTracesFields, thresholds, contextLinks) are properly populated.",
 		),
-		mcp.WithRawInputSchema(json.RawMessage(`{
+		withFlatInputSchema(json.RawMessage(`{
 			"type": "object",
 			"properties": {
 				"title": {"type": "string", "description": "The display name of the dashboard."},
@@ -522,7 +533,7 @@ func (h *Handler) RegisterDashboardHandlers(s *server.MCPServer) {
 				"WARNING: Failing to consult widgets-examples will result in incomplete widget configurations missing required fields "+
 				"(id, panelTypes, title, query, selectedLogFields, selectedTracesFields, thresholds, contextLinks).",
 		),
-		mcp.WithRawInputSchema(json.RawMessage(`{
+		withFlatInputSchema(json.RawMessage(`{
 			"type": "object",
 			"properties": {
 				"uuid": {"type": "string", "description": "Dashboard UUID to update."},


### PR DESCRIPTION
## Problem

`signoz_create_dashboard` and `signoz_update_dashboard` use `mcp.WithInputSchema[types.Dashboard]()` which auto-generates JSON schemas via `invopop/jsonschema` with `DoNotReference: true` (fully inlined). The resulting schemas have **20–22 levels of nesting depth** due to the recursive Go struct hierarchy:

```
Dashboard → Widget → WidgetQuery → BuilderQueryDashboard → BuilderQuery
  → FilterSet → FilterItem → AttributeKey (8 levels, duplicated inline at every reference)
```

OpenAI's API rejects requests when tool schemas exceed its complexity limits, returning a generic **"Provider Error"**. This causes all GPT models to fail silently whenever the signoz MCP server is connected — even for simple prompts with no dashboard intent.

**Measured impact:**
- `signoz_create_dashboard` schema: **20,461 bytes**, depth **20**
- `signoz_update_dashboard` schema: **20,709 bytes**, depth **22**
- Total signoz tool schemas: **58,273 bytes**

## Fix

Replace the auto-generated schemas with flat `withFlatInputSchema()` definitions that describe only the top-level structure (`title`, `tags`, `layout`, `variables`, `widgets` as generic objects). The handlers already accept `map[string]any` and re-unmarshal at runtime, so this has **no effect on functionality**.

### Why `mcp.WithRawInputSchema()` alone doesn't work

`mcp.NewTool()` initializes `InputSchema.Type = "object"` by default. `mcp.WithRawInputSchema()` sets `RawInputSchema` but does **not** clear `InputSchema.Type`. When `MarshalJSON` runs, it sees both `InputSchema` (with `Type != ""`) and `RawInputSchema` (non-nil) and fatally errors:

```
tool signoz_create_dashboard has both InputSchema and RawInputSchema set:
  provide either InputSchema or RawInputSchema, not both
```

This causes the MCP server to crash on the first `tools/list` request, silently returning **0 tools** to the client. The fix adds a `withFlatInputSchema()` helper that clears `InputSchema.Type` before setting `RawInputSchema`.

**After fix:**
- `signoz_create_dashboard` schema: **780 bytes**, depth **4**
- `signoz_update_dashboard` schema: **1,028 bytes**, depth **6**
- Total signoz tool schemas: **18,911 bytes** (68% reduction)

The tool descriptions already instruct the LLM to read `signoz://dashboard/instructions` and related MCP resources for the full schema — so the simplified input schema doesn't reduce guidance quality.

## Reproduction

Confirmed by running `cursor-agent` (Cursor CLI) in Docker with the signoz MCP server connected to `gpt-5.3-codex`:

| Test | MCP Tools | Result |
|------|-----------|--------|
| Baseline (no MCP) | n/a | ✅ "Hello!" |
| Main (unfixed, depth 20-22) | 30 tools (58KB) | ❌ Provider Error |
| WithRawInputSchema only | 0 tools (MarshalJSON crash) | ❌ Tools silently missing |
| **withFlatInputSchema (this PR)** | **30 tools (19KB)** | ✅ **Model calls signoz tools** |
