### PR TITLE
feat: add Segment analytics for session and tool call tracking

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -11,6 +11,9 @@ import (
 	"github.com/SigNoz/signoz-mcp-server/internal/handler/tools"
 	mcpserver "github.com/SigNoz/signoz-mcp-server/internal/mcp-server"
 	"github.com/SigNoz/signoz-mcp-server/internal/telemetry"
+	"github.com/SigNoz/signoz-mcp-server/pkg/analytics"
+	"github.com/SigNoz/signoz-mcp-server/pkg/analytics/noopanalytics"
+	"github.com/SigNoz/signoz-mcp-server/pkg/analytics/segmentanalytics"
 	"github.com/SigNoz/signoz-mcp-server/pkg/dashboard"
 )
 
@@ -64,11 +67,31 @@ func main() {
 		log.Info("OpenTelemetry meter provider initialized successfully")
 	}
 
+	var analyticsInstance analytics.Analytics
+	if cfg.AnalyticsEnabled && cfg.SegmentKey != "" {
+		var err error
+		analyticsInstance, err = segmentanalytics.New(log, analytics.Config{
+			Enabled: true,
+			Segment: analytics.SegmentConfig{Key: cfg.SegmentKey},
+		})
+		if err != nil {
+			log.Warn("Failed to initialize Segment analytics, continuing without analytics", zap.Error(err))
+			analyticsInstance = noopanalytics.New()
+		}
+	} else {
+		analyticsInstance = noopanalytics.New()
+	}
+	defer func() {
+		if err := analyticsInstance.Stop(context.Background()); err != nil {
+			log.Error("Failed to stop analytics", zap.Error(err))
+		}
+	}()
+
 	handler := tools.NewHandler(log, cfg)
 
 	dashboard.InitClickhouseSchema()
 
-	if err := mcpserver.NewMCPServer(log, handler, cfg).Start(); err != nil {
+	if err := mcpserver.NewMCPServer(log, handler, cfg, analyticsInstance).Start(); err != nil {
 		log.Fatal(fmt.Sprintf("Failed to start server: %v", err))
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/SigNoz/signoz-otel-collector v0.129.12
 	github.com/hashicorp/golang-lru/v2 v2.0.7
 	github.com/mark3labs/mcp-go v0.38.0
+	github.com/segmentio/analytics-go/v3 v3.2.1
 	github.com/stretchr/testify v1.11.1
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.67.0
 	go.opentelemetry.io/otel v1.42.0
@@ -22,6 +23,7 @@ require (
 	github.com/ClickHouse/clickhouse-go/v2 v2.36.0 // indirect
 	github.com/andybalholm/brotli v1.1.1 // indirect
 	github.com/bahlo/generic-list-go v0.2.0 // indirect
+	github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869 // indirect
 	github.com/buger/jsonparser v1.1.1 // indirect
 	github.com/cenkalti/backoff/v4 v4.3.0 // indirect
 	github.com/cenkalti/backoff/v5 v5.0.3 // indirect
@@ -41,6 +43,7 @@ require (
 	github.com/pierrec/lz4/v4 v4.1.22 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/segmentio/asm v1.2.0 // indirect
+	github.com/segmentio/backo-go v1.0.0 // indirect
 	github.com/shopspring/decimal v1.4.0 // indirect
 	github.com/spf13/cast v1.9.2 // indirect
 	github.com/wk8/go-ordered-map/v2 v2.1.8 // indirect

--- a/go.sum
+++ b/go.sum
@@ -8,6 +8,8 @@ github.com/andybalholm/brotli v1.1.1 h1:PR2pgnyFznKEugtsUo0xLdDop5SKXd5Qf5ysW+7X
 github.com/andybalholm/brotli v1.1.1/go.mod h1:05ib4cKhjx3OQYUY22hTVd34Bc8upXjOLL2rKwwZBoA=
 github.com/bahlo/generic-list-go v0.2.0 h1:5sz/EEAK+ls5wF+NeqDpk5+iNdMDXrh3z3nPnH1Wvgk=
 github.com/bahlo/generic-list-go v0.2.0/go.mod h1:2KvAjgMlE5NNynlg/5iLrrCCZ2+5xWbdbCW3pNTGyYg=
+github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869 h1:DDGfHa7BWjL4YnC6+E63dPcxHo2sUxDIu8g3QgEJdRY=
+github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869/go.mod h1:Ekp36dRnpXw/yCqJaO+ZrUyxD+3VXMFFr56k5XYrpB4=
 github.com/buger/jsonparser v1.1.1 h1:2PnMjfWD7wBILjqQbt530v576A/cAbQvEW9gGIpYMUs=
 github.com/buger/jsonparser v1.1.1/go.mod h1:6RYKKt7H4d4+iWqouImQ9R2FZql3VbhNgx27UK13J/0=
 github.com/cenkalti/backoff/v4 v4.3.0 h1:MyRJ/UdXutAwSAT+s3wNd7MfTIcy71VQueUuFK343L8=
@@ -79,8 +81,12 @@ github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRI
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=
 github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
+github.com/segmentio/analytics-go/v3 v3.2.1 h1:G+f90zxtc1p9G+WigVyTR0xNfOghOGs/PYAlljLOyeg=
+github.com/segmentio/analytics-go/v3 v3.2.1/go.mod h1:p8owAF8X+5o27jmvUognuXxdtqvSGtD0ZrfY2kcS9bE=
 github.com/segmentio/asm v1.2.0 h1:9BQrFxC+YOHJlTlHGkTrFWf59nbL3XnCoFLTwDCI7ys=
 github.com/segmentio/asm v1.2.0/go.mod h1:BqMnlJP91P8d+4ibuonYZw9mfnzI9HfxselHZr5aAcs=
+github.com/segmentio/backo-go v1.0.0 h1:kbOAtGJY2DqOR0jfRkYEorx/b18RgtepGtY3+Cpe6qA=
+github.com/segmentio/backo-go v1.0.0/go.mod h1:kJ9mm9YmoWSkk+oQ+5Cj8DEoRCX2JT6As4kEtIIOp1M=
 github.com/shopspring/decimal v1.4.0 h1:bxl37RwXBklmTi0C79JfXCEBD1cqqHt0bbgBAGFp81k=
 github.com/shopspring/decimal v1.4.0/go.mod h1:gawqmDU56v4yIKSwfBSFip1HdCCXN8/+DMd9qYNcwME=
 github.com/spf13/cast v1.9.2 h1:SsGfm7M8QOFtEzumm7UZrZdLLquNdzFYfIbEXntcFbE=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -25,6 +25,10 @@ type Config struct {
 	// Client cache settings for multi-tenant mode
 	ClientCacheSize int
 	ClientCacheTTL  time.Duration
+
+	// Analytics settings
+	AnalyticsEnabled bool
+	SegmentKey       string
 }
 
 const (
@@ -36,6 +40,9 @@ const (
 
 	ClientCacheSize = "CLIENT_CACHE_SIZE"
 	ClientCacheTTL  = "CLIENT_CACHE_TTL_MINUTES"
+
+	AnalyticsEnabledEnv = "ANALYTICS_ENABLED"
+	SegmentKeyEnv       = "SEGMENT_KEY"
 
 	OAuthEnabledEnv         = "OAUTH_ENABLED"
 	OAuthTokenSecretEnv     = "OAUTH_TOKEN_SECRET"
@@ -75,6 +82,8 @@ func LoadConfig() (*Config, error) {
 		AuthCodeTTL:      time.Duration(authCodeTTLSeconds) * time.Second,
 		ClientCacheSize:  cacheSize,
 		ClientCacheTTL:   time.Duration(cacheTTLMinutes) * time.Minute,
+		AnalyticsEnabled: getEnvBool(AnalyticsEnabledEnv, false),
+		SegmentKey:       getEnv(SegmentKeyEnv, ""),
 	}, nil
 }
 

--- a/internal/mcp-server/server.go
+++ b/internal/mcp-server/server.go
@@ -87,26 +87,6 @@ func (m *MCPServer) buildHooks() *server.Hooks {
 			fields = append(fields, zap.String("mcp.tenant_url", signozURL))
 		}
 		m.logger.Debug("mcp request", fields...)
-
-		// Analytics: track session registration on initialize.
-		// OnRegisterSession hooks only fire for SSE (GET) connections,
-		// so we also track here to cover POST-only streamable HTTP.
-		if method == mcp.MethodInitialize {
-			if signozURL, ok := util.GetSigNozURL(ctx); ok && signozURL != "" {
-				traits := map[string]any{
-					string(telemetry.MCPTenantURLKey): signozURL,
-				}
-				m.analytics.IdentifyGroup(ctx, signozURL, traits)
-
-				props := map[string]any{
-					string(telemetry.MCPTenantURLKey): signozURL,
-				}
-				if session := server.ClientSessionFromContext(ctx); session != nil {
-					props[string(telemetry.MCPSessionIDKey)] = session.SessionID()
-				}
-				m.analytics.TrackGroup(ctx, signozURL, "MCP Registered", props)
-			}
-		}
 	})
 	hooks.AddOnError(func(ctx context.Context, id any, method mcp.MCPMethod, message any, err error) {
 		span := trace.SpanFromContext(ctx)
@@ -117,6 +97,24 @@ func (m *MCPServer) buildHooks() *server.Hooks {
 			fields = append(fields, zap.String("mcp.tenant_url", signozURL))
 		}
 		m.logger.Error("mcp error", fields...)
+	})
+	// Analytics: track session registration after successful initialize.
+	// Uses AfterInitialize (not BeforeAny) so failed initializations are not counted.
+	hooks.AddAfterInitialize(func(ctx context.Context, id any, message *mcp.InitializeRequest, result *mcp.InitializeResult) {
+		if signozURL, ok := util.GetSigNozURL(ctx); ok && signozURL != "" {
+			traits := map[string]any{
+				string(telemetry.MCPTenantURLKey): signozURL,
+			}
+			m.analytics.IdentifyGroup(ctx, signozURL, traits)
+
+			props := map[string]any{
+				string(telemetry.MCPTenantURLKey): signozURL,
+			}
+			if session := server.ClientSessionFromContext(ctx); session != nil {
+				props[string(telemetry.MCPSessionIDKey)] = session.SessionID()
+			}
+			m.analytics.TrackGroup(ctx, signozURL, "MCP Registered", props)
+		}
 	})
 	hooks.AddOnRegisterSession(func(ctx context.Context, session server.ClientSession) {
 		fields := []zap.Field{}

--- a/internal/mcp-server/server.go
+++ b/internal/mcp-server/server.go
@@ -12,6 +12,7 @@ import (
 	"github.com/SigNoz/signoz-mcp-server/internal/handler/tools"
 	"github.com/SigNoz/signoz-mcp-server/internal/oauth"
 	"github.com/SigNoz/signoz-mcp-server/internal/telemetry"
+	"github.com/SigNoz/signoz-mcp-server/pkg/analytics"
 	"github.com/SigNoz/signoz-mcp-server/pkg/instructions"
 	"github.com/SigNoz/signoz-mcp-server/pkg/prompts"
 	"github.com/SigNoz/signoz-mcp-server/pkg/util"
@@ -25,13 +26,14 @@ import (
 )
 
 type MCPServer struct {
-	logger  *zap.Logger
-	handler *tools.Handler
-	config  *config.Config
+	logger    *zap.Logger
+	handler   *tools.Handler
+	config    *config.Config
+	analytics analytics.Analytics
 }
 
-func NewMCPServer(log *zap.Logger, handler *tools.Handler, cfg *config.Config) *MCPServer {
-	return &MCPServer{logger: log, handler: handler, config: cfg}
+func NewMCPServer(log *zap.Logger, handler *tools.Handler, cfg *config.Config, a analytics.Analytics) *MCPServer {
+	return &MCPServer{logger: log, handler: handler, config: cfg, analytics: a}
 }
 
 func (m *MCPServer) Start() error {
@@ -85,6 +87,26 @@ func (m *MCPServer) buildHooks() *server.Hooks {
 			fields = append(fields, zap.String("mcp.tenant_url", signozURL))
 		}
 		m.logger.Debug("mcp request", fields...)
+
+		// Analytics: track session registration on initialize.
+		// OnRegisterSession hooks only fire for SSE (GET) connections,
+		// so we also track here to cover POST-only streamable HTTP.
+		if method == mcp.MethodInitialize {
+			if signozURL, ok := util.GetSigNozURL(ctx); ok && signozURL != "" {
+				traits := map[string]any{
+					string(telemetry.MCPTenantURLKey): signozURL,
+				}
+				m.analytics.IdentifyGroup(ctx, signozURL, traits)
+
+				props := map[string]any{
+					string(telemetry.MCPTenantURLKey): signozURL,
+				}
+				if session := server.ClientSessionFromContext(ctx); session != nil {
+					props[string(telemetry.MCPSessionIDKey)] = session.SessionID()
+				}
+				m.analytics.TrackGroup(ctx, signozURL, "MCP Registered", props)
+			}
+		}
 	})
 	hooks.AddOnError(func(ctx context.Context, id any, method mcp.MCPMethod, message any, err error) {
 		span := trace.SpanFromContext(ctx)
@@ -98,17 +120,36 @@ func (m *MCPServer) buildHooks() *server.Hooks {
 	})
 	hooks.AddOnRegisterSession(func(ctx context.Context, session server.ClientSession) {
 		fields := []zap.Field{}
+		var tenantURL string
 		if signozURL, ok := util.GetSigNozURL(ctx); ok && signozURL != "" {
 			fields = append(fields, zap.String("mcp.tenant_url", signozURL))
+			tenantURL = signozURL
 		}
 		m.logger.Info("mcp session registered", fields...)
+
+		if tenantURL != "" {
+			traits := map[string]any{
+				string(telemetry.MCPTenantURLKey): tenantURL,
+			}
+			m.analytics.IdentifyGroup(ctx, tenantURL, traits)
+		}
 	})
 	hooks.AddOnUnregisterSession(func(ctx context.Context, session server.ClientSession) {
 		fields := []zap.Field{}
+		var tenantURL string
 		if signozURL, ok := util.GetSigNozURL(ctx); ok && signozURL != "" {
 			fields = append(fields, zap.String("mcp.tenant_url", signozURL))
+			tenantURL = signozURL
 		}
 		m.logger.Info("mcp session unregistered", fields...)
+
+		if tenantURL != "" {
+			props := map[string]any{
+				string(telemetry.MCPTenantURLKey): tenantURL,
+				string(telemetry.MCPSessionIDKey): session.SessionID(),
+			}
+			m.analytics.TrackGroup(ctx, tenantURL, "MCP Unregistered", props)
+		}
 	})
 	return hooks
 }
@@ -194,6 +235,21 @@ func (m *MCPServer) loggingMiddleware() server.ToolHandlerMiddleware {
 				append(fields,
 					zap.Duration("duration", time.Since(start)),
 					zap.Bool("mcp.tool.is_error", isErr))...)
+
+			// Analytics: track tool call
+			if signozURL, ok := util.GetSigNozURL(ctx); ok && signozURL != "" {
+				props := map[string]any{
+					string(telemetry.MCPTenantURLKey):  signozURL,
+					string(telemetry.GenAIToolNameKey): req.Params.Name,
+					string(telemetry.MCPToolIsErrorKey): isErr,
+					"duration_ms": time.Since(start).Milliseconds(),
+				}
+				if sid, ok := util.GetSessionID(ctx); ok && sid != "" {
+					props[string(telemetry.MCPSessionIDKey)] = sid
+				}
+				m.analytics.TrackGroup(ctx, signozURL, "Tool Call", props)
+			}
+
 			return result, err
 		}
 	}

--- a/internal/mcp-server/server_test.go
+++ b/internal/mcp-server/server_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/SigNoz/signoz-mcp-server/internal/config"
 	"github.com/SigNoz/signoz-mcp-server/internal/oauth"
+	"github.com/SigNoz/signoz-mcp-server/pkg/analytics/noopanalytics"
 	"github.com/SigNoz/signoz-mcp-server/pkg/util"
 )
 
@@ -156,7 +157,7 @@ func TestAuthMiddlewareAcceptsOAuthBearerToken(t *testing.T) {
 		t.Fatalf("EncryptToken() error = %v", err)
 	}
 
-	server := &MCPServer{logger: zap.NewNop(), config: cfg}
+	server := &MCPServer{logger: zap.NewNop(), config: cfg, analytics: noopanalytics.New()}
 	req := httptest.NewRequest(http.MethodPost, "/mcp", nil)
 	req.Header.Set("Authorization", "Bearer "+token)
 	// req.Header.Set("X-SigNoz-URL", "https://1.1.1.1")
@@ -188,7 +189,7 @@ func TestAuthMiddlewareFallsBackToRawAPIKey(t *testing.T) {
 		OAuthIssuerURL:   "https://mcp.example.com",
 	}
 
-	server := &MCPServer{logger: zap.NewNop(), config: cfg}
+	server := &MCPServer{logger: zap.NewNop(), config: cfg, analytics: noopanalytics.New()}
 	req := httptest.NewRequest(http.MethodPost, "/mcp", nil)
 	req.Header.Set("Authorization", "Bearer raw-api-key")
 	req.Header.Set("X-SigNoz-URL", "https://1.1.1.1")
@@ -220,7 +221,7 @@ func TestAuthMiddlewareRejectsInvalidOAuthBearerWithoutSigNozURL(t *testing.T) {
 		OAuthIssuerURL:   "https://mcp.example.com",
 	}
 
-	server := &MCPServer{logger: zap.NewNop(), config: cfg}
+	server := &MCPServer{logger: zap.NewNop(), config: cfg, analytics: noopanalytics.New()}
 	req := httptest.NewRequest(http.MethodPost, "/mcp", nil)
 	req.Header.Set("Authorization", "Bearer stale-token")
 
@@ -245,7 +246,7 @@ func TestAuthMiddlewareReturnsOAuthChallengeWhenMissingAuth(t *testing.T) {
 		OAuthIssuerURL: "https://mcp.example.com",
 	}
 
-	server := &MCPServer{logger: zap.NewNop(), config: cfg}
+	server := &MCPServer{logger: zap.NewNop(), config: cfg, analytics: noopanalytics.New()}
 	req := httptest.NewRequest(http.MethodPost, "/mcp", nil)
 	rr := httptest.NewRecorder()
 

--- a/pkg/analytics/analytics.go
+++ b/pkg/analytics/analytics.go
@@ -1,0 +1,30 @@
+package analytics
+
+import (
+	"context"
+
+	"github.com/SigNoz/signoz-mcp-server/pkg/types/analyticstypes"
+)
+
+type Analytics interface {
+	// Start blocks until the analytics backend is stopped.
+	Start(context.Context) error
+	// Stop flushes pending events and closes the client.
+	Stop(context.Context) error
+
+	// Send sends raw analytics messages.
+	Send(context.Context, ...analyticstypes.Message)
+
+	// TrackGroup tracks an event at the organization/group level.
+	// The group value is used directly as the userId and associated via Context.Extra groupId.
+	TrackGroup(ctx context.Context, group string, event string, properties map[string]any)
+
+	// TrackUser tracks an event attributed to a specific user within a group.
+	TrackUser(ctx context.Context, group string, user string, event string, properties map[string]any)
+
+	// IdentifyGroup sets traits on an organization/group.
+	IdentifyGroup(ctx context.Context, group string, traits map[string]any)
+
+	// IdentifyUser sets traits on a user and associates them with a group.
+	IdentifyUser(ctx context.Context, group string, user string, traits map[string]any)
+}

--- a/pkg/analytics/analyticstest/provider.go
+++ b/pkg/analytics/analyticstest/provider.go
@@ -1,0 +1,26 @@
+package analyticstest
+
+import (
+	"context"
+
+	"github.com/SigNoz/signoz-mcp-server/pkg/types/analyticstypes"
+)
+
+// Provider is an exported test-only analytics provider.
+// All methods are no-ops. The exported type allows direct construction
+// in test packages without going through the factory.
+type Provider struct {
+	stopC chan struct{}
+}
+
+func New() *Provider {
+	return &Provider{stopC: make(chan struct{})}
+}
+
+func (p *Provider) Start(_ context.Context) error  { <-p.stopC; return nil }
+func (p *Provider) Stop(_ context.Context) error   { close(p.stopC); return nil }
+func (p *Provider) Send(_ context.Context, _ ...analyticstypes.Message) {}
+func (p *Provider) TrackGroup(_ context.Context, _, _ string, _ map[string]any)     {}
+func (p *Provider) TrackUser(_ context.Context, _, _, _ string, _ map[string]any)    {}
+func (p *Provider) IdentifyGroup(_ context.Context, _ string, _ map[string]any)      {}
+func (p *Provider) IdentifyUser(_ context.Context, _, _ string, _ map[string]any)    {}

--- a/pkg/analytics/config.go
+++ b/pkg/analytics/config.go
@@ -1,0 +1,10 @@
+package analytics
+
+type Config struct {
+	Enabled bool
+	Segment SegmentConfig
+}
+
+type SegmentConfig struct {
+	Key string
+}

--- a/pkg/analytics/noopanalytics/provider.go
+++ b/pkg/analytics/noopanalytics/provider.go
@@ -1,0 +1,24 @@
+package noopanalytics
+
+import (
+	"context"
+
+	"github.com/SigNoz/signoz-mcp-server/pkg/analytics"
+	"github.com/SigNoz/signoz-mcp-server/pkg/types/analyticstypes"
+)
+
+type provider struct {
+	stopC chan struct{}
+}
+
+func New() analytics.Analytics {
+	return &provider{stopC: make(chan struct{})}
+}
+
+func (p *provider) Start(_ context.Context) error  { <-p.stopC; return nil }
+func (p *provider) Stop(_ context.Context) error   { close(p.stopC); return nil }
+func (p *provider) Send(_ context.Context, _ ...analyticstypes.Message) {}
+func (p *provider) TrackGroup(_ context.Context, _, _ string, _ map[string]any)     {}
+func (p *provider) TrackUser(_ context.Context, _, _, _ string, _ map[string]any)    {}
+func (p *provider) IdentifyGroup(_ context.Context, _ string, _ map[string]any)      {}
+func (p *provider) IdentifyUser(_ context.Context, _, _ string, _ map[string]any)    {}

--- a/pkg/analytics/segmentanalytics/logger.go
+++ b/pkg/analytics/segmentanalytics/logger.go
@@ -1,0 +1,24 @@
+package segmentanalytics
+
+import (
+	"fmt"
+
+	segment "github.com/segmentio/analytics-go/v3"
+	"go.uber.org/zap"
+)
+
+type zapSegmentLogger struct {
+	logger *zap.Logger
+}
+
+func newSegmentLogger(logger *zap.Logger) segment.Logger {
+	return &zapSegmentLogger{logger: logger.Named("segment")}
+}
+
+func (l *zapSegmentLogger) Logf(format string, args ...interface{}) {
+	l.logger.Info(fmt.Sprintf(format, args...))
+}
+
+func (l *zapSegmentLogger) Errorf(format string, args ...interface{}) {
+	l.logger.Error(fmt.Sprintf(format, args...))
+}

--- a/pkg/analytics/segmentanalytics/provider.go
+++ b/pkg/analytics/segmentanalytics/provider.go
@@ -1,0 +1,126 @@
+package segmentanalytics
+
+import (
+	"context"
+
+	segment "github.com/segmentio/analytics-go/v3"
+	"go.uber.org/zap"
+
+	"github.com/SigNoz/signoz-mcp-server/pkg/analytics"
+	"github.com/SigNoz/signoz-mcp-server/pkg/types/analyticstypes"
+)
+
+type provider struct {
+	client segment.Client
+	logger *zap.Logger
+	stopC  chan struct{}
+}
+
+func New(logger *zap.Logger, cfg analytics.Config) (analytics.Analytics, error) {
+	client, err := segment.NewWithConfig(cfg.Segment.Key, segment.Config{
+		Logger: newSegmentLogger(logger),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return &provider{
+		client: client,
+		logger: logger,
+		stopC:  make(chan struct{}),
+	}, nil
+}
+
+func (p *provider) Start(_ context.Context) error {
+	<-p.stopC
+	return nil
+}
+
+func (p *provider) Stop(_ context.Context) error {
+	if err := p.client.Close(); err != nil {
+		p.logger.Error("failed to close segment client", zap.Error(err))
+	}
+	close(p.stopC)
+	return nil
+}
+
+func (p *provider) Send(_ context.Context, messages ...analyticstypes.Message) {
+	for _, msg := range messages {
+		if err := p.client.Enqueue(msg); err != nil {
+			p.logger.Error("failed to enqueue segment message", zap.Error(err))
+		}
+	}
+}
+
+func (p *provider) TrackGroup(_ context.Context, group, event string, properties map[string]any) {
+	if properties == nil {
+		return
+	}
+	if err := p.client.Enqueue(analyticstypes.Track{
+		UserId:     group,
+		Event:      event,
+		Properties: analyticstypes.NewPropertiesFromMap(properties),
+		Context: &analyticstypes.Context{
+			Extra: map[string]interface{}{
+				analyticstypes.KeyGroupID: group,
+			},
+		},
+	}); err != nil {
+		p.logger.Error("failed to enqueue TrackGroup", zap.String("event", event), zap.Error(err))
+	}
+}
+
+func (p *provider) TrackUser(_ context.Context, group, user, event string, properties map[string]any) {
+	if properties == nil {
+		return
+	}
+	if err := p.client.Enqueue(analyticstypes.Track{
+		UserId:     user,
+		Event:      event,
+		Properties: analyticstypes.NewPropertiesFromMap(properties),
+		Context: &analyticstypes.Context{
+			Extra: map[string]interface{}{
+				analyticstypes.KeyGroupID: group,
+			},
+		},
+	}); err != nil {
+		p.logger.Error("failed to enqueue TrackUser", zap.String("event", event), zap.Error(err))
+	}
+}
+
+func (p *provider) IdentifyGroup(_ context.Context, group string, traits map[string]any) {
+	if traits == nil {
+		return
+	}
+	if err := p.client.Enqueue(analyticstypes.Identify{
+		UserId: group,
+		Traits: analyticstypes.NewTraitsFromMap(traits),
+	}); err != nil {
+		p.logger.Error("failed to enqueue IdentifyGroup Identify", zap.Error(err))
+	}
+	if err := p.client.Enqueue(analyticstypes.Group{
+		UserId:  group,
+		GroupId: group,
+		Traits:  analyticstypes.NewTraitsFromMap(traits),
+	}); err != nil {
+		p.logger.Error("failed to enqueue IdentifyGroup Group", zap.Error(err))
+	}
+}
+
+func (p *provider) IdentifyUser(_ context.Context, group, user string, traits map[string]any) {
+	if traits == nil {
+		return
+	}
+	if err := p.client.Enqueue(analyticstypes.Identify{
+		UserId: user,
+		Traits: analyticstypes.NewTraitsFromMap(traits),
+	}); err != nil {
+		p.logger.Error("failed to enqueue IdentifyUser Identify", zap.Error(err))
+	}
+	if err := p.client.Enqueue(analyticstypes.Group{
+		UserId:  user,
+		GroupId: group,
+		Traits:  analyticstypes.NewTraits().Set("id", group),
+	}); err != nil {
+		p.logger.Error("failed to enqueue IdentifyUser Group", zap.Error(err))
+	}
+}

--- a/pkg/types/analyticstypes/message.go
+++ b/pkg/types/analyticstypes/message.go
@@ -1,0 +1,49 @@
+package analyticstypes
+
+import (
+	"strings"
+
+	segment "github.com/segmentio/analytics-go/v3"
+)
+
+const (
+	KeyGroupID string = "groupId"
+)
+
+// Type aliases to the Segment SDK — keeps the rest of the codebase
+// decoupled from the specific analytics vendor.
+type Message = segment.Message
+type Group = segment.Group
+type Identify = segment.Identify
+type Track = segment.Track
+type Traits = segment.Traits
+type Properties = segment.Properties
+type Context = segment.Context
+
+func NewTraits() Traits {
+	return segment.NewTraits()
+}
+
+func NewProperties() Properties {
+	return segment.NewProperties()
+}
+
+// NewPropertiesFromMap converts a map to Segment Properties.
+// Dots in keys are replaced with underscores (Segment limitation).
+func NewPropertiesFromMap(m map[string]any) Properties {
+	properties := NewProperties()
+	for k, v := range m {
+		properties.Set(strings.ReplaceAll(k, ".", "_"), v)
+	}
+	return properties
+}
+
+// NewTraitsFromMap converts a map to Segment Traits.
+// Dots in keys are replaced with underscores (Segment limitation).
+func NewTraitsFromMap(m map[string]any) Traits {
+	traits := NewTraits()
+	for k, v := range m {
+		traits.Set(strings.ReplaceAll(k, ".", "_"), v)
+	}
+	return traits
+}

--- a/plans/analytics.md
+++ b/plans/analytics.md
@@ -1,0 +1,796 @@
+# Analytics Integration Plan — Extract & Replicate from SigNoz
+
+## Context
+
+SigNoz uses a clean, provider-based analytics system that sends events to **Segment** (the only backend — no Mixpanel integration exists). The architecture is well-abstracted behind interfaces, making it straightforward to extract and replicate in another Go repo. This document captures every pattern, struct, function, and wiring detail needed to reproduce the analytics foundation in a new codebase.
+
+---
+
+## 1. Architecture Overview
+
+```
+┌─────────────────────────────────────────────────────┐
+│                   Your Application                   │
+│                                                      │
+│  ┌──────────┐  ┌──────────┐  ┌──────────────────┐   │
+│  │ Module A  │  │ Module B │  │ HTTP Handler     │   │
+│  │ (e.g.    │  │ (e.g.    │  │ (e.g. /api/v1/   │   │
+│  │  users)  │  │ dashbrd) │  │      event)      │   │
+│  └────┬─────┘  └────┬─────┘  └───────┬──────────┘   │
+│       │              │                │              │
+│       ▼              ▼                ▼              │
+│  ┌──────────────────────────────────────────────┐    │
+│  │          analytics.Analytics interface        │    │
+│  │  TrackUser · TrackGroup · IdentifyUser ·     │    │
+│  │  IdentifyGroup · Send                        │    │
+│  └────────────────────┬─────────────────────────┘    │
+│                       │                              │
+│            ┌──────────┴──────────┐                   │
+│            ▼                     ▼                   │
+│  ┌──────────────────┐  ┌─────────────────┐           │
+│  │ segmentanalytics │  │ noopanalytics   │           │
+│  │ (real Segment)   │  │ (disabled)      │           │
+│  └──────────────────┘  └─────────────────┘           │
+│                                                      │
+│  ┌──────────────────────────────────────────────┐    │
+│  │        StatsReporter (periodic ticker)        │    │
+│  │  Collects stats → IdentifyGroup + TrackGroup │    │
+│  │  Runs every N hours (default: 6h)            │    │
+│  └──────────────────────────────────────────────┘    │
+└─────────────────────────────────────────────────────┘
+```
+
+**Key design principles:**
+- Interface-driven: all modules depend on the `Analytics` interface, never the Segment SDK directly
+- Provider pattern: "segment" or "noop" chosen at startup based on config
+- Group-aware: every event is tied to both a user and an organization (group)
+- Periodic stats: a background ticker reports system-level stats on a schedule
+
+---
+
+## 2. Go Dependency
+
+```
+go get github.com/segmentio/analytics-go/v3@v3.2.1
+```
+
+This is the only external analytics dependency needed.
+
+---
+
+## 3. Core Types — `pkg/types/analyticstypes/`
+
+Create `pkg/types/analyticstypes/message.go`:
+
+```go
+package analyticstypes
+
+import (
+    "strings"
+    segment "github.com/segmentio/analytics-go/v3"
+)
+
+const (
+    KeyGroupID string = "groupId"
+)
+
+// Type aliases to the Segment SDK — keeps the rest of the codebase
+// decoupled from the specific analytics vendor.
+type Message    = segment.Message
+type Group      = segment.Group
+type Identify   = segment.Identify
+type Track      = segment.Track
+type Traits     = segment.Traits
+type Properties = segment.Properties
+type Context    = segment.Context
+
+func NewTraits() Traits {
+    return segment.NewTraits()
+}
+
+func NewProperties() Properties {
+    return segment.NewProperties()
+}
+
+// NewPropertiesFromMap converts a map to Segment Properties.
+// Dots in keys are replaced with underscores (Segment limitation).
+func NewPropertiesFromMap(m map[string]any) Properties {
+    properties := NewProperties()
+    for k, v := range m {
+        properties.Set(strings.ReplaceAll(k, ".", "_"), v)
+    }
+    return properties
+}
+
+// NewTraitsFromMap converts a map to Segment Traits.
+// Dots in keys are replaced with underscores.
+func NewTraitsFromMap(m map[string]any) Traits {
+    traits := NewTraits()
+    for k, v := range m {
+        traits.Set(strings.ReplaceAll(k, ".", "_"), v)
+    }
+    return traits
+}
+```
+
+**Important detail:** Segment does not support dots in property/trait keys. The `strings.ReplaceAll(k, ".", "_")` conversion is critical.
+
+---
+
+## 4. Analytics Interface — `pkg/analytics/analytics.go`
+
+```go
+package analytics
+
+import (
+    "context"
+    "<your-module>/pkg/types/analyticstypes"
+)
+
+type Analytics interface {
+    // Start blocks until the analytics backend is stopped.
+    Start(context.Context) error
+    // Stop flushes pending events and closes the client.
+    Stop(context.Context) error
+
+    // Send sends raw analytics messages.
+    Send(context.Context, ...analyticstypes.Message)
+
+    // TrackGroup tracks an event at the organization/group level.
+    // The userId is automatically set to "stats_<group>".
+    // Parameters: group (org ID), event name, properties map.
+    TrackGroup(context.Context, string, string, map[string]any)
+
+    // TrackUser tracks an event attributed to a specific user within a group.
+    // Parameters: group (org ID), user (user ID), event name, properties map.
+    TrackUser(context.Context, string, string, string, map[string]any)
+
+    // IdentifyGroup sets traits on an organization/group.
+    // Parameters: group (org ID), traits map.
+    IdentifyGroup(context.Context, string, map[string]any)
+
+    // IdentifyUser sets traits on a user and associates them with a group.
+    // Parameters: group (org ID), user (user ID), traits map.
+    IdentifyUser(context.Context, string, string, map[string]any)
+}
+```
+
+---
+
+## 5. Configuration — `pkg/analytics/config.go`
+
+```go
+package analytics
+
+type Config struct {
+    Enabled bool   `mapstructure:"enabled"` // env: ANALYTICS_ENABLED
+    Segment SegmentConfig `mapstructure:"segment"`
+}
+
+type SegmentConfig struct {
+    Key string `mapstructure:"key"` // env: ANALYTICS_SEGMENT_KEY (or set via ldflags)
+}
+
+// Provider returns the provider name based on the enabled flag.
+func (c Config) Provider() string {
+    if c.Enabled {
+        return "segment"
+    }
+    return "noop"
+}
+```
+
+### How the Segment API key is passed (3 mechanisms, in priority order)
+
+**1. Deprecated env var (highest priority, runs last — overwrites everything):**
+`SIGNOZ_SAAS_SEGMENT_KEY` is handled in `pkg/signoz/config.go:278-281` after koanf config loading. It directly sets `config.Analytics.Segment.Key` with a deprecation warning.
+
+**2. Environment variable (primary, recommended):**
+`SIGNOZ_ANALYTICS_SEGMENT_KEY` — picked up by the koanf env provider (`pkg/config/envprovider/provider.go`).
+The env provider strips the `SIGNOZ_` prefix, converts single `_` to `.` (double `__` becomes literal `_`), so:
+`SIGNOZ_ANALYTICS_SEGMENT_KEY` → config path `analytics.segment.key` → `Config.Analytics.Segment.Key`
+
+**3. Build-time ldflags (lowest priority, default value):**
+The `var key string = "<unset>"` in `pkg/analytics/config.go` is used in `newConfig()` as the default. Override at build time:
+```
+go build -ldflags "-X <module>/pkg/analytics.key=YOUR_SEGMENT_WRITE_KEY"
+```
+Note: SigNoz's current Makefile does NOT set this — the key comes from env vars in practice.
+
+**For the target repo:** Use environment variables (mechanism #2). Set `YOURPREFIX_ANALYTICS_SEGMENT_KEY` if using the same koanf env provider pattern, or just read `ANALYTICS_SEGMENT_KEY` directly from `os.Getenv()` for simplicity.
+
+---
+
+## 6. Segment Provider — `pkg/analytics/segmentanalytics/provider.go`
+
+This is the real implementation. Key behaviors:
+
+### 6.1 Initialization
+```go
+client, err := segment.NewWithConfig(config.Segment.Key, segment.Config{
+    Logger: yourLogger, // optional
+})
+```
+
+### 6.2 TrackGroup — Organization-level events
+```go
+func (p *provider) TrackGroup(ctx context.Context, group, event string, properties map[string]any) {
+    if properties == nil { return } // nil-guard, skip if no properties
+
+    p.client.Enqueue(analyticstypes.Track{
+        UserId:     "stats_" + group,           // synthetic user for org-level tracking
+        Event:      event,
+        Properties: analyticstypes.NewPropertiesFromMap(properties),
+        Context: &analyticstypes.Context{
+            Extra: map[string]interface{}{
+                analyticstypes.KeyGroupID: group, // associates event with the org
+            },
+        },
+    })
+}
+```
+
+**Critical pattern — `"stats_" + orgID`:** Organization-level events use a synthetic user ID prefixed with `stats_`. This keeps org events separate from individual user activity in Segment.
+
+### 6.3 TrackUser — User-level events
+```go
+func (p *provider) TrackUser(ctx context.Context, group, user, event string, properties map[string]any) {
+    if properties == nil { return }
+
+    p.client.Enqueue(analyticstypes.Track{
+        UserId:     user,                       // actual user ID
+        Event:      event,
+        Properties: analyticstypes.NewPropertiesFromMap(properties),
+        Context: &analyticstypes.Context{
+            Extra: map[string]interface{}{
+                analyticstypes.KeyGroupID: group, // associates user event with their org
+            },
+        },
+    })
+}
+```
+
+### 6.4 IdentifyGroup — Set org traits (sends 2 messages)
+```go
+func (p *provider) IdentifyGroup(ctx context.Context, group string, traits map[string]any) {
+    if traits == nil { return }
+
+    // 1. Identify the synthetic stats user with org traits
+    p.client.Enqueue(analyticstypes.Identify{
+        UserId: "stats_" + group,
+        Traits: analyticstypes.NewTraitsFromMap(traits),
+    })
+
+    // 2. Associate stats user with the group (org)
+    p.client.Enqueue(analyticstypes.Group{
+        UserId:  "stats_" + group,
+        GroupId: group,
+        Traits:  analyticstypes.NewTraitsFromMap(traits),
+    })
+}
+```
+
+### 6.5 IdentifyUser — Set user traits + associate with org (sends 2 messages)
+```go
+func (p *provider) IdentifyUser(ctx context.Context, group, user string, traits map[string]any) {
+    if traits == nil { return }
+
+    // 1. Identify the actual user with their traits
+    p.client.Enqueue(analyticstypes.Identify{
+        UserId: user,
+        Traits: analyticstypes.NewTraitsFromMap(traits),
+    })
+
+    // 2. Associate the user with their org/group
+    p.client.Enqueue(analyticstypes.Group{
+        UserId:  user,
+        GroupId: group,
+        Traits:  analyticstypes.NewTraits().Set("id", group), // minimal trait required
+    })
+}
+```
+
+### 6.6 Lifecycle
+- **Start:** Blocks on `<-stopC` channel (keeps the service alive in the registry)
+- **Stop:** Calls `client.Close()` to flush queued events, then closes stopC
+
+---
+
+## 7. No-op Provider — `pkg/analytics/noopanalytics/provider.go`
+
+Every method is empty. Used when `Enabled: false`. Important for:
+- Local development (no events sent)
+- Testing (no side effects)
+- Self-hosted deployments that opt out of analytics
+
+```go
+type provider struct {
+    stopC chan struct{}
+}
+
+func (p *provider) Start(_ context.Context) error { <-p.stopC; return nil }
+func (p *provider) Stop(_ context.Context) error  { close(p.stopC); return nil }
+func (p *provider) Send(ctx context.Context, messages ...analyticstypes.Message) {}
+func (p *provider) TrackGroup(ctx context.Context, group, event string, attrs map[string]any) {}
+func (p *provider) TrackUser(ctx context.Context, group, user, event string, attrs map[string]any) {}
+func (p *provider) IdentifyGroup(ctx context.Context, group string, traits map[string]any) {}
+func (p *provider) IdentifyUser(ctx context.Context, group, user string, traits map[string]any) {}
+```
+
+---
+
+## 8. Provider Wiring at Startup
+
+### 8.1 Provider factory registration
+```go
+func NewAnalyticsProviderFactories() NamedMap[ProviderFactory[analytics.Analytics, analytics.Config]] {
+    return MustNewNamedMap(
+        noopanalytics.NewFactory(),
+        segmentanalytics.NewFactory(),
+    )
+}
+```
+
+### 8.2 Initialization at application startup
+```go
+analyticsInstance, err := factory.NewProviderFromNamedMap(
+    ctx,
+    providerSettings,
+    config.Analytics,
+    NewAnalyticsProviderFactories(),
+    config.Analytics.Provider(), // returns "segment" or "noop"
+)
+```
+
+### 8.3 Injection into modules
+Modules receive `analytics.Analytics` as a constructor parameter:
+```go
+func NewModule(store Store, analytics analytics.Analytics, ...) Module {
+    return &module{
+        analytics: analytics,
+        ...
+    }
+}
+```
+
+### 8.4 Simplified wiring (without the factory framework)
+If your repo doesn't use the same factory pattern, you can simplify:
+```go
+func NewAnalytics(config analytics.Config) (analytics.Analytics, error) {
+    if !config.Enabled {
+        return noopanalytics.New(context.Background(), nil, config)
+    }
+    return segmentanalytics.New(context.Background(), nil, config)
+}
+```
+
+---
+
+## 9. Periodic Stats Reporter — `pkg/statsreporter/`
+
+### 9.1 Interface
+```go
+type StatsReporter interface {
+    Start(context.Context) error
+    Stop(context.Context) error
+    Report(context.Context) error
+}
+
+type StatsCollector interface {
+    Collect(ctx context.Context, orgID uuid.UUID) (map[string]any, error)
+}
+```
+
+### 9.2 Config
+```go
+type Config struct {
+    Enabled  bool          `mapstructure:"enabled"`    // default: true
+    Interval time.Duration `mapstructure:"interval"`   // default: 6 hours
+    Collect  Collect       `mapstructure:"collect"`
+}
+
+type Collect struct {
+    Identities bool `mapstructure:"identities"` // default: true
+}
+```
+
+### 9.3 Report cycle (every 6 hours by default)
+1. Start a `time.Ticker` at the configured interval
+2. On each tick, for each organization:
+   a. Run all registered `StatsCollector.Collect()` in parallel (using `sync.WaitGroup`)
+   b. Merge all stats into a single `map[string]any`
+   c. Add build/deployment metadata (version, branch, OS, arch, etc.)
+   d. Add org metadata (name, display_name, created_at)
+   e. Call `analytics.IdentifyGroup(orgID, stats)`
+   f. Call `analytics.TrackGroup(orgID, "Stats Reported", stats)`
+   g. If `Collect.Identities` is enabled, for each user in the org:
+      - Call `analytics.IdentifyUser(orgID, userID, userTraits)`
+3. On Stop: run one final Report, then stop the analytics client
+
+### 9.4 StatsCollector pattern
+Each module that has stats to report implements:
+```go
+func (m *module) Collect(ctx context.Context, orgID uuid.UUID) (map[string]any, error) {
+    // Query your data store for counts, etc.
+    return map[string]any{
+        "dashboard.count": 42,
+        "dashboard.panels.count": 128,
+    }, nil
+}
+```
+
+Collectors are registered at startup:
+```go
+statsCollectors := []statsreporter.StatsCollector{
+    dashboardModule,
+    userModule,
+    alertModule,
+    // ...
+}
+```
+
+---
+
+## 10. Event Tracking Patterns in Modules
+
+### 10.1 Track on entity lifecycle (most common)
+```go
+// After creating an entity:
+traits := map[string]any{
+    "name":       user.DisplayName,
+    "email":      user.Email,
+    "created_at": user.CreatedAt,
+}
+module.analytics.IdentifyUser(ctx, orgID.String(), userID.String(), traits)
+module.analytics.TrackUser(ctx, orgID.String(), userID.String(), "User Created", traits)
+
+// After updating:
+module.analytics.TrackUser(ctx, orgID.String(), userID.String(), "User Updated", traits)
+
+// After deleting:
+module.analytics.TrackUser(ctx, orgID.String(), userID.String(), "User Deleted", map[string]any{...})
+```
+
+### 10.2 Track on action
+```go
+module.analytics.TrackUser(ctx, orgID.String(), userID.String(), "Invite Sent", map[string]any{
+    "invitee_email": invitee.Email,
+    "invitee_role":  invitee.Role,
+})
+```
+
+### 10.3 Track from HTTP handler (generic endpoint)
+SigNoz exposes a `POST /api/v1/event` endpoint that accepts:
+```go
+type RegisterEventParams struct {
+    EventType   string                 `json:"eventType"`   // "track", "identify", "group"
+    EventName   string                 `json:"eventName"`
+    Attributes  map[string]interface{} `json:"attributes"`
+    RateLimited bool                   `json:"rateLimited"`
+}
+```
+
+The handler extracts the authenticated user's orgID and userID from JWT claims and calls:
+```go
+analytics.TrackUser(ctx, claims.OrgID, claims.IdentityID(), request.EventName, request.Attributes)
+```
+
+This allows the frontend to send custom events without needing direct access to Segment.
+
+---
+
+## 11. Frontend Event Tracking (TypeScript/React)
+
+### 11.1 Backend relay function — `logEvent()`
+```typescript
+const logEvent = async (
+    eventName: string,
+    attributes: Record<string, unknown>,
+    eventType?: 'track' | 'group' | 'identify',
+    rateLimited?: boolean,
+): Promise<SuccessResponse | ErrorResponse> => {
+    const { hostname } = window.location;
+    const userEmail = getLocalStorageApi('LOGGED_IN_USER_EMAIL');
+    const updatedAttributes = {
+        ...attributes,
+        deployment_url: hostname,
+        user_email: userEmail,
+    };
+    return axios.post('/event', {
+        eventName,
+        attributes: updatedAttributes,
+        eventType: eventType || 'track',
+        rateLimited: rateLimited || false,
+    });
+};
+```
+
+### 11.2 Usage in components
+```typescript
+logEvent('Dashboard Created', { dashboard_id: id, panel_count: panels.length });
+logEvent('User Activated', { email }, 'identify');
+```
+
+### 11.3 PostHog (separate from Segment, direct frontend tracking)
+SigNoz also uses PostHog directly on the frontend for product analytics:
+```typescript
+posthog.init(process.env.POSTHOG_KEY, {
+    api_host: 'https://us.i.posthog.com',
+    person_profiles: 'identified_only',
+});
+
+posthog.identify(userId, { email, name, orgName, ... });
+posthog.group('company', orgId, { name: orgName, ... });
+```
+
+This is a **separate** integration — not related to the Segment backend analytics. Include only if you want direct frontend analytics in addition to the backend relay.
+
+---
+
+## 12. Event Naming Conventions
+
+| Event Name | Level | When | Key Properties |
+|---|---|---|---|
+| `Stats Reported` | Group | Every 6h (periodic) | build.*, deployment.*, telemetry.*.count |
+| `User Created` | User | On user creation | name, email, created_at |
+| `User Updated` | User | On user update | changed fields |
+| `User Deleted` | User | On user deletion | user traits |
+| `User Activated` | User | On user activation | user traits |
+| `Invite Sent` | User | On invite | invitee_email, invitee_role |
+| `Dashboard Created` | User | On dashboard creation | dashboard.count, panels.count |
+| `Service Account Created` | User | On SA creation | SA traits |
+
+---
+
+## 13. Implementation Checklist for Target Repo
+
+### Step 1: Add Segment dependency
+```bash
+go get github.com/segmentio/analytics-go/v3@v3.2.1
+```
+
+### Step 2: Create analytics types package
+- `pkg/types/analyticstypes/message.go` — type aliases + helper functions (Section 3)
+
+### Step 3: Create analytics interface
+- `pkg/analytics/analytics.go` — interface definition (Section 4)
+- `pkg/analytics/config.go` — Config struct (Section 5)
+
+### Step 4: Create provider implementations
+- `pkg/analytics/segmentanalytics/provider.go` — Segment provider (Section 6)
+- `pkg/analytics/noopanalytics/provider.go` — No-op provider (Section 7)
+
+### Step 5: Wire analytics at startup
+- Create analytics instance based on config (Section 8)
+- Pass as dependency to modules that need to track events
+
+### Step 6: Add event tracking to modules
+- Follow patterns in Section 10 — inject `analytics.Analytics`, call `TrackUser`/`IdentifyUser` at lifecycle points
+
+### Step 7: (Optional) Add generic event endpoint
+- `POST /api/v1/event` handler (Section 10.3) for frontend-originated events
+
+### Step 8: (Optional) Add periodic stats reporter
+- `pkg/statsreporter/` — interface, config, and analytics stats reporter (Section 9)
+- Register `StatsCollector` implementations from modules
+- Start reporter as a background goroutine
+
+### Step 9: (Optional) Add frontend event tracking
+- `logEvent()` function (Section 11) that relays events to backend endpoint
+
+---
+
+## 14. Key Design Decisions to Be Aware Of
+
+1. **Dots → underscores in keys:** All property/trait keys have `.` replaced with `_` before sending to Segment. Your property naming should account for this.
+
+2. **`stats_<orgID>` synthetic user:** Organization-level events use this prefix to avoid polluting real user profiles. This is a deliberate choice that affects how you query data in downstream tools.
+
+3. **Nil-guard on properties:** All tracking methods return early if `properties` or `traits` are nil. This prevents sending empty events to Segment.
+
+4. **IdentifyUser sends 2 Segment messages:** Both an `Identify` (set traits) and a `Group` (associate with org). This is required for Segment's group analytics to work properly.
+
+5. **IdentifyGroup also sends 2 messages:** An `Identify` for the synthetic `stats_` user and a `Group` association.
+
+6. **Stop flushes events:** The `Stop()` method calls `client.Close()` which flushes any queued events. The stats reporter also does a final `Report()` on shutdown to capture last-moment stats.
+
+7. **No Mixpanel:** Despite the question, SigNoz only uses Segment. If you need Mixpanel, you can either route through Segment (which supports Mixpanel as a destination), or create a `mixpanelanalytics` provider implementing the same `Analytics` interface.
+
+---
+
+## 15. Missing Pieces — Additional Files
+
+### 15.1 Segment Logger Adapter — `pkg/analytics/segmentanalytics/logger.go`
+
+The Segment SDK requires a `segment.Logger` interface. This adapter bridges it to your app's structured logger:
+
+```go
+package segmentanalytics
+
+import (
+    "context"
+    segment "github.com/segmentio/analytics-go/v3"
+)
+
+type logger struct {
+    // your logger
+    log *slog.Logger
+}
+
+func newSegmentLogger(log *slog.Logger) segment.Logger {
+    return &logger{log: log}
+}
+
+// segment.Logger requires Logf and Errorf
+func (l *logger) Logf(format string, args ...interface{}) {
+    l.log.InfoContext(context.TODO(), format, args...)
+}
+
+func (l *logger) Errorf(format string, args ...interface{}) {
+    l.log.ErrorContext(context.TODO(), format, args...)
+}
+```
+
+This is passed to `segment.NewWithConfig(key, segment.Config{Logger: newSegmentLogger(log)})`.
+
+### 15.2 Test Provider — `pkg/analytics/analyticstest/provider.go`
+
+A test-only implementation with exported `Provider` struct (unlike the other providers which are unexported). Used in unit tests to avoid Segment side effects:
+
+```go
+package analyticstest
+
+type Provider struct {
+    stopC chan struct{}
+}
+
+func New() *Provider {
+    return &Provider{stopC: make(chan struct{})}
+}
+
+// All methods are no-ops (same as noop provider)
+// Key difference: Provider is an EXPORTED type, so tests can create it directly
+// without going through the factory pattern.
+```
+
+### 15.3 No-op StatsReporter — `pkg/statsreporter/noopstatsreporter/provider.go`
+
+Used when stats reporting is disabled. Blocks on `Start()` until `Stop()` is called. `Report()` is a no-op.
+
+### 15.4 Event Model Types — `pkg/query-service/model/queryParams.go`
+
+The model for the generic event endpoint:
+
+```go
+type EventType string
+
+const (
+    TrackEvent    EventType = "track"
+    IdentifyEvent EventType = "identify"
+    GroupEvent    EventType = "group"
+)
+
+func (e EventType) IsValid() bool {
+    return e == TrackEvent || e == IdentifyEvent || e == GroupEvent
+}
+
+type RegisterEventParams struct {
+    EventType   EventType              `json:"eventType"`
+    EventName   string                 `json:"eventName"`
+    Attributes  map[string]interface{} `json:"attributes"`
+    RateLimited bool                   `json:"rateLimited"`
+}
+```
+
+### 15.5 Querier Event Tracking — `pkg/querier/api.go`
+
+Tracks query execution results. The `logEvent()` method:
+- Extracts user claims from context
+- Skips if no signal type (logs/traces/metrics) was used
+- Skips if no referrer header is present
+- Attaches query metadata as properties: `version`, `logs_used`, `traces_used`, `metrics_used`, `source`, `filter_applied`, `group_by_applied`, `query_type`, `panel_type`, `number_of_queries`
+- Attaches instrumentation context comments (like code namespace, function name)
+- Sends either `"Telemetry Query Returned Empty"` or `"Telemetry Query Returned Results"`
+
+### 15.6 Important: StatsReporter creates its OWN Segment client
+
+A subtle but important detail in `pkg/statsreporter/analyticsstatsreporter/provider.go:83`:
+
+```go
+analytics, err := segmentanalytics.New(ctx, providerSettings, analyticsConfig)
+```
+
+The StatsReporter creates a **separate** Segment analytics instance — it does NOT reuse the main application-level analytics instance. This means:
+- Two Segment clients exist at runtime (main app + stats reporter)
+- Each has its own event queue and flush cycle
+- The stats reporter's instance is independently started/stopped
+
+---
+
+## 16. Complete File Tree
+
+```
+pkg/
+├── analytics/
+│   ├── analytics.go              # Analytics interface (5 methods + Start/Stop)
+│   ├── config.go                 # Config struct, ldflags key var, provider selector
+│   ├── analyticstest/
+│   │   └── provider.go           # Test provider (exported type, no-op)
+│   ├── noopanalytics/
+│   │   └── provider.go           # No-op provider (disabled analytics)
+│   └── segmentanalytics/
+│       ├── provider.go           # Segment implementation (Enqueue Track/Identify/Group)
+│       └── logger.go             # Segment SDK logger adapter
+├── types/
+│   └── analyticstypes/
+│       └── message.go            # Type aliases (Track, Identify, Group, etc.) + helpers
+├── statsreporter/
+│   ├── statsreporter.go          # StatsReporter + StatsCollector interfaces
+│   ├── config.go                 # Config (enabled, interval, collect.identities)
+│   ├── analyticsstatsreporter/
+│   │   └── provider.go           # Periodic reporter (ticker + parallel collectors)
+│   └── noopstatsreporter/
+│       └── provider.go           # No-op reporter
+├── signoz/
+│   ├── config.go                 # Top-level config with env var backward compat
+│   ├── provider.go               # Factory registration (NewAnalyticsProviderFactories)
+│   └── signoz.go                 # Startup wiring + service registry
+├── query-service/
+│   ├── model/
+│   │   └── queryParams.go        # EventType enum + RegisterEventParams struct
+│   └── app/
+│       └── http_handler.go       # POST /api/v1/event handler + query tracking
+└── querier/
+    └── api.go                    # Query result event tracking (logEvent method)
+
+frontend/
+└── src/
+    └── api/
+        └── common/
+            └── logEvent.ts       # Frontend event relay to backend
+```
+
+---
+
+## 17. Source File Reference
+
+| File (in SigNoz repo) | What to extract |
+|---|---|
+| `pkg/types/analyticstypes/message.go` | Type aliases, helper functions |
+| `pkg/analytics/analytics.go` | Interface definition |
+| `pkg/analytics/config.go` | Configuration + ldflags key var |
+| `pkg/analytics/segmentanalytics/provider.go` | Segment implementation |
+| `pkg/analytics/segmentanalytics/logger.go` | Segment SDK logger adapter |
+| `pkg/analytics/noopanalytics/provider.go` | No-op implementation |
+| `pkg/analytics/analyticstest/provider.go` | Test provider (exported, for unit tests) |
+| `pkg/statsreporter/statsreporter.go` | StatsReporter + StatsCollector interfaces |
+| `pkg/statsreporter/config.go` | StatsReporter config |
+| `pkg/statsreporter/analyticsstatsreporter/provider.go` | Periodic reporter implementation |
+| `pkg/statsreporter/noopstatsreporter/provider.go` | No-op stats reporter |
+| `pkg/signoz/config.go:278-286` | Env var backward compatibility |
+| `pkg/signoz/provider.go:77-82` | Factory registration pattern |
+| `pkg/signoz/signoz.go:131-140` | Startup wiring |
+| `pkg/config/envprovider/provider.go` | Koanf env provider (SIGNOZ_ prefix → config path) |
+| `pkg/query-service/model/queryParams.go:53-70` | EventType enum + RegisterEventParams struct |
+| `pkg/query-service/app/http_handler.go:1495-1510` | Generic event endpoint handler |
+| `pkg/querier/api.go:238-276` | Query result event tracking |
+| `pkg/modules/user/impluser/setter.go` | Example: user event tracking |
+| `pkg/modules/dashboard/impldashboard/module.go` | Example: dashboard event tracking |
+| `frontend/src/api/common/logEvent.ts` | Frontend event relay |
+
+Based on above doc implement analytics in this repo following pieces from https://github.com/SigNoz/signoz. You need to record below attributes whereever possible:
+1. MCP registered
+2. MCP un-registerd
+3. Tenant URL
+4. Session ID
+5. Tool call
+6. Use the same semantics for the above attributes as used by traces and logs
+7. At the end I should be able to ask the below questions to an analytics platform
+    1. Daily tenant count
+    2. Daily session count
+    3. Weekly active tenant count
+    4. Avg Session count per tenant
+    5. Avg tool calls per session
+    6. Avg tool calls per tenant
+8. Verify the events and attributes sent using console log and iterate till you do it properly
+9. Remove the console logs from step 8 post verification


### PR DESCRIPTION
Add Segment-based analytics to track MCP session lifecycle and tool usage. Events sent: MCP Registered, MCP Unregistered, Tool Call — each with tenant URL, session ID, and tool metadata. Identify and Group calls create tenant profiles in Segment on session init. Controlled via ANALYTICS_ENABLED and SEGMENT_KEY env vars (disabled by default).