### PR TITLE
refactor: add tool annotations, extract doRequest helper, name constants

### DIFF
--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -19,6 +19,11 @@ import (
 const (
 	SignozApiKey = "SIGNOZ-API-KEY"
 	ContentType  = "Content-Type"
+
+	// DefaultQueryTimeout is used for read-only API calls.
+	DefaultQueryTimeout = 600 * time.Second
+	// DashboardWriteTimeout is used for dashboard create/update operations.
+	DashboardWriteTimeout = 30 * time.Second
 )
 
 type SigNoz struct {
@@ -37,6 +42,43 @@ func NewClient(log *zap.Logger, baseURL, apiKey string) *SigNoz {
 			Transport: otelhttp.NewTransport(http.DefaultTransport),
 		},
 	}
+}
+
+// doRequest performs an HTTP request with standard headers, timeout, status
+// checking, and body reading. It is the single place where all SigNoz API
+// calls funnel through.
+func (s *SigNoz) doRequest(ctx context.Context, method, reqURL string, body io.Reader, timeout time.Duration) (json.RawMessage, error) {
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, method, reqURL, body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	req.Header.Set(ContentType, "application/json")
+	req.Header.Set(SignozApiKey, s.apiKey)
+
+	resp, err := s.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to do request: %w", err)
+	}
+	defer func() {
+		if closeErr := resp.Body.Close(); closeErr != nil {
+			s.logger.Warn("Failed to close response body", zap.Error(closeErr))
+		}
+	}()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response body: %w", err)
+	}
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, fmt.Errorf("unexpected status %d: %s", resp.StatusCode, string(respBody))
+	}
+
+	return respBody, nil
 }
 
 func (s *SigNoz) ListMetrics(ctx context.Context, start, end int64, limit int, searchText, source string) (json.RawMessage, error) {
@@ -58,557 +100,138 @@ func (s *SigNoz) ListMetrics(ctx context.Context, start, end int64, limit int, s
 	}
 
 	reqURL := fmt.Sprintf("%s/api/v2/metrics?%s", s.baseURL, params.Encode())
-
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, nil)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create request: %w", err)
-	}
-
-	req.Header.Set(ContentType, "application/json")
-	req.Header.Set(SignozApiKey, s.apiKey)
-
-	ctx, cancel := context.WithTimeout(ctx, 600*time.Second)
-	defer cancel()
-	req = req.WithContext(ctx)
-
 	s.logger.Debug("Listing metrics", zap.String("searchText", searchText))
-
-	resp, err := s.httpClient.Do(req)
-	if err != nil {
-		s.logger.Error("HTTP request failed", zap.String("url", reqURL), zap.Error(err))
-		return nil, fmt.Errorf("failed to do request: %w", err)
-	}
-	defer func() {
-		if err := resp.Body.Close(); err != nil {
-			s.logger.Warn("Failed to close response body", zap.Error(err))
-		}
-	}()
-
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		s.logger.Error("Failed to read response body", zap.String("url", reqURL), zap.Error(err))
-		return nil, fmt.Errorf("failed to read response body: %w", err)
-	}
-
-	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		s.logger.Error("API request failed", zap.String("url", reqURL), zap.Int("status", resp.StatusCode), zap.String("response", string(body)))
-		return nil, fmt.Errorf("unexpected status %d: %s", resp.StatusCode, string(body))
-	}
-
-	s.logger.Debug("Successfully listed metrics", zap.String("url", reqURL), zap.Int("status", resp.StatusCode))
-	return body, nil
+	return s.doRequest(ctx, http.MethodGet, reqURL, nil, DefaultQueryTimeout)
 }
 
 func (s *SigNoz) ListAlerts(ctx context.Context) (json.RawMessage, error) {
 	reqURL := fmt.Sprintf("%s/api/v1/alerts", s.baseURL)
-
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, nil)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create request: %w", err)
-	}
-
-	req.Header.Set(ContentType, "application/json")
-	req.Header.Set(SignozApiKey, s.apiKey)
-
-	ctx, cancel := context.WithTimeout(ctx, 600*time.Second)
-	defer cancel()
-	req = req.WithContext(ctx)
-
 	s.logger.Debug("Fetching alerts from SigNoz")
-
-	resp, err := s.httpClient.Do(req)
-	if err != nil {
-		s.logger.Error("HTTP request failed", zap.String("url", reqURL), zap.Error(err))
-		return nil, fmt.Errorf("failed to do request: %w", err)
-	}
-	defer func() {
-		if err := resp.Body.Close(); err != nil {
-			s.logger.Warn("Failed to close response body", zap.Error(err))
-		}
-	}()
-
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		s.logger.Error("Failed to read response body", zap.String("url", reqURL), zap.Error(err))
-		return nil, fmt.Errorf("failed to read response body: %w", err)
-	}
-
-	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		s.logger.Error("API request failed", zap.String("url", reqURL), zap.Int("status", resp.StatusCode), zap.String("response", string(body)))
-		return nil, fmt.Errorf("unexpected status %d: %s", resp.StatusCode, string(body))
-	}
-
-	s.logger.Debug("Successfully retrieved alerts", zap.Int("status", resp.StatusCode))
-	return body, nil
+	return s.doRequest(ctx, http.MethodGet, reqURL, nil, DefaultQueryTimeout)
 }
 
 func (s *SigNoz) GetAlertByRuleID(ctx context.Context, ruleID string) (json.RawMessage, error) {
 	reqURL := fmt.Sprintf("%s/api/v1/rules/%s", s.baseURL, url.PathEscape(ruleID))
-
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, nil)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create request: %w", err)
-	}
-	req.Header.Set(ContentType, "application/json")
-	req.Header.Set(SignozApiKey, s.apiKey)
-
-	ctx, cancel := context.WithTimeout(ctx, 600*time.Second)
-	defer cancel()
-	req = req.WithContext(ctx)
-
 	s.logger.Debug("Fetching alert rule details", zap.String("ruleID", ruleID))
-
-	resp, err := s.httpClient.Do(req)
-	if err != nil {
-		s.logger.Error("HTTP request failed", zap.String("url", reqURL), zap.String("ruleID", ruleID), zap.Error(err))
-		return nil, fmt.Errorf("request error: %w", err)
-	}
-	defer func() {
-		if err := resp.Body.Close(); err != nil {
-			s.logger.Warn("Failed to close response body", zap.Error(err))
-		}
-	}()
-
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		s.logger.Error("Failed to read response body", zap.String("url", reqURL), zap.Error(err))
-		return nil, fmt.Errorf("read error: %w", err)
-	}
-	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		s.logger.Error("API request failed", zap.String("url", reqURL), zap.Int("status", resp.StatusCode), zap.String("response", string(body)))
-		return nil, fmt.Errorf("unexpected status %d: %s", resp.StatusCode, string(body))
-	}
-
-	s.logger.Debug("Successfully retrieved alert rule", zap.String("ruleID", ruleID), zap.Int("status", resp.StatusCode))
-	return body, nil
+	return s.doRequest(ctx, http.MethodGet, reqURL, nil, DefaultQueryTimeout)
 }
 
-// ListDashboards filters data as it returns too much of data even the ui tags
+// ListDashboards filters data as it returns too much data even the ui tags
 // so we filter and only return required information which might help to get
 // detailed info of a dashboard.
 func (s *SigNoz) ListDashboards(ctx context.Context) (json.RawMessage, error) {
 	reqURL := fmt.Sprintf("%s/api/v1/dashboards", s.baseURL)
-
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, nil)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create request: %w", err)
-	}
-
-	req.Header.Set(ContentType, "application/json")
-	req.Header.Set(SignozApiKey, s.apiKey)
-
-	ctx, cancel := context.WithTimeout(ctx, 600*time.Second)
-	defer cancel()
-	req = req.WithContext(ctx)
-
 	s.logger.Debug("Fetching dashboards from SigNoz")
 
-	resp, err := s.httpClient.Do(req)
+	body, err := s.doRequest(ctx, http.MethodGet, reqURL, nil, DefaultQueryTimeout)
 	if err != nil {
-		s.logger.Error("HTTP request failed", zap.String("url", reqURL), zap.Error(err))
-		return nil, fmt.Errorf("failed to do request: %w", err)
-	}
-	defer func() {
-		if err := resp.Body.Close(); err != nil {
-			s.logger.Warn("Failed to close response body", zap.Error(err))
-		}
-	}()
-
-	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		body, _ := io.ReadAll(resp.Body)
-		s.logger.Error("API request failed", zap.String("url", reqURL), zap.Int("status", resp.StatusCode), zap.String("response", string(body)))
-		return nil, fmt.Errorf("unexpected status %d: %s", resp.StatusCode, string(body))
-	}
-
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		s.logger.Error("Failed to read response body", zap.String("url", reqURL), zap.Error(err))
-		return nil, fmt.Errorf("failed to read response: %w", err)
+		return nil, err
 	}
 
 	var rawResponse map[string]interface{}
 	if err := json.Unmarshal(body, &rawResponse); err != nil {
-		s.logger.Error("Failed to parse response", zap.String("url", reqURL), zap.Error(err))
 		return nil, fmt.Errorf("failed to parse response: %w", err)
 	}
 
-	if data, ok := rawResponse["data"].([]interface{}); ok {
-		simplifiedDashboards := make([]map[string]interface{}, 0, len(data))
-
-		for _, dashboard := range data {
-			if dash, ok := dashboard.(map[string]interface{}); ok {
-				var (
-					dashData map[string]interface{}
-					name     any
-					desc     any
-					tags     any
-				)
-				if v, ok := dash["data"].(map[string]interface{}); ok {
-					dashData = v
-					name = dashData["title"]
-					desc = dashData["description"]
-					tags = dashData["tags"]
-				}
-
-				simplified := map[string]interface{}{
-					"uuid":        dash["id"],
-					"name":        name,
-					"description": desc,
-					"tags":        tags,
-					"createdAt":   dash["createdAt"],
-					"updatedAt":   dash["updatedAt"],
-					"createdBy":   dash["createdBy"],
-					"updatedBy":   dash["updatedBy"],
-				}
-				simplifiedDashboards = append(simplifiedDashboards, simplified)
-			}
-		}
-
-		simplifiedResponse := map[string]interface{}{
-			"status": rawResponse["status"],
-			"data":   simplifiedDashboards,
-		}
-
-		simplifiedJSON, err := json.Marshal(simplifiedResponse)
-		if err != nil {
-			s.logger.Error("Failed to marshal simplified response", zap.Error(err))
-			return nil, fmt.Errorf("failed to marshal simplified response: %w", err)
-		}
-
-		s.logger.Debug("Successfully retrieved and simplified dashboards", zap.Int("count", len(simplifiedDashboards)), zap.Int("status", resp.StatusCode))
-		return simplifiedJSON, nil
+	data, ok := rawResponse["data"].([]interface{})
+	if !ok {
+		return body, nil
 	}
 
-	s.logger.Debug("Successfully retrieved dashboards", zap.Int("status", resp.StatusCode))
-	return body, nil
+	simplifiedDashboards := make([]map[string]interface{}, 0, len(data))
+	for _, dashboard := range data {
+		dash, ok := dashboard.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		var (
+			name any
+			desc any
+			tags any
+		)
+		if v, ok := dash["data"].(map[string]interface{}); ok {
+			name = v["title"]
+			desc = v["description"]
+			tags = v["tags"]
+		}
+
+		simplifiedDashboards = append(simplifiedDashboards, map[string]interface{}{
+			"uuid":        dash["id"],
+			"name":        name,
+			"description": desc,
+			"tags":        tags,
+			"createdAt":   dash["createdAt"],
+			"updatedAt":   dash["updatedAt"],
+			"createdBy":   dash["createdBy"],
+			"updatedBy":   dash["updatedBy"],
+		})
+	}
+
+	simplifiedResponse := map[string]interface{}{
+		"status": rawResponse["status"],
+		"data":   simplifiedDashboards,
+	}
+
+	simplifiedJSON, err := json.Marshal(simplifiedResponse)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal simplified response: %w", err)
+	}
+
+	s.logger.Debug("Successfully retrieved and simplified dashboards", zap.Int("count", len(simplifiedDashboards)))
+	return simplifiedJSON, nil
 }
 
 func (s *SigNoz) GetDashboard(ctx context.Context, uuid string) (json.RawMessage, error) {
 	reqURL := fmt.Sprintf("%s/api/v1/dashboards/%s", s.baseURL, url.PathEscape(uuid))
-
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, nil)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create request: %w", err)
-	}
-
-	req.Header.Set(ContentType, "application/json")
-	req.Header.Set(SignozApiKey, s.apiKey)
-
-	ctx, cancel := context.WithTimeout(ctx, 600*time.Second)
-	defer cancel()
-	req = req.WithContext(ctx)
-
 	s.logger.Debug("Fetching dashboard details", zap.String("uuid", uuid))
-
-	resp, err := s.httpClient.Do(req)
-	if err != nil {
-		s.logger.Error("HTTP request failed", zap.String("url", reqURL), zap.String("uuid", uuid), zap.Error(err))
-		return nil, fmt.Errorf("failed to do request: %w", err)
-	}
-	defer func() {
-		if err := resp.Body.Close(); err != nil {
-			s.logger.Warn("Failed to close response body", zap.Error(err))
-		}
-	}()
-
-	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		body, _ := io.ReadAll(resp.Body)
-		s.logger.Error("API request failed", zap.String("url", reqURL), zap.Int("status", resp.StatusCode), zap.String("response", string(body)))
-		return nil, fmt.Errorf("unexpected status %d: %s", resp.StatusCode, string(body))
-	}
-
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		s.logger.Error("Failed to read response body", zap.String("url", reqURL), zap.Error(err))
-		return nil, fmt.Errorf("failed to read response: %w", err)
-	}
-
-	s.logger.Debug("Successfully retrieved dashboard", zap.String("uuid", uuid), zap.Int("status", resp.StatusCode))
-	return body, nil
+	return s.doRequest(ctx, http.MethodGet, reqURL, nil, DefaultQueryTimeout)
 }
 
 func (s *SigNoz) ListServices(ctx context.Context, start, end string) (json.RawMessage, error) {
 	reqURL := fmt.Sprintf("%s/api/v1/services", s.baseURL)
-
-	payload := map[string]string{
-		"start": start,
-		"end":   end,
-	}
+	payload := map[string]string{"start": start, "end": end}
 	bodyBytes, _ := json.Marshal(payload)
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, reqURL, bytes.NewReader(bodyBytes))
-	if err != nil {
-		return nil, fmt.Errorf("failed to create request: %w", err)
-	}
-
-	req.Header.Set(ContentType, "application/json")
-	req.Header.Set(SignozApiKey, s.apiKey)
-
 	s.logger.Debug("Fetching services from SigNoz", zap.String("start", start), zap.String("end", end))
-
-	ctx, cancel := context.WithTimeout(ctx, 600*time.Second)
-	defer cancel()
-	req = req.WithContext(ctx)
-	resp, err := s.httpClient.Do(req)
-	if err != nil {
-		s.logger.Error("HTTP request failed", zap.String("url", reqURL), zap.String("start", start), zap.String("end", end), zap.Error(err))
-		return nil, fmt.Errorf("failed to do request: %w", err)
-	}
-	defer func() {
-		if err := resp.Body.Close(); err != nil {
-			s.logger.Warn("Failed to close response body", zap.Error(err))
-		}
-	}()
-
-	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		body, _ := io.ReadAll(resp.Body)
-		s.logger.Error("API request failed", zap.String("url", reqURL), zap.Int("status", resp.StatusCode), zap.String("response", string(body)))
-		return nil, fmt.Errorf("unexpected status %d: %s", resp.StatusCode, string(body))
-	}
-
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		s.logger.Error("Failed to read response body", zap.String("url", reqURL), zap.Error(err))
-		return nil, fmt.Errorf("failed to read response: %w", err)
-	}
-
-	s.logger.Debug("Successfully retrieved services", zap.String("start", start), zap.String("end", end), zap.Int("status", resp.StatusCode))
-	return body, nil
+	return s.doRequest(ctx, http.MethodPost, reqURL, bytes.NewReader(bodyBytes), DefaultQueryTimeout)
 }
 
 func (s *SigNoz) GetServiceTopOperations(ctx context.Context, start, end, service string, tags json.RawMessage) (json.RawMessage, error) {
 	reqURL := fmt.Sprintf("%s/api/v1/service/top_operations", s.baseURL)
-
-	payload := map[string]any{
-		"start":   start,
-		"end":     end,
-		"service": service,
-		"tags":    tags,
-	}
+	payload := map[string]any{"start": start, "end": end, "service": service, "tags": tags}
 	bodyBytes, _ := json.Marshal(payload)
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, reqURL, bytes.NewReader(bodyBytes))
-	if err != nil {
-		return nil, fmt.Errorf("failed to create request: %w", err)
-	}
-
-	req.Header.Set(ContentType, "application/json")
-	req.Header.Set(SignozApiKey, s.apiKey)
-
-	s.logger.Debug("Fetching service top operations", zap.String("start", start), zap.String("end", end), zap.String("service", service))
-
-	ctx, cancel := context.WithTimeout(ctx, 600*time.Second)
-	defer cancel()
-	req = req.WithContext(ctx)
-	resp, err := s.httpClient.Do(req)
-	if err != nil {
-		s.logger.Error("HTTP request failed", zap.String("url", reqURL), zap.String("start", start), zap.String("end", end), zap.String("service", service), zap.Error(err))
-		return nil, fmt.Errorf("failed to do request: %w", err)
-	}
-	defer func() {
-		if err := resp.Body.Close(); err != nil {
-			s.logger.Warn("Failed to close response body", zap.Error(err))
-		}
-	}()
-
-	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		body, _ := io.ReadAll(resp.Body)
-		s.logger.Error("API request failed", zap.String("url", reqURL), zap.Int("status", resp.StatusCode), zap.String("response", string(body)))
-		return nil, fmt.Errorf("unexpected status %d: %s", resp.StatusCode, string(body))
-	}
-
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		s.logger.Error("Failed to read response body", zap.String("url", reqURL), zap.Error(err))
-		return nil, fmt.Errorf("failed to read response: %w", err)
-	}
-
-	s.logger.Debug("Successfully retrieved service top operations", zap.String("start", start), zap.String("end", end), zap.String("service", service), zap.Int("status", resp.StatusCode))
-	return body, nil
+	s.logger.Debug("Fetching service top operations", zap.String("service", service))
+	return s.doRequest(ctx, http.MethodPost, reqURL, bytes.NewReader(bodyBytes), DefaultQueryTimeout)
 }
 
 func (s *SigNoz) QueryBuilderV5(ctx context.Context, body []byte) (json.RawMessage, error) {
 	reqURL := fmt.Sprintf("%s/api/v5/query_range", s.baseURL)
-
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, reqURL, bytes.NewBuffer(body))
-	if err != nil {
-		return nil, fmt.Errorf("failed to create request: %w", err)
-	}
-
-	req.Header.Set(ContentType, "application/json")
-	req.Header.Set(SignozApiKey, s.apiKey)
-
-	ctx, cancel := context.WithTimeout(ctx, 600*time.Second)
-	defer cancel()
-	req = req.WithContext(ctx)
-
 	s.logger.Debug("sending request", zap.String("url", reqURL), zap.Any("body", json.RawMessage(body)))
-
-	resp, err := s.httpClient.Do(req)
-	if err != nil {
-		return nil, fmt.Errorf("failed to do request: %w", err)
-	}
-	defer func() {
-		if err := resp.Body.Close(); err != nil {
-			s.logger.Warn("Failed to close response body", zap.Error(err))
-		}
-	}()
-
-	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		b, _ := io.ReadAll(resp.Body)
-		return nil, fmt.Errorf("unexpected status %d: %s", resp.StatusCode, string(b))
-	}
-
-	b, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, fmt.Errorf("failed to read response: %w", err)
-	}
-
-	return b, nil
+	return s.doRequest(ctx, http.MethodPost, reqURL, bytes.NewBuffer(body), DefaultQueryTimeout)
 }
 
 func (s *SigNoz) GetAlertHistory(ctx context.Context, ruleID string, req types.AlertHistoryRequest) (json.RawMessage, error) {
 	reqURL := fmt.Sprintf("%s/api/v1/rules/%s/history/timeline", s.baseURL, url.PathEscape(ruleID))
-	// includes ruleid to get history
-	// eg: /api/v1/rules/<ruleID>/history/timeline
-
 	reqBody, err := json.Marshal(req)
 	if err != nil {
 		return nil, fmt.Errorf("failed to marshal request: %w", err)
 	}
 
-	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, reqURL, bytes.NewBuffer(reqBody))
-	if err != nil {
-		return nil, fmt.Errorf("failed to create request: %w", err)
-	}
-
-	httpReq.Header.Set(ContentType, "application/json")
-	httpReq.Header.Set(SignozApiKey, s.apiKey)
-
-	s.logger.Debug("sending request", zap.String("url", reqURL), zap.Any("body", json.RawMessage(reqBody)))
-
-	ctx, cancel := context.WithTimeout(ctx, 600*time.Second)
-	defer cancel()
-	httpReq = httpReq.WithContext(ctx)
-
-	s.logger.Debug("Making request to SigNoz API",
-		zap.String("method", "POST"),
-		zap.String("endpoint", fmt.Sprintf("/api/v1/rules/%s/history/timeline", ruleID)))
-
-	resp, err := s.httpClient.Do(httpReq)
-	if err != nil {
-		s.logger.Error("HTTP request failed", zap.String("url", reqURL), zap.Error(err))
-		return nil, fmt.Errorf("failed to do request: %w", err)
-	}
-	defer func() {
-		if err := resp.Body.Close(); err != nil {
-			s.logger.Warn("Failed to close response body", zap.Error(err))
-		}
-	}()
-
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		s.logger.Error("Failed to read response body", zap.Error(err))
-		return nil, fmt.Errorf("failed to read response body: %w", err)
-	}
-
-	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		s.logger.Error("API request failed",
-			zap.String("url", reqURL),
-			zap.Int("status", resp.StatusCode),
-			zap.String("response", string(body)))
-		return nil, fmt.Errorf("unexpected status %d: %s", resp.StatusCode, string(body))
-	}
-
-	return body, nil
+	s.logger.Debug("Fetching alert history", zap.String("ruleID", ruleID))
+	return s.doRequest(ctx, http.MethodPost, reqURL, bytes.NewBuffer(reqBody), DefaultQueryTimeout)
 }
 
 func (s *SigNoz) ListLogViews(ctx context.Context) (json.RawMessage, error) {
 	reqURL := fmt.Sprintf("%s/api/v1/explorer/views?sourcePage=logs", s.baseURL)
-
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, nil)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create request: %w", err)
-	}
-
-	req.Header.Set(ContentType, "application/json")
-	req.Header.Set(SignozApiKey, s.apiKey)
-
-	ctx, cancel := context.WithTimeout(ctx, 600*time.Second)
-	defer cancel()
-	req = req.WithContext(ctx)
-
 	s.logger.Debug("Fetching log views from SigNoz")
-
-	resp, err := s.httpClient.Do(req)
-	if err != nil {
-		s.logger.Error("HTTP request failed", zap.String("url", reqURL), zap.Error(err))
-		return nil, fmt.Errorf("failed to do request: %w", err)
-	}
-	defer func() {
-		if err := resp.Body.Close(); err != nil {
-			s.logger.Warn("Failed to close response body", zap.Error(err))
-		}
-	}()
-
-	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		body, _ := io.ReadAll(resp.Body)
-		s.logger.Error("API request failed", zap.String("url", reqURL), zap.Int("status", resp.StatusCode), zap.String("response", string(body)))
-		return nil, fmt.Errorf("unexpected status %d: %s", resp.StatusCode, string(body))
-	}
-
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		s.logger.Error("Failed to read response body", zap.String("url", reqURL), zap.Error(err))
-		return nil, fmt.Errorf("failed to read response: %w", err)
-	}
-
-	s.logger.Debug("Successfully retrieved log views", zap.Int("status", resp.StatusCode))
-	return body, nil
+	return s.doRequest(ctx, http.MethodGet, reqURL, nil, DefaultQueryTimeout)
 }
 
 func (s *SigNoz) GetLogView(ctx context.Context, viewID string) (json.RawMessage, error) {
 	reqURL := fmt.Sprintf("%s/api/v1/explorer/views/%s", s.baseURL, url.PathEscape(viewID))
-
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, nil)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create request: %w", err)
-	}
-
-	req.Header.Set(ContentType, "application/json")
-	req.Header.Set(SignozApiKey, s.apiKey)
-
-	ctx, cancel := context.WithTimeout(ctx, 600*time.Second)
-	defer cancel()
-	req = req.WithContext(ctx)
-
 	s.logger.Debug("Fetching log view details", zap.String("viewID", viewID))
-
-	resp, err := s.httpClient.Do(req)
-	if err != nil {
-		s.logger.Error("HTTP request failed", zap.String("url", reqURL), zap.String("viewID", viewID), zap.Error(err))
-		return nil, fmt.Errorf("failed to do request: %w", err)
-	}
-	defer func() {
-		if err := resp.Body.Close(); err != nil {
-			s.logger.Warn("Failed to close response body", zap.Error(err))
-		}
-	}()
-
-	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		body, _ := io.ReadAll(resp.Body)
-		s.logger.Error("API request failed", zap.String("url", reqURL), zap.Int("status", resp.StatusCode), zap.String("response", string(body)))
-		return nil, fmt.Errorf("unexpected status %d: %s", resp.StatusCode, string(body))
-	}
-
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		s.logger.Error("Failed to read response body", zap.String("url", reqURL), zap.Error(err))
-		return nil, fmt.Errorf("failed to read response: %w", err)
-	}
-
-	s.logger.Debug("Successfully retrieved log view", zap.String("viewID", viewID), zap.Int("status", resp.StatusCode))
-	return body, nil
+	return s.doRequest(ctx, http.MethodGet, reqURL, nil, DefaultQueryTimeout)
 }
 
 func (s *SigNoz) GetFieldKeys(ctx context.Context, signal, metricName, searchText, fieldContext, fieldDataType, source string) (json.RawMessage, error) {
@@ -630,46 +253,9 @@ func (s *SigNoz) GetFieldKeys(ctx context.Context, signal, metricName, searchTex
 		params.Set("source", source)
 	}
 
-	urlStr := fmt.Sprintf("%s/api/v1/fields/keys?%s", s.baseURL, params.Encode())
-
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, urlStr, nil)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create request: %w", err)
-	}
-
-	req.Header.Set(ContentType, "application/json")
-	req.Header.Set(SignozApiKey, s.apiKey)
-
-	ctx, cancel := context.WithTimeout(ctx, 600*time.Second)
-	defer cancel()
-	req = req.WithContext(ctx)
-
+	reqURL := fmt.Sprintf("%s/api/v1/fields/keys?%s", s.baseURL, params.Encode())
 	s.logger.Debug("Fetching field keys", zap.String("signal", signal), zap.String("searchText", searchText))
-
-	resp, err := s.httpClient.Do(req)
-	if err != nil {
-		s.logger.Error("HTTP request failed", zap.String("url", urlStr), zap.Error(err))
-		return nil, fmt.Errorf("failed to do request: %w", err)
-	}
-	defer func() {
-		if err := resp.Body.Close(); err != nil {
-			s.logger.Warn("Failed to close response body", zap.Error(err))
-		}
-	}()
-
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		s.logger.Error("Failed to read response body", zap.String("url", urlStr), zap.Error(err))
-		return nil, fmt.Errorf("failed to read response: %w", err)
-	}
-
-	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		s.logger.Error("API request failed", zap.String("url", urlStr), zap.Int("status", resp.StatusCode), zap.String("response", string(body)))
-		return nil, fmt.Errorf("unexpected status %d: %s", resp.StatusCode, string(body))
-	}
-
-	s.logger.Debug("Successfully retrieved field keys", zap.String("signal", signal), zap.Int("status", resp.StatusCode))
-	return body, nil
+	return s.doRequest(ctx, http.MethodGet, reqURL, nil, DefaultQueryTimeout)
 }
 
 func (s *SigNoz) GetFieldValues(ctx context.Context, signal, name, metricName, searchText, source string) (json.RawMessage, error) {
@@ -686,46 +272,9 @@ func (s *SigNoz) GetFieldValues(ctx context.Context, signal, name, metricName, s
 		params.Set("source", source)
 	}
 
-	urlStr := fmt.Sprintf("%s/api/v1/fields/values?%s", s.baseURL, params.Encode())
-
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, urlStr, nil)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create request: %w", err)
-	}
-
-	req.Header.Set(ContentType, "application/json")
-	req.Header.Set(SignozApiKey, s.apiKey)
-
-	ctx, cancel := context.WithTimeout(ctx, 600*time.Second)
-	defer cancel()
-	req = req.WithContext(ctx)
-
+	reqURL := fmt.Sprintf("%s/api/v1/fields/values?%s", s.baseURL, params.Encode())
 	s.logger.Debug("Fetching field values", zap.String("signal", signal), zap.String("name", name))
-
-	resp, err := s.httpClient.Do(req)
-	if err != nil {
-		s.logger.Error("HTTP request failed", zap.String("url", urlStr), zap.Error(err))
-		return nil, fmt.Errorf("failed to do request: %w", err)
-	}
-	defer func() {
-		if err := resp.Body.Close(); err != nil {
-			s.logger.Warn("Failed to close response body", zap.Error(err))
-		}
-	}()
-
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		s.logger.Error("Failed to read response body", zap.String("url", urlStr), zap.Error(err))
-		return nil, fmt.Errorf("failed to read response: %w", err)
-	}
-
-	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		s.logger.Error("API request failed", zap.String("url", urlStr), zap.Int("status", resp.StatusCode), zap.String("response", string(body)))
-		return nil, fmt.Errorf("unexpected status %d: %s", resp.StatusCode, string(body))
-	}
-
-	s.logger.Debug("Successfully retrieved field values", zap.String("signal", signal), zap.String("name", name), zap.Int("status", resp.StatusCode))
-	return body, nil
+	return s.doRequest(ctx, http.MethodGet, reqURL, nil, DefaultQueryTimeout)
 }
 
 func (s *SigNoz) GetTraceDetails(ctx context.Context, traceID string, includeSpans bool, startTime, endTime int64) (json.RawMessage, error) {
@@ -747,71 +296,23 @@ func (s *SigNoz) GetTraceDetails(ctx context.Context, traceID string, includeSpa
 
 func (s *SigNoz) CreateDashboard(ctx context.Context, dashboard types.Dashboard) (json.RawMessage, error) {
 	reqURL := fmt.Sprintf("%s/api/v1/dashboards", s.baseURL)
-
 	dashboardJSON, err := json.Marshal(dashboard)
 	if err != nil {
 		return nil, fmt.Errorf("marshal dashboard: %w", err)
 	}
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, reqURL, bytes.NewBuffer(dashboardJSON))
-	if err != nil {
-		return nil, fmt.Errorf("new request: %w", err)
-	}
-
-	req.Header.Set(SignozApiKey, s.apiKey)
-	req.Header.Set(ContentType, "application/json")
-
-	timeoutCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
-	defer cancel()
-
-	resp, err := s.httpClient.Do(req.WithContext(timeoutCtx))
-	if err != nil {
-		return nil, fmt.Errorf("do request: %w", err)
-	}
-	defer func() { _ = resp.Body.Close() }()
-
-	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		body, _ := io.ReadAll(resp.Body)
-		return nil, fmt.Errorf("unexpected status %d: %s", resp.StatusCode, string(body))
-	}
-
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, fmt.Errorf("read response: %w", err)
-	}
-
-	return body, nil
+	s.logger.Debug("Creating dashboard")
+	return s.doRequest(ctx, http.MethodPost, reqURL, bytes.NewBuffer(dashboardJSON), DashboardWriteTimeout)
 }
 
 func (s *SigNoz) UpdateDashboard(ctx context.Context, id string, dashboard types.Dashboard) error {
 	reqURL := fmt.Sprintf("%s/api/v1/dashboards/%s", s.baseURL, url.PathEscape(id))
-
 	dashboardJSON, err := json.Marshal(dashboard)
 	if err != nil {
 		return fmt.Errorf("marshal dashboard: %w", err)
 	}
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodPut, reqURL, bytes.NewBuffer(dashboardJSON))
-	if err != nil {
-		return fmt.Errorf("new request: %w", err)
-	}
-
-	req.Header.Set(SignozApiKey, s.apiKey)
-	req.Header.Set(ContentType, "application/json")
-
-	timeoutCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
-	defer cancel()
-
-	resp, err := s.httpClient.Do(req.WithContext(timeoutCtx))
-	if err != nil {
-		return fmt.Errorf("do request: %w", err)
-	}
-	defer func() { _ = resp.Body.Close() }()
-
-	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		body, _ := io.ReadAll(resp.Body)
-		return fmt.Errorf("unexpected status %d: %s", resp.StatusCode, string(body))
-	}
-
-	return nil
+	s.logger.Debug("Updating dashboard", zap.String("id", id))
+	_, err = s.doRequest(ctx, http.MethodPut, reqURL, bytes.NewBuffer(dashboardJSON), DashboardWriteTimeout)
+	return err
 }

--- a/internal/handler/tools/handler.go
+++ b/internal/handler/tools/handler.go
@@ -76,6 +76,7 @@ func (h *Handler) RegisterMetricsHandlers(s *server.MCPServer) {
 	h.logger.Debug("Registering metrics handlers")
 
 	listMetricsTool := mcp.NewTool("signoz_list_metrics",
+		mcp.WithReadOnlyHintAnnotation(true),
 		mcp.WithDescription("Search and list available metrics from SigNoz. Supports filtering by name substring, time range, and source. Use searchText to find metrics by name."),
 		mcp.WithString("searchText", mcp.Description("Filter metrics by name substring (optional). Example: 'cpu', 'memory', 'http_requests'.")),
 		mcp.WithString("limit", mcp.Description("Maximum number of metrics to return (optional, default 50).")),
@@ -128,6 +129,7 @@ func (h *Handler) RegisterMetricsHandlers(s *server.MCPServer) {
 
 	// signoz_query_metrics — smart metrics query tool with aggregation validation and defaults
 	queryMetricsTool := mcp.NewTool("signoz_query_metrics",
+		mcp.WithReadOnlyHintAnnotation(true),
 		mcp.WithDescription(
 			"Query metrics from SigNoz with smart aggregation defaults and validation. "+
 				"Automatically applies the right timeAggregation and spaceAggregation based on metric type "+
@@ -180,6 +182,7 @@ func (h *Handler) RegisterFieldsHandlers(s *server.MCPServer) {
 	h.logger.Debug("Registering fields handlers")
 
 	getFieldKeysTool := mcp.NewTool("signoz_get_field_keys",
+		mcp.WithReadOnlyHintAnnotation(true),
 		mcp.WithDescription("Get available field keys for a given signal (metrics, traces, or logs). Use this to discover filterable fields before building queries."),
 		mcp.WithString("signal", mcp.Required(), mcp.Description("Signal type: 'metrics', 'traces', or 'logs'.")),
 		mcp.WithString("searchText", mcp.Description("Filter field names by substring (optional).")),
@@ -224,6 +227,7 @@ func (h *Handler) RegisterFieldsHandlers(s *server.MCPServer) {
 	})
 
 	getFieldValuesTool := mcp.NewTool("signoz_get_field_values",
+		mcp.WithReadOnlyHintAnnotation(true),
 		mcp.WithDescription("Get possible values for a specific field key for a given signal (metrics, traces, or logs). Use this to discover valid filter values."),
 		mcp.WithString("signal", mcp.Required(), mcp.Description("Signal type: 'metrics', 'traces', or 'logs'.")),
 		mcp.WithString("name", mcp.Required(), mcp.Description("Field name to get values for (e.g., 'service.name', 'http.status_code').")),
@@ -274,6 +278,7 @@ func (h *Handler) RegisterAlertsHandlers(s *server.MCPServer) {
 	h.logger.Debug("Registering alerts handlers")
 
 	alertsTool := mcp.NewTool("signoz_list_alerts",
+		mcp.WithReadOnlyHintAnnotation(true),
 		mcp.WithDescription("List active alerts from SigNoz. Returns list of alert with: alert name, rule ID, severity, start time, end time, and state. IMPORTANT: This tool supports pagination using 'limit' and 'offset' parameters. The response includes 'pagination' metadata with 'total', 'hasMore', and 'nextOffset' fields. When searching for a specific alert, ALWAYS check 'pagination.hasMore' - if true, continue paginating through all pages using 'nextOffset' until you find the item or 'hasMore' is false. Never conclude an item doesn't exist until you've checked all pages. Default: limit=50, offset=0."),
 		mcp.WithString("limit", mcp.Description("Maximum number of alerts to return per page. Use this to paginate through large result sets. Default: 50. Example: '50' for 50 results, '100' for 100 results. Must be greater than 0.")),
 		mcp.WithString("offset", mcp.Description("Number of results to skip before returning results. Use for pagination: offset=0 for first page, offset=50 for second page (if limit=50), offset=100 for third page, etc. Check 'pagination.nextOffset' in the response to get the next page offset. Default: 0. Must be >= 0.")),
@@ -329,6 +334,7 @@ func (h *Handler) RegisterAlertsHandlers(s *server.MCPServer) {
 	})
 
 	getAlertTool := mcp.NewTool("signoz_get_alert",
+		mcp.WithReadOnlyHintAnnotation(true),
 		mcp.WithDescription("Get details of a specific alert rule by ruleId"),
 		mcp.WithString("ruleId", mcp.Required(), mcp.Description("Alert ruleId")),
 	)
@@ -359,6 +365,7 @@ func (h *Handler) RegisterAlertsHandlers(s *server.MCPServer) {
 	})
 
 	alertHistoryTool := mcp.NewTool("signoz_get_alert_history",
+		mcp.WithReadOnlyHintAnnotation(true),
 		mcp.WithDescription("Get alert history timeline for a specific rule. Defaults to last 6 hours if no time specified."),
 		mcp.WithString("ruleId", mcp.Required(), mcp.Description("Alert rule ID")),
 		mcp.WithString("timeRange", mcp.Description("Time range string (optional, overrides start/end). Format: <number><unit> where unit is 'm' (minutes), 'h' (hours), or 'd' (days). Examples: '30m', '1h', '2h', '6h', '24h', '7d'. Defaults to last 6 hours if not provided.")),
@@ -451,6 +458,7 @@ func (h *Handler) RegisterDashboardHandlers(s *server.MCPServer) {
 	h.logger.Debug("Registering dashboard handlers")
 
 	tool := mcp.NewTool("signoz_list_dashboards",
+		mcp.WithReadOnlyHintAnnotation(true),
 		mcp.WithDescription("List all dashboards from SigNoz (returns summary with name, UUID, description, tags, and timestamps). IMPORTANT: This tool supports pagination using 'limit' and 'offset' parameters. The response includes 'pagination' metadata with 'total', 'hasMore', and 'nextOffset' fields. When searching for a specific dashboard, ALWAYS check 'pagination.hasMore' - if true, continue paginating through all pages using 'nextOffset' until you find the item or 'hasMore' is false. Never conclude an item doesn't exist until you've checked all pages. Default: limit=50, offset=0."),
 		mcp.WithString("limit", mcp.Description("Maximum number of dashboards to return per page. Use this to paginate through large result sets. Default: 50. Example: '50' for 50 results, '100' for 100 results. Must be greater than 0.")),
 		mcp.WithString("offset", mcp.Description("Number of results to skip before returning results. Use for pagination: offset=0 for first page, offset=50 for second page (if limit=50), offset=100 for third page, etc. Check 'pagination.nextOffset' in the response to get the next page offset. Default: 0. Must be >= 0.")),
@@ -496,6 +504,7 @@ func (h *Handler) RegisterDashboardHandlers(s *server.MCPServer) {
 	})
 
 	getDashboardTool := mcp.NewTool("signoz_get_dashboard",
+		mcp.WithReadOnlyHintAnnotation(true),
 		mcp.WithDescription("Get full details of a specific dashboard by UUID (returns complete dashboard configuration with all panels and queries)"),
 		mcp.WithString("uuid", mcp.Required(), mcp.Description("Dashboard UUID")),
 	)
@@ -527,6 +536,7 @@ func (h *Handler) RegisterDashboardHandlers(s *server.MCPServer) {
 
 	createDashboardTool := mcp.NewTool(
 		"signoz_create_dashboard",
+		mcp.WithDestructiveHintAnnotation(true),
 		mcp.WithDescription(
 			"Creates a new monitoring dashboard based on the provided title, layout, and widget configuration. "+
 				"CRITICAL: You MUST read these resources BEFORE generating any dashboard output:\n"+
@@ -586,6 +596,7 @@ func (h *Handler) RegisterDashboardHandlers(s *server.MCPServer) {
 
 	updateDashboardTool := mcp.NewTool(
 		"signoz_update_dashboard",
+		mcp.WithDestructiveHintAnnotation(true),
 		mcp.WithDescription(
 			"Update an existing dashboard by supplying its UUID along with a fully assembled dashboard JSON object.\n\n"+
 				"MANDATORY FIRST STEP: Read signoz://dashboard/widgets-examples before doing ANYTHING else. This is NON-NEGOTIABLE.\n\n"+
@@ -844,6 +855,7 @@ func (h *Handler) RegisterServiceHandlers(s *server.MCPServer) {
 	h.logger.Debug("Registering service handlers")
 
 	listTool := mcp.NewTool("signoz_list_services",
+		mcp.WithReadOnlyHintAnnotation(true),
 		mcp.WithDescription("List all services in SigNoz. Defaults to last 6 hours if no time specified. IMPORTANT: This tool supports pagination using 'limit' and 'offset' parameters. The response includes 'pagination' metadata with 'total', 'hasMore', and 'nextOffset' fields. When searching for a specific service, ALWAYS check 'pagination.hasMore' - if true, continue paginating through all pages using 'nextOffset' until you find the item or 'hasMore' is false. Never conclude an item doesn't exist until you've checked all pages. Default: limit=50, offset=0."),
 		mcp.WithString("timeRange", mcp.Description("Time range string (optional, overrides start/end). Format: <number><unit> where unit is 'm' (minutes), 'h' (hours), or 'd' (days). Examples: '30m', '1h', '2h', '6h', '24h', '7d'. Defaults to last 6 hours if not provided.")),
 		mcp.WithString("start", mcp.Description("Start time in nanoseconds (optional, defaults to 6 hours ago)")),
@@ -889,6 +901,7 @@ func (h *Handler) RegisterServiceHandlers(s *server.MCPServer) {
 	})
 
 	getOpsTool := mcp.NewTool("signoz_get_service_top_operations",
+		mcp.WithReadOnlyHintAnnotation(true),
 		mcp.WithDescription("Get top operations for a specific service. Defaults to last 6 hours if no time specified."),
 		mcp.WithString("service", mcp.Required(), mcp.Description("Service name")),
 		mcp.WithString("timeRange", mcp.Description("Time range string (optional, overrides start/end). Format: <number><unit> where unit is 'm' (minutes), 'h' (hours), or 'd' (days). Examples: '30m', '1h', '2h', '6h', '24h', '7d'. Defaults to last 6 hours if not provided.")),
@@ -947,6 +960,7 @@ func (h *Handler) RegisterQueryBuilderV5Handlers(s *server.MCPServer) {
 
 	// SigNoz Query Builder v5 tool - LLM builds structured query JSON and executes it
 	executeQuery := mcp.NewTool("signoz_execute_builder_query",
+		mcp.WithReadOnlyHintAnnotation(true),
 		mcp.WithDescription(
 			"Execute a SigNoz Query Builder v5 query.\n\n"+
 				"REQUIRED: Read signoz://traces/query-builder-guide BEFORE building any query. "+
@@ -1032,6 +1046,7 @@ func (h *Handler) RegisterLogsHandlers(s *server.MCPServer) {
 	h.logger.Debug("Registering logs handlers")
 
 	listLogViewsTool := mcp.NewTool("signoz_list_log_views",
+		mcp.WithReadOnlyHintAnnotation(true),
 		mcp.WithDescription("List all saved log views from SigNoz (returns summary with name, ID, description, and query details). IMPORTANT: This tool supports pagination using 'limit' and 'offset' parameters. The response includes 'pagination' metadata with 'total', 'hasMore', and 'nextOffset' fields. When searching for a specific log view, ALWAYS check 'pagination.hasMore' - if true, continue paginating through all pages using 'nextOffset' until you find the item or 'hasMore' is false. Never conclude an item doesn't exist until you've checked all pages. Default: limit=50, offset=0."),
 		mcp.WithString("limit", mcp.Description("Maximum number of views to return per page. Use this to paginate through large result sets. Default: 50. Example: '50' for 50 results, '100' for 100 results. Must be greater than 0.")),
 		mcp.WithString("offset", mcp.Description("Number of results to skip before returning results. Use for pagination: offset=0 for first page, offset=50 for second page (if limit=50), offset=100 for third page, etc. Check 'pagination.nextOffset' in the response to get the next page offset. Default: 0. Must be >= 0.")),
@@ -1077,6 +1092,7 @@ func (h *Handler) RegisterLogsHandlers(s *server.MCPServer) {
 	})
 
 	getLogViewTool := mcp.NewTool("signoz_get_log_view",
+		mcp.WithReadOnlyHintAnnotation(true),
 		mcp.WithDescription("Get full details of a specific log view by ID (returns complete log view configuration with query structure)"),
 		mcp.WithString("viewId", mcp.Required(), mcp.Description("Log view ID")),
 	)
@@ -1107,6 +1123,7 @@ func (h *Handler) RegisterLogsHandlers(s *server.MCPServer) {
 	})
 
 	getLogsForAlertTool := mcp.NewTool("signoz_get_logs_for_alert",
+		mcp.WithReadOnlyHintAnnotation(true),
 		mcp.WithDescription("Get logs related to a specific alert (automatically determines time range and service from alert details)"),
 		mcp.WithString("alertId", mcp.Required(), mcp.Description("Alert rule ID")),
 		mcp.WithString("timeRange", mcp.Description("Time range around alert (optional). Format: <number><unit> where unit is 'm' (minutes), 'h' (hours), or 'd' (days). Examples: '15m', '30m', '1h', '2h', '6h'. Defaults to '1h' if not provided.")),
@@ -1197,6 +1214,7 @@ func (h *Handler) RegisterLogsHandlers(s *server.MCPServer) {
 
 	// aggregate_logs: compute statistics over logs with GROUP BY
 	aggregateLogsTool := mcp.NewTool("signoz_aggregate_logs",
+		mcp.WithReadOnlyHintAnnotation(true),
 		mcp.WithDescription("Aggregate logs to compute statistics like count, average, sum, min, max, or percentiles, optionally grouped by fields. "+
 			"Use this for questions like 'how many errors per service?', 'average response time by endpoint', 'top error messages by count'. "+
 			"Defaults to last 1 hour if no time specified."),
@@ -1260,6 +1278,7 @@ func (h *Handler) RegisterLogsHandlers(s *server.MCPServer) {
 	// search_logs: log search with optional filters
 	// ToDo: use this function for error logs or logs by service
 	searchLogsTool := mcp.NewTool("signoz_search_logs",
+		mcp.WithReadOnlyHintAnnotation(true),
 		mcp.WithDescription("Search logs with flexible filtering. Supports free-form query expressions, optional service/severity filters, and body text search. "+
 			"Use service param to scope to a single service, severity param for error-only queries (e.g., severity='ERROR'), or query param for any filter expression. "+
 			"Defaults to last 1 hour if no time specified."),
@@ -1320,6 +1339,7 @@ func (h *Handler) RegisterTracesHandlers(s *server.MCPServer) {
 
 	// aggregate_traces: compute statistics over traces with GROUP BY
 	aggregateTracesTool := mcp.NewTool("signoz_aggregate_traces",
+		mcp.WithReadOnlyHintAnnotation(true),
 		mcp.WithDescription("Aggregate traces to compute statistics like count, average, sum, min, max, or percentiles over spans, optionally grouped by fields. "+
 			"Use this for questions like 'p99 latency by service', 'error count per operation', 'request rate by endpoint', 'average duration by span kind'. "+
 			"Also use this for error analysis — set error='true' and groupBy='service.name' to analyze error patterns across services. "+
@@ -1385,6 +1405,7 @@ func (h *Handler) RegisterTracesHandlers(s *server.MCPServer) {
 	})
 
 	searchTracesTool := mcp.NewTool("signoz_search_traces",
+		mcp.WithReadOnlyHintAnnotation(true),
 		mcp.WithDescription("Search traces with flexible filtering. Supports free-form query expressions, optional service/operation/error filters, and duration filtering. "+
 			"Use service param to scope to a single service, or query param for any filter expression. "+
 			"Defaults to last 1 hour if no time specified."),
@@ -1438,6 +1459,7 @@ func (h *Handler) RegisterTracesHandlers(s *server.MCPServer) {
 	})
 
 	getTraceDetailsTool := mcp.NewTool("signoz_get_trace_details",
+		mcp.WithReadOnlyHintAnnotation(true),
 		mcp.WithDescription("Get comprehensive trace information including all spans, metadata, and span hierarchy/relationships. Defaults to last 6 hours if no time specified."),
 		mcp.WithString("traceId", mcp.Required(), mcp.Description("Trace ID to get details for")),
 		mcp.WithString("timeRange", mcp.Description("Time range string (optional, overrides start/end). Format: <number><unit> where unit is 'm' (minutes), 'h' (hours), or 'd' (days). Examples: '30m', '1h', '2h', '6h', '24h', '7d'. Defaults to last 6 hours if not provided.")),


### PR DESCRIPTION
Phase 1 quick wins:
- Add ReadOnlyHint annotation to 20 read-only tools
- Add DestructiveHint annotation to 2 write tools (create/update dashboard)
- Extract doRequest() helper in client.go, eliminating ~500 lines of duplicated HTTP request boilerplate
- Define named constants DefaultQueryTimeout and DashboardWriteTimeout
- Fix ListDashboards double body-read bug