### PR TITLE
feat: add signoz_create_alert MCP tool with v2 schema validation

### DIFF
--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -400,6 +400,12 @@ func (s *SigNoz) GetAlertHistory(ctx context.Context, ruleID string, req types.A
 	return s.doRequest(ctx, http.MethodPost, reqURL, bytes.NewBuffer(reqBody), DefaultQueryTimeout)
 }
 
+func (s *SigNoz) CreateAlertRule(ctx context.Context, alertJSON []byte) (json.RawMessage, error) {
+	reqURL := fmt.Sprintf("%s/api/v1/rules", s.baseURL)
+	s.requestLogger(ctx).Debug("Creating alert rule")
+	return s.doRequest(ctx, http.MethodPost, reqURL, bytes.NewBuffer(alertJSON), DashboardWriteTimeout)
+}
+
 func (s *SigNoz) ListLogViews(ctx context.Context) (json.RawMessage, error) {
 	reqURL := fmt.Sprintf("%s/api/v1/explorer/views?sourcePage=logs", s.baseURL)
 	s.requestLogger(ctx).Debug("Fetching log views from SigNoz")

--- a/internal/client/interface.go
+++ b/internal/client/interface.go
@@ -29,4 +29,5 @@ type Client interface {
 	GetFieldKeys(ctx context.Context, signal, metricName, searchText, fieldContext, fieldDataType, source string) (json.RawMessage, error)
 	GetFieldValues(ctx context.Context, signal, name, metricName, searchText, source string) (json.RawMessage, error)
 	GetTraceDetails(ctx context.Context, traceID string, includeSpans bool, startTime, endTime int64) (json.RawMessage, error)
+	CreateAlertRule(ctx context.Context, alertJSON []byte) (json.RawMessage, error)
 }

--- a/internal/client/mock.go
+++ b/internal/client/mock.go
@@ -30,6 +30,7 @@ type MockClient struct {
 	GetFieldKeysFn            func(ctx context.Context, signal, metricName, searchText, fieldContext, fieldDataType, source string) (json.RawMessage, error)
 	GetFieldValuesFn          func(ctx context.Context, signal, name, metricName, searchText, source string) (json.RawMessage, error)
 	GetTraceDetailsFn         func(ctx context.Context, traceID string, includeSpans bool, startTime, endTime int64) (json.RawMessage, error)
+	CreateAlertRuleFn         func(ctx context.Context, alertJSON []byte) (json.RawMessage, error)
 }
 
 // Compile-time check that MockClient satisfies Client.
@@ -164,6 +165,13 @@ func (m *MockClient) GetFieldValues(ctx context.Context, signal, name, metricNam
 func (m *MockClient) GetTraceDetails(ctx context.Context, traceID string, includeSpans bool, startTime, endTime int64) (json.RawMessage, error) {
 	if m.GetTraceDetailsFn != nil {
 		return m.GetTraceDetailsFn(ctx, traceID, includeSpans, startTime, endTime)
+	}
+	return json.RawMessage(`{}`), nil
+}
+
+func (m *MockClient) CreateAlertRule(ctx context.Context, alertJSON []byte) (json.RawMessage, error) {
+	if m.CreateAlertRuleFn != nil {
+		return m.CreateAlertRuleFn(ctx, alertJSON)
 	}
 	return json.RawMessage(`{}`), nil
 }

--- a/internal/handler/tools/alerts.go
+++ b/internal/handler/tools/alerts.go
@@ -71,8 +71,8 @@ func (h *Handler) RegisterAlertsHandlers(s *server.MCPServer) {
 				"2. signoz://alert/examples — REQUIRED: Complete working examples for each alert type\n\n"+
 				"RECOMMENDED: Use signoz_get_alert on an existing alert to study the exact structure.\n\n"+
 				"Supports all alert types (metrics, logs, traces, exceptions) and rule types (threshold, promql, anomaly).\n"+
-				"Always uses v2 schema with structured thresholds (multi-threshold with per-level channel routing), "+
-				"evaluation block, and notificationSettings. If v1-style fields (op/target/matchType) are provided, they are auto-converted to v2.\n"+
+				"Uses v2alpha1 schema with structured thresholds (multi-threshold with per-level channel routing), "+
+				"evaluation block, and notificationSettings.\n"+
 				"Labels enable routing policies — always include severity (info, warning, critical) and team/service labels for routing.",
 		),
 		mcp.WithInputSchema[types.AlertRule](),
@@ -310,7 +310,7 @@ func (h *Handler) registerAlertResources(s *server.MCPServer) {
 	alertInstructions := mcp.NewResource(
 		"signoz://alert/instructions",
 		"Alert Rule Instructions",
-		mcp.WithResourceDescription("SigNoz alert rule creation guide: alert types, rule types, condition structure, threshold configuration (v1 and v2 schema), composite query format, filter expressions, labels, routing, and notification settings."),
+		mcp.WithResourceDescription("SigNoz alert rule creation guide: alert types, rule types, condition structure, threshold configuration (v2alpha1 schema), composite query format, filter expressions, labels, routing, and notification settings."),
 		mcp.WithMIMEType("text/plain"),
 	)
 

--- a/internal/handler/tools/alerts.go
+++ b/internal/handler/tools/alerts.go
@@ -65,7 +65,7 @@ func (h *Handler) RegisterAlertsHandlers(s *server.MCPServer) {
 		mcp.WithDestructiveHintAnnotation(true),
 		mcp.WithString("searchContext", mcp.Description("The user's original question or search text that triggered this tool call. Always include the user's raw query here for better results.")),
 		mcp.WithDescription(
-			"Creates a new alert rule in SigNoz using v2 schema.\n\n"+
+			"Creates a new alert rule in SigNoz using v2alpha1 schema.\n\n"+
 				"CRITICAL: You MUST read these resources BEFORE generating any alert payload:\n"+
 				"1. signoz://alert/instructions — REQUIRED: Alert structure, field descriptions, valid values\n"+
 				"2. signoz://alert/examples — REQUIRED: Complete working examples for each alert type\n\n"+

--- a/internal/handler/tools/alerts.go
+++ b/internal/handler/tools/alerts.go
@@ -11,6 +11,7 @@ import (
 	"github.com/mark3labs/mcp-go/server"
 	"go.uber.org/zap"
 
+	"github.com/SigNoz/signoz-mcp-server/pkg/alert"
 	"github.com/SigNoz/signoz-mcp-server/pkg/paginate"
 	"github.com/SigNoz/signoz-mcp-server/pkg/timeutil"
 	"github.com/SigNoz/signoz-mcp-server/pkg/types"
@@ -58,6 +59,28 @@ func (h *Handler) RegisterAlertsHandlers(s *server.MCPServer) {
 		mcp.WithString("order", mcp.Description("Sort order: 'asc' or 'desc' (default: 'asc')")),
 	)
 	s.AddTool(alertHistoryTool, h.handleGetAlertHistory)
+
+	createAlertTool := mcp.NewTool(
+		"signoz_create_alert",
+		mcp.WithDestructiveHintAnnotation(true),
+		mcp.WithString("searchContext", mcp.Description("The user's original question or search text that triggered this tool call. Always include the user's raw query here for better results.")),
+		mcp.WithDescription(
+			"Creates a new alert rule in SigNoz using v2 schema.\n\n"+
+				"CRITICAL: You MUST read these resources BEFORE generating any alert payload:\n"+
+				"1. signoz://alert/instructions — REQUIRED: Alert structure, field descriptions, valid values\n"+
+				"2. signoz://alert/examples — REQUIRED: Complete working examples for each alert type\n\n"+
+				"RECOMMENDED: Use signoz_get_alert on an existing alert to study the exact structure.\n\n"+
+				"Supports all alert types (metrics, logs, traces, exceptions) and rule types (threshold, promql, anomaly).\n"+
+				"Always uses v2 schema with structured thresholds (multi-threshold with per-level channel routing), "+
+				"evaluation block, and notificationSettings. If v1-style fields (op/target/matchType) are provided, they are auto-converted to v2.\n"+
+				"Labels enable routing policies — always include severity (info, warning, critical) and team/service labels for routing.",
+		),
+		mcp.WithInputSchema[types.AlertRule](),
+	)
+	s.AddTool(createAlertTool, h.handleCreateAlert)
+
+	// Register alert resources for create alert
+	h.registerAlertResources(s)
 }
 
 func parseBoolParam(args map[string]any, key string) *bool {
@@ -249,4 +272,72 @@ func (h *Handler) handleGetAlertHistory(ctx context.Context, req mcp.CallToolReq
 		return mcp.NewToolResultError(err.Error()), nil
 	}
 	return mcp.NewToolResultText(string(respJSON)), nil
+}
+
+func (h *Handler) handleCreateAlert(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	log := h.tenantLogger(ctx)
+	rawConfig, ok := req.Params.Arguments.(map[string]any)
+
+	if !ok || len(rawConfig) == 0 {
+		log.Warn("Received empty or invalid arguments map for create alert.")
+		return mcp.NewToolResultError(`Parameter validation failed: The alert configuration object is empty or improperly formatted.`), nil
+	}
+
+	// Validate and normalize the alert payload.
+	cleanJSON, err := alert.ValidateFromMap(rawConfig)
+	if err != nil {
+		log.Warn("Alert validation failed", zap.Error(err))
+		return mcp.NewToolResultError(fmt.Sprintf("Alert validation error: %s", err.Error())), nil
+	}
+
+	log.Debug("Tool called: signoz_create_alert")
+	client, err := h.GetClient(ctx)
+	if err != nil {
+		return mcp.NewToolResultError(err.Error()), nil
+	}
+	data, err := client.CreateAlertRule(ctx, cleanJSON)
+
+	if err != nil {
+		log.Error("Failed to create alert rule in SigNoz", zap.Error(err))
+		return mcp.NewToolResultError(fmt.Sprintf("SigNoz API Error: %s", err.Error())), nil
+	}
+
+	return mcp.NewToolResultText(string(data)), nil
+}
+
+// registerAlertResources registers MCP resources needed for alert creation.
+func (h *Handler) registerAlertResources(s *server.MCPServer) {
+	alertInstructions := mcp.NewResource(
+		"signoz://alert/instructions",
+		"Alert Rule Instructions",
+		mcp.WithResourceDescription("SigNoz alert rule creation guide: alert types, rule types, condition structure, threshold configuration (v1 and v2 schema), composite query format, filter expressions, labels, routing, and notification settings."),
+		mcp.WithMIMEType("text/plain"),
+	)
+
+	s.AddResource(alertInstructions, func(ctx context.Context, req mcp.ReadResourceRequest) ([]mcp.ResourceContents, error) {
+		return []mcp.ResourceContents{
+			mcp.TextResourceContents{
+				URI:      req.Params.URI,
+				MIMEType: "text/plain",
+				Text:     alert.Instructions,
+			},
+		}, nil
+	})
+
+	alertExamples := mcp.NewResource(
+		"signoz://alert/examples",
+		"Alert Rule Examples",
+		mcp.WithResourceDescription("Complete working alert rule examples for all types: metrics threshold, logs with v2 multi-threshold routing, traces latency, PromQL, ClickHouse SQL exceptions, anomaly detection, and formula-based alerts."),
+		mcp.WithMIMEType("text/plain"),
+	)
+
+	s.AddResource(alertExamples, func(ctx context.Context, req mcp.ReadResourceRequest) ([]mcp.ResourceContents, error) {
+		return []mcp.ResourceContents{
+			mcp.TextResourceContents{
+				URI:      req.Params.URI,
+				MIMEType: "text/plain",
+				Text:     alert.Examples,
+			},
+		}, nil
+	})
 }

--- a/internal/handler/tools/alerts.go
+++ b/internal/handler/tools/alerts.go
@@ -283,6 +283,9 @@ func (h *Handler) handleCreateAlert(ctx context.Context, req mcp.CallToolRequest
 		return mcp.NewToolResultError(`Parameter validation failed: The alert configuration object is empty or improperly formatted.`), nil
 	}
 
+	// Remove MCP-specific metadata that is not part of the alert rule schema.
+	delete(rawConfig, "searchContext")
+
 	// Validate and normalize the alert payload.
 	cleanJSON, err := alert.ValidateFromMap(rawConfig)
 	if err != nil {

--- a/internal/handler/tools/alerts_test.go
+++ b/internal/handler/tools/alerts_test.go
@@ -435,9 +435,17 @@ func TestHandleCreateAlert(t *testing.T) {
 					},
 				},
 			},
-			"op":        "1",
-			"target":    float64(100),
-			"matchType": "1",
+			"thresholds": map[string]any{
+				"kind": "basic",
+				"spec": []any{
+					map[string]any{
+						"name":      "warning",
+						"target":    float64(100),
+						"op":        "1",
+						"matchType": "1",
+					},
+				},
+			},
 		},
 	})
 
@@ -459,6 +467,9 @@ func TestHandleCreateAlert(t *testing.T) {
 	}
 	if parsed["version"] != "v5" {
 		t.Errorf("expected version=v5, got %v", parsed["version"])
+	}
+	if parsed["schemaVersion"] != "v2alpha1" {
+		t.Errorf("expected schemaVersion=v2alpha1, got %v", parsed["schemaVersion"])
 	}
 }
 
@@ -522,9 +533,17 @@ func TestHandleCreateAlert_ClientError(t *testing.T) {
 					},
 				},
 			},
-			"op":        "1",
-			"target":    float64(100),
-			"matchType": "1",
+			"thresholds": map[string]any{
+				"kind": "basic",
+				"spec": []any{
+					map[string]any{
+						"name":      "warning",
+						"target":    float64(100),
+						"op":        "1",
+						"matchType": "1",
+					},
+				},
+			},
 		},
 	})
 

--- a/internal/handler/tools/alerts_test.go
+++ b/internal/handler/tools/alerts_test.go
@@ -403,3 +403,136 @@ func TestHandleListAlerts_FilterSplitAndTrim(t *testing.T) {
 		t.Errorf("expected second filter='severity=\"critical\"', got %q", capturedParams.Filter[1])
 	}
 }
+
+func TestHandleCreateAlert(t *testing.T) {
+	var capturedJSON []byte
+	mock := &client.MockClient{
+		CreateAlertRuleFn: func(ctx context.Context, alertJSON []byte) (json.RawMessage, error) {
+			capturedJSON = alertJSON
+			return json.RawMessage(`{"status":"success","data":{"id":"rule-123"}}`), nil
+		},
+	}
+	h := newTestHandler(mock)
+	req := makeToolRequest("signoz_create_alert", map[string]any{
+		"alert":     "Test Alert",
+		"alertType": "METRIC_BASED_ALERT",
+		"ruleType":  "threshold_rule",
+		"condition": map[string]any{
+			"compositeQuery": map[string]any{
+				"queryType": "builder",
+				"panelType": "graph",
+				"queries": []any{
+					map[string]any{
+						"type": "builder_query",
+						"spec": map[string]any{
+							"name":   "A",
+							"signal": "metrics",
+							"aggregations": []any{
+								map[string]any{"expression": "count()"},
+							},
+							"filter": map[string]any{"expression": ""},
+						},
+					},
+				},
+			},
+			"op":        "1",
+			"target":    float64(100),
+			"matchType": "1",
+		},
+	})
+
+	result, err := h.handleCreateAlert(testCtx(), req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("handler returned error result: %v", result.Content)
+	}
+	if capturedJSON == nil {
+		t.Fatal("expected CreateAlertRuleFn to be called")
+	}
+
+	// Verify defaults were applied in the JSON sent to the API
+	var parsed map[string]any
+	if err := json.Unmarshal(capturedJSON, &parsed); err != nil {
+		t.Fatalf("failed to parse captured JSON: %v", err)
+	}
+	if parsed["version"] != "v5" {
+		t.Errorf("expected version=v5, got %v", parsed["version"])
+	}
+}
+
+func TestHandleCreateAlert_EmptyArgs(t *testing.T) {
+	mock := &client.MockClient{}
+	h := newTestHandler(mock)
+	req := makeToolRequest("signoz_create_alert", map[string]any{})
+
+	result, err := h.handleCreateAlert(testCtx(), req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !result.IsError {
+		t.Error("expected error result for empty args")
+	}
+}
+
+func TestHandleCreateAlert_ValidationError(t *testing.T) {
+	mock := &client.MockClient{}
+	h := newTestHandler(mock)
+	// Missing required fields
+	req := makeToolRequest("signoz_create_alert", map[string]any{
+		"alert": "Test Alert",
+		// missing alertType, ruleType, condition
+	})
+
+	result, err := h.handleCreateAlert(testCtx(), req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !result.IsError {
+		t.Error("expected error result for validation failure")
+	}
+}
+
+func TestHandleCreateAlert_ClientError(t *testing.T) {
+	mock := &client.MockClient{
+		CreateAlertRuleFn: func(ctx context.Context, alertJSON []byte) (json.RawMessage, error) {
+			return nil, fmt.Errorf("unexpected status 400: bad request")
+		},
+	}
+	h := newTestHandler(mock)
+	req := makeToolRequest("signoz_create_alert", map[string]any{
+		"alert":     "Test Alert",
+		"alertType": "METRIC_BASED_ALERT",
+		"ruleType":  "threshold_rule",
+		"condition": map[string]any{
+			"compositeQuery": map[string]any{
+				"queryType": "builder",
+				"queries": []any{
+					map[string]any{
+						"type": "builder_query",
+						"spec": map[string]any{
+							"name":   "A",
+							"signal": "metrics",
+							"aggregations": []any{
+								map[string]any{"expression": "count()"},
+							},
+							"filter": map[string]any{"expression": ""},
+						},
+					},
+				},
+			},
+			"op":        "1",
+			"target":    float64(100),
+			"matchType": "1",
+		},
+	})
+
+	result, err := h.handleCreateAlert(testCtx(), req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !result.IsError {
+		t.Error("expected error result when client returns error")
+	}
+}

--- a/internal/handler/tools/alerts_test.go
+++ b/internal/handler/tools/alerts_test.go
@@ -473,6 +473,66 @@ func TestHandleCreateAlert(t *testing.T) {
 	}
 }
 
+func TestHandleCreateAlert_StripsSearchContext(t *testing.T) {
+	var capturedJSON []byte
+	mock := &client.MockClient{
+		CreateAlertRuleFn: func(ctx context.Context, alertJSON []byte) (json.RawMessage, error) {
+			capturedJSON = alertJSON
+			return json.RawMessage(`{"status":"success","data":{"id":"rule-456"}}`), nil
+		},
+	}
+	h := newTestHandler(mock)
+	req := makeToolRequest("signoz_create_alert", map[string]any{
+		"searchContext": "user wants to create an alert for high CPU",
+		"alert":         "CPU Alert",
+		"alertType":     "METRIC_BASED_ALERT",
+		"ruleType":      "threshold_rule",
+		"condition": map[string]any{
+			"compositeQuery": map[string]any{
+				"queryType": "builder",
+				"queries": []any{
+					map[string]any{
+						"type": "builder_query",
+						"spec": map[string]any{
+							"name":   "A",
+							"signal": "metrics",
+							"aggregations": []any{
+								map[string]any{"expression": "count()"},
+							},
+							"filter": map[string]any{"expression": ""},
+						},
+					},
+				},
+			},
+			"thresholds": map[string]any{
+				"kind": "basic",
+				"spec": []any{
+					map[string]any{
+						"name": "warning", "target": float64(90),
+						"op": "1", "matchType": "1",
+					},
+				},
+			},
+		},
+	})
+
+	result, err := h.handleCreateAlert(testCtx(), req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("handler returned error result: %v", result.Content)
+	}
+
+	var parsed map[string]any
+	if err := json.Unmarshal(capturedJSON, &parsed); err != nil {
+		t.Fatalf("failed to parse captured JSON: %v", err)
+	}
+	if _, hasSearchContext := parsed["searchContext"]; hasSearchContext {
+		t.Error("searchContext should be stripped from the API payload")
+	}
+}
+
 func TestHandleCreateAlert_EmptyArgs(t *testing.T) {
 	mock := &client.MockClient{}
 	h := newTestHandler(mock)

--- a/internal/mcp-server/integration_test.go
+++ b/internal/mcp-server/integration_test.go
@@ -83,7 +83,7 @@ func TestIntegration_InitializeAndListTools(t *testing.T) {
 		t.Fatalf("ListTools failed: %v", err)
 	}
 
-	const expectedToolCount = 22
+	const expectedToolCount = 23
 	if len(toolsResult.Tools) != expectedToolCount {
 		t.Errorf("expected %d tools, got %d", expectedToolCount, len(toolsResult.Tools))
 		for _, tool := range toolsResult.Tools {

--- a/pkg/alert/resources.go
+++ b/pkg/alert/resources.go
@@ -75,6 +75,34 @@ The filter.expression field uses SigNoz query syntax:
 - IN: severity_text IN ('ERROR', 'WARN', 'FATAL')
 - EXISTS: trace_id EXISTS
 
+## Formulas (builder_formula)
+
+Formulas combine multiple queries using math expressions. Add a builder_formula entry in the queries array:
+
+` + "```" + `json
+{
+  "type": "builder_formula",
+  "spec": {
+    "name": "F1",
+    "expression": "A * 100 / B"
+  }
+}
+` + "```" + `
+
+- name: formula identifier (F1, F2, etc.)
+- expression: math expression referencing other query names (A, B, C). Supports +, -, *, /, and functions like abs(), sqrt(), log(), exp()
+- Set selectedQueryName to the formula name (e.g. "F1") so the alert triggers on the formula result
+
+## Units
+
+Set compositeQuery.unit to specify the unit of the queried data (Y-axis). This is used for:
+- Value formatting in alert messages ({{$value}})
+- Unit conversion when targetUnit on a threshold differs from the query unit
+
+Common units: percent, ms, s, ns, bytes, kbytes, mbytes, gbytes, reqps, ops, cps
+
+When compositeQuery.unit and threshold targetUnit differ, SigNoz auto-converts during evaluation (e.g. query returns bytes but threshold is in gbytes).
+
 ## Threshold Configuration
 
 Use condition.thresholds to define alert thresholds. Each threshold level can route to different channels:
@@ -108,7 +136,7 @@ Use condition.thresholds to define alert thresholds. Each threshold level can ro
 ### Threshold Fields
 - name: severity level (critical, warning, or info)
 - target: numeric threshold value
-- targetUnit: unit for display (e.g. ms, percent, bytes)
+- targetUnit: unit of the target value (e.g. ms, percent, bytes). Auto-converted to compositeQuery.unit during evaluation
 - recoveryTarget: value for recovery (null if not needed)
 - matchType: 1=at_least_once, 2=all_the_times, 3=on_average, 4=in_total, 5=last
 - op: 1=above, 2=below, 3=equal, 4=not_equal
@@ -612,6 +640,7 @@ Use two queries and a formula to calculate error rate percentage.
     "compositeQuery": {
       "queryType": "builder",
       "panelType": "graph",
+      "unit": "percent",
       "queries": [
         {
           "type": "builder_query",

--- a/pkg/alert/resources.go
+++ b/pkg/alert/resources.go
@@ -5,7 +5,7 @@ const Instructions = `# SigNoz Alert Rule — Instructions
 
 ## Overview
 An alert rule monitors a signal (metrics, logs, traces, or exceptions) and fires when a condition is met.
-The alert is created via POST /api/v1/rules. All alerts use v2 schema with structured thresholds and evaluation.
+The alert is created via POST /api/v1/rules. All alerts use v2alpha1 schema with structured thresholds and evaluation.
 
 ## CRITICAL: Before Creating an Alert
 1. ALWAYS read signoz://alert/examples for complete working payloads
@@ -172,7 +172,7 @@ Controls grouping and re-notification:
 
 ## Auto-Applied Defaults
 - version → "v5"
-- schemaVersion → "v2"
+- schemaVersion → "v2alpha1"
 - evaluation → {kind: "rolling", spec: {evalWindow: "5m0s", frequency: "1m0s"}}
 - notificationSettings → {renotify: {enabled: false, interval: "30m"}}
 - panelType → "graph"
@@ -180,13 +180,12 @@ Controls grouping and re-notification:
 - source → "mcp"
 - labels.severity → "warning" (if not set)
 - annotations → default description and summary templates
-- If op/target/matchType are provided without thresholds, they are auto-converted to v2 thresholds
 `
 
 // Examples is the MCP resource content for signoz://alert/examples.
 const Examples = `# SigNoz Alert Rule — Examples
 
-All examples use v2 schema. Fields like schemaVersion, evaluation, and notificationSettings
+All examples use v2alpha1 schema. Fields like schemaVersion, evaluation, and notificationSettings
 are auto-generated if omitted, but shown here for clarity.
 
 ## Example 1: Metrics Threshold Alert
@@ -682,6 +681,5 @@ Use two queries and a formula to calculate error rate percentage.
 3. The selectedQueryName should reference the query or formula that determines the alert condition
 4. Use signoz_get_alert to inspect existing alerts for the exact format your SigNoz version expects
 5. Channel names in thresholds.spec[].channels must match exactly the channel names configured in SigNoz
-6. If you provide deprecated v1 fields (op/target/matchType at condition level), they are auto-converted to v2 thresholds
-7. schemaVersion, evaluation, and notificationSettings are auto-generated if omitted
+6. schemaVersion, evaluation, and notificationSettings are auto-generated if omitted
 `

--- a/pkg/alert/resources.go
+++ b/pkg/alert/resources.go
@@ -11,6 +11,7 @@ The alert is created via POST /api/v1/rules. All alerts use v2alpha1 schema with
 1. ALWAYS read signoz://alert/examples for complete working payloads
 2. Use signoz_get_alert on an existing alert to study the exact structure your SigNoz instance expects
 3. Use signoz_get_field_keys to discover available attributes for filters and groupBy
+4. Use signoz_list_notification_channels to discover available notification channel names for thresholds and preferredChannels
 
 ## Alert Types (alertType)
 | Value | Signal | Use When |
@@ -111,7 +112,7 @@ Use condition.thresholds to define alert thresholds. Each threshold level can ro
 - recoveryTarget: value for recovery (null if not needed)
 - matchType: 1=at_least_once, 2=all_the_times, 3=on_average, 4=in_total, 5=last
 - op: 1=above, 2=below, 3=equal, 4=not_equal
-- channels: notification channel names for this threshold level
+- channels: notification channel names for this threshold level (use signoz_list_notification_channels to discover available names)
 
 ## Evaluation Configuration
 
@@ -154,7 +155,7 @@ Controls grouping and re-notification:
 ## Labels & Routing
 - labels.severity: MUST be set (info, warning, or critical) — auto-defaults to warning
 - Additional labels like team, service, environment enable routing policies
-- preferredChannels: fallback notification channel names (thresholds.channels takes priority)
+- preferredChannels: fallback notification channel names (thresholds.channels takes priority). Use signoz_list_notification_channels to discover available names
 - Set usePolicy: true in notificationSettings to enable label-based routing
 
 ## Annotations
@@ -680,6 +681,6 @@ Use two queries and a formula to calculate error rate percentage.
 2. For logs/traces alerts, aggregations use the expression format: {expression: "count()"} or {expression: "avg(duration)"}
 3. The selectedQueryName should reference the query or formula that determines the alert condition
 4. Use signoz_get_alert to inspect existing alerts for the exact format your SigNoz version expects
-5. Channel names in thresholds.spec[].channels must match exactly the channel names configured in SigNoz
+5. Channel names in thresholds.spec[].channels must match exactly the names from signoz_list_notification_channels
 6. schemaVersion, evaluation, and notificationSettings are auto-generated if omitted
 `

--- a/pkg/alert/resources.go
+++ b/pkg/alert/resources.go
@@ -1,0 +1,687 @@
+package alert
+
+// Instructions is the MCP resource content for signoz://alert/instructions.
+const Instructions = `# SigNoz Alert Rule — Instructions
+
+## Overview
+An alert rule monitors a signal (metrics, logs, traces, or exceptions) and fires when a condition is met.
+The alert is created via POST /api/v1/rules. All alerts use v2 schema with structured thresholds and evaluation.
+
+## CRITICAL: Before Creating an Alert
+1. ALWAYS read signoz://alert/examples for complete working payloads
+2. Use signoz_get_alert on an existing alert to study the exact structure your SigNoz instance expects
+3. Use signoz_get_field_keys to discover available attributes for filters and groupBy
+
+## Alert Types (alertType)
+| Value | Signal | Use When |
+|-------|--------|----------|
+| METRIC_BASED_ALERT | metrics | Monitoring numeric metrics (CPU, memory, request rate, latency) |
+| LOGS_BASED_ALERT | logs | Monitoring log patterns, error counts, log volume |
+| TRACES_BASED_ALERT | traces | Monitoring span latency, error rates, throughput |
+| EXCEPTIONS_BASED_ALERT | exceptions | Monitoring exception counts (typically uses clickhouse_sql) |
+
+## Rule Types (ruleType)
+| Value | Description | Constraints |
+|-------|-------------|-------------|
+| threshold_rule | Compare metric against a static threshold | Works with all alert types |
+| promql_rule | Evaluate a PromQL expression | queryType must be "promql" |
+| anomaly_rule | Detect anomalies using seasonal decomposition | Only with METRIC_BASED_ALERT |
+
+## Composite Query Structure
+
+### Query Format
+The condition.compositeQuery uses the v5 query format:
+- queryType: "builder" | "promql" | "clickhouse_sql"
+- panelType: always "graph" for alerts (auto-set)
+- queries: array of query objects
+
+### Builder Query Format
+Each query in the queries array has:
+- type: "builder_query" (for data queries) or "builder_formula" (for formulas like A/B*100)
+- spec: query specification
+
+For builder_query spec:
+- name: query identifier (A, B, C...)
+- signal: "metrics" | "logs" | "traces" (must match alertType)
+- aggregations: [{expression: "count()"}, {expression: "avg(duration)"}]
+- filter: {expression: "service.name = 'frontend' AND http.status_code >= 500"}
+- groupBy: [{name: "service.name", fieldContext: "resource", fieldDataType: "string"}]
+- stepInterval: interval in seconds (use 60 for most alerts)
+
+For promql/clickhouse_sql queries:
+- name: query identifier
+- query: the PromQL or SQL string
+- legend: legend template
+- disabled: false
+
+### Aggregation Expressions
+Common expressions for the aggregations field:
+- count() — count of items
+- avg(fieldName) — average of a field
+- sum(fieldName) — sum of a field
+- min(fieldName) / max(fieldName)
+- p50(fieldName) / p75(fieldName) / p90(fieldName) / p95(fieldName) / p99(fieldName)
+- count_distinct(fieldName) — count of unique values
+- rate(fieldName) — rate of change
+
+### Filter Expressions
+The filter.expression field uses SigNoz query syntax:
+- Equality: service.name = 'frontend'
+- Comparison: http.status_code >= 500
+- Pattern: body CONTAINS 'timeout'
+- Case-insensitive: body ILIKE '%error%'
+- Boolean: service.name = 'frontend' AND http.status_code >= 500
+- IN: severity_text IN ('ERROR', 'WARN', 'FATAL')
+- EXISTS: trace_id EXISTS
+
+## Threshold Configuration
+
+Use condition.thresholds to define alert thresholds. Each threshold level can route to different channels:
+
+` + "```" + `json
+"thresholds": {
+  "kind": "basic",
+  "spec": [
+    {
+      "name": "critical",
+      "target": 1000,
+      "targetUnit": "",
+      "recoveryTarget": null,
+      "matchType": "1",
+      "op": "1",
+      "channels": ["pagerduty-oncall", "slack-alerts"]
+    },
+    {
+      "name": "warning",
+      "target": 100,
+      "targetUnit": "",
+      "recoveryTarget": null,
+      "matchType": "1",
+      "op": "1",
+      "channels": ["slack-alerts"]
+    }
+  ]
+}
+` + "```" + `
+
+### Threshold Fields
+- name: severity level (critical, warning, or info)
+- target: numeric threshold value
+- targetUnit: unit for display (e.g. ms, percent, bytes)
+- recoveryTarget: value for recovery (null if not needed)
+- matchType: 1=at_least_once, 2=all_the_times, 3=on_average, 4=in_total, 5=last
+- op: 1=above, 2=below, 3=equal, 4=not_equal
+- channels: notification channel names for this threshold level
+
+## Evaluation Configuration
+
+Use the evaluation field to control how often the alert is checked:
+
+` + "```" + `json
+"evaluation": {
+  "kind": "rolling",
+  "spec": {
+    "evalWindow": "5m0s",
+    "frequency": "1m0s"
+  }
+}
+` + "```" + `
+
+- evalWindow: how long the condition must persist (5m0s, 10m0s, 15m0s, 1h0m0s, 4h0m0s, 24h0m0s)
+- frequency: how often to evaluate (1m0s, 5m0s)
+- Auto-generated with defaults (5m0s window, 1m0s frequency) if omitted
+
+## Notification Settings
+
+Controls grouping and re-notification:
+
+` + "```" + `json
+"notificationSettings": {
+  "groupBy": ["service.name"],
+  "renotify": {
+    "enabled": true,
+    "interval": "4h0m0s",
+    "alertStates": ["firing", "nodata"]
+  },
+  "usePolicy": true
+}
+` + "```" + `
+
+- groupBy: fields to group notifications by (reduces noise)
+- renotify: re-send alerts at interval for specified states
+- usePolicy: enable routing policy matching based on labels
+
+## Labels & Routing
+- labels.severity: MUST be set (info, warning, or critical) — auto-defaults to warning
+- Additional labels like team, service, environment enable routing policies
+- preferredChannels: fallback notification channel names (thresholds.channels takes priority)
+- Set usePolicy: true in notificationSettings to enable label-based routing
+
+## Annotations
+- Use {{$value}} for the current metric value
+- Use {{$threshold}} for the threshold value
+- Use {{$labels.key}} for label values
+- Common annotations: description, summary, runbook
+
+## Anomaly Alerts (ruleType: anomaly_rule)
+- Must use alertType: METRIC_BASED_ALERT
+- Set condition.algorithm: "zscore"
+- Set condition.seasonality: "hourly" | "daily" | "weekly"
+- target in thresholds is the Z-score threshold (e.g., 3 for 3 standard deviations)
+- op should be "1" (above) for standard anomaly detection
+
+## Auto-Applied Defaults
+- version → "v5"
+- schemaVersion → "v2"
+- evaluation → {kind: "rolling", spec: {evalWindow: "5m0s", frequency: "1m0s"}}
+- notificationSettings → {renotify: {enabled: false, interval: "30m"}}
+- panelType → "graph"
+- selectedQueryName → first query name
+- source → "mcp"
+- labels.severity → "warning" (if not set)
+- annotations → default description and summary templates
+- If op/target/matchType are provided without thresholds, they are auto-converted to v2 thresholds
+`
+
+// Examples is the MCP resource content for signoz://alert/examples.
+const Examples = `# SigNoz Alert Rule — Examples
+
+All examples use v2 schema. Fields like schemaVersion, evaluation, and notificationSettings
+are auto-generated if omitted, but shown here for clarity.
+
+## Example 1: Metrics Threshold Alert
+Alert when average CPU usage exceeds 80%.
+
+` + "```" + `json
+{
+  "alert": "High CPU Usage",
+  "alertType": "METRIC_BASED_ALERT",
+  "ruleType": "threshold_rule",
+  "condition": {
+    "compositeQuery": {
+      "queryType": "builder",
+      "panelType": "graph",
+      "queries": [
+        {
+          "type": "builder_query",
+          "spec": {
+            "name": "A",
+            "signal": "metrics",
+            "stepInterval": 60,
+            "aggregations": [
+              {
+                "metricName": "system.cpu.utilization",
+                "timeAggregation": "avg",
+                "spaceAggregation": "avg"
+              }
+            ],
+            "filter": {"expression": ""},
+            "groupBy": [
+              {"name": "host.name", "fieldContext": "resource", "fieldDataType": "string"}
+            ],
+            "having": {"expression": ""}
+          }
+        }
+      ]
+    },
+    "selectedQueryName": "A",
+    "thresholds": {
+      "kind": "basic",
+      "spec": [
+        {
+          "name": "critical",
+          "target": 90,
+          "targetUnit": "percent",
+          "recoveryTarget": null,
+          "matchType": "1",
+          "op": "1",
+          "channels": ["pagerduty-infra", "slack-infra"]
+        },
+        {
+          "name": "warning",
+          "target": 80,
+          "targetUnit": "percent",
+          "recoveryTarget": null,
+          "matchType": "1",
+          "op": "1",
+          "channels": ["slack-infra"]
+        }
+      ]
+    }
+  },
+  "labels": {
+    "severity": "critical",
+    "team": "infrastructure"
+  },
+  "annotations": {
+    "description": "CPU usage is {{$value}}% on host {{$labels.host_name}}, exceeding threshold of {{$threshold}}%",
+    "summary": "High CPU usage detected"
+  },
+  "evaluation": {
+    "kind": "rolling",
+    "spec": {
+      "evalWindow": "5m0s",
+      "frequency": "1m0s"
+    }
+  },
+  "notificationSettings": {
+    "groupBy": ["host.name"],
+    "renotify": {
+      "enabled": true,
+      "interval": "4h0m0s",
+      "alertStates": ["firing"]
+    }
+  }
+}
+` + "```" + `
+
+## Example 2: Logs Alert with Multi-Threshold Routing
+Alert on high error log volume with different thresholds routing to different channels.
+
+` + "```" + `json
+{
+  "alert": "High Error Log Volume",
+  "alertType": "LOGS_BASED_ALERT",
+  "ruleType": "threshold_rule",
+  "condition": {
+    "compositeQuery": {
+      "queryType": "builder",
+      "panelType": "graph",
+      "queries": [
+        {
+          "type": "builder_query",
+          "spec": {
+            "name": "A",
+            "signal": "logs",
+            "aggregations": [
+              {"expression": "count()"}
+            ],
+            "filter": {"expression": "severity_text IN ('ERROR', 'FATAL')"},
+            "groupBy": [
+              {"name": "service.name", "fieldContext": "resource", "fieldDataType": "string"}
+            ],
+            "having": {"expression": ""}
+          }
+        }
+      ]
+    },
+    "selectedQueryName": "A",
+    "thresholds": {
+      "kind": "basic",
+      "spec": [
+        {
+          "name": "critical",
+          "target": 1000,
+          "targetUnit": "",
+          "recoveryTarget": null,
+          "matchType": "1",
+          "op": "1",
+          "channels": ["pagerduty-oncall", "slack-alerts"]
+        },
+        {
+          "name": "warning",
+          "target": 100,
+          "targetUnit": "",
+          "recoveryTarget": null,
+          "matchType": "1",
+          "op": "1",
+          "channels": ["slack-alerts"]
+        }
+      ]
+    }
+  },
+  "labels": {
+    "severity": "critical",
+    "team": "backend"
+  },
+  "annotations": {
+    "description": "Error log count for {{$labels.service_name}} is {{$value}}, threshold: {{$threshold}}",
+    "summary": "High error log volume"
+  },
+  "evaluation": {
+    "kind": "rolling",
+    "spec": {
+      "evalWindow": "5m0s",
+      "frequency": "1m0s"
+    }
+  },
+  "notificationSettings": {
+    "groupBy": ["service.name"],
+    "renotify": {
+      "enabled": true,
+      "interval": "4h0m0s",
+      "alertStates": ["firing"]
+    },
+    "usePolicy": true
+  }
+}
+` + "```" + `
+
+## Example 3: Traces Alert (Latency Monitoring)
+Alert when p99 latency exceeds 2 seconds for any service.
+
+` + "```" + `json
+{
+  "alert": "High P99 Latency",
+  "alertType": "TRACES_BASED_ALERT",
+  "ruleType": "threshold_rule",
+  "condition": {
+    "compositeQuery": {
+      "queryType": "builder",
+      "panelType": "graph",
+      "queries": [
+        {
+          "type": "builder_query",
+          "spec": {
+            "name": "A",
+            "signal": "traces",
+            "stepInterval": 60,
+            "aggregations": [
+              {"expression": "p99(durationNano)"}
+            ],
+            "filter": {"expression": ""},
+            "groupBy": [
+              {"name": "service.name", "fieldContext": "resource", "fieldDataType": "string"},
+              {"name": "name", "fieldDataType": "string"}
+            ],
+            "having": {"expression": ""}
+          }
+        }
+      ]
+    },
+    "selectedQueryName": "A",
+    "thresholds": {
+      "kind": "basic",
+      "spec": [
+        {
+          "name": "warning",
+          "target": 2000000000,
+          "targetUnit": "ns",
+          "recoveryTarget": null,
+          "matchType": "1",
+          "op": "1"
+        }
+      ]
+    }
+  },
+  "labels": {
+    "severity": "warning"
+  },
+  "annotations": {
+    "description": "P99 latency for {{$labels.service_name}} {{$labels.name}} is {{$value}}ns (threshold: {{$threshold}}ns)",
+    "summary": "High latency detected"
+  },
+  "evaluation": {
+    "kind": "rolling",
+    "spec": {
+      "evalWindow": "5m0s",
+      "frequency": "1m0s"
+    }
+  }
+}
+` + "```" + `
+
+## Example 4: PromQL Alert
+Alert using a PromQL expression for request error rate.
+
+` + "```" + `json
+{
+  "alert": "High Error Rate",
+  "alertType": "METRIC_BASED_ALERT",
+  "ruleType": "promql_rule",
+  "condition": {
+    "compositeQuery": {
+      "queryType": "promql",
+      "panelType": "graph",
+      "queries": [
+        {
+          "type": "builder_query",
+          "spec": {
+            "name": "A",
+            "query": "sum(rate(signoz_calls_total{status_code='STATUS_CODE_ERROR'}[5m])) / sum(rate(signoz_calls_total[5m])) * 100",
+            "legend": "",
+            "disabled": false
+          }
+        }
+      ]
+    },
+    "selectedQueryName": "A",
+    "thresholds": {
+      "kind": "basic",
+      "spec": [
+        {
+          "name": "critical",
+          "target": 5,
+          "targetUnit": "percent",
+          "recoveryTarget": null,
+          "matchType": "1",
+          "op": "1"
+        }
+      ]
+    }
+  },
+  "labels": {
+    "severity": "critical"
+  },
+  "annotations": {
+    "description": "Error rate is {{$value}}% (threshold: {{$threshold}}%)",
+    "summary": "High error rate detected"
+  },
+  "evaluation": {
+    "kind": "rolling",
+    "spec": {
+      "evalWindow": "5m0s",
+      "frequency": "1m0s"
+    }
+  }
+}
+` + "```" + `
+
+## Example 5: ClickHouse SQL Alert (Exceptions)
+Alert on exception count using ClickHouse SQL.
+
+` + "```" + `json
+{
+  "alert": "High Exception Count",
+  "alertType": "EXCEPTIONS_BASED_ALERT",
+  "ruleType": "threshold_rule",
+  "condition": {
+    "compositeQuery": {
+      "queryType": "clickhouse_sql",
+      "panelType": "graph",
+      "queries": [
+        {
+          "type": "builder_query",
+          "spec": {
+            "name": "A",
+            "query": "SELECT toStartOfInterval(timestamp, INTERVAL 1 MINUTE) AS ts, count() AS value FROM signoz_traces.distributed_signoz_error_index_v2 WHERE timestamp >= now() - INTERVAL 5 MINUTE AND exceptionType != '' GROUP BY ts ORDER BY ts",
+            "legend": "",
+            "disabled": false
+          }
+        }
+      ]
+    },
+    "selectedQueryName": "A",
+    "thresholds": {
+      "kind": "basic",
+      "spec": [
+        {
+          "name": "warning",
+          "target": 50,
+          "targetUnit": "",
+          "recoveryTarget": null,
+          "matchType": "4",
+          "op": "1"
+        }
+      ]
+    }
+  },
+  "labels": {
+    "severity": "warning"
+  },
+  "annotations": {
+    "description": "Exception count is {{$value}} (threshold: {{$threshold}})",
+    "summary": "High exception count"
+  },
+  "evaluation": {
+    "kind": "rolling",
+    "spec": {
+      "evalWindow": "5m0s",
+      "frequency": "1m0s"
+    }
+  }
+}
+` + "```" + `
+
+## Example 6: Anomaly Detection Alert
+Detect anomalous metric behavior using seasonal decomposition.
+
+` + "```" + `json
+{
+  "alert": "Anomalous Request Rate",
+  "alertType": "METRIC_BASED_ALERT",
+  "ruleType": "anomaly_rule",
+  "condition": {
+    "compositeQuery": {
+      "queryType": "builder",
+      "panelType": "graph",
+      "queries": [
+        {
+          "type": "builder_query",
+          "spec": {
+            "name": "A",
+            "signal": "metrics",
+            "stepInterval": 60,
+            "aggregations": [
+              {
+                "metricName": "signoz_calls_total",
+                "timeAggregation": "rate",
+                "spaceAggregation": "sum"
+              }
+            ],
+            "filter": {"expression": ""},
+            "groupBy": [],
+            "having": {"expression": ""}
+          }
+        }
+      ]
+    },
+    "selectedQueryName": "A",
+    "algorithm": "zscore",
+    "seasonality": "daily",
+    "thresholds": {
+      "kind": "basic",
+      "spec": [
+        {
+          "name": "warning",
+          "target": 3,
+          "targetUnit": "",
+          "recoveryTarget": null,
+          "matchType": "1",
+          "op": "1"
+        }
+      ]
+    }
+  },
+  "labels": {
+    "severity": "warning"
+  },
+  "annotations": {
+    "description": "Anomalous request rate detected: Z-score is {{$value}} (threshold: {{$threshold}})",
+    "summary": "Request rate anomaly"
+  },
+  "evaluation": {
+    "kind": "rolling",
+    "spec": {
+      "evalWindow": "5m0s",
+      "frequency": "1m0s"
+    }
+  }
+}
+` + "```" + `
+
+## Example 7: Logs Alert with Formula (Error Rate %)
+Use two queries and a formula to calculate error rate percentage.
+
+` + "```" + `json
+{
+  "alert": "Log Error Rate High",
+  "alertType": "LOGS_BASED_ALERT",
+  "ruleType": "threshold_rule",
+  "condition": {
+    "compositeQuery": {
+      "queryType": "builder",
+      "panelType": "graph",
+      "queries": [
+        {
+          "type": "builder_query",
+          "spec": {
+            "name": "A",
+            "signal": "logs",
+            "aggregations": [{"expression": "count()"}],
+            "filter": {"expression": "severity_text IN ('ERROR', 'FATAL')"},
+            "groupBy": [],
+            "having": {"expression": ""}
+          }
+        },
+        {
+          "type": "builder_query",
+          "spec": {
+            "name": "B",
+            "signal": "logs",
+            "aggregations": [{"expression": "count()"}],
+            "filter": {"expression": ""},
+            "groupBy": [],
+            "having": {"expression": ""}
+          }
+        },
+        {
+          "type": "builder_formula",
+          "spec": {
+            "name": "F1",
+            "expression": "A * 100 / B"
+          }
+        }
+      ]
+    },
+    "selectedQueryName": "F1",
+    "thresholds": {
+      "kind": "basic",
+      "spec": [
+        {
+          "name": "warning",
+          "target": 10,
+          "targetUnit": "percent",
+          "recoveryTarget": null,
+          "matchType": "1",
+          "op": "1"
+        }
+      ]
+    }
+  },
+  "labels": {
+    "severity": "warning"
+  },
+  "annotations": {
+    "description": "Log error rate is {{$value}}% (threshold: {{$threshold}}%)",
+    "summary": "High log error rate"
+  },
+  "evaluation": {
+    "kind": "rolling",
+    "spec": {
+      "evalWindow": "5m0s",
+      "frequency": "1m0s"
+    }
+  }
+}
+` + "```" + `
+
+## Key Notes
+1. For metrics alerts, aggregations use the object format with metricName, timeAggregation, spaceAggregation
+2. For logs/traces alerts, aggregations use the expression format: {expression: "count()"} or {expression: "avg(duration)"}
+3. The selectedQueryName should reference the query or formula that determines the alert condition
+4. Use signoz_get_alert to inspect existing alerts for the exact format your SigNoz version expects
+5. Channel names in thresholds.spec[].channels must match exactly the channel names configured in SigNoz
+6. If you provide deprecated v1 fields (op/target/matchType at condition level), they are auto-converted to v2 thresholds
+7. schemaVersion, evaluation, and notificationSettings are auto-generated if omitted
+`

--- a/pkg/alert/validate.go
+++ b/pkg/alert/validate.go
@@ -238,6 +238,13 @@ func validateCondition(rule map[string]any, errs *ValidationError) {
 				errs.Addf(prefix+".spec.query", "is required for %s queries", queryType)
 			}
 		}
+
+		// For builder_formula, require expression
+		if qType == "builder_formula" {
+			if strVal(spec, "expression") == "" {
+				errs.Add(prefix+".spec.expression", "is required for builder_formula (e.g. A / B * 100)")
+			}
+		}
 	}
 
 	// Validate v2alpha1 thresholds structure

--- a/pkg/alert/validate.go
+++ b/pkg/alert/validate.go
@@ -1,0 +1,497 @@
+// Package alert provides validation and normalization for SigNoz alert rule
+// payloads before they are sent to the SigNoz API.
+package alert
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// Valid enum values for alert fields.
+var (
+	validAlertTypes = map[string]bool{
+		"METRIC_BASED_ALERT":     true,
+		"LOGS_BASED_ALERT":       true,
+		"TRACES_BASED_ALERT":     true,
+		"EXCEPTIONS_BASED_ALERT": true,
+	}
+
+	validRuleTypes = map[string]bool{
+		"threshold_rule": true,
+		"promql_rule":    true,
+		"anomaly_rule":   true,
+	}
+
+	validQueryTypes = map[string]bool{
+		"builder":        true,
+		"promql":         true,
+		"clickhouse_sql": true,
+	}
+
+	validCompareOps = map[string]bool{
+		"1": true, "2": true, "3": true, "4": true,
+		"above": true, "below": true, "equal": true, "not_equal": true,
+	}
+
+	validMatchTypes = map[string]bool{
+		"1": true, "2": true, "3": true, "4": true, "5": true,
+		"at_least_once": true, "all_the_times": true,
+		"on_average": true, "in_total": true, "last": true,
+	}
+
+	validBuilderQueryTypes = map[string]bool{
+		"builder_query":   true,
+		"builder_formula": true,
+	}
+
+	validSignals = map[string]bool{
+		"metrics": true,
+		"logs":    true,
+		"traces":  true,
+	}
+
+	// alertTypeToSignal maps alert types to their expected builder query signals.
+	alertTypeToSignal = map[string]string{
+		"METRIC_BASED_ALERT": "metrics",
+		"LOGS_BASED_ALERT":   "logs",
+		"TRACES_BASED_ALERT": "traces",
+	}
+)
+
+// ValidationError accumulates multiple validation errors.
+type ValidationError struct {
+	errors []string
+}
+
+func (v *ValidationError) Add(field, msg string) {
+	v.errors = append(v.errors, fmt.Sprintf("%s: %s", field, msg))
+}
+
+func (v *ValidationError) Addf(field, format string, args ...any) {
+	v.errors = append(v.errors, fmt.Sprintf("%s: %s", field, fmt.Sprintf(format, args...)))
+}
+
+func (v *ValidationError) HasErrors() bool {
+	return len(v.errors) > 0
+}
+
+func (v *ValidationError) Error() string {
+	return fmt.Sprintf("alert validation failed with %d error(s):\n  %s",
+		len(v.errors), strings.Join(v.errors, "\n  "))
+}
+
+// ValidateFromMap validates an alert rule from a map[string]any (MCP tool arguments),
+// applies defaults, and returns clean JSON bytes ready for the SigNoz API.
+func ValidateFromMap(m map[string]any) ([]byte, error) {
+	jsonBytes, err := json.Marshal(m)
+	if err != nil {
+		return nil, fmt.Errorf("cannot marshal arguments: %w", err)
+	}
+	return Validate(jsonBytes)
+}
+
+// Validate parses raw alert JSON, validates required fields, enums, condition
+// structure, cross-validates alert type vs query signal, applies defaults, and
+// returns normalized JSON bytes.
+func Validate(jsonBytes []byte) ([]byte, error) {
+	var rule map[string]any
+	if err := json.Unmarshal(jsonBytes, &rule); err != nil {
+		return nil, fmt.Errorf("invalid JSON: %w", err)
+	}
+
+	errs := &ValidationError{}
+
+	validateRequired(rule, errs)
+	validateEnums(rule, errs)
+	validateCondition(rule, errs)
+	validateCrossConstraints(rule, errs)
+
+	if errs.HasErrors() {
+		return nil, errs
+	}
+
+	applyDefaults(rule)
+	upgradeToV2(rule)
+
+	out, err := json.Marshal(rule)
+	if err != nil {
+		return nil, fmt.Errorf("failed to serialize validated alert: %w", err)
+	}
+	return out, nil
+}
+
+// validateRequired checks that all required top-level fields are present.
+func validateRequired(rule map[string]any, errs *ValidationError) {
+	if strVal(rule, "alert") == "" {
+		errs.Add("alert", "is required and must not be empty")
+	}
+	if strVal(rule, "alertType") == "" {
+		errs.Add("alertType", "is required (METRIC_BASED_ALERT, LOGS_BASED_ALERT, TRACES_BASED_ALERT, or EXCEPTIONS_BASED_ALERT)")
+	}
+	if strVal(rule, "ruleType") == "" {
+		errs.Add("ruleType", "is required (threshold_rule, promql_rule, or anomaly_rule)")
+	}
+	if _, ok := rule["condition"]; !ok {
+		errs.Add("condition", "is required")
+	}
+}
+
+// validateEnums checks that enum fields have valid values.
+func validateEnums(rule map[string]any, errs *ValidationError) {
+	if at := strVal(rule, "alertType"); at != "" && !validAlertTypes[at] {
+		errs.Addf("alertType", "must be one of METRIC_BASED_ALERT, LOGS_BASED_ALERT, TRACES_BASED_ALERT, EXCEPTIONS_BASED_ALERT; got %q", at)
+	}
+	if rt := strVal(rule, "ruleType"); rt != "" && !validRuleTypes[rt] {
+		errs.Addf("ruleType", "must be one of threshold_rule, promql_rule, anomaly_rule; got %q", rt)
+	}
+
+	cond := mapVal(rule, "condition")
+	if cond == nil {
+		return
+	}
+
+	// op and matchType are optional (v2 schema uses thresholds instead)
+	if op := strVal(cond, "op"); op != "" && !validCompareOps[op] {
+		errs.Addf("condition.op", "must be one of 1(above), 2(below), 3(equal), 4(not_equal); got %q", op)
+	}
+	if mt := strVal(cond, "matchType"); mt != "" && !validMatchTypes[mt] {
+		errs.Addf("condition.matchType", "must be one of 1(at_least_once), 2(all_the_times), 3(on_average), 4(in_total), 5(last); got %q", mt)
+	}
+
+	cq := mapVal(cond, "compositeQuery")
+	if cq != nil {
+		if qt := strVal(cq, "queryType"); qt != "" && !validQueryTypes[qt] {
+			errs.Addf("condition.compositeQuery.queryType", "must be one of builder, promql, clickhouse_sql; got %q", qt)
+		}
+	}
+}
+
+// validateCondition checks the condition and composite query structure.
+func validateCondition(rule map[string]any, errs *ValidationError) {
+	cond := mapVal(rule, "condition")
+	if cond == nil {
+		return // already caught by validateRequired
+	}
+
+	cq := mapVal(cond, "compositeQuery")
+	if cq == nil {
+		errs.Add("condition.compositeQuery", "is required")
+		return
+	}
+
+	if strVal(cq, "queryType") == "" {
+		errs.Add("condition.compositeQuery.queryType", "is required (builder, promql, or clickhouse_sql)")
+	}
+
+	queries := sliceVal(cq, "queries")
+	if len(queries) == 0 {
+		errs.Add("condition.compositeQuery.queries", "must contain at least one query")
+		return
+	}
+
+	// Check that either v1 threshold (op+target) or v2 thresholds are specified
+	hasV1Threshold := strVal(cond, "op") != "" || cond["target"] != nil
+	hasV2Thresholds := mapVal(cond, "thresholds") != nil
+	hasAlertOnAbsent := boolVal(cond, "alertOnAbsent")
+
+	if !hasV1Threshold && !hasV2Thresholds && !hasAlertOnAbsent {
+		errs.Add("condition", "must specify either op+target (v1 schema) or thresholds (v2 schema) or alertOnAbsent=true")
+	}
+
+	// Validate individual queries
+	queryType := strVal(cq, "queryType")
+	for i, q := range queries {
+		prefix := fmt.Sprintf("condition.compositeQuery.queries[%d]", i)
+		qm, ok := q.(map[string]any)
+		if !ok {
+			errs.Add(prefix, "must be an object")
+			continue
+		}
+
+		qType := strVal(qm, "type")
+		if qType == "" {
+			errs.Add(prefix+".type", "is required (builder_query or builder_formula)")
+			continue
+		}
+		if !validBuilderQueryTypes[qType] {
+			errs.Addf(prefix+".type", "must be builder_query or builder_formula; got %q", qType)
+			continue
+		}
+
+		spec := mapVal(qm, "spec")
+		if spec == nil {
+			errs.Add(prefix+".spec", "is required")
+			continue
+		}
+
+		if strVal(spec, "name") == "" {
+			errs.Add(prefix+".spec.name", "is required (e.g. A, B, C)")
+		}
+
+		// For builder queries, validate signal
+		if qType == "builder_query" && queryType == "builder" {
+			sig := strVal(spec, "signal")
+			if sig == "" {
+				errs.Add(prefix+".spec.signal", "is required for builder queries (metrics, logs, or traces)")
+			} else if !validSignals[sig] {
+				errs.Addf(prefix+".spec.signal", "must be metrics, logs, or traces; got %q", sig)
+			}
+		}
+	}
+
+	// Validate v2 thresholds structure
+	if hasV2Thresholds {
+		thresholds := mapVal(cond, "thresholds")
+		if strVal(thresholds, "kind") == "" {
+			errs.Add("condition.thresholds.kind", "is required (use 'basic')")
+		}
+		specs := sliceVal(thresholds, "spec")
+		if len(specs) == 0 {
+			errs.Add("condition.thresholds.spec", "must contain at least one threshold")
+		}
+		for i, s := range specs {
+			prefix := fmt.Sprintf("condition.thresholds.spec[%d]", i)
+			sm, ok := s.(map[string]any)
+			if !ok {
+				continue
+			}
+			if strVal(sm, "name") == "" {
+				errs.Add(prefix+".name", "is required (critical, warning, or info)")
+			}
+			if sm["target"] == nil {
+				errs.Add(prefix+".target", "is required")
+			}
+			if op := strVal(sm, "op"); op != "" && !validCompareOps[op] {
+				errs.Addf(prefix+".op", "must be a valid operator; got %q", op)
+			}
+			if mt := strVal(sm, "matchType"); mt != "" && !validMatchTypes[mt] {
+				errs.Addf(prefix+".matchType", "must be a valid match type; got %q", mt)
+			}
+		}
+	}
+}
+
+// validateCrossConstraints checks constraints that span multiple fields.
+func validateCrossConstraints(rule map[string]any, errs *ValidationError) {
+	alertType := strVal(rule, "alertType")
+	ruleType := strVal(rule, "ruleType")
+
+	// anomaly_rule only works with METRIC_BASED_ALERT
+	if ruleType == "anomaly_rule" && alertType != "" && alertType != "METRIC_BASED_ALERT" {
+		errs.Addf("ruleType", "anomaly_rule can only be used with METRIC_BASED_ALERT, got alertType=%q", alertType)
+	}
+
+	// promql_rule requires queryType=promql
+	cond := mapVal(rule, "condition")
+	if cond == nil {
+		return
+	}
+	cq := mapVal(cond, "compositeQuery")
+	if cq == nil {
+		return
+	}
+
+	queryType := strVal(cq, "queryType")
+
+	if ruleType == "promql_rule" && queryType != "" && queryType != "promql" {
+		errs.Addf("condition.compositeQuery.queryType", "must be 'promql' when ruleType is promql_rule; got %q", queryType)
+	}
+
+	// For builder queries, validate signal matches alertType
+	if queryType == "builder" && alertType != "" {
+		expectedSignal, hasExpectedSignal := alertTypeToSignal[alertType]
+		if !hasExpectedSignal {
+			// EXCEPTIONS_BASED_ALERT doesn't enforce a signal — it can use clickhouse_sql or builder
+			return
+		}
+		queries := sliceVal(cq, "queries")
+		for i, q := range queries {
+			qm, ok := q.(map[string]any)
+			if !ok {
+				continue
+			}
+			if strVal(qm, "type") != "builder_query" {
+				continue // formulas don't have signals
+			}
+			spec := mapVal(qm, "spec")
+			if spec == nil {
+				continue
+			}
+			sig := strVal(spec, "signal")
+			if sig != "" && sig != expectedSignal {
+				prefix := fmt.Sprintf("condition.compositeQuery.queries[%d].spec.signal", i)
+				errs.Addf(prefix, "expected %q for alertType=%s, got %q", expectedSignal, alertType, sig)
+			}
+		}
+	}
+}
+
+// applyDefaults fills in missing fields with sensible defaults.
+func applyDefaults(rule map[string]any) {
+	// version defaults to v5
+	if strVal(rule, "version") == "" {
+		rule["version"] = "v5"
+	}
+
+	// source defaults to mcp
+	if strVal(rule, "source") == "" {
+		rule["source"] = "mcp"
+	}
+
+	// Default severity label
+	labels, ok := rule["labels"].(map[string]any)
+	if !ok || labels == nil {
+		labels = map[string]any{}
+		rule["labels"] = labels
+	}
+	if _, hasSeverity := labels["severity"]; !hasSeverity {
+		labels["severity"] = "warning"
+	}
+
+	// Default annotations if missing
+	if _, hasAnnotations := rule["annotations"]; !hasAnnotations {
+		rule["annotations"] = map[string]any{
+			"description": "This alert is fired when the defined metric (current value: {{$value}}) crosses the threshold ({{$threshold}})",
+			"summary":     "The rule threshold is set to {{$threshold}}, and the observed metric value is {{$value}}",
+		}
+	}
+
+	// Default composite query panelType
+	cond := mapVal(rule, "condition")
+	if cond != nil {
+		cq := mapVal(cond, "compositeQuery")
+		if cq != nil {
+			if strVal(cq, "panelType") == "" {
+				cq["panelType"] = "graph"
+			}
+
+			// Default selectedQueryName to first query's name
+			if strVal(cond, "selectedQueryName") == "" {
+				queries := sliceVal(cq, "queries")
+				if len(queries) > 0 {
+					if qm, ok := queries[0].(map[string]any); ok {
+						if spec := mapVal(qm, "spec"); spec != nil {
+							if name := strVal(spec, "name"); name != "" {
+								cond["selectedQueryName"] = name
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+}
+
+// upgradeToV2 converts any v1-style fields to v2 format and ensures the
+// output always uses v2 schema. This runs after applyDefaults.
+func upgradeToV2(rule map[string]any) {
+	// Always set schemaVersion to v2
+	rule["schemaVersion"] = "v2"
+
+	cond := mapVal(rule, "condition")
+	if cond == nil {
+		return
+	}
+
+	// Convert v1 threshold (op/target/matchType) to v2 thresholds
+	if mapVal(cond, "thresholds") == nil && !boolVal(cond, "alertOnAbsent") {
+		op := strVal(cond, "op")
+		matchType := strVal(cond, "matchType")
+		targetUnit := strVal(cond, "targetUnit")
+
+		// Determine severity name from labels
+		severityName := "warning"
+		if labels := mapVal(rule, "labels"); labels != nil {
+			if sev := strVal(labels, "severity"); sev != "" {
+				severityName = sev
+			}
+		}
+
+		threshold := map[string]any{
+			"name":           severityName,
+			"target":         cond["target"],
+			"targetUnit":     targetUnit,
+			"recoveryTarget": nil,
+			"matchType":      matchType,
+			"op":             op,
+		}
+
+		// Carry over preferredChannels as the threshold's channels
+		if channels, ok := rule["preferredChannels"].([]any); ok && len(channels) > 0 {
+			threshold["channels"] = channels
+		}
+
+		cond["thresholds"] = map[string]any{
+			"kind": "basic",
+			"spec": []any{threshold},
+		}
+	}
+
+	// Clear v1 condition-level threshold fields (set to empty for v2)
+	cond["op"] = ""
+	cond["matchType"] = ""
+
+	// Convert v1 evalWindow/frequency to v2 evaluation block
+	if rule["evaluation"] == nil {
+		evalWindow := strVal(rule, "evalWindow")
+		frequency := strVal(rule, "frequency")
+		if evalWindow == "" {
+			evalWindow = "5m0s"
+		}
+		if frequency == "" {
+			frequency = "1m0s"
+		}
+		rule["evaluation"] = map[string]any{
+			"kind": "rolling",
+			"spec": map[string]any{
+				"evalWindow": evalWindow,
+				"frequency":  frequency,
+			},
+		}
+	}
+
+	// Remove v1 top-level evalWindow/frequency
+	delete(rule, "evalWindow")
+	delete(rule, "frequency")
+
+	// Default notificationSettings if not present
+	if rule["notificationSettings"] == nil {
+		rule["notificationSettings"] = map[string]any{
+			"renotify": map[string]any{
+				"enabled":  false,
+				"interval": "30m",
+			},
+		}
+	}
+}
+
+// --- map access helpers ---
+
+func strVal(m map[string]any, key string) string {
+	if v, ok := m[key].(string); ok {
+		return v
+	}
+	return ""
+}
+
+func mapVal(m map[string]any, key string) map[string]any {
+	if v, ok := m[key].(map[string]any); ok {
+		return v
+	}
+	return nil
+}
+
+func sliceVal(m map[string]any, key string) []any {
+	if v, ok := m[key].([]any); ok {
+		return v
+	}
+	return nil
+}
+
+func boolVal(m map[string]any, key string) bool {
+	if v, ok := m[key].(bool); ok {
+		return v
+	}
+	return false
+}

--- a/pkg/alert/validate.go
+++ b/pkg/alert/validate.go
@@ -112,7 +112,7 @@ func Validate(jsonBytes []byte) ([]byte, error) {
 	}
 
 	applyDefaults(rule)
-	upgradeToV2(rule)
+	applyV2Defaults(rule)
 
 	out, err := json.Marshal(rule)
 	if err != nil {
@@ -151,14 +151,6 @@ func validateEnums(rule map[string]any, errs *ValidationError) {
 		return
 	}
 
-	// op and matchType are optional (v2 schema uses thresholds instead)
-	if op := strVal(cond, "op"); op != "" && !validCompareOps[op] {
-		errs.Addf("condition.op", "must be one of 1(above), 2(below), 3(equal), 4(not_equal); got %q", op)
-	}
-	if mt := strVal(cond, "matchType"); mt != "" && !validMatchTypes[mt] {
-		errs.Addf("condition.matchType", "must be one of 1(at_least_once), 2(all_the_times), 3(on_average), 4(in_total), 5(last); got %q", mt)
-	}
-
 	cq := mapVal(cond, "compositeQuery")
 	if cq != nil {
 		if qt := strVal(cq, "queryType"); qt != "" && !validQueryTypes[qt] {
@@ -190,19 +182,12 @@ func validateCondition(rule map[string]any, errs *ValidationError) {
 		return
 	}
 
-	// Check that either v1 threshold (op+target) or v2 thresholds are specified
-	hasOp := strVal(cond, "op") != ""
-	hasTarget := cond["target"] != nil
-	hasV1Threshold := hasOp || hasTarget
-	hasV2Thresholds := mapVal(cond, "thresholds") != nil
+	// Require v2alpha1 thresholds (unless alertOnAbsent is set)
+	hasThresholds := mapVal(cond, "thresholds") != nil
 	hasAlertOnAbsent := boolVal(cond, "alertOnAbsent")
 
-	if hasV1Threshold && !(hasOp && hasTarget) {
-		errs.Add("condition", "v1 threshold requires both op and target; only one was provided")
-	}
-
-	if !hasV1Threshold && !hasV2Thresholds && !hasAlertOnAbsent {
-		errs.Add("condition", "must specify either op+target (v1 schema) or thresholds (v2 schema) or alertOnAbsent=true")
+	if !hasThresholds && !hasAlertOnAbsent {
+		errs.Add("condition.thresholds", "is required (v2alpha1 schema); use condition.thresholds with kind and spec array")
 	}
 
 	// Validate individual queries
@@ -246,8 +231,8 @@ func validateCondition(rule map[string]any, errs *ValidationError) {
 		}
 	}
 
-	// Validate v2 thresholds structure
-	if hasV2Thresholds {
+	// Validate v2alpha1 thresholds structure
+	if hasThresholds {
 		thresholds := mapVal(cond, "thresholds")
 		if strVal(thresholds, "kind") == "" {
 			errs.Add("condition.thresholds.kind", "is required (use 'basic')")
@@ -395,77 +380,21 @@ func applyDefaults(rule map[string]any) {
 	}
 }
 
-// upgradeToV2 converts any v1-style fields to v2 format and ensures the
-// output always uses v2 schema. This runs after applyDefaults.
-func upgradeToV2(rule map[string]any) {
-	// Always set schemaVersion to v2
-	rule["schemaVersion"] = "v2"
+// applyV2Defaults sets v2alpha1 schema fields and defaults.
+// This runs after applyDefaults.
+func applyV2Defaults(rule map[string]any) {
+	rule["schemaVersion"] = "v2alpha1"
 
-	cond := mapVal(rule, "condition")
-	if cond == nil {
-		return
-	}
-
-	// Convert v1 threshold (op/target/matchType) to v2 thresholds
-	if mapVal(cond, "thresholds") == nil && !boolVal(cond, "alertOnAbsent") {
-		op := strVal(cond, "op")
-		matchType := strVal(cond, "matchType")
-		targetUnit := strVal(cond, "targetUnit")
-
-		// Determine severity name from labels
-		severityName := "warning"
-		if labels := mapVal(rule, "labels"); labels != nil {
-			if sev := strVal(labels, "severity"); sev != "" {
-				severityName = sev
-			}
-		}
-
-		threshold := map[string]any{
-			"name":           severityName,
-			"target":         cond["target"],
-			"targetUnit":     targetUnit,
-			"recoveryTarget": nil,
-			"matchType":      matchType,
-			"op":             op,
-		}
-
-		// Carry over preferredChannels as the threshold's channels
-		if channels, ok := rule["preferredChannels"].([]any); ok && len(channels) > 0 {
-			threshold["channels"] = channels
-		}
-
-		cond["thresholds"] = map[string]any{
-			"kind": "basic",
-			"spec": []any{threshold},
-		}
-	}
-
-	// Clear v1 condition-level threshold fields (set to empty for v2)
-	cond["op"] = ""
-	cond["matchType"] = ""
-
-	// Convert v1 evalWindow/frequency to v2 evaluation block
+	// Default evaluation block if missing
 	if rule["evaluation"] == nil {
-		evalWindow := strVal(rule, "evalWindow")
-		frequency := strVal(rule, "frequency")
-		if evalWindow == "" {
-			evalWindow = "5m0s"
-		}
-		if frequency == "" {
-			frequency = "1m0s"
-		}
 		rule["evaluation"] = map[string]any{
 			"kind": "rolling",
 			"spec": map[string]any{
-				"evalWindow": evalWindow,
-				"frequency":  frequency,
+				"evalWindow": "5m0s",
+				"frequency":  "1m0s",
 			},
 		}
 	}
-
-	// Remove v1 top-level evalWindow/frequency
-	delete(rule, "evalWindow")
-	delete(rule, "frequency")
 
 	// Default notificationSettings if not present
 	if rule["notificationSettings"] == nil {

--- a/pkg/alert/validate.go
+++ b/pkg/alert/validate.go
@@ -132,8 +132,10 @@ func validateRequired(rule map[string]any, errs *ValidationError) {
 	if strVal(rule, "ruleType") == "" {
 		errs.Add("ruleType", "is required (threshold_rule, promql_rule, or anomaly_rule)")
 	}
-	if _, ok := rule["condition"]; !ok {
+	if v, ok := rule["condition"]; !ok {
 		errs.Add("condition", "is required")
+	} else if _, isMap := v.(map[string]any); !isMap {
+		errs.Add("condition", "must be an object containing compositeQuery and thresholds")
 	}
 }
 
@@ -196,7 +198,7 @@ func validateCondition(rule map[string]any, errs *ValidationError) {
 		prefix := fmt.Sprintf("condition.compositeQuery.queries[%d]", i)
 		qm, ok := q.(map[string]any)
 		if !ok {
-			errs.Add(prefix, "must be an object")
+			errs.Add(prefix, "must be an object with type and spec fields")
 			continue
 		}
 
@@ -229,6 +231,13 @@ func validateCondition(rule map[string]any, errs *ValidationError) {
 				errs.Addf(prefix+".spec.signal", "must be metrics, logs, or traces; got %q", sig)
 			}
 		}
+
+		// For promql/clickhouse_sql queries, require the query text
+		if qType == "builder_query" && (queryType == "promql" || queryType == "clickhouse_sql") {
+			if strVal(spec, "query") == "" {
+				errs.Addf(prefix+".spec.query", "is required for %s queries", queryType)
+			}
+		}
 	}
 
 	// Validate v2alpha1 thresholds structure
@@ -245,6 +254,7 @@ func validateCondition(rule map[string]any, errs *ValidationError) {
 			prefix := fmt.Sprintf("condition.thresholds.spec[%d]", i)
 			sm, ok := s.(map[string]any)
 			if !ok {
+				errs.Add(prefix, "must be an object with name, target, op, and matchType fields")
 				continue
 			}
 			if strVal(sm, "name") == "" {

--- a/pkg/alert/validate.go
+++ b/pkg/alert/validate.go
@@ -191,9 +191,15 @@ func validateCondition(rule map[string]any, errs *ValidationError) {
 	}
 
 	// Check that either v1 threshold (op+target) or v2 thresholds are specified
-	hasV1Threshold := strVal(cond, "op") != "" || cond["target"] != nil
+	hasOp := strVal(cond, "op") != ""
+	hasTarget := cond["target"] != nil
+	hasV1Threshold := hasOp || hasTarget
 	hasV2Thresholds := mapVal(cond, "thresholds") != nil
 	hasAlertOnAbsent := boolVal(cond, "alertOnAbsent")
+
+	if hasV1Threshold && !(hasOp && hasTarget) {
+		errs.Add("condition", "v1 threshold requires both op and target; only one was provided")
+	}
 
 	if !hasV1Threshold && !hasV2Thresholds && !hasAlertOnAbsent {
 		errs.Add("condition", "must specify either op+target (v1 schema) or thresholds (v2 schema) or alertOnAbsent=true")
@@ -262,10 +268,16 @@ func validateCondition(rule map[string]any, errs *ValidationError) {
 			if sm["target"] == nil {
 				errs.Add(prefix+".target", "is required")
 			}
-			if op := strVal(sm, "op"); op != "" && !validCompareOps[op] {
+			op := strVal(sm, "op")
+			if op == "" {
+				errs.Add(prefix+".op", "is required (e.g. above, below, equal, not_equal)")
+			} else if !validCompareOps[op] {
 				errs.Addf(prefix+".op", "must be a valid operator; got %q", op)
 			}
-			if mt := strVal(sm, "matchType"); mt != "" && !validMatchTypes[mt] {
+			mt := strVal(sm, "matchType")
+			if mt == "" {
+				errs.Add(prefix+".matchType", "is required (e.g. at_least_once, all_the_times, on_average, in_total, last)")
+			} else if !validMatchTypes[mt] {
 				errs.Addf(prefix+".matchType", "must be a valid match type; got %q", mt)
 			}
 		}

--- a/pkg/alert/validate_test.go
+++ b/pkg/alert/validate_test.go
@@ -1,0 +1,664 @@
+package alert
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// minimalValidAlert returns a minimal valid alert rule as map[string]any.
+// Uses v1-style op/target/matchType which will be auto-converted to v2.
+func minimalValidAlert() map[string]any {
+	return map[string]any{
+		"alert":     "Test Alert",
+		"alertType": "METRIC_BASED_ALERT",
+		"ruleType":  "threshold_rule",
+		"condition": map[string]any{
+			"compositeQuery": map[string]any{
+				"queryType": "builder",
+				"panelType": "graph",
+				"queries": []any{
+					map[string]any{
+						"type": "builder_query",
+						"spec": map[string]any{
+							"name":         "A",
+							"signal":       "metrics",
+							"stepInterval": 60,
+							"aggregations": []any{
+								map[string]any{"expression": "count()"},
+							},
+							"filter": map[string]any{"expression": ""},
+						},
+					},
+				},
+			},
+			"op":        "1",
+			"target":    float64(100),
+			"matchType": "1",
+		},
+	}
+}
+
+func TestValidate_MinimalValidAlert(t *testing.T) {
+	alert := minimalValidAlert()
+	result, err := ValidateFromMap(alert)
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+
+	var parsed map[string]any
+	if err := json.Unmarshal(result, &parsed); err != nil {
+		t.Fatalf("failed to parse result: %v", err)
+	}
+
+	// Check v2 defaults were applied
+	if parsed["version"] != "v5" {
+		t.Errorf("expected version=v5, got %v", parsed["version"])
+	}
+	if parsed["schemaVersion"] != "v2" {
+		t.Errorf("expected schemaVersion=v2, got %v", parsed["schemaVersion"])
+	}
+	if parsed["source"] != "mcp" {
+		t.Errorf("expected source=mcp, got %v", parsed["source"])
+	}
+
+	// v1 evalWindow/frequency should be removed
+	if _, has := parsed["evalWindow"]; has {
+		t.Error("evalWindow should be removed (converted to evaluation block)")
+	}
+	if _, has := parsed["frequency"]; has {
+		t.Error("frequency should be removed (converted to evaluation block)")
+	}
+
+	// evaluation block should exist
+	eval, ok := parsed["evaluation"].(map[string]any)
+	if !ok {
+		t.Fatal("expected evaluation block")
+	}
+	if eval["kind"] != "rolling" {
+		t.Errorf("expected evaluation.kind=rolling, got %v", eval["kind"])
+	}
+	evalSpec := eval["spec"].(map[string]any)
+	if evalSpec["evalWindow"] != "5m0s" {
+		t.Errorf("expected evaluation.spec.evalWindow=5m0s, got %v", evalSpec["evalWindow"])
+	}
+
+	// notificationSettings should exist
+	if _, ok := parsed["notificationSettings"].(map[string]any); !ok {
+		t.Error("expected notificationSettings to be set")
+	}
+
+	// labels
+	labels, ok := parsed["labels"].(map[string]any)
+	if !ok {
+		t.Fatal("expected labels to be a map")
+	}
+	if labels["severity"] != "warning" {
+		t.Errorf("expected severity=warning, got %v", labels["severity"])
+	}
+
+	// Check v1→v2 threshold conversion
+	cond := parsed["condition"].(map[string]any)
+	if cond["selectedQueryName"] != "A" {
+		t.Errorf("expected selectedQueryName=A, got %v", cond["selectedQueryName"])
+	}
+	thresholds := cond["thresholds"].(map[string]any)
+	if thresholds["kind"] != "basic" {
+		t.Errorf("expected thresholds.kind=basic, got %v", thresholds["kind"])
+	}
+	specs := thresholds["spec"].([]any)
+	if len(specs) != 1 {
+		t.Fatalf("expected 1 threshold spec, got %d", len(specs))
+	}
+	spec := specs[0].(map[string]any)
+	if spec["target"] != float64(100) {
+		t.Errorf("expected threshold target=100, got %v", spec["target"])
+	}
+	if spec["op"] != "1" {
+		t.Errorf("expected threshold op=1, got %v", spec["op"])
+	}
+	if spec["matchType"] != "1" {
+		t.Errorf("expected threshold matchType=1, got %v", spec["matchType"])
+	}
+	if spec["name"] != "warning" {
+		t.Errorf("expected threshold name=warning (from default severity), got %v", spec["name"])
+	}
+
+	// v1 condition-level fields should be cleared
+	if cond["op"] != "" {
+		t.Errorf("expected condition.op to be cleared, got %v", cond["op"])
+	}
+	if cond["matchType"] != "" {
+		t.Errorf("expected condition.matchType to be cleared, got %v", cond["matchType"])
+	}
+
+	// annotations
+	annotations, ok := parsed["annotations"].(map[string]any)
+	if !ok {
+		t.Fatal("expected annotations to be a map")
+	}
+	if _, hasDesc := annotations["description"]; !hasDesc {
+		t.Error("expected default description annotation")
+	}
+}
+
+func TestValidate_V1ToV2Conversion(t *testing.T) {
+	alert := map[string]any{
+		"alert":     "V1 Alert",
+		"alertType": "LOGS_BASED_ALERT",
+		"ruleType":  "threshold_rule",
+		"evalWindow": "10m0s",
+		"frequency":  "2m0s",
+		"labels": map[string]any{
+			"severity": "critical",
+		},
+		"preferredChannels": []any{"slack-alerts"},
+		"condition": map[string]any{
+			"compositeQuery": map[string]any{
+				"queryType": "builder",
+				"queries": []any{
+					map[string]any{
+						"type": "builder_query",
+						"spec": map[string]any{
+							"name":   "A",
+							"signal": "logs",
+							"aggregations": []any{
+								map[string]any{"expression": "count()"},
+							},
+							"filter": map[string]any{"expression": ""},
+						},
+					},
+				},
+			},
+			"op":        "1",
+			"target":    float64(500),
+			"matchType": "4",
+			"targetUnit": "count",
+		},
+	}
+
+	result, err := ValidateFromMap(alert)
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+
+	var parsed map[string]any
+	json.Unmarshal(result, &parsed)
+
+	// schemaVersion should be v2
+	if parsed["schemaVersion"] != "v2" {
+		t.Errorf("expected schemaVersion=v2, got %v", parsed["schemaVersion"])
+	}
+
+	// evalWindow/frequency should be removed, evaluation block created
+	if _, has := parsed["evalWindow"]; has {
+		t.Error("evalWindow should be removed")
+	}
+	if _, has := parsed["frequency"]; has {
+		t.Error("frequency should be removed")
+	}
+	eval := parsed["evaluation"].(map[string]any)
+	evalSpec := eval["spec"].(map[string]any)
+	if evalSpec["evalWindow"] != "10m0s" {
+		t.Errorf("expected evaluation.spec.evalWindow=10m0s (from v1), got %v", evalSpec["evalWindow"])
+	}
+	if evalSpec["frequency"] != "2m0s" {
+		t.Errorf("expected evaluation.spec.frequency=2m0s (from v1), got %v", evalSpec["frequency"])
+	}
+
+	// v1 threshold should be converted to v2
+	cond := parsed["condition"].(map[string]any)
+	thresholds := cond["thresholds"].(map[string]any)
+	specs := thresholds["spec"].([]any)
+	spec := specs[0].(map[string]any)
+	if spec["name"] != "critical" {
+		t.Errorf("expected threshold name=critical (from severity label), got %v", spec["name"])
+	}
+	if spec["target"] != float64(500) {
+		t.Errorf("expected threshold target=500, got %v", spec["target"])
+	}
+	if spec["targetUnit"] != "count" {
+		t.Errorf("expected threshold targetUnit=count, got %v", spec["targetUnit"])
+	}
+	if spec["op"] != "1" {
+		t.Errorf("expected threshold op=1, got %v", spec["op"])
+	}
+	if spec["matchType"] != "4" {
+		t.Errorf("expected threshold matchType=4, got %v", spec["matchType"])
+	}
+
+	// preferredChannels should be copied to threshold channels
+	channels, ok := spec["channels"].([]any)
+	if !ok || len(channels) != 1 || channels[0] != "slack-alerts" {
+		t.Errorf("expected threshold channels=[slack-alerts], got %v", spec["channels"])
+	}
+}
+
+func TestValidate_V2ThresholdsPreserved(t *testing.T) {
+	alert := map[string]any{
+		"alert":     "V2 Alert",
+		"alertType": "METRIC_BASED_ALERT",
+		"ruleType":  "threshold_rule",
+		"condition": map[string]any{
+			"compositeQuery": map[string]any{
+				"queryType": "builder",
+				"queries": []any{
+					map[string]any{
+						"type": "builder_query",
+						"spec": map[string]any{
+							"name":   "A",
+							"signal": "metrics",
+							"aggregations": []any{
+								map[string]any{"expression": "count()"},
+							},
+							"filter": map[string]any{"expression": ""},
+						},
+					},
+				},
+			},
+			"selectedQueryName": "A",
+			"thresholds": map[string]any{
+				"kind": "basic",
+				"spec": []any{
+					map[string]any{
+						"name":      "critical",
+						"target":    float64(100),
+						"op":        "1",
+						"matchType": "1",
+						"channels":  []any{"pagerduty"},
+					},
+					map[string]any{
+						"name":      "warning",
+						"target":    float64(50),
+						"op":        "1",
+						"matchType": "1",
+						"channels":  []any{"slack"},
+					},
+				},
+			},
+		},
+		"evaluation": map[string]any{
+			"kind": "rolling",
+			"spec": map[string]any{
+				"evalWindow": "15m0s",
+				"frequency":  "5m0s",
+			},
+		},
+	}
+
+	result, err := ValidateFromMap(alert)
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+
+	var parsed map[string]any
+	json.Unmarshal(result, &parsed)
+
+	// v2 thresholds should be preserved as-is
+	cond := parsed["condition"].(map[string]any)
+	thresholds := cond["thresholds"].(map[string]any)
+	specs := thresholds["spec"].([]any)
+	if len(specs) != 2 {
+		t.Fatalf("expected 2 threshold specs preserved, got %d", len(specs))
+	}
+
+	// evaluation should be preserved
+	eval := parsed["evaluation"].(map[string]any)
+	evalSpec := eval["spec"].(map[string]any)
+	if evalSpec["evalWindow"] != "15m0s" {
+		t.Errorf("expected preserved evalWindow=15m0s, got %v", evalSpec["evalWindow"])
+	}
+}
+
+func TestValidate_MissingAlertName(t *testing.T) {
+	alert := minimalValidAlert()
+	delete(alert, "alert")
+
+	_, err := ValidateFromMap(alert)
+	if err == nil {
+		t.Fatal("expected error for missing alert name")
+	}
+	if !strings.Contains(err.Error(), "alert") {
+		t.Errorf("error should mention 'alert', got: %v", err)
+	}
+}
+
+func TestValidate_MissingAlertType(t *testing.T) {
+	alert := minimalValidAlert()
+	delete(alert, "alertType")
+
+	_, err := ValidateFromMap(alert)
+	if err == nil {
+		t.Fatal("expected error for missing alertType")
+	}
+	if !strings.Contains(err.Error(), "alertType") {
+		t.Errorf("error should mention 'alertType', got: %v", err)
+	}
+}
+
+func TestValidate_InvalidAlertType(t *testing.T) {
+	alert := minimalValidAlert()
+	alert["alertType"] = "INVALID_TYPE"
+
+	_, err := ValidateFromMap(alert)
+	if err == nil {
+		t.Fatal("expected error for invalid alertType")
+	}
+	if !strings.Contains(err.Error(), "INVALID_TYPE") {
+		t.Errorf("error should mention the invalid value, got: %v", err)
+	}
+}
+
+func TestValidate_InvalidRuleType(t *testing.T) {
+	alert := minimalValidAlert()
+	alert["ruleType"] = "invalid_rule"
+
+	_, err := ValidateFromMap(alert)
+	if err == nil {
+		t.Fatal("expected error for invalid ruleType")
+	}
+	if !strings.Contains(err.Error(), "invalid_rule") {
+		t.Errorf("error should mention the invalid value, got: %v", err)
+	}
+}
+
+func TestValidate_MissingCondition(t *testing.T) {
+	alert := minimalValidAlert()
+	delete(alert, "condition")
+
+	_, err := ValidateFromMap(alert)
+	if err == nil {
+		t.Fatal("expected error for missing condition")
+	}
+	if !strings.Contains(err.Error(), "condition") {
+		t.Errorf("error should mention 'condition', got: %v", err)
+	}
+}
+
+func TestValidate_MissingCompositeQuery(t *testing.T) {
+	alert := minimalValidAlert()
+	cond := alert["condition"].(map[string]any)
+	delete(cond, "compositeQuery")
+
+	_, err := ValidateFromMap(alert)
+	if err == nil {
+		t.Fatal("expected error for missing compositeQuery")
+	}
+	if !strings.Contains(err.Error(), "compositeQuery") {
+		t.Errorf("error should mention 'compositeQuery', got: %v", err)
+	}
+}
+
+func TestValidate_EmptyQueries(t *testing.T) {
+	alert := minimalValidAlert()
+	cond := alert["condition"].(map[string]any)
+	cq := cond["compositeQuery"].(map[string]any)
+	cq["queries"] = []any{}
+
+	_, err := ValidateFromMap(alert)
+	if err == nil {
+		t.Fatal("expected error for empty queries")
+	}
+	if !strings.Contains(err.Error(), "at least one query") {
+		t.Errorf("error should mention queries requirement, got: %v", err)
+	}
+}
+
+func TestValidate_NoThresholdOrOp(t *testing.T) {
+	alert := minimalValidAlert()
+	cond := alert["condition"].(map[string]any)
+	delete(cond, "op")
+	delete(cond, "target")
+	delete(cond, "matchType")
+
+	_, err := ValidateFromMap(alert)
+	if err == nil {
+		t.Fatal("expected error when neither op/target nor thresholds is set")
+	}
+	if !strings.Contains(err.Error(), "op+target") || !strings.Contains(err.Error(), "thresholds") {
+		t.Errorf("error should mention both options, got: %v", err)
+	}
+}
+
+func TestValidate_InvalidCompareOp(t *testing.T) {
+	alert := minimalValidAlert()
+	cond := alert["condition"].(map[string]any)
+	cond["op"] = "invalid_op"
+
+	_, err := ValidateFromMap(alert)
+	if err == nil {
+		t.Fatal("expected error for invalid op")
+	}
+	if !strings.Contains(err.Error(), "invalid_op") {
+		t.Errorf("error should mention the invalid value, got: %v", err)
+	}
+}
+
+func TestValidate_InvalidMatchType(t *testing.T) {
+	alert := minimalValidAlert()
+	cond := alert["condition"].(map[string]any)
+	cond["matchType"] = "invalid_match"
+
+	_, err := ValidateFromMap(alert)
+	if err == nil {
+		t.Fatal("expected error for invalid matchType")
+	}
+	if !strings.Contains(err.Error(), "invalid_match") {
+		t.Errorf("error should mention the invalid value, got: %v", err)
+	}
+}
+
+func TestValidate_AnomalyRuleWithNonMetricAlertType(t *testing.T) {
+	alert := minimalValidAlert()
+	alert["ruleType"] = "anomaly_rule"
+	alert["alertType"] = "LOGS_BASED_ALERT"
+	cond := alert["condition"].(map[string]any)
+	cq := cond["compositeQuery"].(map[string]any)
+	queries := cq["queries"].([]any)
+	spec := queries[0].(map[string]any)["spec"].(map[string]any)
+	spec["signal"] = "logs"
+
+	_, err := ValidateFromMap(alert)
+	if err == nil {
+		t.Fatal("expected error for anomaly_rule with non-metric alertType")
+	}
+	if !strings.Contains(err.Error(), "anomaly_rule") && !strings.Contains(err.Error(), "METRIC_BASED_ALERT") {
+		t.Errorf("error should mention the constraint, got: %v", err)
+	}
+}
+
+func TestValidate_PromQLRuleWithBuilderQueryType(t *testing.T) {
+	alert := minimalValidAlert()
+	alert["ruleType"] = "promql_rule"
+
+	_, err := ValidateFromMap(alert)
+	if err == nil {
+		t.Fatal("expected error for promql_rule with builder queryType")
+	}
+	if !strings.Contains(err.Error(), "promql") {
+		t.Errorf("error should mention promql constraint, got: %v", err)
+	}
+}
+
+func TestValidate_SignalMismatch(t *testing.T) {
+	alert := minimalValidAlert()
+	alert["alertType"] = "LOGS_BASED_ALERT"
+
+	_, err := ValidateFromMap(alert)
+	if err == nil {
+		t.Fatal("expected error for signal mismatch")
+	}
+	if !strings.Contains(err.Error(), "signal") {
+		t.Errorf("error should mention signal mismatch, got: %v", err)
+	}
+}
+
+func TestValidate_AlertOnAbsentNoThreshold(t *testing.T) {
+	alert := minimalValidAlert()
+	cond := alert["condition"].(map[string]any)
+	delete(cond, "op")
+	delete(cond, "target")
+	delete(cond, "matchType")
+	cond["alertOnAbsent"] = true
+
+	result, err := ValidateFromMap(alert)
+	if err != nil {
+		t.Fatalf("expected no error for alertOnAbsent=true without threshold, got: %v", err)
+	}
+	if result == nil {
+		t.Fatal("expected non-nil result")
+	}
+
+	// Should still have v2 schema but no auto-generated thresholds
+	var parsed map[string]any
+	json.Unmarshal(result, &parsed)
+	if parsed["schemaVersion"] != "v2" {
+		t.Errorf("expected schemaVersion=v2, got %v", parsed["schemaVersion"])
+	}
+}
+
+func TestValidate_PreservesExistingLabels(t *testing.T) {
+	alert := minimalValidAlert()
+	alert["labels"] = map[string]any{
+		"severity": "critical",
+		"team":     "backend",
+	}
+
+	result, err := ValidateFromMap(alert)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var parsed map[string]any
+	json.Unmarshal(result, &parsed)
+	labels := parsed["labels"].(map[string]any)
+	if labels["severity"] != "critical" {
+		t.Errorf("should preserve existing severity=critical, got %v", labels["severity"])
+	}
+	if labels["team"] != "backend" {
+		t.Errorf("should preserve team label, got %v", labels["team"])
+	}
+}
+
+func TestValidate_V2ThresholdsMissingSpec(t *testing.T) {
+	alert := minimalValidAlert()
+	cond := alert["condition"].(map[string]any)
+	delete(cond, "op")
+	delete(cond, "target")
+	delete(cond, "matchType")
+	cond["thresholds"] = map[string]any{
+		"kind": "basic",
+		"spec": []any{},
+	}
+
+	_, err := ValidateFromMap(alert)
+	if err == nil {
+		t.Fatal("expected error for empty thresholds spec")
+	}
+	if !strings.Contains(err.Error(), "at least one threshold") {
+		t.Errorf("error should mention threshold requirement, got: %v", err)
+	}
+}
+
+func TestValidate_QueryMissingName(t *testing.T) {
+	alert := minimalValidAlert()
+	cond := alert["condition"].(map[string]any)
+	cq := cond["compositeQuery"].(map[string]any)
+	queries := cq["queries"].([]any)
+	spec := queries[0].(map[string]any)["spec"].(map[string]any)
+	delete(spec, "name")
+
+	_, err := ValidateFromMap(alert)
+	if err == nil {
+		t.Fatal("expected error for missing query name")
+	}
+	if !strings.Contains(err.Error(), "name") {
+		t.Errorf("error should mention 'name', got: %v", err)
+	}
+}
+
+func TestValidate_QueryMissingSignal(t *testing.T) {
+	alert := minimalValidAlert()
+	cond := alert["condition"].(map[string]any)
+	cq := cond["compositeQuery"].(map[string]any)
+	queries := cq["queries"].([]any)
+	spec := queries[0].(map[string]any)["spec"].(map[string]any)
+	delete(spec, "signal")
+
+	_, err := ValidateFromMap(alert)
+	if err == nil {
+		t.Fatal("expected error for missing signal")
+	}
+	if !strings.Contains(err.Error(), "signal") {
+		t.Errorf("error should mention 'signal', got: %v", err)
+	}
+}
+
+func TestValidate_InvalidQueryType(t *testing.T) {
+	alert := minimalValidAlert()
+	cond := alert["condition"].(map[string]any)
+	cq := cond["compositeQuery"].(map[string]any)
+	cq["queryType"] = "invalid_query_type"
+
+	_, err := ValidateFromMap(alert)
+	if err == nil {
+		t.Fatal("expected error for invalid queryType")
+	}
+	if !strings.Contains(err.Error(), "invalid_query_type") {
+		t.Errorf("error should mention the invalid value, got: %v", err)
+	}
+}
+
+func TestValidate_MultipleErrors(t *testing.T) {
+	alert := map[string]any{
+		"alert":     "",
+		"alertType": "INVALID",
+		"ruleType":  "INVALID",
+	}
+
+	_, err := ValidateFromMap(alert)
+	if err == nil {
+		t.Fatal("expected error for multiple invalid fields")
+	}
+	errStr := err.Error()
+	if !strings.Contains(errStr, "alert") || !strings.Contains(errStr, "alertType") || !strings.Contains(errStr, "ruleType") || !strings.Contains(errStr, "condition") {
+		t.Errorf("error should mention all invalid fields, got: %v", errStr)
+	}
+}
+
+func TestValidate_ExistingEvaluationPreserved(t *testing.T) {
+	alert := minimalValidAlert()
+	alert["evaluation"] = map[string]any{
+		"kind": "rolling",
+		"spec": map[string]any{
+			"evalWindow": "10m0s",
+			"frequency":  "2m0s",
+		},
+	}
+
+	result, err := ValidateFromMap(alert)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var parsed map[string]any
+	json.Unmarshal(result, &parsed)
+
+	// evalWindow/frequency should be removed
+	if _, has := parsed["evalWindow"]; has {
+		t.Error("evalWindow should be removed")
+	}
+	if _, has := parsed["frequency"]; has {
+		t.Error("frequency should be removed")
+	}
+
+	// existing evaluation should be preserved
+	eval := parsed["evaluation"].(map[string]any)
+	evalSpec := eval["spec"].(map[string]any)
+	if evalSpec["evalWindow"] != "10m0s" {
+		t.Errorf("expected preserved evalWindow=10m0s, got %v", evalSpec["evalWindow"])
+	}
+	if evalSpec["frequency"] != "2m0s" {
+		t.Errorf("expected preserved frequency=2m0s, got %v", evalSpec["frequency"])
+	}
+}

--- a/pkg/alert/validate_test.go
+++ b/pkg/alert/validate_test.go
@@ -618,3 +618,59 @@ func TestValidate_PromQLQueryMissingQueryText(t *testing.T) {
 		t.Errorf("error should mention missing query, got: %v", err)
 	}
 }
+
+func TestValidate_FormulaMissingExpression(t *testing.T) {
+	alert := minimalValidAlert()
+	cond := alert["condition"].(map[string]any)
+	cq := cond["compositeQuery"].(map[string]any)
+	queries := cq["queries"].([]any)
+	// Add a formula with empty expression
+	queries = append(queries, map[string]any{
+		"type": "builder_formula",
+		"spec": map[string]any{
+			"name": "F1",
+		},
+	})
+	cq["queries"] = queries
+
+	_, err := ValidateFromMap(alert)
+	if err == nil {
+		t.Fatal("expected error when builder_formula is missing expression")
+	}
+	if !strings.Contains(err.Error(), "expression") {
+		t.Errorf("error should mention missing expression, got: %v", err)
+	}
+}
+
+func TestValidate_FormulaWithExpression(t *testing.T) {
+	alert := minimalValidAlert()
+	cond := alert["condition"].(map[string]any)
+	cq := cond["compositeQuery"].(map[string]any)
+	cq["unit"] = "percent"
+	queries := cq["queries"].([]any)
+	queries = append(queries, map[string]any{
+		"type": "builder_formula",
+		"spec": map[string]any{
+			"name":       "F1",
+			"expression": "A * 100",
+		},
+	})
+	cq["queries"] = queries
+	cond["selectedQueryName"] = "F1"
+
+	result, err := ValidateFromMap(alert)
+	if err != nil {
+		t.Fatalf("expected no error for valid formula, got: %v", err)
+	}
+
+	var parsed map[string]any
+	if err := json.Unmarshal(result, &parsed); err != nil {
+		t.Fatalf("failed to unmarshal result: %v", err)
+	}
+	// unit should be preserved
+	parsedCond := parsed["condition"].(map[string]any)
+	parsedCQ := parsedCond["compositeQuery"].(map[string]any)
+	if parsedCQ["unit"] != "percent" {
+		t.Errorf("expected compositeQuery.unit=percent, got %v", parsedCQ["unit"])
+	}
+}

--- a/pkg/alert/validate_test.go
+++ b/pkg/alert/validate_test.go
@@ -6,8 +6,7 @@ import (
 	"testing"
 )
 
-// minimalValidAlert returns a minimal valid alert rule as map[string]any.
-// Uses v1-style op/target/matchType which will be auto-converted to v2.
+// minimalValidAlert returns a minimal valid alert rule using v2alpha1 schema.
 func minimalValidAlert() map[string]any {
 	return map[string]any{
 		"alert":     "Test Alert",
@@ -32,9 +31,17 @@ func minimalValidAlert() map[string]any {
 					},
 				},
 			},
-			"op":        "1",
-			"target":    float64(100),
-			"matchType": "1",
+			"thresholds": map[string]any{
+				"kind": "basic",
+				"spec": []any{
+					map[string]any{
+						"name":      "warning",
+						"target":    float64(100),
+						"op":        "1",
+						"matchType": "1",
+					},
+				},
+			},
 		},
 	}
 }
@@ -51,23 +58,15 @@ func TestValidate_MinimalValidAlert(t *testing.T) {
 		t.Fatalf("failed to parse result: %v", err)
 	}
 
-	// Check v2 defaults were applied
+	// Check defaults were applied
 	if parsed["version"] != "v5" {
 		t.Errorf("expected version=v5, got %v", parsed["version"])
 	}
-	if parsed["schemaVersion"] != "v2" {
-		t.Errorf("expected schemaVersion=v2, got %v", parsed["schemaVersion"])
+	if parsed["schemaVersion"] != "v2alpha1" {
+		t.Errorf("expected schemaVersion=v2alpha1, got %v", parsed["schemaVersion"])
 	}
 	if parsed["source"] != "mcp" {
 		t.Errorf("expected source=mcp, got %v", parsed["source"])
-	}
-
-	// v1 evalWindow/frequency should be removed
-	if _, has := parsed["evalWindow"]; has {
-		t.Error("evalWindow should be removed (converted to evaluation block)")
-	}
-	if _, has := parsed["frequency"]; has {
-		t.Error("frequency should be removed (converted to evaluation block)")
 	}
 
 	// evaluation block should exist
@@ -97,7 +96,7 @@ func TestValidate_MinimalValidAlert(t *testing.T) {
 		t.Errorf("expected severity=warning, got %v", labels["severity"])
 	}
 
-	// Check v1→v2 threshold conversion
+	// thresholds should be preserved
 	cond := parsed["condition"].(map[string]any)
 	if cond["selectedQueryName"] != "A" {
 		t.Errorf("expected selectedQueryName=A, got %v", cond["selectedQueryName"])
@@ -114,23 +113,6 @@ func TestValidate_MinimalValidAlert(t *testing.T) {
 	if spec["target"] != float64(100) {
 		t.Errorf("expected threshold target=100, got %v", spec["target"])
 	}
-	if spec["op"] != "1" {
-		t.Errorf("expected threshold op=1, got %v", spec["op"])
-	}
-	if spec["matchType"] != "1" {
-		t.Errorf("expected threshold matchType=1, got %v", spec["matchType"])
-	}
-	if spec["name"] != "warning" {
-		t.Errorf("expected threshold name=warning (from default severity), got %v", spec["name"])
-	}
-
-	// v1 condition-level fields should be cleared
-	if cond["op"] != "" {
-		t.Errorf("expected condition.op to be cleared, got %v", cond["op"])
-	}
-	if cond["matchType"] != "" {
-		t.Errorf("expected condition.matchType to be cleared, got %v", cond["matchType"])
-	}
 
 	// annotations
 	annotations, ok := parsed["annotations"].(map[string]any)
@@ -139,100 +121,6 @@ func TestValidate_MinimalValidAlert(t *testing.T) {
 	}
 	if _, hasDesc := annotations["description"]; !hasDesc {
 		t.Error("expected default description annotation")
-	}
-}
-
-func TestValidate_V1ToV2Conversion(t *testing.T) {
-	alert := map[string]any{
-		"alert":     "V1 Alert",
-		"alertType": "LOGS_BASED_ALERT",
-		"ruleType":  "threshold_rule",
-		"evalWindow": "10m0s",
-		"frequency":  "2m0s",
-		"labels": map[string]any{
-			"severity": "critical",
-		},
-		"preferredChannels": []any{"slack-alerts"},
-		"condition": map[string]any{
-			"compositeQuery": map[string]any{
-				"queryType": "builder",
-				"queries": []any{
-					map[string]any{
-						"type": "builder_query",
-						"spec": map[string]any{
-							"name":   "A",
-							"signal": "logs",
-							"aggregations": []any{
-								map[string]any{"expression": "count()"},
-							},
-							"filter": map[string]any{"expression": ""},
-						},
-					},
-				},
-			},
-			"op":        "1",
-			"target":    float64(500),
-			"matchType": "4",
-			"targetUnit": "count",
-		},
-	}
-
-	result, err := ValidateFromMap(alert)
-	if err != nil {
-		t.Fatalf("expected no error, got: %v", err)
-	}
-
-	var parsed map[string]any
-	if err := json.Unmarshal(result, &parsed); err != nil {
-		t.Fatalf("failed to unmarshal result: %v", err)
-	}
-
-	// schemaVersion should be v2
-	if parsed["schemaVersion"] != "v2" {
-		t.Errorf("expected schemaVersion=v2, got %v", parsed["schemaVersion"])
-	}
-
-	// evalWindow/frequency should be removed, evaluation block created
-	if _, has := parsed["evalWindow"]; has {
-		t.Error("evalWindow should be removed")
-	}
-	if _, has := parsed["frequency"]; has {
-		t.Error("frequency should be removed")
-	}
-	eval := parsed["evaluation"].(map[string]any)
-	evalSpec := eval["spec"].(map[string]any)
-	if evalSpec["evalWindow"] != "10m0s" {
-		t.Errorf("expected evaluation.spec.evalWindow=10m0s (from v1), got %v", evalSpec["evalWindow"])
-	}
-	if evalSpec["frequency"] != "2m0s" {
-		t.Errorf("expected evaluation.spec.frequency=2m0s (from v1), got %v", evalSpec["frequency"])
-	}
-
-	// v1 threshold should be converted to v2
-	cond := parsed["condition"].(map[string]any)
-	thresholds := cond["thresholds"].(map[string]any)
-	specs := thresholds["spec"].([]any)
-	spec := specs[0].(map[string]any)
-	if spec["name"] != "critical" {
-		t.Errorf("expected threshold name=critical (from severity label), got %v", spec["name"])
-	}
-	if spec["target"] != float64(500) {
-		t.Errorf("expected threshold target=500, got %v", spec["target"])
-	}
-	if spec["targetUnit"] != "count" {
-		t.Errorf("expected threshold targetUnit=count, got %v", spec["targetUnit"])
-	}
-	if spec["op"] != "1" {
-		t.Errorf("expected threshold op=1, got %v", spec["op"])
-	}
-	if spec["matchType"] != "4" {
-		t.Errorf("expected threshold matchType=4, got %v", spec["matchType"])
-	}
-
-	// preferredChannels should be copied to threshold channels
-	channels, ok := spec["channels"].([]any)
-	if !ok || len(channels) != 1 || channels[0] != "slack-alerts" {
-		t.Errorf("expected threshold channels=[slack-alerts], got %v", spec["channels"])
 	}
 }
 
@@ -408,56 +296,23 @@ func TestValidate_EmptyQueries(t *testing.T) {
 	}
 }
 
-func TestValidate_NoThresholdOrOp(t *testing.T) {
+func TestValidate_NoThresholds(t *testing.T) {
 	alert := minimalValidAlert()
 	cond := alert["condition"].(map[string]any)
-	delete(cond, "op")
-	delete(cond, "target")
-	delete(cond, "matchType")
+	delete(cond, "thresholds")
 
 	_, err := ValidateFromMap(alert)
 	if err == nil {
-		t.Fatal("expected error when neither op/target nor thresholds is set")
+		t.Fatal("expected error when thresholds are missing")
 	}
-	if !strings.Contains(err.Error(), "op+target") || !strings.Contains(err.Error(), "thresholds") {
-		t.Errorf("error should mention both options, got: %v", err)
-	}
-}
-
-func TestValidate_V1ThresholdPartialOpOnly(t *testing.T) {
-	alert := minimalValidAlert()
-	cond := alert["condition"].(map[string]any)
-	delete(cond, "target")
-
-	_, err := ValidateFromMap(alert)
-	if err == nil {
-		t.Fatal("expected error when only op is set without target")
-	}
-	if !strings.Contains(err.Error(), "both op and target") {
-		t.Errorf("error should mention both op and target, got: %v", err)
-	}
-}
-
-func TestValidate_V1ThresholdPartialTargetOnly(t *testing.T) {
-	alert := minimalValidAlert()
-	cond := alert["condition"].(map[string]any)
-	delete(cond, "op")
-
-	_, err := ValidateFromMap(alert)
-	if err == nil {
-		t.Fatal("expected error when only target is set without op")
-	}
-	if !strings.Contains(err.Error(), "both op and target") {
-		t.Errorf("error should mention both op and target, got: %v", err)
+	if !strings.Contains(err.Error(), "thresholds") {
+		t.Errorf("error should mention thresholds, got: %v", err)
 	}
 }
 
 func TestValidate_V2ThresholdMissingOpAndMatchType(t *testing.T) {
 	alert := minimalValidAlert()
 	cond := alert["condition"].(map[string]any)
-	delete(cond, "op")
-	delete(cond, "target")
-	delete(cond, "matchType")
 	cond["thresholds"] = map[string]any{
 		"kind": "basic",
 		"spec": []any{
@@ -478,34 +333,6 @@ func TestValidate_V2ThresholdMissingOpAndMatchType(t *testing.T) {
 	}
 	if !strings.Contains(errStr, ".matchType") {
 		t.Errorf("error should mention missing matchType, got: %v", errStr)
-	}
-}
-
-func TestValidate_InvalidCompareOp(t *testing.T) {
-	alert := minimalValidAlert()
-	cond := alert["condition"].(map[string]any)
-	cond["op"] = "invalid_op"
-
-	_, err := ValidateFromMap(alert)
-	if err == nil {
-		t.Fatal("expected error for invalid op")
-	}
-	if !strings.Contains(err.Error(), "invalid_op") {
-		t.Errorf("error should mention the invalid value, got: %v", err)
-	}
-}
-
-func TestValidate_InvalidMatchType(t *testing.T) {
-	alert := minimalValidAlert()
-	cond := alert["condition"].(map[string]any)
-	cond["matchType"] = "invalid_match"
-
-	_, err := ValidateFromMap(alert)
-	if err == nil {
-		t.Fatal("expected error for invalid matchType")
-	}
-	if !strings.Contains(err.Error(), "invalid_match") {
-		t.Errorf("error should mention the invalid value, got: %v", err)
 	}
 }
 
@@ -557,9 +384,7 @@ func TestValidate_SignalMismatch(t *testing.T) {
 func TestValidate_AlertOnAbsentNoThreshold(t *testing.T) {
 	alert := minimalValidAlert()
 	cond := alert["condition"].(map[string]any)
-	delete(cond, "op")
-	delete(cond, "target")
-	delete(cond, "matchType")
+	delete(cond, "thresholds")
 	cond["alertOnAbsent"] = true
 
 	result, err := ValidateFromMap(alert)
@@ -570,13 +395,12 @@ func TestValidate_AlertOnAbsentNoThreshold(t *testing.T) {
 		t.Fatal("expected non-nil result")
 	}
 
-	// Should still have v2 schema but no auto-generated thresholds
 	var parsed map[string]any
 	if err := json.Unmarshal(result, &parsed); err != nil {
 		t.Fatalf("failed to unmarshal result: %v", err)
 	}
-	if parsed["schemaVersion"] != "v2" {
-		t.Errorf("expected schemaVersion=v2, got %v", parsed["schemaVersion"])
+	if parsed["schemaVersion"] != "v2alpha1" {
+		t.Errorf("expected schemaVersion=v2alpha1, got %v", parsed["schemaVersion"])
 	}
 }
 
@@ -608,9 +432,6 @@ func TestValidate_PreservesExistingLabels(t *testing.T) {
 func TestValidate_V2ThresholdsMissingSpec(t *testing.T) {
 	alert := minimalValidAlert()
 	cond := alert["condition"].(map[string]any)
-	delete(cond, "op")
-	delete(cond, "target")
-	delete(cond, "matchType")
 	cond["thresholds"] = map[string]any{
 		"kind": "basic",
 		"spec": []any{},
@@ -711,12 +532,8 @@ func TestValidate_ExistingEvaluationPreserved(t *testing.T) {
 		t.Fatalf("failed to unmarshal result: %v", err)
 	}
 
-	// evalWindow/frequency should be removed
-	if _, has := parsed["evalWindow"]; has {
-		t.Error("evalWindow should be removed")
-	}
-	if _, has := parsed["frequency"]; has {
-		t.Error("frequency should be removed")
+	if parsed["schemaVersion"] != "v2alpha1" {
+		t.Errorf("expected schemaVersion=v2alpha1, got %v", parsed["schemaVersion"])
 	}
 
 	// existing evaluation should be preserved

--- a/pkg/alert/validate_test.go
+++ b/pkg/alert/validate_test.go
@@ -546,3 +546,75 @@ func TestValidate_ExistingEvaluationPreserved(t *testing.T) {
 		t.Errorf("expected preserved frequency=2m0s, got %v", evalSpec["frequency"])
 	}
 }
+
+func TestValidate_ConditionNotObject(t *testing.T) {
+	alert := map[string]any{
+		"alert":     "Test",
+		"alertType": "METRIC_BASED_ALERT",
+		"ruleType":  "threshold_rule",
+		"condition": "not-an-object",
+	}
+
+	_, err := ValidateFromMap(alert)
+	if err == nil {
+		t.Fatal("expected error when condition is not an object")
+	}
+	if !strings.Contains(err.Error(), "condition") || !strings.Contains(err.Error(), "compositeQuery") {
+		t.Errorf("error should mention condition must be an object with compositeQuery, got: %v", err)
+	}
+}
+
+func TestValidate_ThresholdSpecNotObject(t *testing.T) {
+	alert := minimalValidAlert()
+	cond := alert["condition"].(map[string]any)
+	cond["thresholds"] = map[string]any{
+		"kind": "basic",
+		"spec": []any{"not-an-object"},
+	}
+
+	_, err := ValidateFromMap(alert)
+	if err == nil {
+		t.Fatal("expected error when threshold spec entry is not an object")
+	}
+	if !strings.Contains(err.Error(), "name, target, op, and matchType") {
+		t.Errorf("error should describe expected threshold fields, got: %v", err)
+	}
+}
+
+func TestValidate_PromQLQueryMissingQueryText(t *testing.T) {
+	alert := map[string]any{
+		"alert":     "PromQL Alert",
+		"alertType": "METRIC_BASED_ALERT",
+		"ruleType":  "promql_rule",
+		"condition": map[string]any{
+			"compositeQuery": map[string]any{
+				"queryType": "promql",
+				"queries": []any{
+					map[string]any{
+						"type": "builder_query",
+						"spec": map[string]any{
+							"name": "A",
+						},
+					},
+				},
+			},
+			"thresholds": map[string]any{
+				"kind": "basic",
+				"spec": []any{
+					map[string]any{
+						"name": "warning", "target": float64(5),
+						"op": "1", "matchType": "1",
+					},
+				},
+			},
+		},
+	}
+
+	_, err := ValidateFromMap(alert)
+	if err == nil {
+		t.Fatal("expected error when promql query is missing query text")
+	}
+	if !strings.Contains(err.Error(), "query") {
+		t.Errorf("error should mention missing query, got: %v", err)
+	}
+}

--- a/pkg/alert/validate_test.go
+++ b/pkg/alert/validate_test.go
@@ -183,7 +183,9 @@ func TestValidate_V1ToV2Conversion(t *testing.T) {
 	}
 
 	var parsed map[string]any
-	json.Unmarshal(result, &parsed)
+	if err := json.Unmarshal(result, &parsed); err != nil {
+		t.Fatalf("failed to unmarshal result: %v", err)
+	}
 
 	// schemaVersion should be v2
 	if parsed["schemaVersion"] != "v2" {
@@ -292,7 +294,9 @@ func TestValidate_V2ThresholdsPreserved(t *testing.T) {
 	}
 
 	var parsed map[string]any
-	json.Unmarshal(result, &parsed)
+	if err := json.Unmarshal(result, &parsed); err != nil {
+		t.Fatalf("failed to unmarshal result: %v", err)
+	}
 
 	// v2 thresholds should be preserved as-is
 	cond := parsed["condition"].(map[string]any)
@@ -420,6 +424,63 @@ func TestValidate_NoThresholdOrOp(t *testing.T) {
 	}
 }
 
+func TestValidate_V1ThresholdPartialOpOnly(t *testing.T) {
+	alert := minimalValidAlert()
+	cond := alert["condition"].(map[string]any)
+	delete(cond, "target")
+
+	_, err := ValidateFromMap(alert)
+	if err == nil {
+		t.Fatal("expected error when only op is set without target")
+	}
+	if !strings.Contains(err.Error(), "both op and target") {
+		t.Errorf("error should mention both op and target, got: %v", err)
+	}
+}
+
+func TestValidate_V1ThresholdPartialTargetOnly(t *testing.T) {
+	alert := minimalValidAlert()
+	cond := alert["condition"].(map[string]any)
+	delete(cond, "op")
+
+	_, err := ValidateFromMap(alert)
+	if err == nil {
+		t.Fatal("expected error when only target is set without op")
+	}
+	if !strings.Contains(err.Error(), "both op and target") {
+		t.Errorf("error should mention both op and target, got: %v", err)
+	}
+}
+
+func TestValidate_V2ThresholdMissingOpAndMatchType(t *testing.T) {
+	alert := minimalValidAlert()
+	cond := alert["condition"].(map[string]any)
+	delete(cond, "op")
+	delete(cond, "target")
+	delete(cond, "matchType")
+	cond["thresholds"] = map[string]any{
+		"kind": "basic",
+		"spec": []any{
+			map[string]any{
+				"name":   "critical",
+				"target": float64(5),
+			},
+		},
+	}
+
+	_, err := ValidateFromMap(alert)
+	if err == nil {
+		t.Fatal("expected error when v2 threshold spec is missing op and matchType")
+	}
+	errStr := err.Error()
+	if !strings.Contains(errStr, ".op") {
+		t.Errorf("error should mention missing op, got: %v", errStr)
+	}
+	if !strings.Contains(errStr, ".matchType") {
+		t.Errorf("error should mention missing matchType, got: %v", errStr)
+	}
+}
+
 func TestValidate_InvalidCompareOp(t *testing.T) {
 	alert := minimalValidAlert()
 	cond := alert["condition"].(map[string]any)
@@ -511,7 +572,9 @@ func TestValidate_AlertOnAbsentNoThreshold(t *testing.T) {
 
 	// Should still have v2 schema but no auto-generated thresholds
 	var parsed map[string]any
-	json.Unmarshal(result, &parsed)
+	if err := json.Unmarshal(result, &parsed); err != nil {
+		t.Fatalf("failed to unmarshal result: %v", err)
+	}
 	if parsed["schemaVersion"] != "v2" {
 		t.Errorf("expected schemaVersion=v2, got %v", parsed["schemaVersion"])
 	}
@@ -530,7 +593,9 @@ func TestValidate_PreservesExistingLabels(t *testing.T) {
 	}
 
 	var parsed map[string]any
-	json.Unmarshal(result, &parsed)
+	if err := json.Unmarshal(result, &parsed); err != nil {
+		t.Fatalf("failed to unmarshal result: %v", err)
+	}
 	labels := parsed["labels"].(map[string]any)
 	if labels["severity"] != "critical" {
 		t.Errorf("should preserve existing severity=critical, got %v", labels["severity"])
@@ -642,7 +707,9 @@ func TestValidate_ExistingEvaluationPreserved(t *testing.T) {
 	}
 
 	var parsed map[string]any
-	json.Unmarshal(result, &parsed)
+	if err := json.Unmarshal(result, &parsed); err != nil {
+		t.Fatalf("failed to unmarshal result: %v", err)
+	}
 
 	// evalWindow/frequency should be removed
 	if _, has := parsed["evalWindow"]; has {

--- a/pkg/types/alertrule.go
+++ b/pkg/types/alertrule.go
@@ -1,0 +1,177 @@
+package types
+
+// AlertType identifies the signal an alert monitors.
+type AlertType string
+
+const (
+	AlertTypeMetric     AlertType = "METRIC_BASED_ALERT"
+	AlertTypeLogs       AlertType = "LOGS_BASED_ALERT"
+	AlertTypeTraces     AlertType = "TRACES_BASED_ALERT"
+	AlertTypeExceptions AlertType = "EXCEPTIONS_BASED_ALERT"
+)
+
+// RuleType identifies how the alert condition is evaluated.
+type RuleType string
+
+const (
+	RuleTypeThreshold RuleType = "threshold_rule"
+	RuleTypePromQL    RuleType = "promql_rule"
+	RuleTypeAnomaly   RuleType = "anomaly_rule"
+)
+
+// AlertRule is the payload for creating an alert rule via POST /api/v1/rules.
+// It matches the SigNoz PostableRule structure.
+type AlertRule struct {
+	Alert             string            `json:"alert" jsonschema:"required" jsonschema_extras:"description=Name of the alert rule. Must be unique and descriptive."`
+	AlertType         AlertType         `json:"alertType" jsonschema:"required" jsonschema_extras:"description=Signal type: METRIC_BASED_ALERT or LOGS_BASED_ALERT or TRACES_BASED_ALERT or EXCEPTIONS_BASED_ALERT."`
+	RuleType          RuleType          `json:"ruleType" jsonschema:"required" jsonschema_extras:"description=Evaluation type: threshold_rule (compare against value) or promql_rule (PromQL expression) or anomaly_rule (anomaly detection on metrics)."`
+	Description       string            `json:"description,omitempty" jsonschema_extras:"description=Human-readable description of what this alert monitors."`
+	EvalWindow        string            `json:"evalWindow,omitempty" jsonschema_extras:"description=Deprecated: use evaluation field instead. Auto-converted to v2 evaluation block. Go duration string (e.g. 5m0s)."`
+	Frequency         string            `json:"frequency,omitempty" jsonschema_extras:"description=Deprecated: use evaluation field instead. Auto-converted to v2 evaluation block. Go duration string (e.g. 1m0s)."`
+	Condition         AlertCondition    `json:"condition" jsonschema:"required" jsonschema_extras:"description=Alert condition containing the query and threshold configuration."`
+	Labels            map[string]string `json:"labels,omitempty" jsonschema_extras:"description=Labels for the alert rule. MUST include severity (info or warning or critical). Labels enable routing policies - use labels like team or service or environment for routing."`
+	Annotations       map[string]string `json:"annotations,omitempty" jsonschema_extras:"description=Annotations like description and summary. Supports template variables: {{$value}} for current metric value and {{$threshold}} for the threshold and {{$labels.key}} for label values."`
+	Disabled          bool              `json:"disabled,omitempty" jsonschema_extras:"description=Whether the alert rule is disabled. Defaults to false (enabled)."`
+	Source            string            `json:"source,omitempty" jsonschema_extras:"description=Source URL for the alert. Set automatically."`
+	PreferredChannels []string          `json:"preferredChannels,omitempty" jsonschema_extras:"description=Notification channel names to send alerts to. Use signoz_get_alert on an existing alert to discover available channel names."`
+	Version           string            `json:"version,omitempty" jsonschema_extras:"description=API version. Always v5. Set automatically if omitted."`
+
+	// v2 schema fields
+	Evaluation           *AlertEvaluation     `json:"evaluation,omitempty" jsonschema_extras:"description=Evaluation configuration. Specifies eval window and frequency. Auto-generated with defaults (5m0s window and 1m0s frequency) if omitted."`
+	SchemaVersion        string               `json:"schemaVersion,omitempty" jsonschema_extras:"description=Schema version. Always set to v2 automatically."`
+	NotificationSettings *NotificationSettings `json:"notificationSettings,omitempty" jsonschema_extras:"description=Notification settings. Controls grouping and re-notification behavior. Auto-generated with defaults if omitted."`
+}
+
+// AlertCondition defines when an alert should fire.
+type AlertCondition struct {
+	CompositeQuery AlertCompositeQuery `json:"compositeQuery" jsonschema:"required" jsonschema_extras:"description=The composite query defining what data to monitor."`
+
+	// Deprecated: use thresholds instead. These are auto-converted to v2 thresholds.
+	CompareOp string   `json:"op,omitempty" jsonschema_extras:"description=Deprecated: use thresholds instead. Auto-converted to v2 thresholds. Numeric codes: 1=above 2=below 3=equal 4=not_equal."`
+	Target    *float64 `json:"target,omitempty" jsonschema_extras:"description=Deprecated: use thresholds instead. Auto-converted to v2 thresholds. Threshold value to compare against."`
+	MatchType string   `json:"matchType,omitempty" jsonschema_extras:"description=Deprecated: use thresholds instead. Auto-converted to v2 thresholds. Numeric codes: 1=at_least_once 2=all_the_times 3=on_average 4=in_total 5=last."`
+
+	SelectedQuery string `json:"selectedQueryName,omitempty" jsonschema_extras:"description=Which query name triggers the alert (e.g. A or B or F1). Required when multiple queries exist. Defaults to the first query name."`
+	TargetUnit    string `json:"targetUnit,omitempty" jsonschema_extras:"description=Unit for the target value (e.g. ms percent bytes)."`
+
+	// Absent data alerting
+	AlertOnAbsent     bool   `json:"alertOnAbsent,omitempty" jsonschema_extras:"description=Alert when no data is received within the evaluation window."`
+	AbsentFor         uint64 `json:"absentFor,omitempty" jsonschema_extras:"description=Duration in milliseconds to wait before firing an absent-data alert."`
+	RequireMinPoints  bool   `json:"requireMinPoints,omitempty" jsonschema_extras:"description=Require a minimum number of data points before evaluating the condition."`
+	RequiredNumPoints int    `json:"requiredNumPoints,omitempty" jsonschema_extras:"description=Minimum number of data points required when requireMinPoints is true."`
+
+	// Anomaly detection fields (for ruleType=anomaly_rule)
+	Algorithm   string `json:"algorithm,omitempty" jsonschema_extras:"description=Anomaly detection algorithm. Currently only zscore is supported."`
+	Seasonality string `json:"seasonality,omitempty" jsonschema_extras:"description=Seasonality pattern for anomaly detection: hourly or daily or weekly."`
+
+	// Threshold configuration — the primary way to define alert thresholds.
+	Thresholds *AlertThresholds `json:"thresholds,omitempty" jsonschema_extras:"description=Threshold configuration. Each threshold level (critical or warning or info) can route to different notification channels. Auto-generated from op/target/matchType if not provided."`
+}
+
+// AlertCompositeQuery contains the queries that define what data to monitor.
+type AlertCompositeQuery struct {
+	QueryType QueryType    `json:"queryType" jsonschema:"required" jsonschema_extras:"description=Query type: builder for Query Builder or promql for PromQL or clickhouse_sql for ClickHouse SQL."`
+	PanelType string       `json:"panelType,omitempty" jsonschema_extras:"description=Panel type. Use graph for alerts. Defaults to graph."`
+	Unit      string       `json:"unit,omitempty" jsonschema_extras:"description=Unit for the query result display."`
+	Queries   []AlertQuery `json:"queries" jsonschema:"required" jsonschema_extras:"description=Array of queries. At least one query is required."`
+}
+
+// AlertQuery wraps a single query within the composite query.
+type AlertQuery struct {
+	Type string         `json:"type" jsonschema:"required" jsonschema_extras:"description=Query type: builder_query for data queries or builder_formula for formulas combining queries."`
+	Spec AlertQuerySpec `json:"spec" jsonschema:"required" jsonschema_extras:"description=Query specification."`
+}
+
+// AlertQuerySpec is the specification for a single query within an alert.
+// For builder_query type this uses the v5 query builder format.
+// For promql/clickhouse_sql types only name query legend and disabled are used.
+type AlertQuerySpec struct {
+	Name         string              `json:"name" jsonschema:"required" jsonschema_extras:"description=Query name (e.g. A or B or C). Used as reference in formulas and selectedQueryName."`
+	Signal       string              `json:"signal,omitempty" jsonschema_extras:"description=Signal type for builder queries: metrics or logs or traces. Required for builder_query type."`
+	StepInterval *int64              `json:"stepInterval,omitempty" jsonschema_extras:"description=Step interval in seconds for time aggregation. Use 60 for metrics alerts."`
+	Disabled     bool                `json:"disabled,omitempty" jsonschema_extras:"description=Whether this query is disabled."`
+	Source       string              `json:"source,omitempty"`
+	Aggregations []AlertAggregation  `json:"aggregations,omitempty" jsonschema_extras:"description=Aggregation expressions for builder queries. Example: [{expression: count()}] or [{expression: avg(duration)}]."`
+	Filter       *AlertQueryFilter   `json:"filter,omitempty" jsonschema_extras:"description=Filter expression for builder queries. Example: {expression: service.name = frontend AND http.status_code >= 500}."`
+	GroupBy      []AlertGroupByField `json:"groupBy,omitempty" jsonschema_extras:"description=Fields to group by. Grouped dimensions appear as labels in alert notifications."`
+	Order        []AlertOrderField   `json:"order,omitempty" jsonschema_extras:"description=Order by specification."`
+	Having       *AlertQueryFilter   `json:"having,omitempty" jsonschema_extras:"description=Having clause to filter aggregation results."`
+
+	// For promql / clickhouse_sql query types
+	Query  string `json:"query,omitempty" jsonschema_extras:"description=PromQL or ClickHouse SQL query string. Used when queryType is promql or clickhouse_sql."`
+	Legend string `json:"legend,omitempty" jsonschema_extras:"description=Legend template for the query."`
+
+	// For builder_formula type
+	Expression string `json:"expression,omitempty" jsonschema_extras:"description=Formula expression referencing other query names (e.g. A / B * 100). Used for builder_formula type."`
+}
+
+// AlertAggregation represents an aggregation expression in a builder query.
+type AlertAggregation struct {
+	Expression string `json:"expression" jsonschema:"required" jsonschema_extras:"description=Aggregation expression. Examples: count() or avg(duration) or p99(durationNano) or count_distinct(user_id) or sum(bytes)."`
+}
+
+// AlertQueryFilter holds a filter or having expression.
+type AlertQueryFilter struct {
+	Expression string `json:"expression" jsonschema_extras:"description=Filter expression using field operators. Example: service.name = frontend AND http.status_code >= 500. Use empty string for no filter."`
+}
+
+// AlertGroupByField identifies a field to group by.
+type AlertGroupByField struct {
+	Name          string `json:"name" jsonschema:"required" jsonschema_extras:"description=Field name to group by (e.g. service.name or http.method or severity_text)."`
+	FieldContext  string `json:"fieldContext,omitempty" jsonschema_extras:"description=Field context: resource for resource attributes or tag for span/log attributes. Required for non-top-level fields."`
+	FieldDataType string `json:"fieldDataType,omitempty" jsonschema_extras:"description=Data type of the field: string or int64 or float64 or bool."`
+}
+
+// AlertOrderField specifies ordering for query results.
+type AlertOrderField struct {
+	Key       AlertOrderKey `json:"key" jsonschema:"required"`
+	Direction string        `json:"direction" jsonschema:"required" jsonschema_extras:"description=Sort direction: asc or desc."`
+}
+
+// AlertOrderKey identifies the field to order by.
+type AlertOrderKey struct {
+	Name string `json:"name" jsonschema:"required" jsonschema_extras:"description=Field or aggregation expression to order by (e.g. timestamp or count())."`
+}
+
+// AlertThresholds holds multi-threshold configuration for v2 schema alerts.
+type AlertThresholds struct {
+	Kind string           `json:"kind" jsonschema:"required" jsonschema_extras:"description=Threshold kind. Currently only basic is supported."`
+	Spec []BasicThreshold `json:"spec" jsonschema:"required" jsonschema_extras:"description=Array of threshold specifications. Each threshold can route to different channels."`
+}
+
+// BasicThreshold defines a single threshold level with routing.
+type BasicThreshold struct {
+	Name           string   `json:"name" jsonschema:"required" jsonschema_extras:"description=Threshold name: critical or warning or info."`
+	Target         *float64 `json:"target" jsonschema:"required" jsonschema_extras:"description=Threshold value to compare against."`
+	TargetUnit     string   `json:"targetUnit,omitempty" jsonschema_extras:"description=Unit for the target value."`
+	RecoveryTarget *float64 `json:"recoveryTarget" jsonschema_extras:"description=Value below which the alert is considered recovered. Use null if not needed."`
+	MatchType      string   `json:"matchType" jsonschema:"required" jsonschema_extras:"description=How to evaluate: 1=at_least_once 2=all_the_times 3=on_average 4=in_total 5=last."`
+	CompareOp      string   `json:"op" jsonschema:"required" jsonschema_extras:"description=Comparison operator: 1=above 2=below 3=equal 4=not_equal."`
+	Channels       []string `json:"channels,omitempty" jsonschema_extras:"description=Notification channel names for this threshold level."`
+}
+
+// AlertEvaluation holds the evaluation schedule for v2 schema alerts.
+type AlertEvaluation struct {
+	Kind string              `json:"kind" jsonschema:"required" jsonschema_extras:"description=Evaluation kind. Currently only rolling is supported."`
+	Spec AlertEvaluationSpec `json:"spec" jsonschema:"required" jsonschema_extras:"description=Evaluation specification."`
+}
+
+// AlertEvaluationSpec defines the evaluation window and frequency.
+type AlertEvaluationSpec struct {
+	EvalWindow string `json:"evalWindow" jsonschema:"required" jsonschema_extras:"description=Evaluation window as a Go duration string (e.g. 5m0s 10m0s 15m0s 1h0m0s)."`
+	Frequency  string `json:"frequency" jsonschema:"required" jsonschema_extras:"description=Evaluation frequency as a Go duration string (e.g. 1m0s 5m0s)."`
+}
+
+// NotificationSettings controls alert notification behavior for v2 schema.
+type NotificationSettings struct {
+	GroupBy  []string  `json:"groupBy,omitempty" jsonschema_extras:"description=Fields to group alert notifications by (e.g. service.name). Reduces notification noise by batching alerts with the same group key."`
+	Renotify *Renotify `json:"renotify,omitempty" jsonschema_extras:"description=Re-notification configuration."`
+	UsePolicy bool     `json:"usePolicy,omitempty" jsonschema_extras:"description=Whether to use routing policies for notification routing."`
+}
+
+// Renotify controls re-notification behavior.
+type Renotify struct {
+	Enabled     bool     `json:"enabled" jsonschema_extras:"description=Whether re-notification is enabled."`
+	Interval    string   `json:"interval,omitempty" jsonschema_extras:"description=Re-notification interval as a Go duration string (e.g. 30m 4h0m0s)."`
+	AlertStates []string `json:"alertStates,omitempty" jsonschema_extras:"description=Alert states that trigger re-notification: firing or nodata."`
+}

--- a/pkg/types/alertrule.go
+++ b/pkg/types/alertrule.go
@@ -26,8 +26,6 @@ type AlertRule struct {
 	AlertType         AlertType         `json:"alertType" jsonschema:"required" jsonschema_extras:"description=Signal type: METRIC_BASED_ALERT or LOGS_BASED_ALERT or TRACES_BASED_ALERT or EXCEPTIONS_BASED_ALERT."`
 	RuleType          RuleType          `json:"ruleType" jsonschema:"required" jsonschema_extras:"description=Evaluation type: threshold_rule (compare against value) or promql_rule (PromQL expression) or anomaly_rule (anomaly detection on metrics)."`
 	Description       string            `json:"description,omitempty" jsonschema_extras:"description=Human-readable description of what this alert monitors."`
-	EvalWindow        string            `json:"evalWindow,omitempty" jsonschema_extras:"description=Deprecated: use evaluation field instead. Auto-converted to v2 evaluation block. Go duration string (e.g. 5m0s)."`
-	Frequency         string            `json:"frequency,omitempty" jsonschema_extras:"description=Deprecated: use evaluation field instead. Auto-converted to v2 evaluation block. Go duration string (e.g. 1m0s)."`
 	Condition         AlertCondition    `json:"condition" jsonschema:"required" jsonschema_extras:"description=Alert condition containing the query and threshold configuration."`
 	Labels            map[string]string `json:"labels,omitempty" jsonschema_extras:"description=Labels for the alert rule. MUST include severity (info or warning or critical). Labels enable routing policies - use labels like team or service or environment for routing."`
 	Annotations       map[string]string `json:"annotations,omitempty" jsonschema_extras:"description=Annotations like description and summary. Supports template variables: {{$value}} for current metric value and {{$threshold}} for the threshold and {{$labels.key}} for label values."`
@@ -38,7 +36,7 @@ type AlertRule struct {
 
 	// v2 schema fields
 	Evaluation           *AlertEvaluation     `json:"evaluation,omitempty" jsonschema_extras:"description=Evaluation configuration. Specifies eval window and frequency. Auto-generated with defaults (5m0s window and 1m0s frequency) if omitted."`
-	SchemaVersion        string               `json:"schemaVersion,omitempty" jsonschema_extras:"description=Schema version. Always set to v2 automatically."`
+	SchemaVersion        string               `json:"schemaVersion,omitempty" jsonschema_extras:"description=Schema version. Always set to v2alpha1 automatically."`
 	NotificationSettings *NotificationSettings `json:"notificationSettings,omitempty" jsonschema_extras:"description=Notification settings. Controls grouping and re-notification behavior. Auto-generated with defaults if omitted."`
 }
 
@@ -46,13 +44,7 @@ type AlertRule struct {
 type AlertCondition struct {
 	CompositeQuery AlertCompositeQuery `json:"compositeQuery" jsonschema:"required" jsonschema_extras:"description=The composite query defining what data to monitor."`
 
-	// Deprecated: use thresholds instead. These are auto-converted to v2 thresholds.
-	CompareOp string   `json:"op,omitempty" jsonschema_extras:"description=Deprecated: use thresholds instead. Auto-converted to v2 thresholds. Numeric codes: 1=above 2=below 3=equal 4=not_equal."`
-	Target    *float64 `json:"target,omitempty" jsonschema_extras:"description=Deprecated: use thresholds instead. Auto-converted to v2 thresholds. Threshold value to compare against."`
-	MatchType string   `json:"matchType,omitempty" jsonschema_extras:"description=Deprecated: use thresholds instead. Auto-converted to v2 thresholds. Numeric codes: 1=at_least_once 2=all_the_times 3=on_average 4=in_total 5=last."`
-
 	SelectedQuery string `json:"selectedQueryName,omitempty" jsonschema_extras:"description=Which query name triggers the alert (e.g. A or B or F1). Required when multiple queries exist. Defaults to the first query name."`
-	TargetUnit    string `json:"targetUnit,omitempty" jsonschema_extras:"description=Unit for the target value (e.g. ms percent bytes)."`
 
 	// Absent data alerting
 	AlertOnAbsent     bool   `json:"alertOnAbsent,omitempty" jsonschema_extras:"description=Alert when no data is received within the evaluation window."`
@@ -64,8 +56,8 @@ type AlertCondition struct {
 	Algorithm   string `json:"algorithm,omitempty" jsonschema_extras:"description=Anomaly detection algorithm. Currently only zscore is supported."`
 	Seasonality string `json:"seasonality,omitempty" jsonschema_extras:"description=Seasonality pattern for anomaly detection: hourly or daily or weekly."`
 
-	// Threshold configuration — the primary way to define alert thresholds.
-	Thresholds *AlertThresholds `json:"thresholds,omitempty" jsonschema_extras:"description=Threshold configuration. Each threshold level (critical or warning or info) can route to different notification channels. Auto-generated from op/target/matchType if not provided."`
+	// Threshold configuration (v2alpha1 schema).
+	Thresholds *AlertThresholds `json:"thresholds,omitempty" jsonschema_extras:"description=Threshold configuration (v2alpha1 schema). Each threshold level (critical or warning or info) can route to different notification channels. Required unless alertOnAbsent is true."`
 }
 
 // AlertCompositeQuery contains the queries that define what data to monitor.

--- a/pkg/types/alertrule.go
+++ b/pkg/types/alertrule.go
@@ -31,7 +31,7 @@ type AlertRule struct {
 	Annotations       map[string]string `json:"annotations,omitempty" jsonschema_extras:"description=Annotations like description and summary. Supports template variables: {{$value}} for current metric value and {{$threshold}} for the threshold and {{$labels.key}} for label values."`
 	Disabled          bool              `json:"disabled,omitempty" jsonschema_extras:"description=Whether the alert rule is disabled. Defaults to false (enabled)."`
 	Source            string            `json:"source,omitempty" jsonschema_extras:"description=Source URL for the alert. Set automatically."`
-	PreferredChannels []string          `json:"preferredChannels,omitempty" jsonschema_extras:"description=Notification channel names to send alerts to. Use signoz_get_alert on an existing alert to discover available channel names."`
+	PreferredChannels []string          `json:"preferredChannels,omitempty" jsonschema_extras:"description=Notification channel names to send alerts to. Use signoz_list_notification_channels to discover available channel names."`
 	Version           string            `json:"version,omitempty" jsonschema_extras:"description=API version. Always v5. Set automatically if omitted."`
 
 	// v2 schema fields
@@ -139,7 +139,7 @@ type BasicThreshold struct {
 	RecoveryTarget *float64 `json:"recoveryTarget" jsonschema_extras:"description=Value below which the alert is considered recovered. Use null if not needed."`
 	MatchType      string   `json:"matchType" jsonschema:"required" jsonschema_extras:"description=How to evaluate: 1=at_least_once 2=all_the_times 3=on_average 4=in_total 5=last."`
 	CompareOp      string   `json:"op" jsonschema:"required" jsonschema_extras:"description=Comparison operator: 1=above 2=below 3=equal 4=not_equal."`
-	Channels       []string `json:"channels,omitempty" jsonschema_extras:"description=Notification channel names for this threshold level."`
+	Channels       []string `json:"channels,omitempty" jsonschema_extras:"description=Notification channel names for this threshold level. Use signoz_list_notification_channels to discover available names."`
 }
 
 // AlertEvaluation holds the evaluation schedule for v2 schema alerts.

--- a/pkg/types/alertrule.go
+++ b/pkg/types/alertrule.go
@@ -64,7 +64,7 @@ type AlertCondition struct {
 type AlertCompositeQuery struct {
 	QueryType QueryType    `json:"queryType" jsonschema:"required" jsonschema_extras:"description=Query type: builder for Query Builder or promql for PromQL or clickhouse_sql for ClickHouse SQL."`
 	PanelType string       `json:"panelType,omitempty" jsonschema_extras:"description=Panel type. Use graph for alerts. Defaults to graph."`
-	Unit      string       `json:"unit,omitempty" jsonschema_extras:"description=Unit for the query result display."`
+	Unit      string       `json:"unit,omitempty" jsonschema_extras:"description=Unit of the queried data (Y-axis unit). Used for value formatting in alert messages and for unit conversion with targetUnit in thresholds. Common values: percent, ms, s, bytes, ns, reqps, ops."`
 	Queries   []AlertQuery `json:"queries" jsonschema:"required" jsonschema_extras:"description=Array of queries. At least one query is required."`
 }
 
@@ -135,7 +135,7 @@ type AlertThresholds struct {
 type BasicThreshold struct {
 	Name           string   `json:"name" jsonschema:"required" jsonschema_extras:"description=Threshold name: critical or warning or info."`
 	Target         *float64 `json:"target" jsonschema:"required" jsonschema_extras:"description=Threshold value to compare against."`
-	TargetUnit     string   `json:"targetUnit,omitempty" jsonschema_extras:"description=Unit for the target value."`
+	TargetUnit     string   `json:"targetUnit,omitempty" jsonschema_extras:"description=Unit of the threshold target value. If different from compositeQuery.unit the backend converts between them during evaluation. Common values: percent, ms, s, bytes, ns."`
 	RecoveryTarget *float64 `json:"recoveryTarget" jsonschema_extras:"description=Value below which the alert is considered recovered. Use null if not needed."`
 	MatchType      string   `json:"matchType" jsonschema:"required" jsonschema_extras:"description=How to evaluate: 1=at_least_once 2=all_the_times 3=on_average 4=in_total 5=last."`
 	CompareOp      string   `json:"op" jsonschema:"required" jsonschema_extras:"description=Comparison operator: 1=above 2=below 3=equal 4=not_equal."`


### PR DESCRIPTION
Add a new MCP tool for creating alert rules in SigNoz via POST /api/v1/rules. Supports all alert types (metrics, logs, traces, exceptions) and rule types (threshold, promql, anomaly) with automatic v2 schema enforcement.

Key features:
- AlertRule type with jsonschema tags for auto-generated JSON schema
- Validation pipeline (required fields, enums, condition structure, cross-constraints)
- Auto-conversion of v1 fields (op/target/matchType) to v2 thresholds
- Auto-generation of evaluation block and notificationSettings
- MCP resources (signoz://alert/instructions and signoz://alert/examples)
- 7 complete working examples covering all alert types
- 28 unit tests (24 validation + 4 handler)