### PR TITLE
feat: delegate step interval to backend and enhance server instructions

### DIFF
--- a/internal/handler/tools/metrics_helper.go
+++ b/internal/handler/tools/metrics_helper.go
@@ -159,17 +159,25 @@ func detectFieldContext(name string) string {
 	return "attribute"
 }
 
-// autoStepInterval calculates a step interval targeting ~300 data points, minimum 60s.
-func autoStepInterval(startMs, endMs int64) int64 {
-	rangeMs := endMs - startMs
-	if rangeMs <= 0 {
-		return 60
+// extractStepInterval parses meta.stepIntervals from the backend response JSON
+// and returns the step interval for the first query (typically "A").
+// Returns 0 if not found or on parse error.
+func extractStepInterval(response json.RawMessage) int64 {
+	var resp struct {
+		Data struct {
+			Meta struct {
+				StepIntervals map[string]int64 `json:"stepIntervals"`
+			} `json:"meta"`
+		} `json:"data"`
 	}
-	step := rangeMs / 300 / 1000 // convert ms range to seconds, divide by 300 points
-	if step < 60 {
-		return 60
+	if err := json.Unmarshal(response, &resp); err != nil {
+		return 0
 	}
-	return step
+	// Return the first (usually "A") step interval
+	for _, v := range resp.Data.Meta.StepIntervals {
+		return v
+	}
+	return 0
 }
 
 // --- helpers ---

--- a/internal/handler/tools/metrics_query.go
+++ b/internal/handler/tools/metrics_query.go
@@ -78,12 +78,10 @@ func (h *Handler) handleQueryMetrics(ctx context.Context, req mcp.CallToolReques
 		return mcp.NewToolResultError(err.Error()), nil
 	}
 
-	// Auto step interval
+	// Step interval: use caller-provided value or let the backend decide
 	stepInterval := mqr.StepInterval
-	if stepInterval <= 0 {
-		stepInterval = autoStepInterval(startTime, endTime)
-		decisions = append(decisions, fmt.Sprintf("stepInterval: %ds (auto-calculated)", stepInterval))
-	} else {
+	callerProvidedStep := stepInterval > 0
+	if callerProvidedStep {
 		decisions = append(decisions, fmt.Sprintf("stepInterval: %ds (caller-provided)", stepInterval))
 	}
 
@@ -174,6 +172,13 @@ func (h *Handler) handleQueryMetrics(ctx context.Context, req mcp.CallToolReques
 	if err != nil {
 		log.Error("Metrics query failed", zap.Error(err))
 		return mcp.NewToolResultError(fmt.Sprintf("Query execution failed: %s", err.Error())), nil
+	}
+
+	// Extract backend-determined stepInterval from response if caller didn't provide one
+	if !callerProvidedStep {
+		if si := extractStepInterval(result); si > 0 {
+			decisions = append(decisions, fmt.Sprintf("stepInterval: %ds (backend-determined)", si))
+		}
 	}
 
 	// Build response with decisions block

--- a/pkg/instructions/instructions.go
+++ b/pkg/instructions/instructions.go
@@ -15,4 +15,31 @@ const ServerInstructions = `# SigNoz MCP Server — Instructions
    If the user already provides resource attributes, proceed directly without extra prompting.
 
 3. **Clarify the signal before querying.** If it is not clear which signal to use, ask the user whether to start with metrics, traces, or logs.
+
+4. **Choose the right filter operator for the intent and data type.**
+
+   **By query intent:**
+   | Intent | Operator | Example |
+   |---|---|---|
+   | Field exists / is present | EXISTS | trace_id EXISTS |
+   | Field is absent | NOT EXISTS | k8s.pod.name NOT EXISTS |
+   | Exact match | = | service.name = 'frontend' |
+   | Exclude (field must exist) | EXISTS AND != | service.name EXISTS AND service.name != 'redis' |
+   | One of several values | IN | severity_text IN ('ERROR', 'WARN', 'FATAL') |
+   | Substring / pattern | LIKE | name LIKE '%payment%' |
+   | Case-insensitive pattern | ILIKE | body ILIKE '%timeout%' |
+   | Simple text containment | CONTAINS | body CONTAINS 'timeout' |
+   | Regex | REGEXP | name REGEXP '^grpc\.' |
+
+   **By data type:**
+   | Data type | Safe operators |
+   |---|---|
+   | bool | = , != , EXISTS, NOT EXISTS |
+   | int64 | = , != , > , >= , < , <= , IN, EXISTS, NOT EXISTS |
+   | string | = , != , LIKE, ILIKE, CONTAINS, REGEXP, IN, NOT IN, EXISTS, NOT EXISTS |
+
+   **Important:** Negative operators (!=, NOT LIKE, NOT IN, NOT CONTAINS, NOT REGEXP) also match records where the field is **absent**. To exclude a value while requiring the field, combine with EXISTS:
+   ` + "`" + `service.name EXISTS AND service.name != 'redis'` + "`" + `
+
+5. **Never convert Unix timestamps manually.** All SigNoz timestamps (start, end, and time series values) are Unix milliseconds. When presenting timestamps to the user, always use a programmatic method (e.g., a date conversion tool or function) to convert them to human-readable format. Do NOT attempt mental arithmetic or manual offset calculations — this is error-prone and leads to incorrect times being reported.
 `

--- a/pkg/types/querybuilder.go
+++ b/pkg/types/querybuilder.go
@@ -107,10 +107,6 @@ func (q *QueryPayload) Validate() error {
 			if q.RequestType != "time_series" && q.RequestType != "scalar" {
 				q.RequestType = "time_series"
 			}
-			if spec.StepInterval == nil || *spec.StepInterval <= 0 {
-				def := int64(60)
-				spec.StepInterval = &def
-			}
 
 		case "traces":
 			// Traces support both raw queries and time series aggregations.
@@ -129,10 +125,6 @@ func (q *QueryPayload) Validate() error {
 			case "time_series":
 				if len(spec.Aggregations) == 0 {
 					return fmt.Errorf("%s: missing aggregations for time_series traces query", queryName)
-				}
-				if spec.StepInterval == nil || *spec.StepInterval <= 0 {
-					def := int64(60)
-					spec.StepInterval = &def
 				}
 			default:
 				return fmt.Errorf("%s: unsupported requestType '%s' for traces", queryName, q.RequestType)
@@ -155,10 +147,6 @@ func (q *QueryPayload) Validate() error {
 			case "time_series":
 				if len(spec.Aggregations) == 0 {
 					return fmt.Errorf("%s: missing aggregations for time_series logs query", queryName)
-				}
-				if spec.StepInterval == nil || *spec.StepInterval <= 0 {
-					def := int64(60)
-					spec.StepInterval = &def
 				}
 			default:
 				return fmt.Errorf("%s: unsupported requestType '%s' for logs", queryName, q.RequestType)
@@ -297,15 +285,17 @@ func BuildMetricsQueryPayload(startTime, endTime, stepInterval int64, queries []
 			continue
 		}
 
-		step := stepInterval
 		spec := QuerySpec{
-			Name:         q.Name,
-			Signal:       "metrics",
-			StepInterval: &step,
-			Disabled:     false,
+			Name:     q.Name,
+			Signal:   "metrics",
+			Disabled: false,
 			Aggregations: []any{q.Aggregation},
 			GroupBy:      q.GroupBy,
 			Having:       Having{Expression: ""},
+		}
+		if stepInterval > 0 {
+			step := stepInterval
+			spec.StepInterval = &step
 		}
 		if q.Filter != "" {
 			spec.Filter = &Filter{Expression: q.Filter}
@@ -369,15 +359,17 @@ func BuildMetricsQueryPayloadJSON(startTime, endTime, stepInterval int64, querie
 			continue
 		}
 
-		step := stepInterval
 		spec := QuerySpec{
-			Name:         q.Name,
-			Signal:       "metrics",
-			StepInterval: &step,
-			Disabled:     false,
+			Name:     q.Name,
+			Signal:   "metrics",
+			Disabled: false,
 			Aggregations: []any{q.Aggregation},
 			GroupBy:      q.GroupBy,
 			Having:       Having{Expression: ""},
+		}
+		if stepInterval > 0 {
+			step := stepInterval
+			spec.StepInterval = &step
 		}
 		if q.Filter != "" {
 			spec.Filter = &Filter{Expression: q.Filter}


### PR DESCRIPTION
1. Remove client-side auto step interval calculation and let the SigNoz backend determine the optimal step interval when the caller doesn't provide one. 
2. Extract the backend-determined value from the response meta for display in the decisions block. 
3. Add filter operator reference guide and timestamp conversion rule to server instructions.