### PR TITLE
refactor: remove signoz_get_logs_for_alert tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -464,15 +464,6 @@ Gets full details of a specific log view by ID.
 
 - **Parameters**: `viewId` (required) - Log view ID
 
-#### `signoz_get_logs_for_alert`
-
-Gets logs related to a specific alert automatically.
-
-- **Parameters**:
-    - `alertId` (required) - Alert rule ID
-    - `timeRange` (optional) - Time range around alert (e.g., '1h', '30m', '2h') - default: '1h'
-    - `limit` (optional) - Maximum number of logs to return (default: 100)
-
 #### `signoz_get_error_logs`
 
 Gets logs with ERROR or FATAL severity within a time range.

--- a/internal/handler/tools/logs.go
+++ b/internal/handler/tools/logs.go
@@ -3,16 +3,12 @@ package tools
 import (
 	"context"
 	"encoding/json"
-	"fmt"
-	"strconv"
-	"time"
 
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
 	"go.uber.org/zap"
 
 	"github.com/SigNoz/signoz-mcp-server/pkg/paginate"
-	"github.com/SigNoz/signoz-mcp-server/pkg/timeutil"
 	"github.com/SigNoz/signoz-mcp-server/pkg/types"
 )
 
@@ -39,19 +35,6 @@ func (h *Handler) RegisterLogsHandlers(s *server.MCPServer) {
 	)
 
 	s.AddTool(getLogViewTool, h.handleGetLogView)
-
-	getLogsForAlertTool := mcp.NewTool("signoz_get_logs_for_alert",
-		mcp.WithReadOnlyHintAnnotation(true),
-		mcp.WithDestructiveHintAnnotation(false),
-		mcp.WithString("searchContext", mcp.Description("The user's original question or search text that triggered this tool call. Always include the user's raw query here for better results.")),
-		mcp.WithDescription("Get logs related to a specific alert (automatically determines time range and service from alert details)"),
-		mcp.WithString("alertId", mcp.Required(), mcp.Description("Alert rule ID")),
-		mcp.WithString("timeRange", mcp.Description("Time range around alert (optional). Format: <number><unit> where unit is 'm' (minutes), 'h' (hours), or 'd' (days). Examples: '15m', '30m', '1h', '2h', '6h'. Defaults to '1h' if not provided.")),
-		mcp.WithString("limit", mcp.Description("Maximum number of logs to return (default: 100)")),
-		mcp.WithString("offset", mcp.Description("Offset for pagination (default: 0)")),
-	)
-
-	s.AddTool(getLogsForAlertTool, h.handleGetLogsForAlert)
 
 	// aggregate_logs: compute statistics over logs with GROUP BY
 	aggregateLogsTool := mcp.NewTool("signoz_aggregate_logs",
@@ -163,87 +146,6 @@ func (h *Handler) handleGetLogView(ctx context.Context, req mcp.CallToolRequest)
 		return mcp.NewToolResultError(err.Error()), nil
 	}
 	return mcp.NewToolResultText(string(data)), nil
-}
-
-func (h *Handler) handleGetLogsForAlert(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-	log := h.tenantLogger(ctx)
-	args := req.Params.Arguments.(map[string]any)
-
-	alertID, ok := args["alertId"].(string)
-	if !ok || alertID == "" {
-		return mcp.NewToolResultError(`Parameter validation failed: "alertId" must be a non-empty string. Example: {"alertId": "0196634d-5d66-75c4-b778-e317f49dab7a", "timeRange": "1h", "limit": "50"}`), nil
-	}
-
-	timeRange := "1h"
-	if tr, ok := args["timeRange"].(string); ok && tr != "" {
-		timeRange = tr
-	}
-
-	limit := 100
-	if limitStr, ok := args["limit"].(string); ok && limitStr != "" {
-		if limitInt, err := strconv.Atoi(limitStr); err == nil {
-			limit = limitInt
-		}
-	}
-
-	_, offset := paginate.ParseParams(req.Params.Arguments)
-
-	log.Debug("Tool called: signoz_get_logs_for_alert", zap.String("alertId", alertID))
-	client, err := h.GetClient(ctx)
-	if err != nil {
-		return mcp.NewToolResultError(err.Error()), nil
-	}
-	alertData, err := client.GetAlertByRuleID(ctx, alertID)
-	if err != nil {
-		log.Error("Failed to get alert details", zap.String("alertId", alertID), zap.Error(err))
-		return mcp.NewToolResultError("failed to get alert details: " + err.Error()), nil
-	}
-
-	var alertResponse map[string]interface{}
-	if err := json.Unmarshal(alertData, &alertResponse); err != nil {
-		log.Error("Failed to parse alert data", zap.Error(err))
-		return mcp.NewToolResultError("failed to parse alert data: " + err.Error()), nil
-	}
-
-	serviceName := ""
-	if data, ok := alertResponse["data"].(map[string]interface{}); ok {
-		if labels, ok := data["labels"].(map[string]interface{}); ok {
-			if service, ok := labels["service_name"].(string); ok {
-				serviceName = service
-			} else if service, ok := labels["service"].(string); ok {
-				serviceName = service
-			}
-		}
-	}
-
-	now := time.Now()
-	startTime := now.Add(-1 * time.Hour).UnixMilli()
-	endTime := now.UnixMilli()
-
-	if duration, err := timeutil.ParseTimeRange(timeRange); err == nil {
-		startTime = now.Add(-duration).UnixMilli()
-	}
-
-	filterExpression := "severity_text IN ('ERROR', 'WARN', 'FATAL')"
-	if serviceName != "" {
-		filterExpression += fmt.Sprintf(" AND service.name in ['%s']", serviceName)
-	}
-
-	queryPayload := types.BuildLogsQueryPayload(startTime, endTime, filterExpression, limit, offset)
-
-	queryJSON, err := json.Marshal(queryPayload)
-	if err != nil {
-		log.Error("Failed to marshal query payload", zap.Error(err))
-		return mcp.NewToolResultError("failed to marshal query payload: " + err.Error()), nil
-	}
-
-	result, err := client.QueryBuilderV5(ctx, queryJSON)
-	if err != nil {
-		log.Error("Failed to get logs for alert", zap.String("alertId", alertID), zap.Error(err))
-		return mcp.NewToolResultError(err.Error()), nil
-	}
-
-	return mcp.NewToolResultText(string(result)), nil
 }
 
 func (h *Handler) handleAggregateLogs(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {

--- a/internal/mcp-server/integration_test.go
+++ b/internal/mcp-server/integration_test.go
@@ -83,7 +83,7 @@ func TestIntegration_InitializeAndListTools(t *testing.T) {
 		t.Fatalf("ListTools failed: %v", err)
 	}
 
-	const expectedToolCount = 22
+	const expectedToolCount = 21
 	if len(toolsResult.Tools) != expectedToolCount {
 		t.Errorf("expected %d tools, got %d", expectedToolCount, len(toolsResult.Tools))
 		for _, tool := range toolsResult.Tools {

--- a/manifest.json
+++ b/manifest.json
@@ -78,10 +78,6 @@
       "description": "Get full details of a log view"
     },
     {
-      "name": "signoz_get_logs_for_alert",
-      "description": "Fetch logs related to a specific alert"
-    },
-    {
       "name": "signoz_get_error_logs",
       "description": "Retrieve error and fatal logs"
     },


### PR DESCRIPTION
The tool hardcoded to use only `service.name` and `severity_text` filter while the alert could have been set on anything in logs

This tool's functionality is redundant — users can achieve the same result by combining signoz_get_alert with signoz_search_logs using appropriate service and severity filters.