### PR TITLE
feat: add signoz_create_notification_channel MCP tool

### DIFF
--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -518,3 +518,19 @@ func (s *SigNoz) DeleteDashboard(ctx context.Context, id string) error {
 	_, err := s.doRequest(ctx, http.MethodDelete, reqURL, nil, DashboardWriteTimeout)
 	return err
 }
+
+// ChannelWriteTimeout is used for notification channel create/test operations.
+const ChannelWriteTimeout = 30 * time.Second
+
+func (s *SigNoz) CreateNotificationChannel(ctx context.Context, receiverJSON []byte) (json.RawMessage, error) {
+	reqURL := fmt.Sprintf("%s/api/v1/channels", s.baseURL)
+	s.requestLogger(ctx).Debug("Creating notification channel")
+	return s.doRequest(ctx, http.MethodPost, reqURL, bytes.NewReader(receiverJSON), ChannelWriteTimeout)
+}
+
+func (s *SigNoz) TestNotificationChannel(ctx context.Context, receiverJSON []byte) error {
+	reqURL := fmt.Sprintf("%s/api/v1/testChannel", s.baseURL)
+	s.requestLogger(ctx).Debug("Testing notification channel")
+	_, err := s.doRequest(ctx, http.MethodPost, reqURL, bytes.NewReader(receiverJSON), ChannelWriteTimeout)
+	return err
+}

--- a/internal/client/interface.go
+++ b/internal/client/interface.go
@@ -29,4 +29,6 @@ type Client interface {
 	GetFieldKeys(ctx context.Context, signal, metricName, searchText, fieldContext, fieldDataType, source string) (json.RawMessage, error)
 	GetFieldValues(ctx context.Context, signal, name, metricName, searchText, source string) (json.RawMessage, error)
 	GetTraceDetails(ctx context.Context, traceID string, includeSpans bool, startTime, endTime int64) (json.RawMessage, error)
+	CreateNotificationChannel(ctx context.Context, receiverJSON []byte) (json.RawMessage, error)
+	TestNotificationChannel(ctx context.Context, receiverJSON []byte) error
 }

--- a/internal/client/mock.go
+++ b/internal/client/mock.go
@@ -29,7 +29,9 @@ type MockClient struct {
 	GetLogViewFn              func(ctx context.Context, viewID string) (json.RawMessage, error)
 	GetFieldKeysFn            func(ctx context.Context, signal, metricName, searchText, fieldContext, fieldDataType, source string) (json.RawMessage, error)
 	GetFieldValuesFn          func(ctx context.Context, signal, name, metricName, searchText, source string) (json.RawMessage, error)
-	GetTraceDetailsFn         func(ctx context.Context, traceID string, includeSpans bool, startTime, endTime int64) (json.RawMessage, error)
+	GetTraceDetailsFn              func(ctx context.Context, traceID string, includeSpans bool, startTime, endTime int64) (json.RawMessage, error)
+	CreateNotificationChannelFn    func(ctx context.Context, receiverJSON []byte) (json.RawMessage, error)
+	TestNotificationChannelFn      func(ctx context.Context, receiverJSON []byte) error
 }
 
 // Compile-time check that MockClient satisfies Client.
@@ -166,4 +168,18 @@ func (m *MockClient) GetTraceDetails(ctx context.Context, traceID string, includ
 		return m.GetTraceDetailsFn(ctx, traceID, includeSpans, startTime, endTime)
 	}
 	return json.RawMessage(`{}`), nil
+}
+
+func (m *MockClient) CreateNotificationChannel(ctx context.Context, receiverJSON []byte) (json.RawMessage, error) {
+	if m.CreateNotificationChannelFn != nil {
+		return m.CreateNotificationChannelFn(ctx, receiverJSON)
+	}
+	return json.RawMessage(`{}`), nil
+}
+
+func (m *MockClient) TestNotificationChannel(ctx context.Context, receiverJSON []byte) error {
+	if m.TestNotificationChannelFn != nil {
+		return m.TestNotificationChannelFn(ctx, receiverJSON)
+	}
+	return nil
 }

--- a/internal/handler/tools/notification_channels.go
+++ b/internal/handler/tools/notification_channels.go
@@ -1,0 +1,262 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
+	"go.uber.org/zap"
+
+	"github.com/SigNoz/signoz-mcp-server/pkg/types"
+)
+
+var validChannelTypes = map[string]bool{
+	"slack":    true,
+	"webhook":  true,
+	"pagerduty": true,
+	"email":    true,
+	"opsgenie": true,
+	"msteams":  true,
+}
+
+func (h *Handler) RegisterNotificationChannelHandlers(s *server.MCPServer) {
+	h.logger.Debug("Registering notification channel handlers")
+
+	createChannelTool := mcp.NewTool("signoz_create_notification_channel",
+		mcp.WithDestructiveHintAnnotation(true),
+		mcp.WithString("searchContext", mcp.Description("The user's original question or search text that triggered this tool call. Always include the user's raw query here for better results.")),
+		mcp.WithDescription(
+			"Create a notification channel in SigNoz and send a test notification to verify it works.\n\n"+
+				"SUPPORTED TYPES: slack, webhook, pagerduty, email, opsgenie, msteams\n\n"+
+				"REQUIRED FIELDS BY TYPE:\n"+
+				"- slack: name, slack_api_url (Slack incoming webhook URL)\n"+
+				"- webhook: name, webhook_url (endpoint URL)\n"+
+				"- pagerduty: name, pagerduty_routing_key (integration/routing key)\n"+
+				"- email: name, email_to (comma-separated email addresses)\n"+
+				"- opsgenie: name, opsgenie_api_key (OpsGenie API key)\n"+
+				"- msteams: name, msteams_webhook_url (MS Teams incoming webhook URL)\n\n"+
+				"After creating the channel, a test notification is always sent to verify the channel is working. "+
+				"The response includes both the channel creation result and the test notification outcome.",
+		),
+		// Common fields
+		mcp.WithString("type", mcp.Required(), mcp.Description("Channel type. One of: slack, webhook, pagerduty, email, opsgenie, msteams")),
+		mcp.WithString("name", mcp.Required(), mcp.Description("Unique name for the notification channel")),
+		mcp.WithString("send_resolved", mcp.Description("Whether to send notifications when alerts resolve. Values: 'true' or 'false'. Default: 'true'")),
+
+		// Slack fields
+		mcp.WithString("slack_api_url", mcp.Description("Slack incoming webhook URL. Required when type=slack. Example: https://hooks.slack.com/services/T.../B.../xxx")),
+		mcp.WithString("slack_channel", mcp.Description("Slack channel or username to post to. Example: '#alerts' or '@oncall'")),
+		mcp.WithString("slack_title", mcp.Description("Message title template (Go template syntax supported)")),
+		mcp.WithString("slack_text", mcp.Description("Message body template (Go template syntax supported)")),
+
+		// Webhook fields
+		mcp.WithString("webhook_url", mcp.Description("Webhook endpoint URL. Required when type=webhook")),
+		mcp.WithString("webhook_username", mcp.Description("Username for basic authentication (optional)")),
+		mcp.WithString("webhook_password", mcp.Description("Password for basic authentication (optional)")),
+
+		// PagerDuty fields
+		mcp.WithString("pagerduty_routing_key", mcp.Description("PagerDuty integration/routing key. Required when type=pagerduty")),
+		mcp.WithString("pagerduty_description", mcp.Description("Incident description (Go template syntax supported)")),
+		mcp.WithString("pagerduty_severity", mcp.Description("Incident severity: critical, error, warning, or info")),
+
+		// Email fields
+		mcp.WithString("email_to", mcp.Description("Comma-separated list of email addresses. Required when type=email")),
+		mcp.WithString("email_html", mcp.Description("Custom HTML email template (Go template syntax supported)")),
+
+		// OpsGenie fields
+		mcp.WithString("opsgenie_api_key", mcp.Description("OpsGenie API key. Required when type=opsgenie")),
+		mcp.WithString("opsgenie_message", mcp.Description("Alert message (Go template syntax supported)")),
+		mcp.WithString("opsgenie_description", mcp.Description("Alert description (Go template syntax supported)")),
+		mcp.WithString("opsgenie_priority", mcp.Description("Alert priority: P1, P2, P3, P4, or P5")),
+
+		// MS Teams fields
+		mcp.WithString("msteams_webhook_url", mcp.Description("MS Teams incoming webhook URL. Required when type=msteams")),
+		mcp.WithString("msteams_title", mcp.Description("Message title template (Go template syntax supported)")),
+		mcp.WithString("msteams_text", mcp.Description("Message body template (Go template syntax supported)")),
+	)
+
+	s.AddTool(createChannelTool, h.handleCreateNotificationChannel)
+}
+
+func (h *Handler) handleCreateNotificationChannel(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	log := h.tenantLogger(ctx)
+	log.Debug("Tool called: signoz_create_notification_channel")
+
+	args := req.Params.Arguments.(map[string]any)
+
+	// Validate required fields
+	channelType, _ := args["type"].(string)
+	if channelType == "" {
+		return mcp.NewToolResultError(`Parameter validation failed: "type" is required. Must be one of: slack, webhook, pagerduty, email, opsgenie, msteams`), nil
+	}
+	if !validChannelTypes[channelType] {
+		return mcp.NewToolResultError(fmt.Sprintf(`Invalid channel type: "%s". Must be one of: slack, webhook, pagerduty, email, opsgenie, msteams`, channelType)), nil
+	}
+
+	name, _ := args["name"].(string)
+	if name == "" {
+		return mcp.NewToolResultError(`Parameter validation failed: "name" is required. Provide a unique name for the notification channel.`), nil
+	}
+
+	sendResolved := true
+	if sr, ok := args["send_resolved"].(string); ok && sr != "" {
+		if sr == "false" {
+			sendResolved = false
+		} else if sr != "true" {
+			return mcp.NewToolResultError(fmt.Sprintf(`Invalid "send_resolved" value: "%s". Must be "true" or "false"`, sr)), nil
+		}
+	}
+
+	// Build receiver JSON based on type
+	receiverJSON, err := buildReceiverJSON(channelType, name, sendResolved, args)
+	if err != nil {
+		log.Warn("Failed to build receiver JSON", zap.Error(err))
+		return mcp.NewToolResultError(err.Error()), nil
+	}
+
+	client, err := h.GetClient(ctx)
+	if err != nil {
+		return mcp.NewToolResultError(err.Error()), nil
+	}
+
+	// Step 1: Create the channel
+	createResp, err := client.CreateNotificationChannel(ctx, receiverJSON)
+	if err != nil {
+		log.Error("Failed to create notification channel", zap.String("type", channelType), zap.String("name", name), zap.Error(err))
+		return mcp.NewToolResultError(fmt.Sprintf("Failed to create notification channel: %s", err.Error())), nil
+	}
+
+	log.Info("Notification channel created", zap.String("type", channelType), zap.String("name", name))
+
+	// Step 2: Test the channel
+	testErr := client.TestNotificationChannel(ctx, receiverJSON)
+
+	// Build combined response
+	result := map[string]any{
+		"channel": json.RawMessage(createResp),
+	}
+
+	if testErr != nil {
+		log.Warn("Test notification failed", zap.String("name", name), zap.Error(testErr))
+		result["test_notification"] = map[string]any{
+			"success": false,
+			"error":   testErr.Error(),
+			"message": fmt.Sprintf("Channel '%s' was created but the test notification failed: %s. Please verify the channel configuration.", name, testErr.Error()),
+		}
+	} else {
+		log.Info("Test notification sent successfully", zap.String("name", name))
+		result["test_notification"] = map[string]any{
+			"success": true,
+			"message": fmt.Sprintf("Test notification sent successfully to channel '%s'. The channel is working correctly.", name),
+		}
+	}
+
+	resultJSON, err := json.Marshal(result)
+	if err != nil {
+		return mcp.NewToolResultError("failed to marshal response: " + err.Error()), nil
+	}
+
+	return mcp.NewToolResultText(string(resultJSON)), nil
+}
+
+func getStringParam(args map[string]any, key string) string {
+	v, _ := args[key].(string)
+	return v
+}
+
+func buildReceiverJSON(channelType, name string, sendResolved bool, args map[string]any) ([]byte, error) {
+	receiver := types.Receiver{Name: name}
+
+	switch channelType {
+	case "slack":
+		apiURL := getStringParam(args, "slack_api_url")
+		if apiURL == "" {
+			return nil, fmt.Errorf(`parameter validation failed: "slack_api_url" is required when type=slack. Provide the Slack incoming webhook URL`)
+		}
+		cfg := types.SlackConfig{
+			SendResolved: sendResolved,
+			APIURL:       apiURL,
+			Channel:      getStringParam(args, "slack_channel"),
+			Title:        getStringParam(args, "slack_title"),
+			Text:         getStringParam(args, "slack_text"),
+		}
+		receiver.SlackConfigs = []types.SlackConfig{cfg}
+
+	case "webhook":
+		webhookURL := getStringParam(args, "webhook_url")
+		if webhookURL == "" {
+			return nil, fmt.Errorf(`parameter validation failed: "webhook_url" is required when type=webhook. Provide the webhook endpoint URL`)
+		}
+		cfg := types.WebhookConfig{
+			SendResolved: sendResolved,
+			URL:          webhookURL,
+		}
+		username := getStringParam(args, "webhook_username")
+		password := getStringParam(args, "webhook_password")
+		if username != "" || password != "" {
+			cfg.HTTPConfig = &types.WebhookHTTPConfig{
+				BasicAuth: &types.WebhookBasicAuth{
+					Username: username,
+					Password: password,
+				},
+			}
+		}
+		receiver.WebhookConfigs = []types.WebhookConfig{cfg}
+
+	case "pagerduty":
+		routingKey := getStringParam(args, "pagerduty_routing_key")
+		if routingKey == "" {
+			return nil, fmt.Errorf(`parameter validation failed: "pagerduty_routing_key" is required when type=pagerduty. Provide the PagerDuty integration/routing key`)
+		}
+		cfg := types.PagerdutyConfig{
+			SendResolved: sendResolved,
+			RoutingKey:   routingKey,
+			Description:  getStringParam(args, "pagerduty_description"),
+			Severity:     getStringParam(args, "pagerduty_severity"),
+		}
+		receiver.PagerdutyConfigs = []types.PagerdutyConfig{cfg}
+
+	case "email":
+		to := getStringParam(args, "email_to")
+		if to == "" {
+			return nil, fmt.Errorf(`parameter validation failed: "email_to" is required when type=email. Provide comma-separated email addresses`)
+		}
+		cfg := types.EmailConfig{
+			SendResolved: sendResolved,
+			To:           to,
+			HTML:         getStringParam(args, "email_html"),
+		}
+		receiver.EmailConfigs = []types.EmailConfig{cfg}
+
+	case "opsgenie":
+		apiKey := getStringParam(args, "opsgenie_api_key")
+		if apiKey == "" {
+			return nil, fmt.Errorf(`parameter validation failed: "opsgenie_api_key" is required when type=opsgenie. Provide the OpsGenie API key`)
+		}
+		cfg := types.OpsgenieConfig{
+			SendResolved: sendResolved,
+			APIKey:       apiKey,
+			Message:      getStringParam(args, "opsgenie_message"),
+			Description:  getStringParam(args, "opsgenie_description"),
+			Priority:     getStringParam(args, "opsgenie_priority"),
+		}
+		receiver.OpsgenieConfigs = []types.OpsgenieConfig{cfg}
+
+	case "msteams":
+		webhookURL := getStringParam(args, "msteams_webhook_url")
+		if webhookURL == "" {
+			return nil, fmt.Errorf(`parameter validation failed: "msteams_webhook_url" is required when type=msteams. Provide the MS Teams incoming webhook URL`)
+		}
+		cfg := types.MSTeamsV2Config{
+			SendResolved: sendResolved,
+			WebhookURL:   webhookURL,
+			Title:        getStringParam(args, "msteams_title"),
+			Text:         getStringParam(args, "msteams_text"),
+		}
+		receiver.MSTeamsV2Configs = []types.MSTeamsV2Config{cfg}
+	}
+
+	return types.MarshalReceiver(receiver)
+}

--- a/internal/handler/tools/notification_channels_test.go
+++ b/internal/handler/tools/notification_channels_test.go
@@ -1,0 +1,501 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/SigNoz/signoz-mcp-server/internal/client"
+	"github.com/mark3labs/mcp-go/mcp"
+)
+
+func TestHandleCreateNotificationChannel_Slack(t *testing.T) {
+	var capturedBody []byte
+	mock := &client.MockClient{
+		CreateNotificationChannelFn: func(ctx context.Context, receiverJSON []byte) (json.RawMessage, error) {
+			capturedBody = receiverJSON
+			return json.RawMessage(`{"data":{"id":"ch-1","name":"my-slack","type":"slack"}}`), nil
+		},
+		TestNotificationChannelFn: func(ctx context.Context, receiverJSON []byte) error {
+			return nil
+		},
+	}
+	h := newTestHandler(mock)
+	req := makeToolRequest("signoz_create_notification_channel", map[string]any{
+		"type":          "slack",
+		"name":          "my-slack",
+		"slack_api_url": "https://hooks.slack.com/services/T123/B456/xxx",
+		"slack_channel": "#alerts",
+		"slack_title":   "{{ .CommonLabels.alertname }}",
+	})
+
+	result, err := h.handleCreateNotificationChannel(testCtx(), req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("handler returned error result: %v", result.Content)
+	}
+
+	// Verify receiver JSON structure
+	var receiver map[string]any
+	if err := json.Unmarshal(capturedBody, &receiver); err != nil {
+		t.Fatalf("failed to parse captured body: %v", err)
+	}
+	if receiver["name"] != "my-slack" {
+		t.Errorf("expected name=my-slack, got %v", receiver["name"])
+	}
+	slackConfigs, ok := receiver["slack_configs"].([]any)
+	if !ok || len(slackConfigs) != 1 {
+		t.Fatalf("expected 1 slack_configs entry, got %v", receiver["slack_configs"])
+	}
+	cfg := slackConfigs[0].(map[string]any)
+	if cfg["api_url"] != "https://hooks.slack.com/services/T123/B456/xxx" {
+		t.Errorf("expected api_url to match, got %v", cfg["api_url"])
+	}
+	if cfg["channel"] != "#alerts" {
+		t.Errorf("expected channel=#alerts, got %v", cfg["channel"])
+	}
+
+	// Verify response contains test_notification success
+	text := result.Content[0].(mcp.TextContent).Text
+	if !strings.Contains(text, `"success":true`) {
+		t.Errorf("expected test_notification success in response, got: %s", text)
+	}
+}
+
+func TestHandleCreateNotificationChannel_Webhook(t *testing.T) {
+	var capturedBody []byte
+	mock := &client.MockClient{
+		CreateNotificationChannelFn: func(ctx context.Context, receiverJSON []byte) (json.RawMessage, error) {
+			capturedBody = receiverJSON
+			return json.RawMessage(`{"data":{"id":"ch-2","name":"my-webhook","type":"webhook"}}`), nil
+		},
+		TestNotificationChannelFn: func(ctx context.Context, receiverJSON []byte) error {
+			return nil
+		},
+	}
+	h := newTestHandler(mock)
+	req := makeToolRequest("signoz_create_notification_channel", map[string]any{
+		"type":             "webhook",
+		"name":             "my-webhook",
+		"webhook_url":      "https://example.com/hook",
+		"webhook_username": "user1",
+		"webhook_password": "pass1",
+	})
+
+	result, err := h.handleCreateNotificationChannel(testCtx(), req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("handler returned error result: %v", result.Content)
+	}
+
+	var receiver map[string]any
+	if err := json.Unmarshal(capturedBody, &receiver); err != nil {
+		t.Fatalf("failed to parse captured body: %v", err)
+	}
+	webhookConfigs, ok := receiver["webhook_configs"].([]any)
+	if !ok || len(webhookConfigs) != 1 {
+		t.Fatalf("expected 1 webhook_configs entry, got %v", receiver["webhook_configs"])
+	}
+	cfg := webhookConfigs[0].(map[string]any)
+	if cfg["url"] != "https://example.com/hook" {
+		t.Errorf("expected url to match, got %v", cfg["url"])
+	}
+	httpConfig, ok := cfg["http_config"].(map[string]any)
+	if !ok {
+		t.Fatal("expected http_config in webhook config")
+	}
+	basicAuth, ok := httpConfig["basic_auth"].(map[string]any)
+	if !ok {
+		t.Fatal("expected basic_auth in http_config")
+	}
+	if basicAuth["username"] != "user1" {
+		t.Errorf("expected username=user1, got %v", basicAuth["username"])
+	}
+}
+
+func TestHandleCreateNotificationChannel_PagerDuty(t *testing.T) {
+	var capturedBody []byte
+	mock := &client.MockClient{
+		CreateNotificationChannelFn: func(ctx context.Context, receiverJSON []byte) (json.RawMessage, error) {
+			capturedBody = receiverJSON
+			return json.RawMessage(`{"data":{"id":"ch-3","name":"my-pd","type":"pagerduty"}}`), nil
+		},
+		TestNotificationChannelFn: func(ctx context.Context, receiverJSON []byte) error {
+			return nil
+		},
+	}
+	h := newTestHandler(mock)
+	req := makeToolRequest("signoz_create_notification_channel", map[string]any{
+		"type":                  "pagerduty",
+		"name":                  "my-pd",
+		"pagerduty_routing_key": "key-123",
+		"pagerduty_severity":    "critical",
+	})
+
+	result, err := h.handleCreateNotificationChannel(testCtx(), req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("handler returned error result: %v", result.Content)
+	}
+
+	var receiver map[string]any
+	if err := json.Unmarshal(capturedBody, &receiver); err != nil {
+		t.Fatalf("failed to parse captured body: %v", err)
+	}
+	pdConfigs, ok := receiver["pagerduty_configs"].([]any)
+	if !ok || len(pdConfigs) != 1 {
+		t.Fatalf("expected 1 pagerduty_configs entry, got %v", receiver["pagerduty_configs"])
+	}
+	cfg := pdConfigs[0].(map[string]any)
+	if cfg["routing_key"] != "key-123" {
+		t.Errorf("expected routing_key=key-123, got %v", cfg["routing_key"])
+	}
+	if cfg["severity"] != "critical" {
+		t.Errorf("expected severity=critical, got %v", cfg["severity"])
+	}
+}
+
+func TestHandleCreateNotificationChannel_Email(t *testing.T) {
+	var capturedBody []byte
+	mock := &client.MockClient{
+		CreateNotificationChannelFn: func(ctx context.Context, receiverJSON []byte) (json.RawMessage, error) {
+			capturedBody = receiverJSON
+			return json.RawMessage(`{"data":{"id":"ch-4","name":"my-email","type":"email"}}`), nil
+		},
+		TestNotificationChannelFn: func(ctx context.Context, receiverJSON []byte) error {
+			return nil
+		},
+	}
+	h := newTestHandler(mock)
+	req := makeToolRequest("signoz_create_notification_channel", map[string]any{
+		"type":     "email",
+		"name":     "my-email",
+		"email_to": "oncall@example.com,backup@example.com",
+	})
+
+	result, err := h.handleCreateNotificationChannel(testCtx(), req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("handler returned error result: %v", result.Content)
+	}
+
+	var receiver map[string]any
+	if err := json.Unmarshal(capturedBody, &receiver); err != nil {
+		t.Fatalf("failed to parse captured body: %v", err)
+	}
+	emailConfigs, ok := receiver["email_configs"].([]any)
+	if !ok || len(emailConfigs) != 1 {
+		t.Fatalf("expected 1 email_configs entry, got %v", receiver["email_configs"])
+	}
+	cfg := emailConfigs[0].(map[string]any)
+	if cfg["to"] != "oncall@example.com,backup@example.com" {
+		t.Errorf("expected to field to match, got %v", cfg["to"])
+	}
+}
+
+func TestHandleCreateNotificationChannel_OpsGenie(t *testing.T) {
+	var capturedBody []byte
+	mock := &client.MockClient{
+		CreateNotificationChannelFn: func(ctx context.Context, receiverJSON []byte) (json.RawMessage, error) {
+			capturedBody = receiverJSON
+			return json.RawMessage(`{"data":{"id":"ch-5","name":"my-og","type":"opsgenie"}}`), nil
+		},
+		TestNotificationChannelFn: func(ctx context.Context, receiverJSON []byte) error {
+			return nil
+		},
+	}
+	h := newTestHandler(mock)
+	req := makeToolRequest("signoz_create_notification_channel", map[string]any{
+		"type":                 "opsgenie",
+		"name":                 "my-og",
+		"opsgenie_api_key":     "og-key-abc",
+		"opsgenie_priority":    "P1",
+		"opsgenie_message":     "{{ .CommonLabels.alertname }}",
+		"opsgenie_description": "Alert fired",
+	})
+
+	result, err := h.handleCreateNotificationChannel(testCtx(), req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("handler returned error result: %v", result.Content)
+	}
+
+	var receiver map[string]any
+	if err := json.Unmarshal(capturedBody, &receiver); err != nil {
+		t.Fatalf("failed to parse captured body: %v", err)
+	}
+	ogConfigs, ok := receiver["opsgenie_configs"].([]any)
+	if !ok || len(ogConfigs) != 1 {
+		t.Fatalf("expected 1 opsgenie_configs entry, got %v", receiver["opsgenie_configs"])
+	}
+	cfg := ogConfigs[0].(map[string]any)
+	if cfg["api_key"] != "og-key-abc" {
+		t.Errorf("expected api_key=og-key-abc, got %v", cfg["api_key"])
+	}
+	if cfg["priority"] != "P1" {
+		t.Errorf("expected priority=P1, got %v", cfg["priority"])
+	}
+}
+
+func TestHandleCreateNotificationChannel_MSTeams(t *testing.T) {
+	var capturedBody []byte
+	mock := &client.MockClient{
+		CreateNotificationChannelFn: func(ctx context.Context, receiverJSON []byte) (json.RawMessage, error) {
+			capturedBody = receiverJSON
+			return json.RawMessage(`{"data":{"id":"ch-6","name":"my-teams","type":"msteams"}}`), nil
+		},
+		TestNotificationChannelFn: func(ctx context.Context, receiverJSON []byte) error {
+			return nil
+		},
+	}
+	h := newTestHandler(mock)
+	req := makeToolRequest("signoz_create_notification_channel", map[string]any{
+		"type":               "msteams",
+		"name":               "my-teams",
+		"msteams_webhook_url": "https://outlook.webhook.office.com/webhookb2/xxx",
+		"msteams_title":      "Alert",
+	})
+
+	result, err := h.handleCreateNotificationChannel(testCtx(), req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("handler returned error result: %v", result.Content)
+	}
+
+	var receiver map[string]any
+	if err := json.Unmarshal(capturedBody, &receiver); err != nil {
+		t.Fatalf("failed to parse captured body: %v", err)
+	}
+	teamsConfigs, ok := receiver["msteamsv2_configs"].([]any)
+	if !ok || len(teamsConfigs) != 1 {
+		t.Fatalf("expected 1 msteamsv2_configs entry, got %v", receiver["msteamsv2_configs"])
+	}
+	cfg := teamsConfigs[0].(map[string]any)
+	if cfg["webhook_url"] != "https://outlook.webhook.office.com/webhookb2/xxx" {
+		t.Errorf("expected webhook_url to match, got %v", cfg["webhook_url"])
+	}
+}
+
+func TestHandleCreateNotificationChannel_MissingType(t *testing.T) {
+	mock := &client.MockClient{}
+	h := newTestHandler(mock)
+	req := makeToolRequest("signoz_create_notification_channel", map[string]any{
+		"name": "test",
+	})
+
+	result, err := h.handleCreateNotificationChannel(testCtx(), req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !result.IsError {
+		t.Error("expected error result for missing type")
+	}
+}
+
+func TestHandleCreateNotificationChannel_InvalidType(t *testing.T) {
+	mock := &client.MockClient{}
+	h := newTestHandler(mock)
+	req := makeToolRequest("signoz_create_notification_channel", map[string]any{
+		"type": "invalid",
+		"name": "test",
+	})
+
+	result, err := h.handleCreateNotificationChannel(testCtx(), req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !result.IsError {
+		t.Error("expected error result for invalid type")
+	}
+}
+
+func TestHandleCreateNotificationChannel_MissingName(t *testing.T) {
+	mock := &client.MockClient{}
+	h := newTestHandler(mock)
+	req := makeToolRequest("signoz_create_notification_channel", map[string]any{
+		"type": "slack",
+	})
+
+	result, err := h.handleCreateNotificationChannel(testCtx(), req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !result.IsError {
+		t.Error("expected error result for missing name")
+	}
+}
+
+func TestHandleCreateNotificationChannel_MissingRequiredField(t *testing.T) {
+	tests := []struct {
+		name string
+		args map[string]any
+	}{
+		{
+			name: "slack missing api_url",
+			args: map[string]any{"type": "slack", "name": "test"},
+		},
+		{
+			name: "webhook missing url",
+			args: map[string]any{"type": "webhook", "name": "test"},
+		},
+		{
+			name: "pagerduty missing routing_key",
+			args: map[string]any{"type": "pagerduty", "name": "test"},
+		},
+		{
+			name: "email missing to",
+			args: map[string]any{"type": "email", "name": "test"},
+		},
+		{
+			name: "opsgenie missing api_key",
+			args: map[string]any{"type": "opsgenie", "name": "test"},
+		},
+		{
+			name: "msteams missing webhook_url",
+			args: map[string]any{"type": "msteams", "name": "test"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mock := &client.MockClient{}
+			h := newTestHandler(mock)
+			req := makeToolRequest("signoz_create_notification_channel", tt.args)
+
+			result, err := h.handleCreateNotificationChannel(testCtx(), req)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if !result.IsError {
+				t.Error("expected error result for missing required field")
+			}
+		})
+	}
+}
+
+func TestHandleCreateNotificationChannel_CreateError(t *testing.T) {
+	mock := &client.MockClient{
+		CreateNotificationChannelFn: func(ctx context.Context, receiverJSON []byte) (json.RawMessage, error) {
+			return nil, fmt.Errorf("channel name already exists")
+		},
+	}
+	h := newTestHandler(mock)
+	req := makeToolRequest("signoz_create_notification_channel", map[string]any{
+		"type":          "slack",
+		"name":          "duplicate",
+		"slack_api_url": "https://hooks.slack.com/services/T/B/x",
+	})
+
+	result, err := h.handleCreateNotificationChannel(testCtx(), req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !result.IsError {
+		t.Error("expected error result when create fails")
+	}
+}
+
+func TestHandleCreateNotificationChannel_TestFails(t *testing.T) {
+	mock := &client.MockClient{
+		CreateNotificationChannelFn: func(ctx context.Context, receiverJSON []byte) (json.RawMessage, error) {
+			return json.RawMessage(`{"data":{"id":"ch-1","name":"bad-slack","type":"slack"}}`), nil
+		},
+		TestNotificationChannelFn: func(ctx context.Context, receiverJSON []byte) error {
+			return fmt.Errorf("webhook returned 403 forbidden")
+		},
+	}
+	h := newTestHandler(mock)
+	req := makeToolRequest("signoz_create_notification_channel", map[string]any{
+		"type":          "slack",
+		"name":          "bad-slack",
+		"slack_api_url": "https://hooks.slack.com/services/invalid",
+	})
+
+	result, err := h.handleCreateNotificationChannel(testCtx(), req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// The tool should NOT return an error result — channel was created, only test failed
+	if result.IsError {
+		t.Fatal("expected success result (channel was created, test failure is in the response body)")
+	}
+
+	text := result.Content[0].(mcp.TextContent).Text
+	if !strings.Contains(text, `"success":false`) {
+		t.Errorf("expected test_notification failure in response, got: %s", text)
+	}
+	if !strings.Contains(text, "webhook returned 403 forbidden") {
+		t.Errorf("expected test error message in response, got: %s", text)
+	}
+}
+
+func TestHandleCreateNotificationChannel_SendResolvedFalse(t *testing.T) {
+	var capturedBody []byte
+	mock := &client.MockClient{
+		CreateNotificationChannelFn: func(ctx context.Context, receiverJSON []byte) (json.RawMessage, error) {
+			capturedBody = receiverJSON
+			return json.RawMessage(`{"data":{"id":"ch-1"}}`), nil
+		},
+		TestNotificationChannelFn: func(ctx context.Context, receiverJSON []byte) error {
+			return nil
+		},
+	}
+	h := newTestHandler(mock)
+	req := makeToolRequest("signoz_create_notification_channel", map[string]any{
+		"type":          "slack",
+		"name":          "test-sr",
+		"slack_api_url": "https://hooks.slack.com/services/T/B/x",
+		"send_resolved": "false",
+	})
+
+	result, err := h.handleCreateNotificationChannel(testCtx(), req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("handler returned error result: %v", result.Content)
+	}
+
+	var receiver map[string]any
+	if err := json.Unmarshal(capturedBody, &receiver); err != nil {
+		t.Fatalf("failed to parse captured body: %v", err)
+	}
+	slackConfigs := receiver["slack_configs"].([]any)
+	cfg := slackConfigs[0].(map[string]any)
+	if cfg["send_resolved"] != false {
+		t.Errorf("expected send_resolved=false, got %v", cfg["send_resolved"])
+	}
+}
+
+func TestHandleCreateNotificationChannel_InvalidSendResolved(t *testing.T) {
+	mock := &client.MockClient{}
+	h := newTestHandler(mock)
+	req := makeToolRequest("signoz_create_notification_channel", map[string]any{
+		"type":          "slack",
+		"name":          "test",
+		"slack_api_url": "https://hooks.slack.com/services/T/B/x",
+		"send_resolved": "maybe",
+	})
+
+	result, err := h.handleCreateNotificationChannel(testCtx(), req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !result.IsError {
+		t.Error("expected error result for invalid send_resolved value")
+	}
+}

--- a/internal/mcp-server/server.go
+++ b/internal/mcp-server/server.go
@@ -59,6 +59,7 @@ func (m *MCPServer) Start() error {
 	m.handler.RegisterQueryBuilderV5Handlers(s)
 	m.handler.RegisterLogsHandlers(s)
 	m.handler.RegisterTracesHandlers(s)
+	m.handler.RegisterNotificationChannelHandlers(s)
 	m.handler.RegisterResourceTemplates(s)
 
 	// Register prompts

--- a/pkg/types/notification_channels.go
+++ b/pkg/types/notification_channels.go
@@ -1,0 +1,81 @@
+package types
+
+import "encoding/json"
+
+// Receiver is the top-level structure sent to SigNoz's /api/v1/channels
+// and /api/v1/testChannel endpoints. Only one of the *_configs fields
+// should be populated per receiver.
+type Receiver struct {
+	Name              string              `json:"name"`
+	SlackConfigs      []SlackConfig       `json:"slack_configs,omitempty"`
+	WebhookConfigs    []WebhookConfig     `json:"webhook_configs,omitempty"`
+	PagerdutyConfigs  []PagerdutyConfig   `json:"pagerduty_configs,omitempty"`
+	EmailConfigs      []EmailConfig       `json:"email_configs,omitempty"`
+	OpsgenieConfigs   []OpsgenieConfig    `json:"opsgenie_configs,omitempty"`
+	MSTeamsV2Configs  []MSTeamsV2Config   `json:"msteamsv2_configs,omitempty"`
+}
+
+// MarshalReceiver serialises a Receiver to JSON bytes suitable for the
+// SigNoz API request body.
+func MarshalReceiver(r Receiver) ([]byte, error) {
+	return json.Marshal(r)
+}
+
+// SlackConfig mirrors the SigNoz/Alertmanager slack_configs entry.
+type SlackConfig struct {
+	SendResolved bool   `json:"send_resolved"`
+	APIURL       string `json:"api_url"`
+	Channel      string `json:"channel,omitempty"`
+	Title        string `json:"title,omitempty"`
+	Text         string `json:"text,omitempty"`
+}
+
+// WebhookConfig mirrors the SigNoz/Alertmanager webhook_configs entry.
+type WebhookConfig struct {
+	SendResolved bool              `json:"send_resolved"`
+	URL          string            `json:"url"`
+	HTTPConfig   *WebhookHTTPConfig `json:"http_config,omitempty"`
+}
+
+// WebhookHTTPConfig holds optional basic auth for webhook channels.
+type WebhookHTTPConfig struct {
+	BasicAuth *WebhookBasicAuth `json:"basic_auth,omitempty"`
+}
+
+// WebhookBasicAuth holds username/password for webhook basic auth.
+type WebhookBasicAuth struct {
+	Username string `json:"username,omitempty"`
+	Password string `json:"password,omitempty"`
+}
+
+// PagerdutyConfig mirrors the SigNoz/Alertmanager pagerduty_configs entry.
+type PagerdutyConfig struct {
+	SendResolved bool   `json:"send_resolved"`
+	RoutingKey   string `json:"routing_key"`
+	Description  string `json:"description,omitempty"`
+	Severity     string `json:"severity,omitempty"`
+}
+
+// EmailConfig mirrors the SigNoz/Alertmanager email_configs entry.
+type EmailConfig struct {
+	SendResolved bool   `json:"send_resolved"`
+	To           string `json:"to"`
+	HTML         string `json:"html,omitempty"`
+}
+
+// OpsgenieConfig mirrors the SigNoz/Alertmanager opsgenie_configs entry.
+type OpsgenieConfig struct {
+	SendResolved bool   `json:"send_resolved"`
+	APIKey       string `json:"api_key"`
+	Message      string `json:"message,omitempty"`
+	Description  string `json:"description,omitempty"`
+	Priority     string `json:"priority,omitempty"`
+}
+
+// MSTeamsV2Config mirrors the SigNoz/Alertmanager msteamsv2_configs entry.
+type MSTeamsV2Config struct {
+	SendResolved bool   `json:"send_resolved"`
+	WebhookURL   string `json:"webhook_url"`
+	Title        string `json:"title,omitempty"`
+	Text         string `json:"text,omitempty"`
+}


### PR DESCRIPTION
Adds a new MCP tool to create notification channels in SigNoz with automatic test notification verification. Supports slack, webhook, pagerduty, email, opsgenie, and msteams channel types.