### PR TITLE
feat: add signoz_update_notification_channel MCP tool

### DIFF
--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -528,6 +528,12 @@ func (s *SigNoz) CreateNotificationChannel(ctx context.Context, receiverJSON []b
 	return s.doRequest(ctx, http.MethodPost, reqURL, bytes.NewReader(receiverJSON), ChannelWriteTimeout)
 }
 
+func (s *SigNoz) UpdateNotificationChannel(ctx context.Context, id string, receiverJSON []byte) (json.RawMessage, error) {
+	reqURL := fmt.Sprintf("%s/api/v1/channels/%s", s.baseURL, url.PathEscape(id))
+	s.requestLogger(ctx).Debug("Updating notification channel", zap.String("id", id))
+	return s.doRequest(ctx, http.MethodPut, reqURL, bytes.NewReader(receiverJSON), ChannelWriteTimeout)
+}
+
 func (s *SigNoz) TestNotificationChannel(ctx context.Context, receiverJSON []byte) error {
 	reqURL := fmt.Sprintf("%s/api/v1/testChannel", s.baseURL)
 	s.requestLogger(ctx).Debug("Testing notification channel")

--- a/internal/client/interface.go
+++ b/internal/client/interface.go
@@ -30,5 +30,6 @@ type Client interface {
 	GetFieldValues(ctx context.Context, signal, name, metricName, searchText, source string) (json.RawMessage, error)
 	GetTraceDetails(ctx context.Context, traceID string, includeSpans bool, startTime, endTime int64) (json.RawMessage, error)
 	CreateNotificationChannel(ctx context.Context, receiverJSON []byte) (json.RawMessage, error)
+	UpdateNotificationChannel(ctx context.Context, id string, receiverJSON []byte) (json.RawMessage, error)
 	TestNotificationChannel(ctx context.Context, receiverJSON []byte) error
 }

--- a/internal/client/mock.go
+++ b/internal/client/mock.go
@@ -31,6 +31,7 @@ type MockClient struct {
 	GetFieldValuesFn          func(ctx context.Context, signal, name, metricName, searchText, source string) (json.RawMessage, error)
 	GetTraceDetailsFn              func(ctx context.Context, traceID string, includeSpans bool, startTime, endTime int64) (json.RawMessage, error)
 	CreateNotificationChannelFn    func(ctx context.Context, receiverJSON []byte) (json.RawMessage, error)
+	UpdateNotificationChannelFn    func(ctx context.Context, id string, receiverJSON []byte) (json.RawMessage, error)
 	TestNotificationChannelFn      func(ctx context.Context, receiverJSON []byte) error
 }
 
@@ -173,6 +174,13 @@ func (m *MockClient) GetTraceDetails(ctx context.Context, traceID string, includ
 func (m *MockClient) CreateNotificationChannel(ctx context.Context, receiverJSON []byte) (json.RawMessage, error) {
 	if m.CreateNotificationChannelFn != nil {
 		return m.CreateNotificationChannelFn(ctx, receiverJSON)
+	}
+	return json.RawMessage(`{}`), nil
+}
+
+func (m *MockClient) UpdateNotificationChannel(ctx context.Context, id string, receiverJSON []byte) (json.RawMessage, error) {
+	if m.UpdateNotificationChannelFn != nil {
+		return m.UpdateNotificationChannelFn(ctx, id, receiverJSON)
 	}
 	return json.RawMessage(`{}`), nil
 }

--- a/internal/handler/tools/notification_channels.go
+++ b/internal/handler/tools/notification_channels.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strconv"
 
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
@@ -78,6 +79,68 @@ func (h *Handler) RegisterNotificationChannelHandlers(s *server.MCPServer) {
 	)
 
 	s.AddTool(createChannelTool, h.handleCreateNotificationChannel)
+
+	updateChannelTool := mcp.NewTool("signoz_update_notification_channel",
+		mcp.WithDestructiveHintAnnotation(true),
+		mcp.WithString("searchContext", mcp.Description("The user's original question or search text that triggered this tool call. Always include the user's raw query here for better results.")),
+		mcp.WithDescription(
+			"Update an existing notification channel in SigNoz and send a test notification to verify it works.\n\n"+
+				"IMPORTANT: This replaces the full channel configuration. All fields must be provided, not just the ones being changed.\n\n"+
+				"SUPPORTED TYPES: slack, webhook, pagerduty, email, opsgenie, msteams\n\n"+
+				"REQUIRED FIELDS:\n"+
+				"- id: The numeric ID of the channel to update\n"+
+				"- type: Channel type (slack, webhook, pagerduty, email, opsgenie, msteams)\n"+
+				"- name: Channel name\n\n"+
+				"REQUIRED FIELDS BY TYPE:\n"+
+				"- slack: slack_api_url (Slack incoming webhook URL)\n"+
+				"- webhook: webhook_url (endpoint URL)\n"+
+				"- pagerduty: pagerduty_routing_key (integration/routing key)\n"+
+				"- email: email_to (comma-separated email addresses)\n"+
+				"- opsgenie: opsgenie_api_key (OpsGenie API key)\n"+
+				"- msteams: msteams_webhook_url (MS Teams incoming webhook URL)\n\n"+
+				"After updating the channel, a test notification is always sent to verify the channel is working. "+
+				"The response includes both the channel update result and the test notification outcome.",
+		),
+		// ID field (required for update)
+		mcp.WithString("id", mcp.Required(), mcp.Description("The numeric ID of the notification channel to update")),
+		// Common fields
+		mcp.WithString("type", mcp.Required(), mcp.Description("Channel type. One of: slack, webhook, pagerduty, email, opsgenie, msteams")),
+		mcp.WithString("name", mcp.Required(), mcp.Description("Unique name for the notification channel")),
+		mcp.WithString("send_resolved", mcp.Description("Whether to send notifications when alerts resolve. Values: 'true' or 'false'. Default: 'true'")),
+
+		// Slack fields
+		mcp.WithString("slack_api_url", mcp.Description("Slack incoming webhook URL. Required when type=slack. Example: https://hooks.slack.com/services/T.../B.../xxx")),
+		mcp.WithString("slack_channel", mcp.Description("Slack channel or username to post to. Example: '#alerts' or '@oncall'")),
+		mcp.WithString("slack_title", mcp.Description("Message title template (Go template syntax supported)")),
+		mcp.WithString("slack_text", mcp.Description("Message body template (Go template syntax supported)")),
+
+		// Webhook fields
+		mcp.WithString("webhook_url", mcp.Description("Webhook endpoint URL. Required when type=webhook")),
+		mcp.WithString("webhook_username", mcp.Description("Username for basic authentication (optional)")),
+		mcp.WithString("webhook_password", mcp.Description("Password for basic authentication (optional)")),
+
+		// PagerDuty fields
+		mcp.WithString("pagerduty_routing_key", mcp.Description("PagerDuty integration/routing key. Required when type=pagerduty")),
+		mcp.WithString("pagerduty_description", mcp.Description("Incident description (Go template syntax supported)")),
+		mcp.WithString("pagerduty_severity", mcp.Description("Incident severity: critical, error, warning, or info")),
+
+		// Email fields
+		mcp.WithString("email_to", mcp.Description("Comma-separated list of email addresses. Required when type=email")),
+		mcp.WithString("email_html", mcp.Description("Custom HTML email template (Go template syntax supported)")),
+
+		// OpsGenie fields
+		mcp.WithString("opsgenie_api_key", mcp.Description("OpsGenie API key. Required when type=opsgenie")),
+		mcp.WithString("opsgenie_message", mcp.Description("Alert message (Go template syntax supported)")),
+		mcp.WithString("opsgenie_description", mcp.Description("Alert description (Go template syntax supported)")),
+		mcp.WithString("opsgenie_priority", mcp.Description("Alert priority: P1, P2, P3, P4, or P5")),
+
+		// MS Teams fields
+		mcp.WithString("msteams_webhook_url", mcp.Description("MS Teams incoming webhook URL. Required when type=msteams")),
+		mcp.WithString("msteams_title", mcp.Description("Message title template (Go template syntax supported)")),
+		mcp.WithString("msteams_text", mcp.Description("Message body template (Go template syntax supported)")),
+	)
+
+	s.AddTool(updateChannelTool, h.handleUpdateNotificationChannel)
 }
 
 func (h *Handler) handleCreateNotificationChannel(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
@@ -144,6 +207,109 @@ func (h *Handler) handleCreateNotificationChannel(ctx context.Context, req mcp.C
 			"success": false,
 			"error":   testErr.Error(),
 			"message": fmt.Sprintf("Channel '%s' was created but the test notification failed: %s. Please verify the channel configuration.", name, testErr.Error()),
+		}
+	} else {
+		log.Info("Test notification sent successfully", zap.String("name", name))
+		result["test_notification"] = map[string]any{
+			"success": true,
+			"message": fmt.Sprintf("Test notification sent successfully to channel '%s'. The channel is working correctly.", name),
+		}
+	}
+
+	resultJSON, err := json.Marshal(result)
+	if err != nil {
+		return mcp.NewToolResultError("failed to marshal response: " + err.Error()), nil
+	}
+
+	return mcp.NewToolResultText(string(resultJSON)), nil
+}
+
+func (h *Handler) handleUpdateNotificationChannel(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	log := h.tenantLogger(ctx)
+	log.Debug("Tool called: signoz_update_notification_channel")
+
+	args := req.Params.Arguments.(map[string]any)
+
+	// Validate id
+	id, _ := args["id"].(string)
+	if id == "" {
+		return mcp.NewToolResultError(`Parameter validation failed: "id" is required. Provide the numeric ID of the notification channel to update.`), nil
+	}
+
+	// Validate required fields
+	channelType, _ := args["type"].(string)
+	if channelType == "" {
+		return mcp.NewToolResultError(`Parameter validation failed: "type" is required. Must be one of: slack, webhook, pagerduty, email, opsgenie, msteams`), nil
+	}
+	if !validChannelTypes[channelType] {
+		return mcp.NewToolResultError(fmt.Sprintf(`Invalid channel type: "%s". Must be one of: slack, webhook, pagerduty, email, opsgenie, msteams`, channelType)), nil
+	}
+
+	name, _ := args["name"].(string)
+	if name == "" {
+		return mcp.NewToolResultError(`Parameter validation failed: "name" is required. Provide a unique name for the notification channel.`), nil
+	}
+
+	sendResolved := true
+	if sr, ok := args["send_resolved"].(string); ok && sr != "" {
+		if sr == "false" {
+			sendResolved = false
+		} else if sr != "true" {
+			return mcp.NewToolResultError(fmt.Sprintf(`Invalid "send_resolved" value: "%s". Must be "true" or "false"`, sr)), nil
+		}
+	}
+
+	idInt, err := strconv.Atoi(id)
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf(`Invalid "id" value: "%s". Must be a numeric ID.`, id)), nil
+	}
+
+	// Build receiver JSON based on type
+	receiverJSON, err := buildReceiverJSON(channelType, name, sendResolved, args)
+	if err != nil {
+		log.Warn("Failed to build receiver JSON", zap.Error(err))
+		return mcp.NewToolResultError(err.Error()), nil
+	}
+
+	// Inject the channel ID into the receiver JSON for the update request body
+	var receiver types.Receiver
+	if err := json.Unmarshal(receiverJSON, &receiver); err != nil {
+		return mcp.NewToolResultError("failed to parse receiver JSON: " + err.Error()), nil
+	}
+	receiver.ID = idInt
+	receiverJSON, err = types.MarshalReceiver(receiver)
+	if err != nil {
+		return mcp.NewToolResultError("failed to marshal receiver JSON: " + err.Error()), nil
+	}
+
+	client, err := h.GetClient(ctx)
+	if err != nil {
+		return mcp.NewToolResultError(err.Error()), nil
+	}
+
+	// Step 1: Update the channel
+	updateResp, err := client.UpdateNotificationChannel(ctx, id, receiverJSON)
+	if err != nil {
+		log.Error("Failed to update notification channel", zap.String("type", channelType), zap.String("name", name), zap.String("id", id), zap.Error(err))
+		return mcp.NewToolResultError(fmt.Sprintf("Failed to update notification channel: %s", err.Error())), nil
+	}
+
+	log.Info("Notification channel updated", zap.String("type", channelType), zap.String("name", name), zap.String("id", id))
+
+	// Step 2: Test the channel
+	testErr := client.TestNotificationChannel(ctx, receiverJSON)
+
+	// Build combined response
+	result := map[string]any{
+		"channel": json.RawMessage(updateResp),
+	}
+
+	if testErr != nil {
+		log.Warn("Test notification failed", zap.String("name", name), zap.Error(testErr))
+		result["test_notification"] = map[string]any{
+			"success": false,
+			"error":   testErr.Error(),
+			"message": fmt.Sprintf("Channel '%s' was updated but the test notification failed: %s. Please verify the channel configuration.", name, testErr.Error()),
 		}
 	} else {
 		log.Info("Test notification sent successfully", zap.String("name", name))

--- a/internal/handler/tools/notification_channels_test.go
+++ b/internal/handler/tools/notification_channels_test.go
@@ -499,3 +499,140 @@ func TestHandleCreateNotificationChannel_InvalidSendResolved(t *testing.T) {
 		t.Error("expected error result for invalid send_resolved value")
 	}
 }
+
+// --- Update notification channel tests ---
+
+func TestHandleUpdateNotificationChannel_Slack(t *testing.T) {
+	var capturedID string
+	var capturedBody []byte
+	mock := &client.MockClient{
+		UpdateNotificationChannelFn: func(ctx context.Context, id string, receiverJSON []byte) (json.RawMessage, error) {
+			capturedID = id
+			capturedBody = receiverJSON
+			return json.RawMessage(`{"data":{"id":"1","name":"my-slack","type":"slack"}}`), nil
+		},
+		TestNotificationChannelFn: func(ctx context.Context, receiverJSON []byte) error {
+			return nil
+		},
+	}
+	h := newTestHandler(mock)
+	req := makeToolRequest("signoz_update_notification_channel", map[string]any{
+		"id":            "1",
+		"type":          "slack",
+		"name":          "my-slack",
+		"slack_api_url": "https://hooks.slack.com/services/T123/B456/new",
+		"slack_channel": "#updated-alerts",
+	})
+
+	result, err := h.handleUpdateNotificationChannel(testCtx(), req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("handler returned error result: %v", result.Content)
+	}
+
+	if capturedID != "1" {
+		t.Errorf("expected id=1, got %v", capturedID)
+	}
+
+	var receiver map[string]any
+	if err := json.Unmarshal(capturedBody, &receiver); err != nil {
+		t.Fatalf("failed to parse captured body: %v", err)
+	}
+	if receiver["name"] != "my-slack" {
+		t.Errorf("expected name=my-slack, got %v", receiver["name"])
+	}
+	slackConfigs, ok := receiver["slack_configs"].([]any)
+	if !ok || len(slackConfigs) != 1 {
+		t.Fatalf("expected 1 slack_configs entry, got %v", receiver["slack_configs"])
+	}
+	cfg := slackConfigs[0].(map[string]any)
+	if cfg["api_url"] != "https://hooks.slack.com/services/T123/B456/new" {
+		t.Errorf("expected api_url to match, got %v", cfg["api_url"])
+	}
+	if cfg["channel"] != "#updated-alerts" {
+		t.Errorf("expected channel=#updated-alerts, got %v", cfg["channel"])
+	}
+
+	text := result.Content[0].(mcp.TextContent).Text
+	if !strings.Contains(text, `"success":true`) {
+		t.Errorf("expected test_notification success in response, got: %s", text)
+	}
+}
+
+func TestHandleUpdateNotificationChannel_MissingID(t *testing.T) {
+	mock := &client.MockClient{}
+	h := newTestHandler(mock)
+	req := makeToolRequest("signoz_update_notification_channel", map[string]any{
+		"type":          "slack",
+		"name":          "test",
+		"slack_api_url": "https://hooks.slack.com/services/T/B/x",
+	})
+
+	result, err := h.handleUpdateNotificationChannel(testCtx(), req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !result.IsError {
+		t.Error("expected error result for missing id")
+	}
+}
+
+func TestHandleUpdateNotificationChannel_UpdateError(t *testing.T) {
+	mock := &client.MockClient{
+		UpdateNotificationChannelFn: func(ctx context.Context, id string, receiverJSON []byte) (json.RawMessage, error) {
+			return nil, fmt.Errorf("channel not found")
+		},
+	}
+	h := newTestHandler(mock)
+	req := makeToolRequest("signoz_update_notification_channel", map[string]any{
+		"id":            "999",
+		"type":          "slack",
+		"name":          "missing",
+		"slack_api_url": "https://hooks.slack.com/services/T/B/x",
+	})
+
+	result, err := h.handleUpdateNotificationChannel(testCtx(), req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !result.IsError {
+		t.Error("expected error result when update fails")
+	}
+}
+
+func TestHandleUpdateNotificationChannel_TestFails(t *testing.T) {
+	mock := &client.MockClient{
+		UpdateNotificationChannelFn: func(ctx context.Context, id string, receiverJSON []byte) (json.RawMessage, error) {
+			return json.RawMessage(`{"data":{"id":"1","name":"bad-slack","type":"slack"}}`), nil
+		},
+		TestNotificationChannelFn: func(ctx context.Context, receiverJSON []byte) error {
+			return fmt.Errorf("webhook returned 403 forbidden")
+		},
+	}
+	h := newTestHandler(mock)
+	req := makeToolRequest("signoz_update_notification_channel", map[string]any{
+		"id":            "1",
+		"type":          "slack",
+		"name":          "bad-slack",
+		"slack_api_url": "https://hooks.slack.com/services/invalid",
+	})
+
+	result, err := h.handleUpdateNotificationChannel(testCtx(), req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// The tool should NOT return an error result — channel was updated, only test failed
+	if result.IsError {
+		t.Fatal("expected success result (channel was updated, test failure is in the response body)")
+	}
+
+	text := result.Content[0].(mcp.TextContent).Text
+	if !strings.Contains(text, `"success":false`) {
+		t.Errorf("expected test_notification failure in response, got: %s", text)
+	}
+	if !strings.Contains(text, "webhook returned 403 forbidden") {
+		t.Errorf("expected test error message in response, got: %s", text)
+	}
+}

--- a/manifest.json
+++ b/manifest.json
@@ -112,6 +112,14 @@
     {
       "name": "signoz_execute_builder_query",
       "description": "Execute a raw SigNoz Query Builder v5 query"
+    },
+    {
+      "name": "signoz_create_notification_channel",
+      "description": "Create a notification channel and send a test notification"
+    },
+    {
+      "name": "signoz_update_notification_channel",
+      "description": "Update an existing notification channel and send a test notification"
     }
   ],
   "compatibility": {

--- a/pkg/types/notification_channels.go
+++ b/pkg/types/notification_channels.go
@@ -6,6 +6,7 @@ import "encoding/json"
 // and /api/v1/testChannel endpoints. Only one of the *_configs fields
 // should be populated per receiver.
 type Receiver struct {
+	ID                int                 `json:"id,omitempty"`
 	Name              string              `json:"name"`
 	SlackConfigs      []SlackConfig       `json:"slack_configs,omitempty"`
 	WebhookConfigs    []WebhookConfig     `json:"webhook_configs,omitempty"`


### PR DESCRIPTION
Adds a new tool to update existing notification channels by ID. Follows the same pattern as create: validates params, builds receiver JSON with channel ID, calls PUT /api/v1/channels/{id}, then sends a test notification and returns combined results.