### PR TITLE
feat: add default SelectFields to BuildLogsQueryPayload for richer log search results

### DIFF
--- a/pkg/types/querybuilder.go
+++ b/pkg/types/querybuilder.go
@@ -166,6 +166,40 @@ func (q *QueryPayload) Validate() error {
 	return nil
 }
 
+// defaultLogSelectFields are the fields returned for every raw log query.
+// Without explicit SelectFields the API only returns body, id, service.name,
+// severity_text and timestamp — important attributes such as
+// exception.stacktrace are omitted.
+var defaultLogSelectFields = []SelectField{
+	// Top-level log fields
+	{Name: "id", FieldDataType: "string", Signal: "logs"},
+	{Name: "timestamp", FieldDataType: "string", Signal: "logs"},
+	{Name: "severity_text", FieldDataType: "string", Signal: "logs"},
+	{Name: "severity_number", FieldDataType: "int32", Signal: "logs"},
+	{Name: "body", FieldDataType: "string", Signal: "logs"},
+	{Name: "trace_id", FieldDataType: "string", Signal: "logs"},
+	{Name: "span_id", FieldDataType: "string", Signal: "logs"},
+	{Name: "trace_flags", FieldDataType: "int32", Signal: "logs"},
+	// Resource attributes
+	{Name: "service.name", FieldDataType: "string", Signal: "logs", FieldContext: "resource"},
+	{Name: "deployment.environment", FieldDataType: "string", Signal: "logs", FieldContext: "resource"},
+	{Name: "host.name", FieldDataType: "string", Signal: "logs", FieldContext: "resource"},
+	{Name: "k8s.pod.name", FieldDataType: "string", Signal: "logs", FieldContext: "resource"},
+	{Name: "k8s.namespace.name", FieldDataType: "string", Signal: "logs", FieldContext: "resource"},
+	{Name: "k8s.cluster.name", FieldDataType: "string", Signal: "logs", FieldContext: "resource"},
+	{Name: "k8s.node.name", FieldDataType: "string", Signal: "logs", FieldContext: "resource"},
+	{Name: "cloud.provider", FieldDataType: "string", Signal: "logs", FieldContext: "resource"},
+	{Name: "cloud.region", FieldDataType: "string", Signal: "logs", FieldContext: "resource"},
+	// Log attributes — exception details (OTel semantic conventions)
+	{Name: "exception.stacktrace", FieldDataType: "string", Signal: "logs", FieldContext: "attribute"},
+	{Name: "exception.message", FieldDataType: "string", Signal: "logs", FieldContext: "attribute"},
+	{Name: "exception.type", FieldDataType: "string", Signal: "logs", FieldContext: "attribute"},
+	// Log attributes — code context
+	{Name: "code.filepath", FieldDataType: "string", Signal: "logs", FieldContext: "attribute"},
+	{Name: "code.function", FieldDataType: "string", Signal: "logs", FieldContext: "attribute"},
+	{Name: "code.lineno", FieldDataType: "int32", Signal: "logs", FieldContext: "attribute"},
+}
+
 // BuildLogsQueryPayload creates a QueryPayload for logs queries
 func BuildLogsQueryPayload(startTime, endTime int64, filterExpression string, limit int, offset int) *QueryPayload {
 	return &QueryPayload{
@@ -178,16 +212,17 @@ func BuildLogsQueryPayload(startTime, endTime int64, filterExpression string, li
 				{
 					Type: "builder_query",
 					Spec: QuerySpec{
-						Name:     "A",
-						Signal:   "logs",
-						Disabled: false,
-						Filter:   &Filter{Expression: filterExpression},
-						Limit:    limit,
-						Offset:   offset,
+						Name:         "A",
+						Signal:       "logs",
+						Disabled:     false,
+						Filter:       &Filter{Expression: filterExpression},
+						Limit:        limit,
+						Offset:       offset,
 						Order: []Order{
 							{Key: Key{Name: "timestamp"}, Direction: "desc"},
 						},
-						Having: Having{Expression: ""},
+						Having:       Having{Expression: ""},
+						SelectFields: defaultLogSelectFields,
 					},
 				},
 			},

--- a/pkg/types/querybuilder_test.go
+++ b/pkg/types/querybuilder_test.go
@@ -60,6 +60,26 @@ func TestQueryPayloadValidate_LogsRawClearsStepInterval(t *testing.T) {
 	require.Nil(t, q.CompositeQuery.Queries[0].Spec.StepInterval)
 }
 
+func TestBuildLogsQueryPayload_IncludesSelectFields(t *testing.T) {
+	p := BuildLogsQueryPayload(1000, 2000, "severity_text = 'error'", 25, 0)
+	require.Len(t, p.CompositeQuery.Queries, 1)
+
+	fields := p.CompositeQuery.Queries[0].Spec.SelectFields
+	require.NotEmpty(t, fields, "logs query must include SelectFields for rich log attributes")
+
+	fieldNames := make(map[string]bool)
+	for _, f := range fields {
+		fieldNames[f.Name] = true
+	}
+
+	for _, expected := range []string{
+		"body", "exception.stacktrace", "exception.message", "exception.type",
+		"trace_id", "span_id", "service.name",
+	} {
+		require.True(t, fieldNames[expected], "expected SelectField %q to be present", expected)
+	}
+}
+
 func TestQueryPayloadValidate_LogsTimeSeriesRequiresAggregations(t *testing.T) {
 	q := &QueryPayload{
 		SchemaVersion: "v1",


### PR DESCRIPTION
## Problem

`BuildLogsQueryPayload` in `pkg/types/querybuilder.go` does not specify any `SelectFields`, so raw log queries via `signoz_search_logs` (and `signoz_search_logs_by_service`, `signoz_get_error_logs`) only return the default fields:

```
body, id, service.name, severity_text, timestamp
```

Critical log attributes — especially the [OTel semantic convention exception fields](https://opentelemetry.io/docs/specs/semconv/exceptions/exceptions-logs/) — are omitted:

- `exception.stacktrace` — the actual exception traceback
- `exception.message` / `exception.type`
- `trace_id` / `span_id` — for log-trace correlation
- Resource attributes like `k8s.pod.name`, `k8s.namespace.name`

Meanwhile, `BuildTracesQueryPayload` in the same file specifies **34 SelectFields** covering top-level span fields, resource attributes, and span attributes. There is no equivalent for logs.

## Impact

When an AI agent uses `signoz_search_logs` to investigate errors, it only sees the log body, but not the `exception.stacktrace` attribute which contains the actual Python traceback.

Without this, the agent has to guess at the root cause instead of reporting the exact exception.

## Changes

Adds a `defaultLogSelectFields` slice to `BuildLogsQueryPayload`, following the same pattern as `BuildTracesQueryPayload`. Fields included:

| Category | Fields |
|---|---|
| Top-level log fields | `id`, `timestamp`, `severity_text`, `severity_number`, `body`, `trace_id`, `span_id`, `trace_flags` |
| Resource attributes | `service.name`, `deployment.environment`, `host.name`, `k8s.pod.name`, `k8s.namespace.name`, `k8s.cluster.name`, `k8s.node.name`, `cloud.provider`, `cloud.region` |
| Exception attributes (OTel) | `exception.stacktrace`, `exception.message`, `exception.type` |
| Code context | `code.filepath`, `code.function`, `code.lineno` |

All fields follow [OTel semantic conventions](https://opentelemetry.io/docs/specs/semconv/). Fields that don't exist on a log entry are returned as empty strings — this is purely additive and backward-compatible.

## Test

Added `TestBuildLogsQueryPayload_IncludesSelectFields` verifying that the key fields (`body`, `exception.stacktrace`, `exception.message`, `exception.type`, `trace_id`, `span_id`, `service.name`) are present in the generated query payload.

```
$ go test ./pkg/types/... -v -run TestBuildLogsQueryPayload
=== RUN   TestBuildLogsQueryPayload_IncludesSelectFields
--- PASS: TestBuildLogsQueryPayload_IncludesSelectFields (0.00s)
PASS
```

Made with [Cursor](https://cursor.com)