### PR TITLE
feat: add `signoz_execute_clickhouse_query` MCP tool via v3 API

### DIFF
--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -883,3 +883,113 @@ func TestUpdateDashboard(t *testing.T) {
 	err := client.UpdateDashboard(context.Background(), "id-123", d)
 	require.NoError(t, err)
 }
+
+func TestExecuteClickHouseSQL(t *testing.T) {
+	tests := []struct {
+		name          string
+		query         string
+		startMs       int64
+		endMs         int64
+		resp          map[string]interface{}
+		statusCode    int
+		expectedError bool
+		checkPayload  func(t *testing.T, payload map[string]interface{})
+	}{
+		{
+			name:       "successful query execution",
+			query:      "SELECT count() FROM signoz_logs.distributed_logs",
+			startMs:    1640995200000,
+			endMs:      1641081600000,
+			resp:       map[string]interface{}{"status": "success", "data": map[string]interface{}{}},
+			statusCode: http.StatusOK,
+			checkPayload: func(t *testing.T, payload map[string]interface{}) {
+				assert.Equal(t, float64(1640995200000*1_000_000), payload["start"])
+				assert.Equal(t, float64(1641081600000*1_000_000), payload["end"])
+				assert.Equal(t, float64(60), payload["step"])
+				cq, ok := payload["compositeQuery"].(map[string]interface{})
+				require.True(t, ok)
+				assert.Equal(t, "clickhouse_sql", cq["queryType"])
+				assert.Equal(t, "table", cq["panelType"])
+				chQueries, ok := cq["chQueries"].(map[string]interface{})
+				require.True(t, ok)
+				queryA, ok := chQueries["A"].(map[string]interface{})
+				require.True(t, ok)
+				assert.Equal(t, "SELECT count() FROM signoz_logs.distributed_logs", queryA["query"])
+				assert.Equal(t, false, queryA["disabled"])
+			},
+		},
+		{
+			name:       "template variables are substituted",
+			query:      "SELECT * FROM t WHERE ts >= {{.start_timestamp}} AND ts <= {{.end_timestamp}} AND dt >= '{{.start_datetime}}' AND dt <= '{{.end_datetime}}'",
+			startMs:    1640995200000,
+			endMs:      1641081600000,
+			resp:       map[string]interface{}{"status": "success"},
+			statusCode: http.StatusOK,
+			checkPayload: func(t *testing.T, payload map[string]interface{}) {
+				cq := payload["compositeQuery"].(map[string]interface{})
+				chQueries := cq["chQueries"].(map[string]interface{})
+				queryA := chQueries["A"].(map[string]interface{})
+				q := queryA["query"].(string)
+				assert.Contains(t, q, "1640995200")
+				assert.Contains(t, q, "1641081600")
+				assert.Contains(t, q, "2022-01-01 00:00:00")
+				assert.Contains(t, q, "2022-01-02 00:00:00")
+				assert.NotContains(t, q, "{{.")
+			},
+		},
+		{
+			name:          "server error",
+			query:         "SELECT 1",
+			startMs:       1640995200000,
+			endMs:         1641081600000,
+			resp:          map[string]interface{}{"status": "error", "message": "Internal server error"},
+			statusCode:    http.StatusInternalServerError,
+			expectedError: true,
+		},
+		{
+			name:          "unauthorized",
+			query:         "SELECT 1",
+			startMs:       1640995200000,
+			endMs:         1641081600000,
+			resp:          map[string]interface{}{"status": "error", "message": "Unauthorized"},
+			statusCode:    http.StatusUnauthorized,
+			expectedError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				assert.Equal(t, http.MethodPost, r.Method)
+				assert.Equal(t, "/api/v3/query_range", r.URL.Path)
+				assert.Equal(t, "application/json", r.Header.Get("Content-Type"))
+				assert.Equal(t, "test-api-key", r.Header.Get("SIGNOZ-API-KEY"))
+
+				if tt.checkPayload != nil {
+					var payload map[string]interface{}
+					err := json.NewDecoder(r.Body).Decode(&payload)
+					require.NoError(t, err)
+					tt.checkPayload(t, payload)
+				}
+
+				w.WriteHeader(tt.statusCode)
+				responseBody, _ := json.Marshal(tt.resp)
+				_, _ = w.Write(responseBody)
+			}))
+			defer server.Close()
+
+			logger, _ := zap.NewDevelopment()
+			client := NewClient(logger, server.URL, "test-api-key")
+
+			result, err := client.ExecuteClickHouseSQL(context.Background(), tt.query, tt.startMs, tt.endMs)
+
+			if tt.expectedError {
+				assert.Error(t, err)
+				assert.Nil(t, result)
+			} else {
+				assert.NoError(t, err)
+				assert.NotNil(t, result)
+			}
+		})
+	}
+}

--- a/internal/mcp-server/server.go
+++ b/internal/mcp-server/server.go
@@ -36,6 +36,7 @@ func (m *MCPServer) Start() error {
 	m.handler.RegisterDashboardHandlers(s)
 	m.handler.RegisterServiceHandlers(s)
 	m.handler.RegisterQueryBuilderV5Handlers(s)
+	m.handler.RegisterClickHouseSQLHandlers(s)
 	m.handler.RegisterLogsHandlers(s)
 	m.handler.RegisterTracesHandlers(s)
 


### PR DESCRIPTION
### Summary

- **Add `signoz_execute_clickhouse_query` MCP tool** to run raw ClickHouse SQL via SigNoz `/api/v3/query_range`.
- **Support time-range templating** in SQL (start/end timestamps and datetimes).
- **Default to last 1 day** when no explicit time range is provided.

### Problem

The existing MCP tools expose high-level query builder and aggregation flows, but **do not support arbitrary ClickHouse SQL**. For complex analyses, schema exploration, or existing SQL workflows, users must leave their MCP client and run queries elsewhere, breaking the AI-assisted workflow and limiting advanced use cases.

### Solution

- Add a new MCP tool `signoz_execute_clickhouse_query` that:
  - Accepts a raw ClickHouse SQL string and executes it via `/api/v3/query_range`.
  - Supports templated time variables:
    - `{{.start_timestamp}}`, `{{.end_timestamp}}` (Unix seconds)
    - `{{.start_datetime}}`, `{{.end_datetime}}` (UTC datetime strings)
  - Resolves time from `timeRange` or explicit `start` / `end`, and defaults to **last 1 day** if none are provided.
- Wire the tool into the MCP server and SigNoz client, and add tests for the new client method.

### Test plan

- [x] Verified the client method calls `/api/v3/query_range` with the expected payload.
- [x] Verified `signoz_execute_clickhouse_query` is registered and callable from MCP clients.
- [x] Verified templating for `{{.start_timestamp}}` / `{{.end_timestamp}}` and datetime variants across different `timeRange` values.
- [x] Verified behavior when no time range is supplied (defaults to last 1 day).
- [x] Re-ran existing tools (metrics/logs/traces/query builder) to confirm no regressions.

