### PR TITLE
fix: set destructiveHint=false on all read-only tools

### DIFF
--- a/internal/handler/tools/alerts.go
+++ b/internal/handler/tools/alerts.go
@@ -21,6 +21,7 @@ func (h *Handler) RegisterAlertsHandlers(s *server.MCPServer) {
 
 	alertsTool := mcp.NewTool("signoz_list_alerts",
 		mcp.WithReadOnlyHintAnnotation(true),
+		mcp.WithDestructiveHintAnnotation(false),
 		mcp.WithDescription("List alerts from SigNoz. Returns alert name, rule ID, severity, start time, end time, and state.\n\nFILTERING: Use server-side filters to narrow results BEFORE paginating.\n- To find a specific alert by name: filter='alertname=\"HighCPU\"'\n- To find alerts by severity: filter='severity=\"critical\"'\n- Combine matchers: filter='alertname=\"HighCPU\",severity=\"critical\"'\n- To see only firing alerts: active='true', silenced='false', inhibited='false'\n- To see only silenced alerts: silenced='true', active='false'\n- To filter by notification receiver: receiver='slack-.*'\nBy default all alert states (active, silenced, inhibited) are included.\n\nPAGINATION: Supports 'limit' and 'offset'. Response includes 'pagination' with 'total', 'hasMore', and 'nextOffset'. Prefer 'filter' to find specific alerts instead of paginating all pages. Default: limit=50, offset=0."),
 		mcp.WithString("limit", mcp.Description("Maximum number of alerts to return per page. Default: 50.")),
 		mcp.WithString("offset", mcp.Description("Number of results to skip for pagination. Default: 0.")),
@@ -34,6 +35,7 @@ func (h *Handler) RegisterAlertsHandlers(s *server.MCPServer) {
 
 	getAlertTool := mcp.NewTool("signoz_get_alert",
 		mcp.WithReadOnlyHintAnnotation(true),
+		mcp.WithDestructiveHintAnnotation(false),
 		mcp.WithDescription("Get details of a specific alert rule by ruleId"),
 		mcp.WithString("ruleId", mcp.Required(), mcp.Description("Alert ruleId")),
 	)
@@ -41,6 +43,7 @@ func (h *Handler) RegisterAlertsHandlers(s *server.MCPServer) {
 
 	alertHistoryTool := mcp.NewTool("signoz_get_alert_history",
 		mcp.WithReadOnlyHintAnnotation(true),
+		mcp.WithDestructiveHintAnnotation(false),
 		mcp.WithDescription("Get alert history timeline for a specific rule. Defaults to last 6 hours if no time specified. Use 'state' to filter by alert state (e.g., only firing transitions or only resolutions)."),
 		mcp.WithString("ruleId", mcp.Required(), mcp.Description("Alert rule ID")),
 		mcp.WithString("timeRange", mcp.Description("Time range string (optional, overrides start/end). Format: <number><unit> where unit is 'm' (minutes), 'h' (hours), or 'd' (days). Examples: '30m', '1h', '2h', '6h', '24h', '7d'. Defaults to last 6 hours if not provided.")),

--- a/internal/handler/tools/dashboards.go
+++ b/internal/handler/tools/dashboards.go
@@ -19,6 +19,7 @@ func (h *Handler) RegisterDashboardHandlers(s *server.MCPServer) {
 
 	tool := mcp.NewTool("signoz_list_dashboards",
 		mcp.WithReadOnlyHintAnnotation(true),
+		mcp.WithDestructiveHintAnnotation(false),
 		mcp.WithDescription("List all dashboards from SigNoz (returns summary with name, UUID, description, tags, and timestamps). IMPORTANT: This tool supports pagination using 'limit' and 'offset' parameters. The response includes 'pagination' metadata with 'total', 'hasMore', and 'nextOffset' fields. When searching for a specific dashboard, ALWAYS check 'pagination.hasMore' - if true, continue paginating through all pages using 'nextOffset' until you find the item or 'hasMore' is false. Never conclude an item doesn't exist until you've checked all pages. Default: limit=50, offset=0."),
 		mcp.WithString("limit", mcp.Description("Maximum number of dashboards to return per page. Use this to paginate through large result sets. Default: 50. Example: '50' for 50 results, '100' for 100 results. Must be greater than 0.")),
 		mcp.WithString("offset", mcp.Description("Number of results to skip before returning results. Use for pagination: offset=0 for first page, offset=50 for second page (if limit=50), offset=100 for third page, etc. Check 'pagination.nextOffset' in the response to get the next page offset. Default: 0. Must be >= 0.")),
@@ -28,6 +29,7 @@ func (h *Handler) RegisterDashboardHandlers(s *server.MCPServer) {
 
 	getDashboardTool := mcp.NewTool("signoz_get_dashboard",
 		mcp.WithReadOnlyHintAnnotation(true),
+		mcp.WithDestructiveHintAnnotation(false),
 		mcp.WithDescription("Get full details of a specific dashboard by UUID (returns complete dashboard configuration with all panels and queries)"),
 		mcp.WithString("uuid", mcp.Required(), mcp.Description("Dashboard UUID")),
 	)

--- a/internal/handler/tools/fields.go
+++ b/internal/handler/tools/fields.go
@@ -13,6 +13,7 @@ func (h *Handler) RegisterFieldsHandlers(s *server.MCPServer) {
 
 	getFieldKeysTool := mcp.NewTool("signoz_get_field_keys",
 		mcp.WithReadOnlyHintAnnotation(true),
+		mcp.WithDestructiveHintAnnotation(false),
 		mcp.WithDescription("Get available field keys for a given signal (metrics, traces, or logs). Use this to discover filterable fields before building queries."),
 		mcp.WithString("signal", mcp.Required(), mcp.Description("Signal type: 'metrics', 'traces', or 'logs'.")),
 		mcp.WithString("searchText", mcp.Description("Filter field names by substring (optional).")),
@@ -26,6 +27,7 @@ func (h *Handler) RegisterFieldsHandlers(s *server.MCPServer) {
 
 	getFieldValuesTool := mcp.NewTool("signoz_get_field_values",
 		mcp.WithReadOnlyHintAnnotation(true),
+		mcp.WithDestructiveHintAnnotation(false),
 		mcp.WithDescription("Get possible values for a specific field key for a given signal (metrics, traces, or logs). Use this to discover valid filter values."),
 		mcp.WithString("signal", mcp.Required(), mcp.Description("Signal type: 'metrics', 'traces', or 'logs'.")),
 		mcp.WithString("name", mcp.Required(), mcp.Description("Field name to get values for (e.g., 'service.name', 'http.status_code').")),

--- a/internal/handler/tools/logs.go
+++ b/internal/handler/tools/logs.go
@@ -21,6 +21,7 @@ func (h *Handler) RegisterLogsHandlers(s *server.MCPServer) {
 
 	listLogViewsTool := mcp.NewTool("signoz_list_log_views",
 		mcp.WithReadOnlyHintAnnotation(true),
+		mcp.WithDestructiveHintAnnotation(false),
 		mcp.WithDescription("List all saved log views from SigNoz (returns summary with name, ID, description, and query details). IMPORTANT: This tool supports pagination using 'limit' and 'offset' parameters. The response includes 'pagination' metadata with 'total', 'hasMore', and 'nextOffset' fields. When searching for a specific log view, ALWAYS check 'pagination.hasMore' - if true, continue paginating through all pages using 'nextOffset' until you find the item or 'hasMore' is false. Never conclude an item doesn't exist until you've checked all pages. Default: limit=50, offset=0."),
 		mcp.WithString("limit", mcp.Description("Maximum number of views to return per page. Use this to paginate through large result sets. Default: 50. Example: '50' for 50 results, '100' for 100 results. Must be greater than 0.")),
 		mcp.WithString("offset", mcp.Description("Number of results to skip before returning results. Use for pagination: offset=0 for first page, offset=50 for second page (if limit=50), offset=100 for third page, etc. Check 'pagination.nextOffset' in the response to get the next page offset. Default: 0. Must be >= 0.")),
@@ -30,6 +31,7 @@ func (h *Handler) RegisterLogsHandlers(s *server.MCPServer) {
 
 	getLogViewTool := mcp.NewTool("signoz_get_log_view",
 		mcp.WithReadOnlyHintAnnotation(true),
+		mcp.WithDestructiveHintAnnotation(false),
 		mcp.WithDescription("Get full details of a specific log view by ID (returns complete log view configuration with query structure)"),
 		mcp.WithString("viewId", mcp.Required(), mcp.Description("Log view ID")),
 	)
@@ -38,6 +40,7 @@ func (h *Handler) RegisterLogsHandlers(s *server.MCPServer) {
 
 	getLogsForAlertTool := mcp.NewTool("signoz_get_logs_for_alert",
 		mcp.WithReadOnlyHintAnnotation(true),
+		mcp.WithDestructiveHintAnnotation(false),
 		mcp.WithDescription("Get logs related to a specific alert (automatically determines time range and service from alert details)"),
 		mcp.WithString("alertId", mcp.Required(), mcp.Description("Alert rule ID")),
 		mcp.WithString("timeRange", mcp.Description("Time range around alert (optional). Format: <number><unit> where unit is 'm' (minutes), 'h' (hours), or 'd' (days). Examples: '15m', '30m', '1h', '2h', '6h'. Defaults to '1h' if not provided.")),
@@ -50,6 +53,7 @@ func (h *Handler) RegisterLogsHandlers(s *server.MCPServer) {
 	// aggregate_logs: compute statistics over logs with GROUP BY
 	aggregateLogsTool := mcp.NewTool("signoz_aggregate_logs",
 		mcp.WithReadOnlyHintAnnotation(true),
+		mcp.WithDestructiveHintAnnotation(false),
 		mcp.WithDescription("Aggregate logs to compute statistics like count, average, sum, min, max, or percentiles, optionally grouped by fields. "+
 			"Use this for questions like 'how many errors per service?', 'average response time by endpoint', 'top error messages by count'. "+
 			"Defaults to last 1 hour if no time specified."),
@@ -74,6 +78,7 @@ func (h *Handler) RegisterLogsHandlers(s *server.MCPServer) {
 	// ToDo: use this function for error logs or logs by service
 	searchLogsTool := mcp.NewTool("signoz_search_logs",
 		mcp.WithReadOnlyHintAnnotation(true),
+		mcp.WithDestructiveHintAnnotation(false),
 		mcp.WithDescription("Search logs with flexible filtering. Supports free-form query expressions, optional service/severity filters, and body text search. "+
 			"Use service param to scope to a single service, severity param for error-only queries (e.g., severity='ERROR'), or query param for any filter expression. "+
 			"Defaults to last 1 hour if no time specified."),

--- a/internal/handler/tools/metrics.go
+++ b/internal/handler/tools/metrics.go
@@ -16,6 +16,7 @@ func (h *Handler) RegisterMetricsHandlers(s *server.MCPServer) {
 
 	listMetricsTool := mcp.NewTool("signoz_list_metrics",
 		mcp.WithReadOnlyHintAnnotation(true),
+		mcp.WithDestructiveHintAnnotation(false),
 		mcp.WithDescription("Search and list available metrics from SigNoz. Supports filtering by name substring, time range, and source. Use searchText to find metrics by name."),
 		mcp.WithString("searchText", mcp.Description("Filter metrics by name substring (optional). Example: 'cpu', 'memory', 'http_requests'.")),
 		mcp.WithString("limit", mcp.Description("Maximum number of metrics to return (optional, default 50).")),
@@ -29,6 +30,7 @@ func (h *Handler) RegisterMetricsHandlers(s *server.MCPServer) {
 	// signoz_query_metrics — smart metrics query tool with aggregation validation and defaults
 	queryMetricsTool := mcp.NewTool("signoz_query_metrics",
 		mcp.WithReadOnlyHintAnnotation(true),
+		mcp.WithDestructiveHintAnnotation(false),
 		mcp.WithDescription(
 			"Query metrics from SigNoz with smart aggregation defaults and validation. "+
 				"Automatically applies the right timeAggregation and spaceAggregation based on metric type "+

--- a/internal/handler/tools/query_builder.go
+++ b/internal/handler/tools/query_builder.go
@@ -18,6 +18,7 @@ func (h *Handler) RegisterQueryBuilderV5Handlers(s *server.MCPServer) {
 	// SigNoz Query Builder v5 tool - LLM builds structured query JSON and executes it
 	executeQuery := mcp.NewTool("signoz_execute_builder_query",
 		mcp.WithReadOnlyHintAnnotation(true),
+		mcp.WithDestructiveHintAnnotation(false),
 		mcp.WithDescription(
 			"Execute a SigNoz Query Builder v5 query.\n\n"+
 				"REQUIRED: Read signoz://traces/query-builder-guide BEFORE building any query. "+

--- a/internal/handler/tools/services.go
+++ b/internal/handler/tools/services.go
@@ -17,6 +17,7 @@ func (h *Handler) RegisterServiceHandlers(s *server.MCPServer) {
 
 	listTool := mcp.NewTool("signoz_list_services",
 		mcp.WithReadOnlyHintAnnotation(true),
+		mcp.WithDestructiveHintAnnotation(false),
 		mcp.WithDescription("List all services in SigNoz. Defaults to last 6 hours if no time specified. IMPORTANT: This tool supports pagination using 'limit' and 'offset' parameters. The response includes 'pagination' metadata with 'total', 'hasMore', and 'nextOffset' fields. When searching for a specific service, ALWAYS check 'pagination.hasMore' - if true, continue paginating through all pages using 'nextOffset' until you find the item or 'hasMore' is false. Never conclude an item doesn't exist until you've checked all pages. Default: limit=50, offset=0."),
 		mcp.WithString("timeRange", mcp.Description("Time range string (optional, overrides start/end). Format: <number><unit> where unit is 'm' (minutes), 'h' (hours), or 'd' (days). Examples: '30m', '1h', '2h', '6h', '24h', '7d'. Defaults to last 6 hours if not provided.")),
 		mcp.WithString("start", mcp.Description("Start time in nanoseconds (optional, defaults to 6 hours ago)")),
@@ -29,6 +30,7 @@ func (h *Handler) RegisterServiceHandlers(s *server.MCPServer) {
 
 	getOpsTool := mcp.NewTool("signoz_get_service_top_operations",
 		mcp.WithReadOnlyHintAnnotation(true),
+		mcp.WithDestructiveHintAnnotation(false),
 		mcp.WithDescription("Get top operations for a specific service. Defaults to last 6 hours if no time specified."),
 		mcp.WithString("service", mcp.Required(), mcp.Description("Service name")),
 		mcp.WithString("timeRange", mcp.Description("Time range string (optional, overrides start/end). Format: <number><unit> where unit is 'm' (minutes), 'h' (hours), or 'd' (days). Examples: '30m', '1h', '2h', '6h', '24h', '7d'. Defaults to last 6 hours if not provided.")),

--- a/internal/handler/tools/traces.go
+++ b/internal/handler/tools/traces.go
@@ -19,6 +19,7 @@ func (h *Handler) RegisterTracesHandlers(s *server.MCPServer) {
 	// aggregate_traces: compute statistics over traces with GROUP BY
 	aggregateTracesTool := mcp.NewTool("signoz_aggregate_traces",
 		mcp.WithReadOnlyHintAnnotation(true),
+		mcp.WithDestructiveHintAnnotation(false),
 		mcp.WithDescription("Aggregate traces to compute statistics like count, average, sum, min, max, or percentiles over spans, optionally grouped by fields. "+
 			"Use this for questions like 'p99 latency by service', 'error count per operation', 'request rate by endpoint', 'average duration by span kind'. "+
 			"Also use this for error analysis — set error='true' and groupBy='service.name' to analyze error patterns across services. "+
@@ -45,6 +46,7 @@ func (h *Handler) RegisterTracesHandlers(s *server.MCPServer) {
 
 	searchTracesTool := mcp.NewTool("signoz_search_traces",
 		mcp.WithReadOnlyHintAnnotation(true),
+		mcp.WithDestructiveHintAnnotation(false),
 		mcp.WithDescription("Search traces with flexible filtering. Supports free-form query expressions, optional service/operation/error filters, and duration filtering. "+
 			"Use service param to scope to a single service, or query param for any filter expression. "+
 			"Defaults to last 1 hour if no time specified."),
@@ -65,6 +67,7 @@ func (h *Handler) RegisterTracesHandlers(s *server.MCPServer) {
 
 	getTraceDetailsTool := mcp.NewTool("signoz_get_trace_details",
 		mcp.WithReadOnlyHintAnnotation(true),
+		mcp.WithDestructiveHintAnnotation(false),
 		mcp.WithDescription("Get comprehensive trace information including all spans, metadata, and span hierarchy/relationships. Defaults to last 6 hours if no time specified."),
 		mcp.WithString("traceId", mcp.Required(), mcp.Description("Trace ID to get details for")),
 		mcp.WithString("timeRange", mcp.Description("Time range string (optional, overrides start/end). Format: <number><unit> where unit is 'm' (minutes), 'h' (hours), or 'd' (days). Examples: '30m', '1h', '2h', '6h', '24h', '7d'. Defaults to last 6 hours if not provided.")),


### PR DESCRIPTION
mcp-go defaults DestructiveHint to true on NewTool(), causing read-only tools to show "read-only, destructive, open-world" in MCP clients. Explicitly set WithDestructiveHintAnnotation(false) on all 20 read-only tools so they correctly display as non-destructive.