### PR TITLE
fix: signoz_list_alerts returns configured rules instead of only triggered alerts

### DIFF
--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -159,6 +159,49 @@ func (s *SigNoz) ListAlertRules(ctx context.Context) (json.RawMessage, error) {
 	return body, nil
 }
 
+func (s *SigNoz) ListTriggeredAlerts(ctx context.Context) (json.RawMessage, error) {
+	url := fmt.Sprintf("%s/api/v1/alerts", s.baseURL)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	req.Header.Set(ContentType, "application/json")
+	req.Header.Set(SignozApiKey, s.apiKey)
+
+	ctx, cancel := context.WithTimeout(ctx, 600*time.Second)
+	defer cancel()
+	req = req.WithContext(ctx)
+
+	s.logger.Debug("Fetching triggered alerts from SigNoz")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		s.logger.Error("HTTP request failed", zap.String("url", url), zap.Error(err))
+		return nil, fmt.Errorf("failed to do request: %w", err)
+	}
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			s.logger.Warn("Failed to close response body", zap.Error(err))
+		}
+	}()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		s.logger.Error("Failed to read response body", zap.String("url", url), zap.Error(err))
+		return nil, fmt.Errorf("failed to read response body: %w", err)
+	}
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		s.logger.Error("API request failed", zap.String("url", url), zap.Int("status", resp.StatusCode), zap.String("response", string(body)))
+		return nil, fmt.Errorf("unexpected status %d: %s", resp.StatusCode, string(body))
+	}
+
+	s.logger.Debug("Successfully retrieved triggered alerts", zap.Int("status", resp.StatusCode))
+	return body, nil
+}
+
 func (s *SigNoz) GetAlertByRuleID(ctx context.Context, ruleID string) (json.RawMessage, error) {
 	url := fmt.Sprintf("%s/api/v1/rules/%s", s.baseURL, ruleID)
 

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -116,8 +116,8 @@ func (s *SigNoz) SearchMetricByText(ctx context.Context, searchText string) (jso
 	return body, nil
 }
 
-func (s *SigNoz) ListAlerts(ctx context.Context) (json.RawMessage, error) {
-	url := fmt.Sprintf("%s/api/v1/alerts", s.baseURL)
+func (s *SigNoz) ListAlertRules(ctx context.Context) (json.RawMessage, error) {
+	url := fmt.Sprintf("%s/api/v1/rules", s.baseURL)
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
@@ -131,7 +131,7 @@ func (s *SigNoz) ListAlerts(ctx context.Context) (json.RawMessage, error) {
 	defer cancel()
 	req = req.WithContext(ctx)
 
-	s.logger.Debug("Fetching alerts from SigNoz")
+	s.logger.Debug("Fetching alert rules from SigNoz")
 
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
@@ -155,7 +155,7 @@ func (s *SigNoz) ListAlerts(ctx context.Context) (json.RawMessage, error) {
 		return nil, fmt.Errorf("unexpected status %d: %s", resp.StatusCode, string(body))
 	}
 
-	s.logger.Debug("Successfully retrieved alerts", zap.Int("status", resp.StatusCode))
+	s.logger.Debug("Successfully retrieved alert rules", zap.Int("status", resp.StatusCode))
 	return body, nil
 }
 

--- a/internal/handler/tools/handler.go
+++ b/internal/handler/tools/handler.go
@@ -206,7 +206,7 @@ func (h *Handler) RegisterAlertsHandlers(s *server.MCPServer) {
 	h.logger.Debug("Registering alerts handlers")
 
 	alertsTool := mcp.NewTool("signoz_list_alerts",
-		mcp.WithDescription("List active alerts from SigNoz. Returns list of alert with: alert name, rule ID, severity, start time, end time, and state. IMPORTANT: This tool supports pagination using 'limit' and 'offset' parameters. The response includes 'pagination' metadata with 'total', 'hasMore', and 'nextOffset' fields. When searching for a specific alert, ALWAYS check 'pagination.hasMore' - if true, continue paginating through all pages using 'nextOffset' until you find the item or 'hasMore' is false. Never conclude an item doesn't exist until you've checked all pages. Default: limit=50, offset=0."),
+		mcp.WithDescription("List configured alert rules from SigNoz. Returns list of alert rules with: alert name, rule ID, severity, state, alert type, and disabled status. IMPORTANT: This tool supports pagination using 'limit' and 'offset' parameters. The response includes 'pagination' metadata with 'total', 'hasMore', and 'nextOffset' fields. When searching for a specific alert, ALWAYS check 'pagination.hasMore' - if true, continue paginating through all pages using 'nextOffset' until you find the item or 'hasMore' is false. Never conclude an item doesn't exist until you've checked all pages. Default: limit=50, offset=0."),
 		mcp.WithString("limit", mcp.Description("Maximum number of alerts to return per page. Use this to paginate through large result sets. Default: 50. Example: '50' for 50 results, '100' for 100 results. Must be greater than 0.")),
 		mcp.WithString("offset", mcp.Description("Number of results to skip before returning results. Use for pagination: offset=0 for first page, offset=50 for second page (if limit=50), offset=100 for third page, etc. Check 'pagination.nextOffset' in the response to get the next page offset. Default: 0. Must be >= 0.")),
 	)
@@ -215,28 +215,28 @@ func (h *Handler) RegisterAlertsHandlers(s *server.MCPServer) {
 		limit, offset := paginate.ParseParams(req.Params.Arguments)
 
 		client := h.GetClient(ctx)
-		alerts, err := client.ListAlerts(ctx)
+		rulesJSON, err := client.ListAlertRules(ctx)
 		if err != nil {
-			h.logger.Error("Failed to list alerts", zap.Error(err))
+			h.logger.Error("Failed to list alert rules", zap.Error(err))
 			return mcp.NewToolResultError(err.Error()), nil
 		}
 
-		var apiResponse types.APIAlertsResponse
-		if err := json.Unmarshal(alerts, &apiResponse); err != nil {
-			h.logger.Error("Failed to parse alerts response", zap.Error(err), zap.String("response", string(alerts)))
-			return mcp.NewToolResultError("failed to parse alerts response: " + err.Error()), nil
+		var apiResponse types.APIAlertRulesResponse
+		if err := json.Unmarshal(rulesJSON, &apiResponse); err != nil {
+			h.logger.Error("Failed to parse alert rules response", zap.Error(err), zap.String("response", string(rulesJSON)))
+			return mcp.NewToolResultError("failed to parse alert rules response: " + err.Error()), nil
 		}
 
-		// takes only meaningful data
-		alertsList := make([]types.Alert, 0, len(apiResponse.Data))
-		for _, apiAlert := range apiResponse.Data {
+		// Extract only meaningful data from each rule
+		alertsList := make([]types.Alert, 0, len(apiResponse.Data.Rules))
+		for _, rule := range apiResponse.Data.Rules {
 			alertsList = append(alertsList, types.Alert{
-				Alertname: apiAlert.Labels.Alertname,
-				RuleID:    apiAlert.Labels.RuleID,
-				Severity:  apiAlert.Labels.Severity,
-				StartsAt:  apiAlert.StartsAt,
-				EndsAt:    apiAlert.EndsAt,
-				State:     apiAlert.Status.State,
+				Name:      rule.Alert,
+				RuleID:    rule.ID,
+				Severity:  rule.Labels.Severity,
+				State:     rule.State,
+				AlertType: rule.AlertType,
+				Disabled:  rule.Disabled,
 			})
 		}
 

--- a/internal/handler/tools/handler.go
+++ b/internal/handler/tools/handler.go
@@ -256,6 +256,56 @@ func (h *Handler) RegisterAlertsHandlers(s *server.MCPServer) {
 		return mcp.NewToolResultText(string(resultJSON)), nil
 	})
 
+	triggeredAlertsTool := mcp.NewTool("signoz_list_triggered_alerts",
+		mcp.WithDescription("List currently firing/triggered alerts from SigNoz Alertmanager. Returns only alerts that are actively firing right now. For configured alert rules (regardless of firing state), use signoz_list_alerts instead. IMPORTANT: This tool supports pagination using 'limit' and 'offset' parameters. The response includes 'pagination' metadata with 'total', 'hasMore', and 'nextOffset' fields. Default: limit=50, offset=0."),
+		mcp.WithString("limit", mcp.Description("Maximum number of triggered alerts to return per page. Default: 50.")),
+		mcp.WithString("offset", mcp.Description("Number of results to skip before returning results. Default: 0.")),
+	)
+	s.AddTool(triggeredAlertsTool, func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		h.logger.Debug("Tool called: signoz_list_triggered_alerts")
+		limit, offset := paginate.ParseParams(req.Params.Arguments)
+
+		client := h.GetClient(ctx)
+		alerts, err := client.ListTriggeredAlerts(ctx)
+		if err != nil {
+			h.logger.Error("Failed to list triggered alerts", zap.Error(err))
+			return mcp.NewToolResultError(err.Error()), nil
+		}
+
+		var apiResponse types.APIAlertsResponse
+		if err := json.Unmarshal(alerts, &apiResponse); err != nil {
+			h.logger.Error("Failed to parse triggered alerts response", zap.Error(err), zap.String("response", string(alerts)))
+			return mcp.NewToolResultError("failed to parse triggered alerts response: " + err.Error()), nil
+		}
+
+		alertsList := make([]types.TriggeredAlert, 0, len(apiResponse.Data))
+		for _, apiAlert := range apiResponse.Data {
+			alertsList = append(alertsList, types.TriggeredAlert{
+				Alertname: apiAlert.Labels.Alertname,
+				RuleID:    apiAlert.Labels.RuleID,
+				Severity:  apiAlert.Labels.Severity,
+				StartsAt:  apiAlert.StartsAt,
+				EndsAt:    apiAlert.EndsAt,
+				State:     apiAlert.Status.State,
+			})
+		}
+
+		total := len(alertsList)
+		alertsArray := make([]any, len(alertsList))
+		for i, v := range alertsList {
+			alertsArray[i] = v
+		}
+		pagedAlerts := paginate.Array(alertsArray, offset, limit)
+
+		resultJSON, err := paginate.Wrap(pagedAlerts, total, offset, limit)
+		if err != nil {
+			h.logger.Error("Failed to wrap triggered alerts with pagination", zap.Error(err))
+			return mcp.NewToolResultError("failed to marshal response: " + err.Error()), nil
+		}
+
+		return mcp.NewToolResultText(string(resultJSON)), nil
+	})
+
 	getAlertTool := mcp.NewTool("signoz_get_alert",
 		mcp.WithDescription("Get details of a specific alert rule by ruleId"),
 		mcp.WithString("ruleId", mcp.Required(), mcp.Description("Alert ruleId")),

--- a/pkg/types/alerts.go
+++ b/pkg/types/alerts.go
@@ -26,6 +26,16 @@ type Alert struct {
 	Disabled  bool   `json:"disabled"`
 }
 
+// TriggeredAlert contains information about a currently firing alert
+type TriggeredAlert struct {
+	Alertname string `json:"alertname"`
+	RuleID    string `json:"ruleId"`
+	Severity  string `json:"severity"`
+	StartsAt  string `json:"startsAt"`
+	EndsAt    string `json:"endsAt"`
+	State     string `json:"state"`
+}
+
 // APIAlertLabels represents labels from the Alertmanager /alerts endpoint
 type APIAlertLabels struct {
 	Alertname string `json:"alertname"`

--- a/pkg/types/alerts.go
+++ b/pkg/types/alerts.go
@@ -16,26 +16,29 @@ type AlertHistoryFilters struct {
 	Op    string        `json:"op"`
 }
 
-// Alert contains only essential information
+// Alert contains only essential information for list display
 type Alert struct {
-	Alertname string `json:"alertname"`
+	Name      string `json:"name"`
 	RuleID    string `json:"ruleId"`
 	Severity  string `json:"severity"`
-	StartsAt  string `json:"startsAt"`
-	EndsAt    string `json:"endsAt"`
 	State     string `json:"state"`
+	AlertType string `json:"alertType"`
+	Disabled  bool   `json:"disabled"`
 }
 
+// APIAlertLabels represents labels from the Alertmanager /alerts endpoint
 type APIAlertLabels struct {
 	Alertname string `json:"alertname"`
 	RuleID    string `json:"ruleId"`
 	Severity  string `json:"severity"`
 }
 
+// APIAlertStatus represents status from the Alertmanager /alerts endpoint
 type APIAlertStatus struct {
 	State string `json:"state"`
 }
 
+// APIAlert represents a single triggered alert from /api/v1/alerts
 type APIAlert struct {
 	Labels   APIAlertLabels `json:"labels"`
 	Status   APIAlertStatus `json:"status"`
@@ -43,7 +46,36 @@ type APIAlert struct {
 	EndsAt   string         `json:"endsAt"`
 }
 
+// APIAlertsResponse is the response from /api/v1/alerts (triggered alerts)
 type APIAlertsResponse struct {
 	Status string     `json:"status"`
 	Data   []APIAlert `json:"data"`
+}
+
+// APIAlertRuleLabels represents labels on a configured alert rule
+type APIAlertRuleLabels struct {
+	Severity string `json:"severity"`
+}
+
+// APIAlertRule represents a single configured alert rule from /api/v1/rules
+type APIAlertRule struct {
+	ID                string             `json:"id"`
+	Alert             string             `json:"alert"`
+	AlertType         string             `json:"alertType"`
+	RuleType          string             `json:"ruleType"`
+	State             string             `json:"state"`
+	Disabled          bool               `json:"disabled"`
+	Labels            APIAlertRuleLabels `json:"labels"`
+	PreferredChannels []string           `json:"preferredChannels"`
+}
+
+// APIAlertRulesData wraps the rules array
+type APIAlertRulesData struct {
+	Rules []APIAlertRule `json:"rules"`
+}
+
+// APIAlertRulesResponse is the response from /api/v1/rules (configured rules)
+type APIAlertRulesResponse struct {
+	Status string            `json:"status"`
+	Data   APIAlertRulesData `json:"data"`
 }

--- a/pkg/types/querybuilder_test.go
+++ b/pkg/types/querybuilder_test.go
@@ -84,4 +84,3 @@ func TestQueryPayloadValidate_LogsTimeSeriesRequiresAggregations(t *testing.T) {
 
 	require.Error(t, q.Validate())
 }
-


### PR DESCRIPTION
## Problem

The `signoz_list_alerts` tool calls `GET /api/v1/alerts`, which is the Alertmanager endpoint that only returns **currently firing/triggered alerts**. When no alerts are actively firing, it returns an empty array — making users think no alerts are configured.

The actual configured alert rules live at `GET /api/v1/rules`. The MCP server already uses this endpoint correctly in `signoz_get_alert` (`/api/v1/rules/<ruleId>`), but `signoz_list_alerts` was pointing to the wrong endpoint.

## Fix

- **Client**: Renamed `ListAlerts` → `ListAlertRules`, changed endpoint from `/api/v1/alerts` to `/api/v1/rules`
- **Types**: Added `APIAlertRulesResponse`, `APIAlertRule`, `APIAlertRuleLabels` structs to match the `/api/v1/rules` response format
- **Handler**: Updated `signoz_list_alerts` to parse the rules response and return: `name`, `ruleId`, `severity`, `state`, `alertType`, `disabled`
- **Description**: Updated tool description from "List active alerts" to "List configured alert rules"

## Before

```json
{"data": [], "pagination": {"total": 0}}
```
(Empty even though 11 alert rules were configured)

## After

```json
{
  "data": [
    {"name": "Errors splash", "ruleId": "019c242e-...", "severity": "error", "state": "inactive", "alertType": "LOGS_BASED_ALERT", "disabled": false},
    {"name": "CPU Load Critical", "ruleId": "019cb9c5-...", "severity": "critical", "state": "inactive", "alertType": "METRIC_BASED_ALERT", "disabled": false}
  ],
  "pagination": {"total": 11}
}
```

## Notes

- The old `APIAlert` / `APIAlertsResponse` types for `/api/v1/alerts` are preserved (not removed) in case they're needed for a future `signoz_list_triggered_alerts` tool
- Existing `signoz_get_alert` and `signoz_get_alert_history` tools are unaffected (they already use `/api/v1/rules/<id>`)
- All existing tests pass