### PR TITLE
feat: add state filter param to signoz_get_alert_history tool

### DIFF
--- a/internal/handler/tools/alerts.go
+++ b/internal/handler/tools/alerts.go
@@ -41,11 +41,12 @@ func (h *Handler) RegisterAlertsHandlers(s *server.MCPServer) {
 
 	alertHistoryTool := mcp.NewTool("signoz_get_alert_history",
 		mcp.WithReadOnlyHintAnnotation(true),
-		mcp.WithDescription("Get alert history timeline for a specific rule. Defaults to last 6 hours if no time specified."),
+		mcp.WithDescription("Get alert history timeline for a specific rule. Defaults to last 6 hours if no time specified. Use 'state' to filter by alert state (e.g., only firing transitions or only resolutions)."),
 		mcp.WithString("ruleId", mcp.Required(), mcp.Description("Alert rule ID")),
 		mcp.WithString("timeRange", mcp.Description("Time range string (optional, overrides start/end). Format: <number><unit> where unit is 'm' (minutes), 'h' (hours), or 'd' (days). Examples: '30m', '1h', '2h', '6h', '24h', '7d'. Defaults to last 6 hours if not provided.")),
 		mcp.WithString("start", mcp.Description("Start timestamp in milliseconds (optional, defaults to 6 hours ago)")),
 		mcp.WithString("end", mcp.Description("End timestamp in milliseconds (optional, defaults to now)")),
+		mcp.WithString("state", mcp.Description("Filter history by alert state: 'firing' or 'inactive'. If omitted, returns all state transitions.")),
 		mcp.WithString("offset", mcp.Description("Offset for pagination (default: 0)")),
 		mcp.WithString("limit", mcp.Description("Limit number of results (default: 20)")),
 		mcp.WithString("order", mcp.Description("Sort order: 'asc' or 'desc' (default: 'asc')")),
@@ -200,9 +201,19 @@ func (h *Handler) handleGetAlertHistory(ctx context.Context, req mcp.CallToolReq
 		}
 	}
 
+	var state string
+	if stateStr, ok := args["state"].(string); ok && stateStr != "" {
+		if stateStr != "firing" && stateStr != "inactive" {
+			log.Warn("Invalid state value", zap.String("state", stateStr))
+			return mcp.NewToolResultError(fmt.Sprintf(`Invalid "state" value: "%s". Must be either "firing" or "inactive"`, stateStr)), nil
+		}
+		state = stateStr
+	}
+
 	historyReq := types.AlertHistoryRequest{
 		Start:  start,
 		End:    end,
+		State:  state,
 		Offset: offset,
 		Limit:  limit,
 		Order:  order,

--- a/internal/handler/tools/alerts_test.go
+++ b/internal/handler/tools/alerts_test.go
@@ -236,6 +236,77 @@ func TestHandleGetAlertHistory_InvalidOrder(t *testing.T) {
 	}
 }
 
+func TestHandleGetAlertHistory_WithStateFilter(t *testing.T) {
+	var capturedReq types.AlertHistoryRequest
+	mock := &client.MockClient{
+		GetAlertHistoryFn: func(ctx context.Context, ruleID string, req types.AlertHistoryRequest) (json.RawMessage, error) {
+			capturedReq = req
+			return json.RawMessage(`{"data":{"items":[]}}`), nil
+		},
+	}
+	h := newTestHandler(mock)
+	req := makeToolRequest("signoz_get_alert_history", map[string]any{
+		"ruleId":    "rule-1",
+		"timeRange": "1h",
+		"state":     "firing",
+	})
+
+	result, err := h.handleGetAlertHistory(testCtx(), req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("handler returned error: %v", result.Content)
+	}
+	if capturedReq.State != "firing" {
+		t.Errorf("expected state=firing, got %q", capturedReq.State)
+	}
+}
+
+func TestHandleGetAlertHistory_InvalidState(t *testing.T) {
+	mock := &client.MockClient{}
+	h := newTestHandler(mock)
+	req := makeToolRequest("signoz_get_alert_history", map[string]any{
+		"ruleId":    "rule-1",
+		"timeRange": "1h",
+		"state":     "invalid",
+	})
+
+	result, err := h.handleGetAlertHistory(testCtx(), req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !result.IsError {
+		t.Error("expected error result for invalid state value")
+	}
+}
+
+func TestHandleGetAlertHistory_StateOmitted(t *testing.T) {
+	var capturedReq types.AlertHistoryRequest
+	mock := &client.MockClient{
+		GetAlertHistoryFn: func(ctx context.Context, ruleID string, req types.AlertHistoryRequest) (json.RawMessage, error) {
+			capturedReq = req
+			return json.RawMessage(`{"data":{"items":[]}}`), nil
+		},
+	}
+	h := newTestHandler(mock)
+	req := makeToolRequest("signoz_get_alert_history", map[string]any{
+		"ruleId":    "rule-1",
+		"timeRange": "1h",
+	})
+
+	result, err := h.handleGetAlertHistory(testCtx(), req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("handler returned error: %v", result.Content)
+	}
+	if capturedReq.State != "" {
+		t.Errorf("expected state to be empty when omitted, got %q", capturedReq.State)
+	}
+}
+
 func TestHandleListAlerts_WithFilterParams(t *testing.T) {
 	var capturedParams types.ListAlertsParams
 	mock := &client.MockClient{

--- a/pkg/types/alerts.go
+++ b/pkg/types/alerts.go
@@ -9,6 +9,7 @@ import (
 type AlertHistoryRequest struct {
 	Start   int64               `json:"start"`
 	End     int64               `json:"end"`
+	State   string              `json:"state,omitempty"`
 	Offset  int                 `json:"offset"`
 	Limit   int                 `json:"limit"`
 	Order   string              `json:"order"`


### PR DESCRIPTION
Allow filtering alert history by state ('firing' or 'inactive') via the backend's POST /api/v1/rules/{id}/history/timeline endpoint. This lets users investigate only firing transitions or only resolutions without paginating through all state changes.