### PR TITLE
feat: add server-side filtering params to signoz_list_alerts tool

### DIFF
--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -213,9 +213,12 @@ func (s *SigNoz) ListMetricKeys(ctx context.Context) (json.RawMessage, error) {
 	return s.doRequest(ctx, http.MethodGet, reqURL, nil, DefaultQueryTimeout)
 }
 
-func (s *SigNoz) ListAlerts(ctx context.Context) (json.RawMessage, error) {
+func (s *SigNoz) ListAlerts(ctx context.Context, params types.ListAlertsParams) (json.RawMessage, error) {
 	reqURL := fmt.Sprintf("%s/api/v1/alerts", s.baseURL)
-	s.logger.Debug("Fetching alerts from SigNoz")
+	if qp := params.QueryParams(); len(qp) > 0 {
+		reqURL += "?" + qp.Encode()
+	}
+	s.logger.Debug("Fetching alerts from SigNoz", zap.String("url", reqURL))
 	return s.doRequest(ctx, http.MethodGet, reqURL, nil, DefaultQueryTimeout)
 }
 

--- a/internal/client/interface.go
+++ b/internal/client/interface.go
@@ -11,7 +11,7 @@ import (
 // Handler code depends on this interface, enabling mock-based unit testing.
 type Client interface {
 	ListMetrics(ctx context.Context, start, end int64, limit int, searchText, source string) (json.RawMessage, error)
-	ListAlerts(ctx context.Context) (json.RawMessage, error)
+	ListAlerts(ctx context.Context, params types.ListAlertsParams) (json.RawMessage, error)
 	GetAlertByRuleID(ctx context.Context, ruleID string) (json.RawMessage, error)
 	GetAlertHistory(ctx context.Context, ruleID string, req types.AlertHistoryRequest) (json.RawMessage, error)
 	ListDashboards(ctx context.Context) (json.RawMessage, error)

--- a/internal/client/mock.go
+++ b/internal/client/mock.go
@@ -12,7 +12,7 @@ import (
 // otherwise returns a default empty JSON object and nil error.
 type MockClient struct {
 	ListMetricsFn            func(ctx context.Context, start, end int64, limit int, searchText, source string) (json.RawMessage, error)
-	ListAlertsFn             func(ctx context.Context) (json.RawMessage, error)
+	ListAlertsFn             func(ctx context.Context, params types.ListAlertsParams) (json.RawMessage, error)
 	GetAlertByRuleIDFn       func(ctx context.Context, ruleID string) (json.RawMessage, error)
 	GetAlertHistoryFn        func(ctx context.Context, ruleID string, req types.AlertHistoryRequest) (json.RawMessage, error)
 	ListDashboardsFn         func(ctx context.Context) (json.RawMessage, error)
@@ -39,9 +39,9 @@ func (m *MockClient) ListMetrics(ctx context.Context, start, end int64, limit in
 	return json.RawMessage(`{}`), nil
 }
 
-func (m *MockClient) ListAlerts(ctx context.Context) (json.RawMessage, error) {
+func (m *MockClient) ListAlerts(ctx context.Context, params types.ListAlertsParams) (json.RawMessage, error) {
 	if m.ListAlertsFn != nil {
-		return m.ListAlertsFn(ctx)
+		return m.ListAlertsFn(ctx, params)
 	}
 	return json.RawMessage(`{}`), nil
 }

--- a/internal/handler/tools/alerts.go
+++ b/internal/handler/tools/alerts.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"strconv"
+	"strings"
 
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
@@ -20,9 +21,14 @@ func (h *Handler) RegisterAlertsHandlers(s *server.MCPServer) {
 
 	alertsTool := mcp.NewTool("signoz_list_alerts",
 		mcp.WithReadOnlyHintAnnotation(true),
-		mcp.WithDescription("List active alerts from SigNoz. Returns list of alert with: alert name, rule ID, severity, start time, end time, and state. IMPORTANT: This tool supports pagination using 'limit' and 'offset' parameters. The response includes 'pagination' metadata with 'total', 'hasMore', and 'nextOffset' fields. When searching for a specific alert, ALWAYS check 'pagination.hasMore' - if true, continue paginating through all pages using 'nextOffset' until you find the item or 'hasMore' is false. Never conclude an item doesn't exist until you've checked all pages. Default: limit=50, offset=0."),
-		mcp.WithString("limit", mcp.Description("Maximum number of alerts to return per page. Use this to paginate through large result sets. Default: 50. Example: '50' for 50 results, '100' for 100 results. Must be greater than 0.")),
-		mcp.WithString("offset", mcp.Description("Number of results to skip before returning results. Use for pagination: offset=0 for first page, offset=50 for second page (if limit=50), offset=100 for third page, etc. Check 'pagination.nextOffset' in the response to get the next page offset. Default: 0. Must be >= 0.")),
+		mcp.WithDescription("List alerts from SigNoz. Returns alert name, rule ID, severity, start time, end time, and state.\n\nFILTERING: Use server-side filters to narrow results BEFORE paginating.\n- To find a specific alert by name: filter='alertname=\"HighCPU\"'\n- To find alerts by severity: filter='severity=\"critical\"'\n- Combine matchers: filter='alertname=\"HighCPU\",severity=\"critical\"'\n- To see only firing alerts: active='true', silenced='false', inhibited='false'\n- To see only silenced alerts: silenced='true', active='false'\n- To filter by notification receiver: receiver='slack-.*'\nBy default all alert states (active, silenced, inhibited) are included.\n\nPAGINATION: Supports 'limit' and 'offset'. Response includes 'pagination' with 'total', 'hasMore', and 'nextOffset'. Prefer 'filter' to find specific alerts instead of paginating all pages. Default: limit=50, offset=0."),
+		mcp.WithString("limit", mcp.Description("Maximum number of alerts to return per page. Default: 50.")),
+		mcp.WithString("offset", mcp.Description("Number of results to skip for pagination. Default: 0.")),
+		mcp.WithString("active", mcp.Description("Include active (firing) alerts. Values: 'true' or 'false'. Default: true.")),
+		mcp.WithString("silenced", mcp.Description("Include silenced alerts. Values: 'true' or 'false'. Default: true.")),
+		mcp.WithString("inhibited", mcp.Description("Include inhibited alerts. Values: 'true' or 'false'. Default: true.")),
+		mcp.WithString("filter", mcp.Description("Comma-separated matcher expressions to filter alerts. Example: 'alertname=\"HighCPU\"' or 'alertname=\"HighCPU\",severity=\"critical\"'. Uses Prometheus matcher syntax.")),
+		mcp.WithString("receiver", mcp.Description("Regex to filter alerts by receiver name. Example: 'slack-.*' to match all Slack receivers.")),
 	)
 	s.AddTool(alertsTool, h.handleListAlerts)
 
@@ -47,16 +53,43 @@ func (h *Handler) RegisterAlertsHandlers(s *server.MCPServer) {
 	s.AddTool(alertHistoryTool, h.handleGetAlertHistory)
 }
 
+func parseBoolParam(args map[string]any, key string) *bool {
+	if v, ok := args[key].(string); ok && v != "" {
+		b, err := strconv.ParseBool(v)
+		if err == nil {
+			return &b
+		}
+	}
+	return nil
+}
+
 func (h *Handler) handleListAlerts(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	log := h.tenantLogger(ctx)
 	log.Debug("Tool called: signoz_list_alerts")
-	limit, offset := paginate.ParseParams(req.Params.Arguments)
+	args := req.Params.Arguments.(map[string]any)
+	limit, offset := paginate.ParseParams(args)
+
+	params := types.ListAlertsParams{
+		Active:    parseBoolParam(args, "active"),
+		Inhibited: parseBoolParam(args, "inhibited"),
+		Silenced:  parseBoolParam(args, "silenced"),
+	}
+	if receiver, ok := args["receiver"].(string); ok && receiver != "" {
+		params.Receiver = receiver
+	}
+	if filterStr, ok := args["filter"].(string); ok && filterStr != "" {
+		for _, f := range strings.Split(filterStr, ",") {
+			if trimmed := strings.TrimSpace(f); trimmed != "" {
+				params.Filter = append(params.Filter, trimmed)
+			}
+		}
+	}
 
 	client, err := h.GetClient(ctx)
 	if err != nil {
 		return mcp.NewToolResultError(err.Error()), nil
 	}
-	alerts, err := client.ListAlerts(ctx)
+	alerts, err := client.ListAlerts(ctx, params)
 	if err != nil {
 		log.Error("Failed to list alerts", zap.Error(err))
 		return mcp.NewToolResultError(err.Error()), nil

--- a/internal/handler/tools/alerts_test.go
+++ b/internal/handler/tools/alerts_test.go
@@ -12,7 +12,7 @@ import (
 
 func TestHandleListAlerts(t *testing.T) {
 	mock := &client.MockClient{
-		ListAlertsFn: func(ctx context.Context) (json.RawMessage, error) {
+		ListAlertsFn: func(ctx context.Context, params types.ListAlertsParams) (json.RawMessage, error) {
 			return json.RawMessage(`{
 				"status": "success",
 				"data": [
@@ -46,7 +46,7 @@ func TestHandleListAlerts(t *testing.T) {
 
 func TestHandleListAlerts_WithPagination(t *testing.T) {
 	mock := &client.MockClient{
-		ListAlertsFn: func(ctx context.Context) (json.RawMessage, error) {
+		ListAlertsFn: func(ctx context.Context, params types.ListAlertsParams) (json.RawMessage, error) {
 			return json.RawMessage(`{
 				"status": "success",
 				"data": [
@@ -74,7 +74,7 @@ func TestHandleListAlerts_WithPagination(t *testing.T) {
 
 func TestHandleListAlerts_ClientError(t *testing.T) {
 	mock := &client.MockClient{
-		ListAlertsFn: func(ctx context.Context) (json.RawMessage, error) {
+		ListAlertsFn: func(ctx context.Context, params types.ListAlertsParams) (json.RawMessage, error) {
 			return nil, fmt.Errorf("connection refused")
 		},
 	}
@@ -233,5 +233,102 @@ func TestHandleGetAlertHistory_InvalidOrder(t *testing.T) {
 	}
 	if !result.IsError {
 		t.Error("expected error result for invalid order value")
+	}
+}
+
+func TestHandleListAlerts_WithFilterParams(t *testing.T) {
+	var capturedParams types.ListAlertsParams
+	mock := &client.MockClient{
+		ListAlertsFn: func(ctx context.Context, params types.ListAlertsParams) (json.RawMessage, error) {
+			capturedParams = params
+			return json.RawMessage(`{"status":"success","data":[]}`), nil
+		},
+	}
+	h := newTestHandler(mock)
+	req := makeToolRequest("signoz_list_alerts", map[string]any{
+		"active":   "false",
+		"silenced": "true",
+		"filter":   `alertname="HighCPU",severity="critical"`,
+		"receiver": "slack-.*",
+	})
+
+	result, err := h.handleListAlerts(testCtx(), req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("handler returned error: %v", result.Content)
+	}
+	if capturedParams.Active == nil || *capturedParams.Active != false {
+		t.Errorf("expected active=false, got %v", capturedParams.Active)
+	}
+	if capturedParams.Silenced == nil || *capturedParams.Silenced != true {
+		t.Errorf("expected silenced=true, got %v", capturedParams.Silenced)
+	}
+	if len(capturedParams.Filter) != 2 {
+		t.Errorf("expected 2 filters, got %d: %v", len(capturedParams.Filter), capturedParams.Filter)
+	}
+	if capturedParams.Receiver != "slack-.*" {
+		t.Errorf("expected receiver='slack-.*', got %q", capturedParams.Receiver)
+	}
+}
+
+func TestHandleListAlerts_BoolParamNilWhenOmitted(t *testing.T) {
+	var capturedParams types.ListAlertsParams
+	mock := &client.MockClient{
+		ListAlertsFn: func(ctx context.Context, params types.ListAlertsParams) (json.RawMessage, error) {
+			capturedParams = params
+			return json.RawMessage(`{"status":"success","data":[]}`), nil
+		},
+	}
+	h := newTestHandler(mock)
+	req := makeToolRequest("signoz_list_alerts", map[string]any{})
+
+	result, err := h.handleListAlerts(testCtx(), req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("handler returned error: %v", result.Content)
+	}
+	if capturedParams.Active != nil {
+		t.Errorf("expected active=nil when omitted, got %v", *capturedParams.Active)
+	}
+	if capturedParams.Silenced != nil {
+		t.Errorf("expected silenced=nil when omitted, got %v", *capturedParams.Silenced)
+	}
+	if capturedParams.Inhibited != nil {
+		t.Errorf("expected inhibited=nil when omitted, got %v", *capturedParams.Inhibited)
+	}
+}
+
+func TestHandleListAlerts_FilterSplitAndTrim(t *testing.T) {
+	var capturedParams types.ListAlertsParams
+	mock := &client.MockClient{
+		ListAlertsFn: func(ctx context.Context, params types.ListAlertsParams) (json.RawMessage, error) {
+			capturedParams = params
+			return json.RawMessage(`{"status":"success","data":[]}`), nil
+		},
+	}
+	h := newTestHandler(mock)
+	req := makeToolRequest("signoz_list_alerts", map[string]any{
+		"filter": ` alertname="A" , severity="critical" `,
+	})
+
+	result, err := h.handleListAlerts(testCtx(), req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("handler returned error: %v", result.Content)
+	}
+	if len(capturedParams.Filter) != 2 {
+		t.Fatalf("expected 2 filters, got %d: %v", len(capturedParams.Filter), capturedParams.Filter)
+	}
+	if capturedParams.Filter[0] != `alertname="A"` {
+		t.Errorf("expected first filter='alertname=\"A\"', got %q", capturedParams.Filter[0])
+	}
+	if capturedParams.Filter[1] != `severity="critical"` {
+		t.Errorf("expected second filter='severity=\"critical\"', got %q", capturedParams.Filter[1])
 	}
 }

--- a/pkg/types/alerts.go
+++ b/pkg/types/alerts.go
@@ -1,5 +1,10 @@
 package types
 
+import (
+	"net/url"
+	"strconv"
+)
+
 // AlertHistoryRequest is the request payload for alert history
 type AlertHistoryRequest struct {
 	Start   int64               `json:"start"`
@@ -46,4 +51,34 @@ type APIAlert struct {
 type APIAlertsResponse struct {
 	Status string     `json:"status"`
 	Data   []APIAlert `json:"data"`
+}
+
+// ListAlertsParams contains query parameters for the GET /api/v1/alerts endpoint.
+type ListAlertsParams struct {
+	Active    *bool
+	Filter    []string
+	Inhibited *bool
+	Receiver  string
+	Silenced  *bool
+}
+
+// QueryParams converts the params to url.Values for the HTTP request.
+func (p ListAlertsParams) QueryParams() url.Values {
+	v := url.Values{}
+	if p.Active != nil {
+		v.Set("active", strconv.FormatBool(*p.Active))
+	}
+	for _, f := range p.Filter {
+		v.Add("filter", f)
+	}
+	if p.Inhibited != nil {
+		v.Set("inhibited", strconv.FormatBool(*p.Inhibited))
+	}
+	if p.Receiver != "" {
+		v.Set("receiver", p.Receiver)
+	}
+	if p.Silenced != nil {
+		v.Set("silenced", strconv.FormatBool(*p.Silenced))
+	}
+	return v
 }


### PR DESCRIPTION
Pass active, silenced, inhibited, filter, and receiver query parameters through to the SigNoz backend GET /api/v1/alerts endpoint, enabling server-side filtering instead of fetching all alerts and paginating client-side. Updated tool description to guide LLM clients on using filters before pagination.