### PR TITLE
feat: validate notification channels before creating alerts

### DIFF
--- a/internal/handler/tools/alerts.go
+++ b/internal/handler/tools/alerts.go
@@ -11,6 +11,7 @@ import (
 	"github.com/mark3labs/mcp-go/server"
 	"go.uber.org/zap"
 
+	signozclient "github.com/SigNoz/signoz-mcp-server/internal/client"
 	"github.com/SigNoz/signoz-mcp-server/pkg/alert"
 	"github.com/SigNoz/signoz-mcp-server/pkg/paginate"
 	"github.com/SigNoz/signoz-mcp-server/pkg/timeutil"
@@ -70,6 +71,11 @@ func (h *Handler) RegisterAlertsHandlers(s *server.MCPServer) {
 				"1. signoz://alert/instructions — REQUIRED: Alert structure, field descriptions, valid values\n"+
 				"2. signoz://alert/examples — REQUIRED: Complete working examples for each alert type\n\n"+
 				"RECOMMENDED: Use signoz_get_alert on an existing alert to study the exact structure.\n\n"+
+				"NOTIFICATION CHANNELS: At least one notification channel is required. "+
+				"If the user explicitly names a channel, use it directly. "+
+				"Otherwise, do NOT guess or assume channel names — call this tool WITHOUT channels to get the list of available channels, "+
+				"present that list to the user, let them choose, then call again with their selection. "+
+				"If no suitable channel exists, use signoz_create_notification_channel first.\n\n"+
 				"Supports all alert types (metrics, logs, traces, exceptions) and rule types (threshold, promql, anomaly).\n"+
 				"Uses v2alpha1 schema with structured thresholds (multi-threshold with per-level channel routing), "+
 				"evaluation block, and notificationSettings.\n"+
@@ -298,14 +304,156 @@ func (h *Handler) handleCreateAlert(ctx context.Context, req mcp.CallToolRequest
 	if err != nil {
 		return mcp.NewToolResultError(err.Error()), nil
 	}
-	data, err := client.CreateAlertRule(ctx, cleanJSON)
 
+	// Fetch existing notification channels and validate channel references.
+	availableChannels, err := fetchChannelNames(ctx, client)
+	if err != nil {
+		log.Warn("Failed to fetch notification channels for validation", zap.Error(err))
+		return mcp.NewToolResultError(fmt.Sprintf("Failed to fetch notification channels: %s", err.Error())), nil
+	}
+
+	referencedChannels := extractReferencedChannels(rawConfig)
+
+	if len(referencedChannels) == 0 {
+		return mcp.NewToolResultError(formatNoChannelsError(availableChannels)), nil
+	}
+
+	// Validate that all referenced channels exist.
+	if invalid := findInvalidChannels(referencedChannels, availableChannels); len(invalid) > 0 {
+		return mcp.NewToolResultError(formatInvalidChannelsError(invalid, availableChannels)), nil
+	}
+
+	data, err := client.CreateAlertRule(ctx, cleanJSON)
 	if err != nil {
 		log.Error("Failed to create alert rule in SigNoz", zap.Error(err))
 		return mcp.NewToolResultError(fmt.Sprintf("SigNoz API Error: %s", err.Error())), nil
 	}
 
 	return mcp.NewToolResultText(string(data)), nil
+}
+
+// fetchChannelNames retrieves all notification channel names from the SigNoz API.
+func fetchChannelNames(ctx context.Context, c signozclient.Client) ([]string, error) {
+	resp, err := c.ListNotificationChannels(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	var parsed struct {
+		Data []struct {
+			Name string `json:"name"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(resp, &parsed); err != nil {
+		return nil, fmt.Errorf("failed to parse notification channels response: %w", err)
+	}
+
+	names := make([]string, 0, len(parsed.Data))
+	for _, ch := range parsed.Data {
+		if ch.Name != "" {
+			names = append(names, ch.Name)
+		}
+	}
+	return names, nil
+}
+
+// extractReferencedChannels collects all channel names referenced in the alert
+// payload from condition.thresholds.spec[].channels and preferredChannels.
+func extractReferencedChannels(rawConfig map[string]any) []string {
+	seen := map[string]bool{}
+
+	// Check preferredChannels
+	if pc, ok := rawConfig["preferredChannels"].([]any); ok {
+		for _, v := range pc {
+			if name, ok := v.(string); ok && name != "" {
+				seen[name] = true
+			}
+		}
+	}
+
+	// Check condition.thresholds.spec[].channels
+	cond, _ := rawConfig["condition"].(map[string]any)
+	if cond == nil {
+		return mapKeys(seen)
+	}
+	thresholds, _ := cond["thresholds"].(map[string]any)
+	if thresholds == nil {
+		return mapKeys(seen)
+	}
+	specs, _ := thresholds["spec"].([]any)
+	for _, s := range specs {
+		spec, ok := s.(map[string]any)
+		if !ok {
+			continue
+		}
+		channels, ok := spec["channels"].([]any)
+		if !ok {
+			continue
+		}
+		for _, ch := range channels {
+			if name, ok := ch.(string); ok && name != "" {
+				seen[name] = true
+			}
+		}
+	}
+
+	return mapKeys(seen)
+}
+
+func mapKeys(m map[string]bool) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	return keys
+}
+
+// findInvalidChannels returns channel names that are not in the available list.
+func findInvalidChannels(referenced, available []string) []string {
+	avail := map[string]bool{}
+	for _, name := range available {
+		avail[name] = true
+	}
+	var invalid []string
+	for _, name := range referenced {
+		if !avail[name] {
+			invalid = append(invalid, name)
+		}
+	}
+	return invalid
+}
+
+func formatNoChannelsError(available []string) string {
+	var sb strings.Builder
+	sb.WriteString("No notification channels specified in the alert. At least one channel is required.\n\n")
+
+	if len(available) > 0 {
+		sb.WriteString("Available notification channels:\n")
+		for _, name := range available {
+			sb.WriteString(fmt.Sprintf("  - %s\n", name))
+		}
+		sb.WriteString("\nPlease choose one or more channels and set them in condition.thresholds.spec[].channels.\n")
+	} else {
+		sb.WriteString("No notification channels exist yet.\n")
+	}
+	sb.WriteString("To create a new channel, use the signoz_create_notification_channel tool first.")
+	return sb.String()
+}
+
+func formatInvalidChannelsError(invalid, available []string) string {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("The following notification channels do not exist: %s\n\n", strings.Join(invalid, ", ")))
+
+	if len(available) > 0 {
+		sb.WriteString("Available notification channels:\n")
+		for _, name := range available {
+			sb.WriteString(fmt.Sprintf("  - %s\n", name))
+		}
+		sb.WriteString("\nPlease use one of the available channels, or create a new one with signoz_create_notification_channel.")
+	} else {
+		sb.WriteString("No notification channels exist yet. Create one with signoz_create_notification_channel first.")
+	}
+	return sb.String()
 }
 
 // registerAlertResources registers MCP resources needed for alert creation.

--- a/internal/handler/tools/alerts_test.go
+++ b/internal/handler/tools/alerts_test.go
@@ -4,7 +4,10 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
 	"testing"
+
+	"github.com/mark3labs/mcp-go/mcp"
 
 	"github.com/SigNoz/signoz-mcp-server/internal/client"
 	"github.com/SigNoz/signoz-mcp-server/pkg/types"
@@ -407,6 +410,9 @@ func TestHandleListAlerts_FilterSplitAndTrim(t *testing.T) {
 func TestHandleCreateAlert(t *testing.T) {
 	var capturedJSON []byte
 	mock := &client.MockClient{
+		ListNotificationChannelsFn: func(ctx context.Context) (json.RawMessage, error) {
+			return json.RawMessage(`{"data":[{"name":"slack-alerts","type":"slack"}]}`), nil
+		},
 		CreateAlertRuleFn: func(ctx context.Context, alertJSON []byte) (json.RawMessage, error) {
 			capturedJSON = alertJSON
 			return json.RawMessage(`{"status":"success","data":{"id":"rule-123"}}`), nil
@@ -443,6 +449,7 @@ func TestHandleCreateAlert(t *testing.T) {
 						"target":    float64(100),
 						"op":        "1",
 						"matchType": "1",
+						"channels":  []any{"slack-alerts"},
 					},
 				},
 			},
@@ -476,6 +483,9 @@ func TestHandleCreateAlert(t *testing.T) {
 func TestHandleCreateAlert_StripsSearchContext(t *testing.T) {
 	var capturedJSON []byte
 	mock := &client.MockClient{
+		ListNotificationChannelsFn: func(ctx context.Context) (json.RawMessage, error) {
+			return json.RawMessage(`{"data":[{"name":"slack-alerts","type":"slack"}]}`), nil
+		},
 		CreateAlertRuleFn: func(ctx context.Context, alertJSON []byte) (json.RawMessage, error) {
 			capturedJSON = alertJSON
 			return json.RawMessage(`{"status":"success","data":{"id":"rule-456"}}`), nil
@@ -510,6 +520,7 @@ func TestHandleCreateAlert_StripsSearchContext(t *testing.T) {
 					map[string]any{
 						"name": "warning", "target": float64(90),
 						"op": "1", "matchType": "1",
+						"channels": []any{"slack-alerts"},
 					},
 				},
 			},
@@ -567,8 +578,63 @@ func TestHandleCreateAlert_ValidationError(t *testing.T) {
 
 func TestHandleCreateAlert_ClientError(t *testing.T) {
 	mock := &client.MockClient{
+		ListNotificationChannelsFn: func(ctx context.Context) (json.RawMessage, error) {
+			return json.RawMessage(`{"data":[{"name":"slack-alerts","type":"slack"}]}`), nil
+		},
 		CreateAlertRuleFn: func(ctx context.Context, alertJSON []byte) (json.RawMessage, error) {
 			return nil, fmt.Errorf("unexpected status 400: bad request")
+		},
+	}
+	h := newTestHandler(mock)
+	req := makeToolRequest("signoz_create_alert", map[string]any{
+		"alert":     "Test Alert",
+		"alertType": "METRIC_BASED_ALERT",
+		"ruleType":  "threshold_rule",
+		"condition": map[string]any{
+			"compositeQuery": map[string]any{
+				"queryType": "builder",
+				"queries": []any{
+					map[string]any{
+						"type": "builder_query",
+						"spec": map[string]any{
+							"name":   "A",
+							"signal": "metrics",
+							"aggregations": []any{
+								map[string]any{"expression": "count()"},
+							},
+							"filter": map[string]any{"expression": ""},
+						},
+					},
+				},
+			},
+			"thresholds": map[string]any{
+				"kind": "basic",
+				"spec": []any{
+					map[string]any{
+						"name":      "warning",
+						"target":    float64(100),
+						"op":        "1",
+						"matchType": "1",
+						"channels":  []any{"slack-alerts"},
+					},
+				},
+			},
+		},
+	})
+
+	result, err := h.handleCreateAlert(testCtx(), req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !result.IsError {
+		t.Error("expected error result when client returns error")
+	}
+}
+
+func TestHandleCreateAlert_NoChannelsReturnsAvailable(t *testing.T) {
+	mock := &client.MockClient{
+		ListNotificationChannelsFn: func(ctx context.Context) (json.RawMessage, error) {
+			return json.RawMessage(`{"data":[{"name":"slack-alerts","type":"slack"},{"name":"pagerduty-oncall","type":"pagerduty"}]}`), nil
 		},
 	}
 	h := newTestHandler(mock)
@@ -612,6 +678,188 @@ func TestHandleCreateAlert_ClientError(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if !result.IsError {
-		t.Error("expected error result when client returns error")
+		t.Error("expected error result when no channels are specified")
+	}
+	text := result.Content[0].(mcp.TextContent).Text
+	if !strings.Contains(text, "slack-alerts") {
+		t.Error("expected error to list available channel 'slack-alerts'")
+	}
+	if !strings.Contains(text, "pagerduty-oncall") {
+		t.Error("expected error to list available channel 'pagerduty-oncall'")
+	}
+	if !strings.Contains(text, "signoz_create_notification_channel") {
+		t.Error("expected error to mention signoz_create_notification_channel")
+	}
+}
+
+func TestHandleCreateAlert_InvalidChannelReturnsError(t *testing.T) {
+	mock := &client.MockClient{
+		ListNotificationChannelsFn: func(ctx context.Context) (json.RawMessage, error) {
+			return json.RawMessage(`{"data":[{"name":"slack-alerts","type":"slack"}]}`), nil
+		},
+	}
+	h := newTestHandler(mock)
+	req := makeToolRequest("signoz_create_alert", map[string]any{
+		"alert":     "Test Alert",
+		"alertType": "METRIC_BASED_ALERT",
+		"ruleType":  "threshold_rule",
+		"condition": map[string]any{
+			"compositeQuery": map[string]any{
+				"queryType": "builder",
+				"queries": []any{
+					map[string]any{
+						"type": "builder_query",
+						"spec": map[string]any{
+							"name":   "A",
+							"signal": "metrics",
+							"aggregations": []any{
+								map[string]any{"expression": "count()"},
+							},
+							"filter": map[string]any{"expression": ""},
+						},
+					},
+				},
+			},
+			"thresholds": map[string]any{
+				"kind": "basic",
+				"spec": []any{
+					map[string]any{
+						"name":      "warning",
+						"target":    float64(100),
+						"op":        "1",
+						"matchType": "1",
+						"channels":  []any{"nonexistent-channel"},
+					},
+				},
+			},
+		},
+	})
+
+	result, err := h.handleCreateAlert(testCtx(), req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !result.IsError {
+		t.Error("expected error result when channel does not exist")
+	}
+	text := result.Content[0].(mcp.TextContent).Text
+	if !strings.Contains(text, "nonexistent-channel") {
+		t.Error("expected error to mention the invalid channel name")
+	}
+	if !strings.Contains(text, "slack-alerts") {
+		t.Error("expected error to list available channels")
+	}
+}
+
+func TestHandleCreateAlert_PreferredChannelsValidated(t *testing.T) {
+	mock := &client.MockClient{
+		ListNotificationChannelsFn: func(ctx context.Context) (json.RawMessage, error) {
+			return json.RawMessage(`{"data":[{"name":"slack-alerts","type":"slack"}]}`), nil
+		},
+		CreateAlertRuleFn: func(ctx context.Context, alertJSON []byte) (json.RawMessage, error) {
+			return json.RawMessage(`{"status":"success","data":{"id":"rule-789"}}`), nil
+		},
+	}
+	h := newTestHandler(mock)
+	req := makeToolRequest("signoz_create_alert", map[string]any{
+		"alert":             "Test Alert",
+		"alertType":         "METRIC_BASED_ALERT",
+		"ruleType":          "threshold_rule",
+		"preferredChannels": []any{"slack-alerts"},
+		"condition": map[string]any{
+			"compositeQuery": map[string]any{
+				"queryType": "builder",
+				"queries": []any{
+					map[string]any{
+						"type": "builder_query",
+						"spec": map[string]any{
+							"name":   "A",
+							"signal": "metrics",
+							"aggregations": []any{
+								map[string]any{"expression": "count()"},
+							},
+							"filter": map[string]any{"expression": ""},
+						},
+					},
+				},
+			},
+			"thresholds": map[string]any{
+				"kind": "basic",
+				"spec": []any{
+					map[string]any{
+						"name":      "warning",
+						"target":    float64(100),
+						"op":        "1",
+						"matchType": "1",
+					},
+				},
+			},
+		},
+	})
+
+	result, err := h.handleCreateAlert(testCtx(), req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("handler returned error result: %v", result.Content)
+	}
+}
+
+func TestHandleCreateAlert_NoChannelsExist(t *testing.T) {
+	mock := &client.MockClient{
+		ListNotificationChannelsFn: func(ctx context.Context) (json.RawMessage, error) {
+			return json.RawMessage(`{"data":[]}`), nil
+		},
+	}
+	h := newTestHandler(mock)
+	req := makeToolRequest("signoz_create_alert", map[string]any{
+		"alert":     "Test Alert",
+		"alertType": "METRIC_BASED_ALERT",
+		"ruleType":  "threshold_rule",
+		"condition": map[string]any{
+			"compositeQuery": map[string]any{
+				"queryType": "builder",
+				"queries": []any{
+					map[string]any{
+						"type": "builder_query",
+						"spec": map[string]any{
+							"name":   "A",
+							"signal": "metrics",
+							"aggregations": []any{
+								map[string]any{"expression": "count()"},
+							},
+							"filter": map[string]any{"expression": ""},
+						},
+					},
+				},
+			},
+			"thresholds": map[string]any{
+				"kind": "basic",
+				"spec": []any{
+					map[string]any{
+						"name":      "warning",
+						"target":    float64(100),
+						"op":        "1",
+						"matchType": "1",
+					},
+				},
+			},
+		},
+	})
+
+	result, err := h.handleCreateAlert(testCtx(), req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !result.IsError {
+		t.Error("expected error result when no channels exist and none specified")
+	}
+	text := result.Content[0].(mcp.TextContent).Text
+	if !strings.Contains(text, "No notification channels exist yet") {
+		t.Error("expected error to indicate no channels exist")
+	}
+	if !strings.Contains(text, "signoz_create_notification_channel") {
+		t.Error("expected error to suggest creating a new channel")
 	}
 }

--- a/internal/handler/tools/notification_channels.go
+++ b/internal/handler/tools/notification_channels.go
@@ -190,24 +190,32 @@ func (h *Handler) handleListNotificationChannels(ctx context.Context, req mcp.Ca
 		return mcp.NewToolResultError("invalid response format: expected data array"), nil
 	}
 
-	// Parse the "data" string field in each channel into a JSON object for readability.
+	// Summarize each channel to essential fields only (id, name, type, timestamps).
+	// The raw "data" field contains the full config (webhook URLs, API keys, templates)
+	// which bloats the response beyond token limits. We parse it only to extract the name.
+	summarized := make([]any, 0, len(data))
 	for _, item := range data {
 		ch, ok := item.(map[string]any)
 		if !ok {
 			continue
 		}
-		dataStr, ok := ch["data"].(string)
-		if !ok || dataStr == "" {
-			continue
+		summary := map[string]any{
+			"id":        ch["id"],
+			"type":      ch["type"],
+			"createdAt": ch["createdAt"],
+			"updatedAt": ch["updatedAt"],
 		}
-		var parsed any
-		if err := json.Unmarshal([]byte(dataStr), &parsed); err == nil {
-			ch["data"] = parsed
+		if dataStr, ok := ch["data"].(string); ok && dataStr != "" {
+			var parsed map[string]any
+			if err := json.Unmarshal([]byte(dataStr), &parsed); err == nil {
+				summary["name"] = parsed["name"]
+			}
 		}
+		summarized = append(summarized, summary)
 	}
 
-	total := len(data)
-	pagedData := paginate.Array(data, offset, limit)
+	total := len(summarized)
+	pagedData := paginate.Array(summarized, offset, limit)
 
 	resultJSON, err := paginate.Wrap(pagedData, total, offset, limit)
 	if err != nil {

--- a/internal/handler/tools/notification_channels_test.go
+++ b/internal/handler/tools/notification_channels_test.go
@@ -42,17 +42,19 @@ func TestHandleListNotificationChannels_Success(t *testing.T) {
 		t.Fatalf("expected 2 channels, got %d", len(data))
 	}
 
-	// Verify the "data" field was parsed from string to object
+	// Verify summarized fields only (id, name, type, timestamps — no full config)
 	ch := data[0].(map[string]any)
 	if ch["name"] != "my-slack" {
 		t.Errorf("expected name=my-slack, got %v", ch["name"])
 	}
-	chData, ok := ch["data"].(map[string]any)
-	if !ok {
-		t.Fatalf("expected data field to be parsed object, got %T", ch["data"])
+	if ch["type"] != "slack" {
+		t.Errorf("expected type=slack, got %v", ch["type"])
 	}
-	if _, ok := chData["slack_configs"]; !ok {
-		t.Error("expected parsed data to contain slack_configs")
+	if ch["id"] != "1" {
+		t.Errorf("expected id=1, got %v", ch["id"])
+	}
+	if _, exists := ch["data"]; exists {
+		t.Error("expected summarized response to omit the full data/config field")
 	}
 
 	// Verify pagination metadata

--- a/pkg/alert/resources.go
+++ b/pkg/alert/resources.go
@@ -11,7 +11,7 @@ The alert is created via POST /api/v1/rules. All alerts use v2alpha1 schema with
 1. ALWAYS read signoz://alert/examples for complete working payloads
 2. Use signoz_get_alert on an existing alert to study the exact structure your SigNoz instance expects
 3. Use signoz_get_field_keys to discover available attributes for filters and groupBy
-4. Use signoz_list_notification_channels to discover available notification channel names for thresholds and preferredChannels
+4. NOTIFICATION CHANNELS: If the user explicitly names a channel, use it directly. Otherwise, do NOT guess channel names — call signoz_create_alert without channels first, it returns available channels. Present the list to the user, let them choose, then retry with their selection. If no suitable channel exists, use signoz_create_notification_channel to create one first
 
 ## Alert Types (alertType)
 | Value | Signal | Use When |


### PR DESCRIPTION
Fetch and validate referenced notification channels (from both preferredChannels and threshold-level channels) before sending the create-alert request. Return actionable errors listing available channels when none are specified or invalid names are used.

Also summarize notification channel list responses to essential fields (id, name, type, timestamps) to reduce token usage.