### PR TITLE
feat: add signoz_delete_dashboard MCP tool

### DIFF
--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -511,3 +511,10 @@ func (s *SigNoz) UpdateDashboardRaw(ctx context.Context, id string, dashboardJSO
 	_, err := s.doRequest(ctx, http.MethodPut, reqURL, bytes.NewBuffer(dashboardJSON), DashboardWriteTimeout)
 	return err
 }
+
+func (s *SigNoz) DeleteDashboard(ctx context.Context, id string) error {
+	reqURL := fmt.Sprintf("%s/api/v1/dashboards/%s", s.baseURL, url.PathEscape(id))
+	s.requestLogger(ctx).Debug("Deleting dashboard", zap.String("id", id))
+	_, err := s.doRequest(ctx, http.MethodDelete, reqURL, nil, DashboardWriteTimeout)
+	return err
+}

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -995,6 +995,23 @@ func TestUpdateDashboard(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestDeleteDashboard(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodDelete, r.Method)
+		assert.Equal(t, "/api/v1/dashboards/dash-456", r.URL.Path)
+		assert.Equal(t, "test-api-key", r.Header.Get("SIGNOZ-API-KEY"))
+
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	logger, _ := zap.NewDevelopment()
+	client := NewClient(logger, srv.URL, "test-api-key", "SIGNOZ-API-KEY")
+
+	err := client.DeleteDashboard(context.Background(), "dash-456")
+	require.NoError(t, err)
+}
+
 func TestGetFieldKeys(t *testing.T) {
 	tests := []struct {
 		name          string

--- a/internal/client/interface.go
+++ b/internal/client/interface.go
@@ -20,6 +20,7 @@ type Client interface {
 	UpdateDashboard(ctx context.Context, id string, dashboard types.Dashboard) error
 	CreateDashboardRaw(ctx context.Context, dashboardJSON []byte) (json.RawMessage, error)
 	UpdateDashboardRaw(ctx context.Context, id string, dashboardJSON []byte) error
+	DeleteDashboard(ctx context.Context, id string) error
 	ListServices(ctx context.Context, start, end string) (json.RawMessage, error)
 	GetServiceTopOperations(ctx context.Context, start, end, service string, tags json.RawMessage) (json.RawMessage, error)
 	QueryBuilderV5(ctx context.Context, body []byte) (json.RawMessage, error)

--- a/internal/client/mock.go
+++ b/internal/client/mock.go
@@ -21,6 +21,7 @@ type MockClient struct {
 	UpdateDashboardFn         func(ctx context.Context, id string, dashboard types.Dashboard) error
 	CreateDashboardRawFn      func(ctx context.Context, dashboardJSON []byte) (json.RawMessage, error)
 	UpdateDashboardRawFn      func(ctx context.Context, id string, dashboardJSON []byte) error
+	DeleteDashboardFn         func(ctx context.Context, id string) error
 	ListServicesFn            func(ctx context.Context, start, end string) (json.RawMessage, error)
 	GetServiceTopOperationsFn func(ctx context.Context, start, end, service string, tags json.RawMessage) (json.RawMessage, error)
 	QueryBuilderV5Fn          func(ctx context.Context, body []byte) (json.RawMessage, error)
@@ -100,6 +101,13 @@ func (m *MockClient) CreateDashboardRaw(ctx context.Context, dashboardJSON []byt
 func (m *MockClient) UpdateDashboardRaw(ctx context.Context, id string, dashboardJSON []byte) error {
 	if m.UpdateDashboardRawFn != nil {
 		return m.UpdateDashboardRawFn(ctx, id, dashboardJSON)
+	}
+	return nil
+}
+
+func (m *MockClient) DeleteDashboard(ctx context.Context, id string) error {
+	if m.DeleteDashboardFn != nil {
+		return m.DeleteDashboardFn(ctx, id)
 	}
 	return nil
 }

--- a/internal/handler/tools/dashboards.go
+++ b/internal/handler/tools/dashboards.go
@@ -88,6 +88,15 @@ func (h *Handler) RegisterDashboardHandlers(s *server.MCPServer) {
 
 	s.AddTool(updateDashboardTool, h.handleUpdateDashboard)
 
+	deleteDashboardTool := mcp.NewTool("signoz_delete_dashboard",
+		mcp.WithDestructiveHintAnnotation(true),
+		mcp.WithString("searchContext", mcp.Description("The user's original question or search text that triggered this tool call. Always include the user's raw query here for better results.")),
+		mcp.WithDescription("Delete a dashboard by its UUID. This action is irreversible. Use signoz_list_dashboards to find dashboard UUIDs."),
+		mcp.WithString("uuid", mcp.Required(), mcp.Description("Dashboard UUID to delete")),
+	)
+
+	s.AddTool(deleteDashboardTool, h.handleDeleteDashboard)
+
 	// resources for create and update dashboard
 	h.registerDashboardResources(s)
 }
@@ -229,6 +238,31 @@ func (h *Handler) handleUpdateDashboard(ctx context.Context, req mcp.CallToolReq
 	}
 
 	return mcp.NewToolResultText("dashboard updated"), nil
+}
+
+func (h *Handler) handleDeleteDashboard(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	log := h.tenantLogger(ctx)
+	uuid, ok := req.Params.Arguments.(map[string]any)["uuid"].(string)
+	if !ok {
+		log.Warn("Invalid uuid parameter type", zap.Any("type", req.Params.Arguments))
+		return mcp.NewToolResultError(`Parameter validation failed: "uuid" must be a string. Example: {"uuid": "a1b2c3d4-e5f6-7890-abcd-ef1234567890"}`), nil
+	}
+	if uuid == "" {
+		log.Warn("Empty uuid parameter")
+		return mcp.NewToolResultError(`Parameter validation failed: "uuid" cannot be empty. Provide a valid dashboard UUID. Use signoz_list_dashboards tool to see available dashboards.`), nil
+	}
+
+	log.Debug("Tool called: signoz_delete_dashboard", zap.String("uuid", uuid))
+	client, err := h.GetClient(ctx)
+	if err != nil {
+		return mcp.NewToolResultError(err.Error()), nil
+	}
+	err = client.DeleteDashboard(ctx, uuid)
+	if err != nil {
+		log.Error("Failed to delete dashboard", zap.String("uuid", uuid), zap.Error(err))
+		return mcp.NewToolResultError(fmt.Sprintf("SigNoz API Error: %s", err.Error())), nil
+	}
+	return mcp.NewToolResultText("dashboard deleted"), nil
 }
 
 // registerDashboardResources registers all MCP resources needed for dashboard creation/update.

--- a/internal/handler/tools/dashboards_test.go
+++ b/internal/handler/tools/dashboards_test.go
@@ -1,0 +1,107 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/SigNoz/signoz-mcp-server/internal/client"
+)
+
+func TestHandleDeleteDashboard_Success(t *testing.T) {
+	// Simulate a create-then-delete flow: the mock "creates" a dashboard and
+	// then the delete handler removes it by UUID.
+	const createdUUID = "abc-123-def"
+
+	created := false
+	deleted := false
+
+	mock := &client.MockClient{
+		CreateDashboardRawFn: func(ctx context.Context, dashboardJSON []byte) (json.RawMessage, error) {
+			created = true
+			return json.RawMessage(fmt.Sprintf(`{"status":"success","data":{"uuid":"%s"}}`, createdUUID)), nil
+		},
+		DeleteDashboardFn: func(ctx context.Context, id string) error {
+			if id != createdUUID {
+				t.Errorf("expected uuid=%s, got %q", createdUUID, id)
+			}
+			deleted = true
+			return nil
+		},
+	}
+
+	h := newTestHandler(mock)
+
+	// Step 1: create a dashboard
+	createResult, err := h.handleCreateDashboard(testCtx(), makeToolRequest("signoz_create_dashboard", map[string]any{
+		"title":   "Temp Dashboard",
+		"widgets": []any{},
+		"layout":  []any{},
+	}))
+	if err != nil {
+		t.Fatalf("unexpected error on create: %v", err)
+	}
+	if createResult.IsError {
+		t.Fatalf("create returned error result: %v", createResult.Content)
+	}
+	if !created {
+		t.Fatal("CreateDashboardRawFn was not called")
+	}
+
+	// Step 2: delete the dashboard we just created
+	deleteResult, err := h.handleDeleteDashboard(testCtx(), makeToolRequest("signoz_delete_dashboard", map[string]any{
+		"uuid": createdUUID,
+	}))
+	if err != nil {
+		t.Fatalf("unexpected error on delete: %v", err)
+	}
+	if deleteResult.IsError {
+		t.Fatalf("delete returned error result: %v", deleteResult.Content)
+	}
+	if !deleted {
+		t.Fatal("DeleteDashboardFn was not called")
+	}
+}
+
+func TestHandleDeleteDashboard_EmptyUUID(t *testing.T) {
+	h := newTestHandler(&client.MockClient{})
+	result, err := h.handleDeleteDashboard(testCtx(), makeToolRequest("signoz_delete_dashboard", map[string]any{
+		"uuid": "",
+	}))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !result.IsError {
+		t.Error("expected error result for empty uuid")
+	}
+}
+
+func TestHandleDeleteDashboard_MissingUUID(t *testing.T) {
+	h := newTestHandler(&client.MockClient{})
+	result, err := h.handleDeleteDashboard(testCtx(), makeToolRequest("signoz_delete_dashboard", map[string]any{}))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !result.IsError {
+		t.Error("expected error result for missing uuid")
+	}
+}
+
+func TestHandleDeleteDashboard_ClientError(t *testing.T) {
+	mock := &client.MockClient{
+		DeleteDashboardFn: func(ctx context.Context, id string) error {
+			return fmt.Errorf("not found")
+		},
+	}
+	h := newTestHandler(mock)
+	result, err := h.handleDeleteDashboard(testCtx(), makeToolRequest("signoz_delete_dashboard", map[string]any{
+		"uuid": "nonexistent-uuid",
+	}))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !result.IsError {
+		t.Error("expected error result when client returns error")
+	}
+}

--- a/internal/mcp-server/integration_test.go
+++ b/internal/mcp-server/integration_test.go
@@ -83,7 +83,7 @@ func TestIntegration_InitializeAndListTools(t *testing.T) {
 		t.Fatalf("ListTools failed: %v", err)
 	}
 
-	const expectedToolCount = 21
+	const expectedToolCount = 22
 	if len(toolsResult.Tools) != expectedToolCount {
 		t.Errorf("expected %d tools, got %d", expectedToolCount, len(toolsResult.Tools))
 		for _, tool := range toolsResult.Tools {

--- a/manifest.json
+++ b/manifest.json
@@ -70,6 +70,10 @@
       "description": "Update an existing dashboard by UUID"
     },
     {
+      "name": "signoz_delete_dashboard",
+      "description": "Delete a dashboard by UUID"
+    },
+    {
       "name": "signoz_list_services",
       "description": "List services within a given time range"
     },


### PR DESCRIPTION
Add a delete dashboard tool to complete CRUD operations for dashboards. Wires DELETE /api/v1/dashboards/{uuid} through the client interface, mock, handler, and manifest.