### PR TITLE
Align analytics identity tracking

### DIFF
--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -33,6 +33,17 @@ const (
 
 var ErrUnauthorized = errors.New("signoz credentials rejected")
 
+// AnalyticsIdentity is the identity tuple used for analytics attribution.
+// UserID is the effective distinct/user identifier for analytics. For API key
+// sessions this is the service account ID; for auth-token sessions this is the
+// SigNoz user ID.
+type AnalyticsIdentity struct {
+	OrgID     string
+	UserID    string
+	Email     string
+	Principal string
+}
+
 type SigNoz struct {
 	baseURL        string
 	apiKey         string
@@ -113,6 +124,70 @@ func (s *SigNoz) ValidateCredentials(ctx context.Context) error {
 	return s.evaluateValidationResponse(log, status, body)
 }
 
+// GetAnalyticsIdentity resolves the org and effective analytics identity for
+// the current credentials.
+//
+// Auth-mode specific behavior:
+//   - Authorization header clients resolve via /api/v2/users/me
+//   - SIGNOZ-API-KEY clients resolve via /api/v1/service_accounts/me
+func (s *SigNoz) GetAnalyticsIdentity(ctx context.Context) (*AnalyticsIdentity, error) {
+	log := s.requestLogger(ctx)
+	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+
+	endpoint := "/api/v1/service_accounts/me"
+	principal := "service_account"
+	if strings.EqualFold(s.authHeaderName, "Authorization") {
+		endpoint = "/api/v2/users/me"
+		principal = "user"
+	}
+
+	reqURL := fmt.Sprintf("%s%s", s.baseURL, endpoint)
+	status, body, err := s.doValidationRequest(ctx, reqURL)
+	if err != nil {
+		log.Error("SigNoz analytics identity request failed", zap.String("url", reqURL), zap.Error(err))
+		return nil, fmt.Errorf("failed to reach SigNoz API: %w", err)
+	}
+	if status != http.StatusOK {
+		return nil, s.evaluateValidationResponse(log, status, body)
+	}
+
+	identity, err := parseAnalyticsIdentity(body, principal)
+	if err != nil {
+		return nil, fmt.Errorf("parse %s response: %w", endpoint, err)
+	}
+
+	return identity, nil
+}
+
+type analyticsIdentityResponse struct {
+	Data struct {
+		ID    string `json:"id"`
+		Email string `json:"email"`
+		OrgID string `json:"orgId"`
+	} `json:"data"`
+}
+
+func parseAnalyticsIdentity(body []byte, principal string) (*AnalyticsIdentity, error) {
+	var resp analyticsIdentityResponse
+	if err := json.Unmarshal(body, &resp); err != nil {
+		return nil, fmt.Errorf("unmarshal response: %w", err)
+	}
+	if resp.Data.ID == "" {
+		return nil, fmt.Errorf("missing data.id")
+	}
+	if resp.Data.OrgID == "" {
+		return nil, fmt.Errorf("missing data.orgId")
+	}
+
+	return &AnalyticsIdentity{
+		OrgID:     resp.Data.OrgID,
+		UserID:    resp.Data.ID,
+		Email:     resp.Data.Email,
+		Principal: principal,
+	}, nil
+}
+
 // doValidationRequest sends a GET request to the given URL with auth headers
 // and returns the HTTP status code, response body, and any transport error.
 func (s *SigNoz) doValidationRequest(ctx context.Context, reqURL string) (int, []byte, error) {
@@ -122,10 +197,10 @@ func (s *SigNoz) doValidationRequest(ctx context.Context, reqURL string) (int, [
 	}
 
 	req.Header.Set(ContentType, "application/json")
-	req.Header.Set(SignozApiKey, s.apiKey)
+	req.Header.Set(s.authHeaderName, s.apiKey)
 
 	for k, v := range s.customHeaders {
-		if !strings.EqualFold(k, ContentType) && !strings.EqualFold(k, SignozApiKey) {
+		if !strings.EqualFold(k, ContentType) && !strings.EqualFold(k, s.authHeaderName) {
 			req.Header.Set(k, v)
 		}
 	}

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -31,18 +31,16 @@ const (
 	// DashboardWriteTimeout is used for dashboard create/update operations.
 	DashboardWriteTimeout = 30 * time.Second
 
-	// analyticsIdentityCacheTTL bounds how stale a cached identity may be.
-	// Identity rarely changes, so a long TTL keeps the SigNoz backend from
-	// absorbing an extra /me request for every analytics event.
+	// analyticsIdentityCacheTTL keeps /me out of the hot analytics path;
+	// identity rarely changes, so 10 min is long enough to absorb bursts.
 	analyticsIdentityCacheTTL = 10 * time.Minute
 )
 
 var ErrUnauthorized = errors.New("signoz credentials rejected")
 
 // AnalyticsIdentity is the identity tuple used for analytics attribution.
-// UserID is the effective distinct/user identifier for analytics. For API key
-// sessions this is the service account ID; for auth-token sessions this is the
-// SigNoz user ID.
+// UserID holds the service-account ID for API-key sessions, or the SigNoz
+// user ID for auth-token sessions.
 type AnalyticsIdentity struct {
 	OrgID     string
 	UserID    string
@@ -134,18 +132,12 @@ func (s *SigNoz) ValidateCredentials(ctx context.Context) error {
 	return s.evaluateValidationResponse(log, status, body)
 }
 
-// GetAnalyticsIdentity resolves the org and effective analytics identity for
-// the current credentials. The result is cached per-client for
-// analyticsIdentityCacheTTL so analytics hot paths (one event per tool call)
-// don't each trigger a /me roundtrip. The lookup is serialized by a mutex, so
-// a burst of concurrent callers during a cache miss results in a single
-// upstream request.
+// GetAnalyticsIdentity returns the org + user identity for the current
+// credentials, cached per-client and mutex-serialized so a burst of events
+// produces a single /me roundtrip.
 //
-// Auth-mode specific behavior:
-//   - Authorization header clients resolve via /api/v2/users/me. v2 is used
-//     (vs. the v1 path in ValidateCredentials) because it returns orgId,
-//     which is required to set the analytics groupId.
-//   - SIGNOZ-API-KEY clients resolve via /api/v1/service_accounts/me.
+// Auth-token clients hit /api/v2/users/me (v2 is required — it returns
+// orgId, v1 doesn't). API-key clients hit /api/v1/service_accounts/me.
 func (s *SigNoz) GetAnalyticsIdentity(ctx context.Context) (*AnalyticsIdentity, error) {
 	s.identityMu.Lock()
 	defer s.identityMu.Unlock()
@@ -247,9 +239,8 @@ func (s *SigNoz) doValidationRequest(ctx context.Context, reqURL string) (int, [
 		_ = resp.Body.Close()
 	}()
 
-	// 64 KiB accommodates the full /api/v2/users/me payload (roles, groups,
-	// nested org metadata) without the risk of truncating valid JSON — the
-	// previous 2 KiB cap caused identity parsing to fail on rich responses.
+	// 64 KiB holds the full /api/v2/users/me payload (roles, groups, nested
+	// org metadata); anything smaller risks truncating valid JSON.
 	body, err := io.ReadAll(io.LimitReader(resp.Body, 64*1024))
 	if err != nil {
 		return 0, nil, fmt.Errorf("failed to read validation response: %w", err)

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"sync"
 	"time"
 
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
@@ -29,6 +30,11 @@ const (
 	DefaultQueryTimeout = 600 * time.Second
 	// DashboardWriteTimeout is used for dashboard create/update operations.
 	DashboardWriteTimeout = 30 * time.Second
+
+	// analyticsIdentityCacheTTL bounds how stale a cached identity may be.
+	// Identity rarely changes, so a long TTL keeps the SigNoz backend from
+	// absorbing an extra /me request for every analytics event.
+	analyticsIdentityCacheTTL = 10 * time.Minute
 )
 
 var ErrUnauthorized = errors.New("signoz credentials rejected")
@@ -51,6 +57,10 @@ type SigNoz struct {
 	logger         *zap.Logger
 	httpClient     *http.Client
 	customHeaders  map[string]string
+
+	identityMu       sync.Mutex
+	cachedIdentity   *AnalyticsIdentity
+	identityCachedAt time.Time
 }
 
 func NewClient(log *zap.Logger, baseURL, apiKey, authHeaderName string, customHeaders map[string]string) *SigNoz {
@@ -125,12 +135,36 @@ func (s *SigNoz) ValidateCredentials(ctx context.Context) error {
 }
 
 // GetAnalyticsIdentity resolves the org and effective analytics identity for
-// the current credentials.
+// the current credentials. The result is cached per-client for
+// analyticsIdentityCacheTTL so analytics hot paths (one event per tool call)
+// don't each trigger a /me roundtrip. The lookup is serialized by a mutex, so
+// a burst of concurrent callers during a cache miss results in a single
+// upstream request.
 //
 // Auth-mode specific behavior:
-//   - Authorization header clients resolve via /api/v2/users/me
-//   - SIGNOZ-API-KEY clients resolve via /api/v1/service_accounts/me
+//   - Authorization header clients resolve via /api/v2/users/me. v2 is used
+//     (vs. the v1 path in ValidateCredentials) because it returns orgId,
+//     which is required to set the analytics groupId.
+//   - SIGNOZ-API-KEY clients resolve via /api/v1/service_accounts/me.
 func (s *SigNoz) GetAnalyticsIdentity(ctx context.Context) (*AnalyticsIdentity, error) {
+	s.identityMu.Lock()
+	defer s.identityMu.Unlock()
+
+	if s.cachedIdentity != nil && time.Since(s.identityCachedAt) < analyticsIdentityCacheTTL {
+		return s.cachedIdentity, nil
+	}
+
+	identity, err := s.fetchAnalyticsIdentity(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	s.cachedIdentity = identity
+	s.identityCachedAt = time.Now()
+	return identity, nil
+}
+
+func (s *SigNoz) fetchAnalyticsIdentity(ctx context.Context) (*AnalyticsIdentity, error) {
 	log := s.requestLogger(ctx)
 	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()
@@ -213,7 +247,10 @@ func (s *SigNoz) doValidationRequest(ctx context.Context, reqURL string) (int, [
 		_ = resp.Body.Close()
 	}()
 
-	body, err := io.ReadAll(io.LimitReader(resp.Body, 2048))
+	// 64 KiB accommodates the full /api/v2/users/me payload (roles, groups,
+	// nested org metadata) without the risk of truncating valid JSON — the
+	// previous 2 KiB cap caused identity parsing to fail on rich responses.
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 64*1024))
 	if err != nil {
 		return 0, nil, fmt.Errorf("failed to read validation response: %w", err)
 	}

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -228,6 +228,123 @@ func TestValidateCredentials(t *testing.T) {
 	}
 }
 
+func TestGetAnalyticsIdentity(t *testing.T) {
+	tests := []struct {
+		name              string
+		authHeaderName    string
+		expectedHeader    string
+		expectedHeaderVal string
+		expectedPath      string
+		statusCode        int
+		responseBody      string
+		expectedIdentity  *AnalyticsIdentity
+		checkErr          func(t *testing.T, err error)
+	}{
+		{
+			name:              "authorization auth resolves via v2 users me",
+			authHeaderName:    "Authorization",
+			expectedHeader:    "Authorization",
+			expectedHeaderVal: "Bearer jwt-token",
+			expectedPath:      "/api/v2/users/me",
+			statusCode:        http.StatusOK,
+			responseBody:      `{"status":"success","data":{"id":"user-123","email":"user@example.com","orgId":"org-123"}}`,
+			expectedIdentity: &AnalyticsIdentity{
+				OrgID:     "org-123",
+				UserID:    "user-123",
+				Email:     "user@example.com",
+				Principal: "user",
+			},
+		},
+		{
+			name:              "api key auth resolves via service accounts me",
+			authHeaderName:    "SIGNOZ-API-KEY",
+			expectedHeader:    "SIGNOZ-API-KEY",
+			expectedHeaderVal: "test-api-key",
+			expectedPath:      "/api/v1/service_accounts/me",
+			statusCode:        http.StatusOK,
+			responseBody:      `{"status":"success","data":{"id":"sa-123","email":"service@example.com","orgId":"org-456"}}`,
+			expectedIdentity: &AnalyticsIdentity{
+				OrgID:     "org-456",
+				UserID:    "sa-123",
+				Email:     "service@example.com",
+				Principal: "service_account",
+			},
+		},
+		{
+			name:              "authorization auth does not fall back from v2 users me",
+			authHeaderName:    "Authorization",
+			expectedHeader:    "Authorization",
+			expectedHeaderVal: "Bearer jwt-token",
+			expectedPath:      "/api/v2/users/me",
+			statusCode:        http.StatusNotFound,
+			responseBody:      `{"status":"error"}`,
+			checkErr: func(t *testing.T, err error) {
+				assert.Contains(t, err.Error(), "unexpected status 404")
+			},
+		},
+		{
+			name:              "unauthorized identity lookup returns auth error",
+			authHeaderName:    "SIGNOZ-API-KEY",
+			expectedHeader:    "SIGNOZ-API-KEY",
+			expectedHeaderVal: "test-api-key",
+			expectedPath:      "/api/v1/service_accounts/me",
+			statusCode:        http.StatusUnauthorized,
+			responseBody:      `{"status":"error"}`,
+			checkErr: func(t *testing.T, err error) {
+				assert.ErrorIs(t, err, ErrUnauthorized)
+			},
+		},
+		{
+			name:              "malformed success response returns parse error",
+			authHeaderName:    "SIGNOZ-API-KEY",
+			expectedHeader:    "SIGNOZ-API-KEY",
+			expectedHeaderVal: "test-api-key",
+			expectedPath:      "/api/v1/service_accounts/me",
+			statusCode:        http.StatusOK,
+			responseBody:      `{"status":"success","data":{"orgId":"org-123"}}`,
+			checkErr: func(t *testing.T, err error) {
+				assert.Contains(t, err.Error(), "missing data.id")
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			requests := 0
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				requests++
+				assert.Equal(t, http.MethodGet, r.Method)
+				assert.Equal(t, "application/json", r.Header.Get("Content-Type"))
+				assert.Equal(t, tt.expectedPath, r.URL.Path)
+				assert.Equal(t, tt.expectedHeaderVal, r.Header.Get(tt.expectedHeader))
+
+				w.WriteHeader(tt.statusCode)
+				_, _ = w.Write([]byte(tt.responseBody))
+			}))
+			defer server.Close()
+
+			logger, _ := zap.NewDevelopment()
+			apiKey := "test-api-key"
+			if tt.authHeaderName == "Authorization" {
+				apiKey = "Bearer jwt-token"
+			}
+			client := NewClient(logger, server.URL, apiKey, tt.authHeaderName, nil)
+
+			identity, err := client.GetAnalyticsIdentity(context.Background())
+
+			if tt.checkErr != nil {
+				assert.Error(t, err)
+				tt.checkErr(t, err)
+				assert.Nil(t, identity)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tt.expectedIdentity, identity)
+			}
+			assert.Equal(t, 1, requests, "expected exactly one identity request")
+		})
+	}
+}
+
 func TestListMetricKeys(t *testing.T) {
 	tests := []struct {
 		name          string
@@ -1380,9 +1497,9 @@ func TestNewClient_EmptyHeaders(t *testing.T) {
 
 func TestNewClient_ReservedHeadersSkipped(t *testing.T) {
 	customHeaders := map[string]string{
-		"Content-Type":            "text/plain",
-		"SIGNOZ-API-KEY":         "overridden-key",
-		"CF-Access-Client-Id":    "test-id",
+		"Content-Type":        "text/plain",
+		"SIGNOZ-API-KEY":      "overridden-key",
+		"CF-Access-Client-Id": "test-id",
 	}
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -7,7 +7,10 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"sync"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -343,6 +346,57 @@ func TestGetAnalyticsIdentity(t *testing.T) {
 			assert.Equal(t, 1, requests, "expected exactly one identity request")
 		})
 	}
+}
+
+func TestGetAnalyticsIdentity_CachesResult(t *testing.T) {
+	requests := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"status":"success","data":{"id":"user-1","email":"u@example.com","orgId":"org-1"}}`))
+	}))
+	defer server.Close()
+
+	logger, _ := zap.NewDevelopment()
+	client := NewClient(logger, server.URL, "Bearer jwt", "Authorization", nil)
+
+	for i := 0; i < 5; i++ {
+		identity, err := client.GetAnalyticsIdentity(context.Background())
+		require.NoError(t, err)
+		assert.Equal(t, "user-1", identity.UserID)
+	}
+
+	assert.Equal(t, 1, requests, "expected identity cache to serve repeated lookups")
+}
+
+func TestGetAnalyticsIdentity_ConcurrentCallsDedupe(t *testing.T) {
+	var requests atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests.Add(1)
+		time.Sleep(20 * time.Millisecond)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"status":"success","data":{"id":"user-1","email":"u@example.com","orgId":"org-1"}}`))
+	}))
+	defer server.Close()
+
+	logger, _ := zap.NewDevelopment()
+	client := NewClient(logger, server.URL, "Bearer jwt", "Authorization", nil)
+
+	const callers = 10
+	var wg sync.WaitGroup
+	wg.Add(callers)
+	for i := 0; i < callers; i++ {
+		go func() {
+			defer wg.Done()
+			_, err := client.GetAnalyticsIdentity(context.Background())
+			assert.NoError(t, err)
+		}()
+	}
+	wg.Wait()
+
+	// The mutex serializes lookups; the first request populates the cache
+	// and every other caller observes the cached result.
+	assert.Equal(t, int32(1), requests.Load(), "expected concurrent callers to share a single upstream request")
 }
 
 func TestListMetricKeys(t *testing.T) {

--- a/internal/client/interface.go
+++ b/internal/client/interface.go
@@ -10,6 +10,7 @@ import (
 // Client defines the interface for interacting with the SigNoz API.
 // Handler code depends on this interface, enabling mock-based unit testing.
 type Client interface {
+	GetAnalyticsIdentity(ctx context.Context) (*AnalyticsIdentity, error)
 	ListMetrics(ctx context.Context, start, end int64, limit int, searchText, source string) (json.RawMessage, error)
 	ListAlerts(ctx context.Context, params types.ListAlertsParams) (json.RawMessage, error)
 	GetAlertByRuleID(ctx context.Context, ruleID string) (json.RawMessage, error)

--- a/internal/client/mock.go
+++ b/internal/client/mock.go
@@ -11,34 +11,42 @@ import (
 // Each method delegates to the corresponding function field when non-nil,
 // otherwise returns a default empty JSON object and nil error.
 type MockClient struct {
-	ListMetricsFn             func(ctx context.Context, start, end int64, limit int, searchText, source string) (json.RawMessage, error)
-	ListAlertsFn              func(ctx context.Context, params types.ListAlertsParams) (json.RawMessage, error)
-	GetAlertByRuleIDFn        func(ctx context.Context, ruleID string) (json.RawMessage, error)
-	GetAlertHistoryFn         func(ctx context.Context, ruleID string, req types.AlertHistoryRequest) (json.RawMessage, error)
-	ListDashboardsFn          func(ctx context.Context) (json.RawMessage, error)
-	GetDashboardFn            func(ctx context.Context, uuid string) (json.RawMessage, error)
-	CreateDashboardFn         func(ctx context.Context, dashboard types.Dashboard) (json.RawMessage, error)
-	UpdateDashboardFn         func(ctx context.Context, id string, dashboard types.Dashboard) error
-	CreateDashboardRawFn      func(ctx context.Context, dashboardJSON []byte) (json.RawMessage, error)
-	UpdateDashboardRawFn      func(ctx context.Context, id string, dashboardJSON []byte) error
-	DeleteDashboardFn         func(ctx context.Context, id string) error
-	ListServicesFn            func(ctx context.Context, start, end string) (json.RawMessage, error)
-	GetServiceTopOperationsFn func(ctx context.Context, start, end, service string, tags json.RawMessage) (json.RawMessage, error)
-	QueryBuilderV5Fn          func(ctx context.Context, body []byte) (json.RawMessage, error)
-	ListLogViewsFn            func(ctx context.Context) (json.RawMessage, error)
-	GetLogViewFn              func(ctx context.Context, viewID string) (json.RawMessage, error)
-	GetFieldKeysFn            func(ctx context.Context, signal, metricName, searchText, fieldContext, fieldDataType, source string) (json.RawMessage, error)
-	GetFieldValuesFn          func(ctx context.Context, signal, name, metricName, searchText, source string) (json.RawMessage, error)
-	GetTraceDetailsFn              func(ctx context.Context, traceID string, includeSpans bool, startTime, endTime int64) (json.RawMessage, error)
-	CreateAlertRuleFn              func(ctx context.Context, alertJSON []byte) (json.RawMessage, error)
-	ListNotificationChannelsFn     func(ctx context.Context) (json.RawMessage, error)
-	CreateNotificationChannelFn    func(ctx context.Context, receiverJSON []byte) (json.RawMessage, error)
-	UpdateNotificationChannelFn    func(ctx context.Context, id string, receiverJSON []byte) (json.RawMessage, error)
-	TestNotificationChannelFn      func(ctx context.Context, receiverJSON []byte) error
+	GetAnalyticsIdentityFn      func(ctx context.Context) (*AnalyticsIdentity, error)
+	ListMetricsFn               func(ctx context.Context, start, end int64, limit int, searchText, source string) (json.RawMessage, error)
+	ListAlertsFn                func(ctx context.Context, params types.ListAlertsParams) (json.RawMessage, error)
+	GetAlertByRuleIDFn          func(ctx context.Context, ruleID string) (json.RawMessage, error)
+	GetAlertHistoryFn           func(ctx context.Context, ruleID string, req types.AlertHistoryRequest) (json.RawMessage, error)
+	ListDashboardsFn            func(ctx context.Context) (json.RawMessage, error)
+	GetDashboardFn              func(ctx context.Context, uuid string) (json.RawMessage, error)
+	CreateDashboardFn           func(ctx context.Context, dashboard types.Dashboard) (json.RawMessage, error)
+	UpdateDashboardFn           func(ctx context.Context, id string, dashboard types.Dashboard) error
+	CreateDashboardRawFn        func(ctx context.Context, dashboardJSON []byte) (json.RawMessage, error)
+	UpdateDashboardRawFn        func(ctx context.Context, id string, dashboardJSON []byte) error
+	DeleteDashboardFn           func(ctx context.Context, id string) error
+	ListServicesFn              func(ctx context.Context, start, end string) (json.RawMessage, error)
+	GetServiceTopOperationsFn   func(ctx context.Context, start, end, service string, tags json.RawMessage) (json.RawMessage, error)
+	QueryBuilderV5Fn            func(ctx context.Context, body []byte) (json.RawMessage, error)
+	ListLogViewsFn              func(ctx context.Context) (json.RawMessage, error)
+	GetLogViewFn                func(ctx context.Context, viewID string) (json.RawMessage, error)
+	GetFieldKeysFn              func(ctx context.Context, signal, metricName, searchText, fieldContext, fieldDataType, source string) (json.RawMessage, error)
+	GetFieldValuesFn            func(ctx context.Context, signal, name, metricName, searchText, source string) (json.RawMessage, error)
+	GetTraceDetailsFn           func(ctx context.Context, traceID string, includeSpans bool, startTime, endTime int64) (json.RawMessage, error)
+	CreateAlertRuleFn           func(ctx context.Context, alertJSON []byte) (json.RawMessage, error)
+	ListNotificationChannelsFn  func(ctx context.Context) (json.RawMessage, error)
+	CreateNotificationChannelFn func(ctx context.Context, receiverJSON []byte) (json.RawMessage, error)
+	UpdateNotificationChannelFn func(ctx context.Context, id string, receiverJSON []byte) (json.RawMessage, error)
+	TestNotificationChannelFn   func(ctx context.Context, receiverJSON []byte) error
 }
 
 // Compile-time check that MockClient satisfies Client.
 var _ Client = (*MockClient)(nil)
+
+func (m *MockClient) GetAnalyticsIdentity(ctx context.Context) (*AnalyticsIdentity, error) {
+	if m.GetAnalyticsIdentityFn != nil {
+		return m.GetAnalyticsIdentityFn(ctx)
+	}
+	return &AnalyticsIdentity{}, nil
+}
 
 func (m *MockClient) ListMetrics(ctx context.Context, start, end int64, limit int, searchText, source string) (json.RawMessage, error) {
 	if m.ListMetricsFn != nil {

--- a/internal/mcp-server/server.go
+++ b/internal/mcp-server/server.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	signozclient "github.com/SigNoz/signoz-mcp-server/internal/client"
 	"github.com/SigNoz/signoz-mcp-server/internal/config"
 	"github.com/SigNoz/signoz-mcp-server/internal/handler/tools"
 	"github.com/SigNoz/signoz-mcp-server/internal/oauth"
@@ -30,6 +31,96 @@ type MCPServer struct {
 	handler   *tools.Handler
 	config    *config.Config
 	analytics analytics.Analytics
+}
+
+func cloneMap(src map[string]any) map[string]any {
+	if len(src) == 0 {
+		return map[string]any{}
+	}
+	dst := make(map[string]any, len(src))
+	for k, v := range src {
+		dst[k] = v
+	}
+	return dst
+}
+
+func (m *MCPServer) enrichAnalyticsAttrs(identity *signozclient.AnalyticsIdentity, attrs map[string]any) map[string]any {
+	enriched := cloneMap(attrs)
+	if identity == nil {
+		return enriched
+	}
+	enriched["org_id"] = identity.OrgID
+	enriched["principal"] = identity.Principal
+	if identity.Email != "" {
+		switch identity.Principal {
+		case "user":
+			enriched["user_email"] = identity.Email
+		case "service_account":
+			enriched["service_email"] = identity.Email
+		}
+	}
+	return enriched
+}
+
+func (m *MCPServer) resolveAnalyticsIdentity(ctx context.Context) (*signozclient.AnalyticsIdentity, error) {
+	if m.handler == nil {
+		return nil, fmt.Errorf("analytics identity resolution requires a handler")
+	}
+
+	client, err := m.handler.GetClient(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return client.GetAnalyticsIdentity(ctx)
+}
+
+func (m *MCPServer) identifyAnalyticsUser(ctx context.Context, attrs map[string]any) (*signozclient.AnalyticsIdentity, bool) {
+	identity, err := m.resolveAnalyticsIdentity(ctx)
+	if err != nil {
+		m.logger.Warn("analytics identity resolution failed; skipping identify",
+			append(m.analyticsLogFields(ctx), zap.Error(err))...)
+		return nil, false
+	}
+
+	m.analytics.IdentifyUser(ctx, identity.OrgID, identity.UserID, m.enrichAnalyticsAttrs(identity, attrs))
+	return identity, true
+}
+
+func (m *MCPServer) trackAnalyticsUser(ctx context.Context, event string, attrs map[string]any) bool {
+	identity, err := m.resolveAnalyticsIdentity(ctx)
+	if err != nil {
+		m.logger.Warn("analytics identity resolution failed; skipping track",
+			append(m.analyticsLogFields(ctx), zap.String("event", event), zap.Error(err))...)
+		return false
+	}
+
+	m.analytics.TrackUser(ctx, identity.OrgID, identity.UserID, event, m.enrichAnalyticsAttrs(identity, attrs))
+	return true
+}
+
+func (m *MCPServer) identifyAndTrackAnalyticsUser(ctx context.Context, event string, traits map[string]any, properties map[string]any) bool {
+	identity, err := m.resolveAnalyticsIdentity(ctx)
+	if err != nil {
+		m.logger.Warn("analytics identity resolution failed; skipping identify+track",
+			append(m.analyticsLogFields(ctx), zap.String("event", event), zap.Error(err))...)
+		return false
+	}
+
+	m.analytics.IdentifyUser(ctx, identity.OrgID, identity.UserID, m.enrichAnalyticsAttrs(identity, traits))
+	m.analytics.TrackUser(ctx, identity.OrgID, identity.UserID, event, m.enrichAnalyticsAttrs(identity, properties))
+	return true
+}
+
+func (m *MCPServer) analyticsLogFields(ctx context.Context) []zap.Field {
+	fields := []zap.Field{}
+	if sid, ok := util.GetSessionID(ctx); ok && sid != "" {
+		fields = append(fields, zap.String("mcp.session.id", sid))
+	}
+	if signozURL, ok := util.GetSigNozURL(ctx); ok && signozURL != "" {
+		fields = append(fields, zap.String("mcp.tenant_url", signozURL))
+	}
+	return fields
 }
 
 func NewMCPServer(log *zap.Logger, handler *tools.Handler, cfg *config.Config, a analytics.Analytics) *MCPServer {
@@ -106,7 +197,6 @@ func (m *MCPServer) buildHooks() *server.Hooks {
 			traits := map[string]any{
 				string(telemetry.MCPTenantURLKey): signozURL,
 			}
-			m.analytics.IdentifyGroup(ctx, signozURL, traits)
 
 			props := map[string]any{
 				string(telemetry.MCPTenantURLKey): signozURL,
@@ -114,40 +204,36 @@ func (m *MCPServer) buildHooks() *server.Hooks {
 			if session := server.ClientSessionFromContext(ctx); session != nil {
 				props[string(telemetry.MCPSessionIDKey)] = session.SessionID()
 			}
-			m.analytics.TrackGroup(ctx, signozURL, "MCP Registered", props)
+			m.identifyAndTrackAnalyticsUser(ctx, "MCP Registered", traits, props)
 		}
 	})
 	hooks.AddOnRegisterSession(func(ctx context.Context, session server.ClientSession) {
 		fields := []zap.Field{}
-		var tenantURL string
 		if signozURL, ok := util.GetSigNozURL(ctx); ok && signozURL != "" {
 			fields = append(fields, zap.String("mcp.tenant_url", signozURL))
-			tenantURL = signozURL
 		}
 		m.logger.Info("mcp session registered", fields...)
 
-		if tenantURL != "" {
+		if signozURL, ok := util.GetSigNozURL(ctx); ok && signozURL != "" {
 			traits := map[string]any{
-				string(telemetry.MCPTenantURLKey): tenantURL,
+				string(telemetry.MCPTenantURLKey): signozURL,
 			}
-			m.analytics.IdentifyGroup(ctx, tenantURL, traits)
+			m.identifyAnalyticsUser(ctx, traits)
 		}
 	})
 	hooks.AddOnUnregisterSession(func(ctx context.Context, session server.ClientSession) {
 		fields := []zap.Field{}
-		var tenantURL string
 		if signozURL, ok := util.GetSigNozURL(ctx); ok && signozURL != "" {
 			fields = append(fields, zap.String("mcp.tenant_url", signozURL))
-			tenantURL = signozURL
 		}
 		m.logger.Info("mcp session unregistered", fields...)
 
-		if tenantURL != "" {
+		if signozURL, ok := util.GetSigNozURL(ctx); ok && signozURL != "" {
 			props := map[string]any{
-				string(telemetry.MCPTenantURLKey): tenantURL,
+				string(telemetry.MCPTenantURLKey): signozURL,
 				string(telemetry.MCPSessionIDKey): session.SessionID(),
 			}
-			m.analytics.TrackGroup(ctx, tenantURL, "MCP Unregistered", props)
+			m.trackAnalyticsUser(ctx, "MCP Unregistered", props)
 		}
 	})
 	return hooks
@@ -238,15 +324,15 @@ func (m *MCPServer) loggingMiddleware() server.ToolHandlerMiddleware {
 			// Analytics: track tool call
 			if signozURL, ok := util.GetSigNozURL(ctx); ok && signozURL != "" {
 				props := map[string]any{
-					string(telemetry.MCPTenantURLKey):  signozURL,
-					string(telemetry.GenAIToolNameKey): req.Params.Name,
+					string(telemetry.MCPTenantURLKey):   signozURL,
+					string(telemetry.GenAIToolNameKey):  req.Params.Name,
 					string(telemetry.MCPToolIsErrorKey): isErr,
-					"duration_ms": time.Since(start).Milliseconds(),
+					"duration_ms":                       time.Since(start).Milliseconds(),
 				}
 				if sid, ok := util.GetSessionID(ctx); ok && sid != "" {
 					props[string(telemetry.MCPSessionIDKey)] = sid
 				}
-				m.analytics.TrackGroup(ctx, signozURL, "Tool Call", props)
+				m.trackAnalyticsUser(ctx, "Tool Call", props)
 			}
 
 			return result, err

--- a/internal/mcp-server/server.go
+++ b/internal/mcp-server/server.go
@@ -33,6 +33,8 @@ type MCPServer struct {
 	analytics analytics.Analytics
 }
 
+const analyticsAsyncTimeout = 5 * time.Second
+
 func (m *MCPServer) analyticsEnabled() bool {
 	return m.analytics != nil && m.analytics.Enabled()
 }
@@ -84,15 +86,18 @@ func (m *MCPServer) identifyAnalyticsUser(ctx context.Context, attrs map[string]
 		return nil, false
 	}
 
-	identity, err := m.resolveAnalyticsIdentity(ctx)
-	if err != nil {
-		m.logger.Warn("analytics identity resolution failed; skipping identify",
-			append(m.analyticsLogFields(ctx), zap.Error(err))...)
-		return nil, false
-	}
+	attrs = cloneMap(attrs)
+	m.dispatchAnalytics(ctx, func(detachedCtx context.Context) {
+		identity, err := m.resolveAnalyticsIdentity(detachedCtx)
+		if err != nil {
+			m.logger.Warn("analytics identity resolution failed; skipping identify",
+				append(m.analyticsLogFields(detachedCtx), zap.Error(err))...)
+			return
+		}
 
-	m.analytics.IdentifyUser(ctx, identity.OrgID, identity.UserID, m.enrichAnalyticsAttrs(identity, attrs))
-	return identity, true
+		m.analytics.IdentifyUser(detachedCtx, identity.OrgID, identity.UserID, m.enrichAnalyticsAttrs(identity, attrs))
+	})
+	return nil, true
 }
 
 func (m *MCPServer) trackAnalyticsUser(ctx context.Context, event string, attrs map[string]any) bool {
@@ -100,14 +105,17 @@ func (m *MCPServer) trackAnalyticsUser(ctx context.Context, event string, attrs 
 		return false
 	}
 
-	identity, err := m.resolveAnalyticsIdentity(ctx)
-	if err != nil {
-		m.logger.Warn("analytics identity resolution failed; skipping track",
-			append(m.analyticsLogFields(ctx), zap.String("event", event), zap.Error(err))...)
-		return false
-	}
+	attrs = cloneMap(attrs)
+	m.dispatchAnalytics(ctx, func(detachedCtx context.Context) {
+		identity, err := m.resolveAnalyticsIdentity(detachedCtx)
+		if err != nil {
+			m.logger.Warn("analytics identity resolution failed; skipping track",
+				append(m.analyticsLogFields(detachedCtx), zap.String("event", event), zap.Error(err))...)
+			return
+		}
 
-	m.analytics.TrackUser(ctx, identity.OrgID, identity.UserID, event, m.enrichAnalyticsAttrs(identity, attrs))
+		m.analytics.TrackUser(detachedCtx, identity.OrgID, identity.UserID, event, m.enrichAnalyticsAttrs(identity, attrs))
+	})
 	return true
 }
 
@@ -116,15 +124,19 @@ func (m *MCPServer) identifyAndTrackAnalyticsUser(ctx context.Context, event str
 		return false
 	}
 
-	identity, err := m.resolveAnalyticsIdentity(ctx)
-	if err != nil {
-		m.logger.Warn("analytics identity resolution failed; skipping identify+track",
-			append(m.analyticsLogFields(ctx), zap.String("event", event), zap.Error(err))...)
-		return false
-	}
+	traits = cloneMap(traits)
+	properties = cloneMap(properties)
+	m.dispatchAnalytics(ctx, func(detachedCtx context.Context) {
+		identity, err := m.resolveAnalyticsIdentity(detachedCtx)
+		if err != nil {
+			m.logger.Warn("analytics identity resolution failed; skipping identify+track",
+				append(m.analyticsLogFields(detachedCtx), zap.String("event", event), zap.Error(err))...)
+			return
+		}
 
-	m.analytics.IdentifyUser(ctx, identity.OrgID, identity.UserID, m.enrichAnalyticsAttrs(identity, traits))
-	m.analytics.TrackUser(ctx, identity.OrgID, identity.UserID, event, m.enrichAnalyticsAttrs(identity, properties))
+		m.analytics.IdentifyUser(detachedCtx, identity.OrgID, identity.UserID, m.enrichAnalyticsAttrs(identity, traits))
+		m.analytics.TrackUser(detachedCtx, identity.OrgID, identity.UserID, event, m.enrichAnalyticsAttrs(identity, properties))
+	})
 	return true
 }
 
@@ -137,6 +149,36 @@ func (m *MCPServer) analyticsLogFields(ctx context.Context) []zap.Field {
 		fields = append(fields, zap.String("mcp.tenant_url", signozURL))
 	}
 	return fields
+}
+
+func (m *MCPServer) detachedAnalyticsContext(parent context.Context) (context.Context, context.CancelFunc) {
+	ctx, cancel := context.WithTimeout(context.Background(), analyticsAsyncTimeout)
+
+	if apiKey, ok := util.GetAPIKey(parent); ok && apiKey != "" {
+		ctx = util.SetAPIKey(ctx, apiKey)
+	}
+	if authHeader, ok := util.GetAuthHeader(parent); ok && authHeader != "" {
+		ctx = util.SetAuthHeader(ctx, authHeader)
+	}
+	if signozURL, ok := util.GetSigNozURL(parent); ok && signozURL != "" {
+		ctx = util.SetSigNozURL(ctx, signozURL)
+	}
+	if searchContext, ok := util.GetSearchContext(parent); ok && searchContext != "" {
+		ctx = util.SetSearchContext(ctx, searchContext)
+	}
+	if sessionID, ok := util.GetSessionID(parent); ok && sessionID != "" {
+		ctx = util.SetSessionID(ctx, sessionID)
+	}
+
+	return ctx, cancel
+}
+
+func (m *MCPServer) dispatchAnalytics(parent context.Context, fn func(context.Context)) {
+	ctx, cancel := m.detachedAnalyticsContext(parent)
+	go func() {
+		defer cancel()
+		fn(ctx)
+	}()
 }
 
 func NewMCPServer(log *zap.Logger, handler *tools.Handler, cfg *config.Config, a analytics.Analytics) *MCPServer {

--- a/internal/mcp-server/server.go
+++ b/internal/mcp-server/server.go
@@ -17,6 +17,7 @@ import (
 	"github.com/SigNoz/signoz-mcp-server/pkg/instructions"
 	"github.com/SigNoz/signoz-mcp-server/pkg/prompts"
 	"github.com/SigNoz/signoz-mcp-server/pkg/util"
+	expirable "github.com/hashicorp/golang-lru/v2/expirable"
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
@@ -26,11 +27,59 @@ import (
 	"go.uber.org/zap"
 )
 
+// Streamable HTTP only fires OnUnregisterSession for the long-lived GET
+// listener — POST-only clients never trigger explicit cleanup — so the
+// session → ClientInfo map needs bounded eviction.
+const (
+	sessionClientCacheSize = 1024
+	sessionClientCacheTTL  = 30 * time.Minute
+)
+
 type MCPServer struct {
-	logger    *zap.Logger
-	handler   *tools.Handler
-	config    *config.Config
-	analytics analytics.Analytics
+	logger         *zap.Logger
+	handler        *tools.Handler
+	config         *config.Config
+	analytics      analytics.Analytics
+	sessionClients *expirable.LRU[string, mcp.Implementation]
+}
+
+func (m *MCPServer) rememberClientInfo(sessionID string, info mcp.Implementation) {
+	if sessionID == "" || info.Name == "" || m.sessionClients == nil {
+		return
+	}
+	m.sessionClients.Add(sessionID, info)
+}
+
+// lookupClientInfo re-Adds on hit so the TTL behaves as a sliding window
+// keyed on last use, keeping long-running sessions from losing attribution.
+func (m *MCPServer) lookupClientInfo(sessionID string) mcp.Implementation {
+	if sessionID == "" || m.sessionClients == nil {
+		return mcp.Implementation{}
+	}
+	v, ok := m.sessionClients.Get(sessionID)
+	if !ok {
+		return mcp.Implementation{}
+	}
+	m.sessionClients.Add(sessionID, v)
+	return v
+}
+
+func (m *MCPServer) forgetClientInfo(sessionID string) {
+	if sessionID == "" || m.sessionClients == nil {
+		return
+	}
+	m.sessionClients.Remove(sessionID)
+}
+
+func (m *MCPServer) attachClientInfo(props map[string]any, sessionID string) {
+	info := m.lookupClientInfo(sessionID)
+	if info.Name == "" {
+		return
+	}
+	props[analytics.AttrClientName] = info.Name
+	if info.Version != "" {
+		props[analytics.AttrClientVersion] = info.Version
+	}
 }
 
 const analyticsAsyncTimeout = 5 * time.Second
@@ -50,21 +99,19 @@ func cloneAttrs(src map[string]any) map[string]any {
 	return dst
 }
 
-// mergeIdentityAttrs returns a copy of attrs augmented with identity-derived
-// fields (org_id, principal, and a principal-scoped email key).
 func (m *MCPServer) mergeIdentityAttrs(identity *signozclient.AnalyticsIdentity, attrs map[string]any) map[string]any {
 	merged := cloneAttrs(attrs)
 	if identity == nil {
 		return merged
 	}
-	merged["org_id"] = identity.OrgID
-	merged["principal"] = identity.Principal
+	merged[analytics.AttrOrgID] = identity.OrgID
+	merged[analytics.AttrPrincipal] = identity.Principal
 	if identity.Email != "" {
 		switch identity.Principal {
 		case "user":
-			merged["user_email"] = identity.Email
+			merged[analytics.AttrUserEmail] = identity.Email
 		case "service_account":
-			merged["service_email"] = identity.Email
+			merged[analytics.AttrServiceEmail] = identity.Email
 		}
 	}
 	return merged
@@ -83,8 +130,6 @@ func (m *MCPServer) resolveIdentity(ctx context.Context) (*signozclient.Analytic
 	return client.GetAnalyticsIdentity(ctx)
 }
 
-// identifyAsync emits an Identify call on a detached goroutine. Returns
-// without blocking the caller; failures are logged, not surfaced.
 func (m *MCPServer) identifyAsync(ctx context.Context, traits map[string]any) {
 	if !m.analyticsEnabled() {
 		return
@@ -103,7 +148,6 @@ func (m *MCPServer) identifyAsync(ctx context.Context, traits map[string]any) {
 	})
 }
 
-// trackEventAsync emits a Track call on a detached goroutine.
 func (m *MCPServer) trackEventAsync(ctx context.Context, event string, properties map[string]any) {
 	if !m.analyticsEnabled() {
 		return
@@ -122,8 +166,8 @@ func (m *MCPServer) trackEventAsync(ctx context.Context, event string, propertie
 	})
 }
 
-// identifyAndTrackAsync resolves identity once and emits both an Identify and
-// a Track call under the same detached goroutine.
+// identifyAndTrackAsync resolves identity once and emits both calls under
+// the same goroutine to avoid a second /me roundtrip.
 func (m *MCPServer) identifyAndTrackAsync(ctx context.Context, event string, traits map[string]any, properties map[string]any) {
 	if !m.analyticsEnabled() {
 		return
@@ -144,6 +188,20 @@ func (m *MCPServer) identifyAndTrackAsync(ctx context.Context, event string, tra
 	})
 }
 
+// trackOAuthEvent seeds tenant credentials on ctx so the async identity
+// lookup can run even though the OAuth HTTP request carried them in form
+// fields or an encrypted grant, not in util-context.
+func (m *MCPServer) trackOAuthEvent(ctx context.Context, event, apiKey, signozURL string, props map[string]any) {
+	if apiKey != "" {
+		ctx = util.SetAPIKey(ctx, apiKey)
+		ctx = util.SetAuthHeader(ctx, "SIGNOZ-API-KEY")
+	}
+	if signozURL != "" {
+		ctx = util.SetSigNozURL(ctx, signozURL)
+	}
+	m.trackEventAsync(ctx, event, props)
+}
+
 func (m *MCPServer) analyticsLogFields(ctx context.Context) []zap.Field {
 	fields := []zap.Field{}
 	if sid, ok := util.GetSessionID(ctx); ok && sid != "" {
@@ -155,11 +213,9 @@ func (m *MCPServer) analyticsLogFields(ctx context.Context) []zap.Field {
 	return fields
 }
 
-// detachedAnalyticsContext returns a background-rooted context (so the async
-// goroutine survives the parent request) bounded by analyticsAsyncTimeout, and
-// carries forward the values the client lookup + analytics call need:
-// credentials, tenant URL, session/search context, and the OTel span so
-// identity HTTP requests remain linked to the originating tool call.
+// detachedAnalyticsContext roots the async goroutine off context.Background
+// (so it survives the parent request) while copying forward the credentials,
+// tenant/session fields, and span context the identity lookup needs.
 func (m *MCPServer) detachedAnalyticsContext(parent context.Context) (context.Context, context.CancelFunc) {
 	ctx, cancel := context.WithTimeout(context.Background(), analyticsAsyncTimeout)
 
@@ -194,7 +250,13 @@ func (m *MCPServer) dispatchAnalytics(parent context.Context, fn func(context.Co
 }
 
 func NewMCPServer(log *zap.Logger, handler *tools.Handler, cfg *config.Config, a analytics.Analytics) *MCPServer {
-	return &MCPServer{logger: log, handler: handler, config: cfg, analytics: a}
+	return &MCPServer{
+		logger:         log,
+		handler:        handler,
+		config:         cfg,
+		analytics:      a,
+		sessionClients: expirable.NewLRU[string, mcp.Implementation](sessionClientCacheSize, nil, sessionClientCacheTTL),
+	}
 }
 
 func (m *MCPServer) Start() error {
@@ -263,18 +325,27 @@ func (m *MCPServer) buildHooks() *server.Hooks {
 	// Analytics: track session registration after successful initialize.
 	// Uses AfterInitialize (not BeforeAny) so failed initializations are not counted.
 	hooks.AddAfterInitialize(func(ctx context.Context, id any, message *mcp.InitializeRequest, result *mcp.InitializeResult) {
+		var sessionID string
+		if session := server.ClientSessionFromContext(ctx); session != nil {
+			sessionID = session.SessionID()
+		}
+		if message != nil {
+			m.rememberClientInfo(sessionID, message.Params.ClientInfo)
+		}
+
 		if signozURL, ok := util.GetSigNozURL(ctx); ok && signozURL != "" {
 			traits := map[string]any{
-				string(telemetry.MCPTenantURLKey): signozURL,
+				analytics.AttrTenantURL: signozURL,
 			}
-
 			props := map[string]any{
-				string(telemetry.MCPTenantURLKey): signozURL,
+				analytics.AttrTenantURL: signozURL,
 			}
-			if session := server.ClientSessionFromContext(ctx); session != nil {
-				props[string(telemetry.MCPSessionIDKey)] = session.SessionID()
+			if sessionID != "" {
+				props[analytics.AttrSessionID] = sessionID
 			}
-			m.identifyAndTrackAsync(ctx, "MCP Registered", traits, props)
+			m.attachClientInfo(traits, sessionID)
+			m.attachClientInfo(props, sessionID)
+			m.identifyAndTrackAsync(ctx, analytics.EventSessionRegistered, traits, props)
 		}
 	})
 	hooks.AddOnRegisterSession(func(ctx context.Context, session server.ClientSession) {
@@ -286,12 +357,14 @@ func (m *MCPServer) buildHooks() *server.Hooks {
 
 		if signozURL, ok := util.GetSigNozURL(ctx); ok && signozURL != "" {
 			traits := map[string]any{
-				string(telemetry.MCPTenantURLKey): signozURL,
+				analytics.AttrTenantURL: signozURL,
 			}
+			m.attachClientInfo(traits, session.SessionID())
 			m.identifyAsync(ctx, traits)
 		}
 	})
 	hooks.AddOnUnregisterSession(func(ctx context.Context, session server.ClientSession) {
+		sessionID := session.SessionID()
 		fields := []zap.Field{}
 		if signozURL, ok := util.GetSigNozURL(ctx); ok && signozURL != "" {
 			fields = append(fields, zap.String("mcp.tenant_url", signozURL))
@@ -300,10 +373,40 @@ func (m *MCPServer) buildHooks() *server.Hooks {
 
 		if signozURL, ok := util.GetSigNozURL(ctx); ok && signozURL != "" {
 			props := map[string]any{
-				string(telemetry.MCPTenantURLKey): signozURL,
-				string(telemetry.MCPSessionIDKey): session.SessionID(),
+				analytics.AttrTenantURL: signozURL,
+				analytics.AttrSessionID: sessionID,
 			}
-			m.trackEventAsync(ctx, "MCP Unregistered", props)
+			m.attachClientInfo(props, sessionID)
+			m.trackEventAsync(ctx, analytics.EventSessionUnregistered, props)
+		}
+
+		// Delete after dispatch — trackEventAsync has already snapshotted props.
+		m.forgetClientInfo(sessionID)
+	})
+	hooks.AddAfterGetPrompt(func(ctx context.Context, id any, message *mcp.GetPromptRequest, result *mcp.GetPromptResult) {
+		if signozURL, ok := util.GetSigNozURL(ctx); ok && signozURL != "" {
+			props := map[string]any{
+				analytics.AttrTenantURL:  signozURL,
+				analytics.AttrPromptName: message.Params.Name,
+			}
+			if session := server.ClientSessionFromContext(ctx); session != nil {
+				props[analytics.AttrSessionID] = session.SessionID()
+				m.attachClientInfo(props, session.SessionID())
+			}
+			m.trackEventAsync(ctx, analytics.EventPromptFetched, props)
+		}
+	})
+	hooks.AddAfterReadResource(func(ctx context.Context, id any, message *mcp.ReadResourceRequest, result *mcp.ReadResourceResult) {
+		if signozURL, ok := util.GetSigNozURL(ctx); ok && signozURL != "" {
+			props := map[string]any{
+				analytics.AttrTenantURL:   signozURL,
+				analytics.AttrResourceURI: message.Params.URI,
+			}
+			if session := server.ClientSessionFromContext(ctx); session != nil {
+				props[analytics.AttrSessionID] = session.SessionID()
+				m.attachClientInfo(props, session.SessionID())
+			}
+			m.trackEventAsync(ctx, analytics.EventResourceFetched, props)
 		}
 	})
 	return hooks
@@ -394,15 +497,19 @@ func (m *MCPServer) loggingMiddleware() server.ToolHandlerMiddleware {
 			// Analytics: track tool call
 			if signozURL, ok := util.GetSigNozURL(ctx); ok && signozURL != "" {
 				props := map[string]any{
-					string(telemetry.MCPTenantURLKey):   signozURL,
-					string(telemetry.GenAIToolNameKey):  req.Params.Name,
-					string(telemetry.MCPToolIsErrorKey): isErr,
-					"duration_ms":                       time.Since(start).Milliseconds(),
+					analytics.AttrTenantURL:   signozURL,
+					analytics.AttrToolName:    req.Params.Name,
+					analytics.AttrToolIsError: isErr,
+					analytics.AttrDurationMs:  time.Since(start).Milliseconds(),
 				}
 				if sid, ok := util.GetSessionID(ctx); ok && sid != "" {
-					props[string(telemetry.MCPSessionIDKey)] = sid
+					props[analytics.AttrSessionID] = sid
+					m.attachClientInfo(props, sid)
 				}
-				m.trackEventAsync(ctx, "Tool Call", props)
+				if sc, ok := util.GetSearchContext(ctx); ok && sc != "" {
+					props[analytics.AttrSearchContext] = sc
+				}
+				m.trackEventAsync(ctx, analytics.EventToolCalled, props)
 			}
 
 			return result, err
@@ -585,7 +692,7 @@ func (m *MCPServer) startHTTP(s *server.MCPServer) error {
 	})
 
 	if m.config.OAuthEnabled {
-		oauthHandler := oauth.NewHandler(m.logger, m.config)
+		oauthHandler := oauth.NewHandler(m.logger, m.config, m.trackOAuthEvent)
 		mux.HandleFunc("GET /.well-known/oauth-protected-resource", oauthHandler.HandleProtectedResourceMetadata)
 		mux.HandleFunc("GET /.well-known/oauth-authorization-server", oauthHandler.HandleAuthorizationServerMetadata)
 		mux.HandleFunc("POST /oauth/register", oauthHandler.HandleRegisterClient)

--- a/internal/mcp-server/server.go
+++ b/internal/mcp-server/server.go
@@ -33,6 +33,10 @@ type MCPServer struct {
 	analytics analytics.Analytics
 }
 
+func (m *MCPServer) analyticsEnabled() bool {
+	return m.analytics != nil && m.analytics.Enabled()
+}
+
 func cloneMap(src map[string]any) map[string]any {
 	if len(src) == 0 {
 		return map[string]any{}
@@ -76,6 +80,10 @@ func (m *MCPServer) resolveAnalyticsIdentity(ctx context.Context) (*signozclient
 }
 
 func (m *MCPServer) identifyAnalyticsUser(ctx context.Context, attrs map[string]any) (*signozclient.AnalyticsIdentity, bool) {
+	if !m.analyticsEnabled() {
+		return nil, false
+	}
+
 	identity, err := m.resolveAnalyticsIdentity(ctx)
 	if err != nil {
 		m.logger.Warn("analytics identity resolution failed; skipping identify",
@@ -88,6 +96,10 @@ func (m *MCPServer) identifyAnalyticsUser(ctx context.Context, attrs map[string]
 }
 
 func (m *MCPServer) trackAnalyticsUser(ctx context.Context, event string, attrs map[string]any) bool {
+	if !m.analyticsEnabled() {
+		return false
+	}
+
 	identity, err := m.resolveAnalyticsIdentity(ctx)
 	if err != nil {
 		m.logger.Warn("analytics identity resolution failed; skipping track",
@@ -100,6 +112,10 @@ func (m *MCPServer) trackAnalyticsUser(ctx context.Context, event string, attrs 
 }
 
 func (m *MCPServer) identifyAndTrackAnalyticsUser(ctx context.Context, event string, traits map[string]any, properties map[string]any) bool {
+	if !m.analyticsEnabled() {
+		return false
+	}
+
 	identity, err := m.resolveAnalyticsIdentity(ctx)
 	if err != nil {
 		m.logger.Warn("analytics identity resolution failed; skipping identify+track",

--- a/internal/mcp-server/server.go
+++ b/internal/mcp-server/server.go
@@ -39,7 +39,7 @@ func (m *MCPServer) analyticsEnabled() bool {
 	return m.analytics != nil && m.analytics.Enabled()
 }
 
-func cloneMap(src map[string]any) map[string]any {
+func cloneAttrs(src map[string]any) map[string]any {
 	if len(src) == 0 {
 		return map[string]any{}
 	}
@@ -50,27 +50,29 @@ func cloneMap(src map[string]any) map[string]any {
 	return dst
 }
 
-func (m *MCPServer) enrichAnalyticsAttrs(identity *signozclient.AnalyticsIdentity, attrs map[string]any) map[string]any {
-	enriched := cloneMap(attrs)
+// mergeIdentityAttrs returns a copy of attrs augmented with identity-derived
+// fields (org_id, principal, and a principal-scoped email key).
+func (m *MCPServer) mergeIdentityAttrs(identity *signozclient.AnalyticsIdentity, attrs map[string]any) map[string]any {
+	merged := cloneAttrs(attrs)
 	if identity == nil {
-		return enriched
+		return merged
 	}
-	enriched["org_id"] = identity.OrgID
-	enriched["principal"] = identity.Principal
+	merged["org_id"] = identity.OrgID
+	merged["principal"] = identity.Principal
 	if identity.Email != "" {
 		switch identity.Principal {
 		case "user":
-			enriched["user_email"] = identity.Email
+			merged["user_email"] = identity.Email
 		case "service_account":
-			enriched["service_email"] = identity.Email
+			merged["service_email"] = identity.Email
 		}
 	}
-	return enriched
+	return merged
 }
 
-func (m *MCPServer) resolveAnalyticsIdentity(ctx context.Context) (*signozclient.AnalyticsIdentity, error) {
+func (m *MCPServer) resolveIdentity(ctx context.Context) (*signozclient.AnalyticsIdentity, error) {
 	if m.handler == nil {
-		return nil, fmt.Errorf("analytics identity resolution requires a handler")
+		return nil, errors.New("analytics identity resolution requires a handler")
 	}
 
 	client, err := m.handler.GetClient(ctx)
@@ -81,63 +83,65 @@ func (m *MCPServer) resolveAnalyticsIdentity(ctx context.Context) (*signozclient
 	return client.GetAnalyticsIdentity(ctx)
 }
 
-func (m *MCPServer) identifyAnalyticsUser(ctx context.Context, attrs map[string]any) (*signozclient.AnalyticsIdentity, bool) {
+// identifyAsync emits an Identify call on a detached goroutine. Returns
+// without blocking the caller; failures are logged, not surfaced.
+func (m *MCPServer) identifyAsync(ctx context.Context, traits map[string]any) {
 	if !m.analyticsEnabled() {
-		return nil, false
+		return
 	}
 
-	attrs = cloneMap(attrs)
+	traits = cloneAttrs(traits)
 	m.dispatchAnalytics(ctx, func(detachedCtx context.Context) {
-		identity, err := m.resolveAnalyticsIdentity(detachedCtx)
+		identity, err := m.resolveIdentity(detachedCtx)
 		if err != nil {
 			m.logger.Warn("analytics identity resolution failed; skipping identify",
 				append(m.analyticsLogFields(detachedCtx), zap.Error(err))...)
 			return
 		}
 
-		m.analytics.IdentifyUser(detachedCtx, identity.OrgID, identity.UserID, m.enrichAnalyticsAttrs(identity, attrs))
+		m.analytics.IdentifyUser(detachedCtx, identity.OrgID, identity.UserID, m.mergeIdentityAttrs(identity, traits))
 	})
-	return nil, true
 }
 
-func (m *MCPServer) trackAnalyticsUser(ctx context.Context, event string, attrs map[string]any) bool {
+// trackEventAsync emits a Track call on a detached goroutine.
+func (m *MCPServer) trackEventAsync(ctx context.Context, event string, properties map[string]any) {
 	if !m.analyticsEnabled() {
-		return false
+		return
 	}
 
-	attrs = cloneMap(attrs)
+	properties = cloneAttrs(properties)
 	m.dispatchAnalytics(ctx, func(detachedCtx context.Context) {
-		identity, err := m.resolveAnalyticsIdentity(detachedCtx)
+		identity, err := m.resolveIdentity(detachedCtx)
 		if err != nil {
 			m.logger.Warn("analytics identity resolution failed; skipping track",
 				append(m.analyticsLogFields(detachedCtx), zap.String("event", event), zap.Error(err))...)
 			return
 		}
 
-		m.analytics.TrackUser(detachedCtx, identity.OrgID, identity.UserID, event, m.enrichAnalyticsAttrs(identity, attrs))
+		m.analytics.TrackUser(detachedCtx, identity.OrgID, identity.UserID, event, m.mergeIdentityAttrs(identity, properties))
 	})
-	return true
 }
 
-func (m *MCPServer) identifyAndTrackAnalyticsUser(ctx context.Context, event string, traits map[string]any, properties map[string]any) bool {
+// identifyAndTrackAsync resolves identity once and emits both an Identify and
+// a Track call under the same detached goroutine.
+func (m *MCPServer) identifyAndTrackAsync(ctx context.Context, event string, traits map[string]any, properties map[string]any) {
 	if !m.analyticsEnabled() {
-		return false
+		return
 	}
 
-	traits = cloneMap(traits)
-	properties = cloneMap(properties)
+	traits = cloneAttrs(traits)
+	properties = cloneAttrs(properties)
 	m.dispatchAnalytics(ctx, func(detachedCtx context.Context) {
-		identity, err := m.resolveAnalyticsIdentity(detachedCtx)
+		identity, err := m.resolveIdentity(detachedCtx)
 		if err != nil {
 			m.logger.Warn("analytics identity resolution failed; skipping identify+track",
 				append(m.analyticsLogFields(detachedCtx), zap.String("event", event), zap.Error(err))...)
 			return
 		}
 
-		m.analytics.IdentifyUser(detachedCtx, identity.OrgID, identity.UserID, m.enrichAnalyticsAttrs(identity, traits))
-		m.analytics.TrackUser(detachedCtx, identity.OrgID, identity.UserID, event, m.enrichAnalyticsAttrs(identity, properties))
+		m.analytics.IdentifyUser(detachedCtx, identity.OrgID, identity.UserID, m.mergeIdentityAttrs(identity, traits))
+		m.analytics.TrackUser(detachedCtx, identity.OrgID, identity.UserID, event, m.mergeIdentityAttrs(identity, properties))
 	})
-	return true
 }
 
 func (m *MCPServer) analyticsLogFields(ctx context.Context) []zap.Field {
@@ -151,6 +155,11 @@ func (m *MCPServer) analyticsLogFields(ctx context.Context) []zap.Field {
 	return fields
 }
 
+// detachedAnalyticsContext returns a background-rooted context (so the async
+// goroutine survives the parent request) bounded by analyticsAsyncTimeout, and
+// carries forward the values the client lookup + analytics call need:
+// credentials, tenant URL, session/search context, and the OTel span so
+// identity HTTP requests remain linked to the originating tool call.
 func (m *MCPServer) detachedAnalyticsContext(parent context.Context) (context.Context, context.CancelFunc) {
 	ctx, cancel := context.WithTimeout(context.Background(), analyticsAsyncTimeout)
 
@@ -168,6 +177,9 @@ func (m *MCPServer) detachedAnalyticsContext(parent context.Context) (context.Co
 	}
 	if sessionID, ok := util.GetSessionID(parent); ok && sessionID != "" {
 		ctx = util.SetSessionID(ctx, sessionID)
+	}
+	if spanCtx := trace.SpanContextFromContext(parent); spanCtx.IsValid() {
+		ctx = trace.ContextWithSpanContext(ctx, spanCtx)
 	}
 
 	return ctx, cancel
@@ -262,7 +274,7 @@ func (m *MCPServer) buildHooks() *server.Hooks {
 			if session := server.ClientSessionFromContext(ctx); session != nil {
 				props[string(telemetry.MCPSessionIDKey)] = session.SessionID()
 			}
-			m.identifyAndTrackAnalyticsUser(ctx, "MCP Registered", traits, props)
+			m.identifyAndTrackAsync(ctx, "MCP Registered", traits, props)
 		}
 	})
 	hooks.AddOnRegisterSession(func(ctx context.Context, session server.ClientSession) {
@@ -276,7 +288,7 @@ func (m *MCPServer) buildHooks() *server.Hooks {
 			traits := map[string]any{
 				string(telemetry.MCPTenantURLKey): signozURL,
 			}
-			m.identifyAnalyticsUser(ctx, traits)
+			m.identifyAsync(ctx, traits)
 		}
 	})
 	hooks.AddOnUnregisterSession(func(ctx context.Context, session server.ClientSession) {
@@ -291,7 +303,7 @@ func (m *MCPServer) buildHooks() *server.Hooks {
 				string(telemetry.MCPTenantURLKey): signozURL,
 				string(telemetry.MCPSessionIDKey): session.SessionID(),
 			}
-			m.trackAnalyticsUser(ctx, "MCP Unregistered", props)
+			m.trackEventAsync(ctx, "MCP Unregistered", props)
 		}
 	})
 	return hooks
@@ -390,7 +402,7 @@ func (m *MCPServer) loggingMiddleware() server.ToolHandlerMiddleware {
 				if sid, ok := util.GetSessionID(ctx); ok && sid != "" {
 					props[string(telemetry.MCPSessionIDKey)] = sid
 				}
-				m.trackAnalyticsUser(ctx, "Tool Call", props)
+				m.trackEventAsync(ctx, "Tool Call", props)
 			}
 
 			return result, err

--- a/internal/mcp-server/server_test.go
+++ b/internal/mcp-server/server_test.go
@@ -25,62 +25,50 @@ import (
 )
 
 type analyticsCall struct {
-	group string
-	user  string
-	event string
-	attrs map[string]any
+	groupID string
+	userID  string
+	event   string
+	attrs   map[string]any
 }
 
 type spyAnalytics struct {
-	mu                sync.Mutex
-	enabled           bool
-	identifyUserCalls []analyticsCall
-	trackUserCalls    []analyticsCall
-	identifyGroupHits int
-	trackGroupHits    int
+	mu            sync.Mutex
+	enabled       bool
+	identifyCalls []analyticsCall
+	trackCalls    []analyticsCall
 }
 
 func (s *spyAnalytics) Enabled() bool                                   { return s.enabled }
 func (s *spyAnalytics) Start(context.Context) error                     { return nil }
 func (s *spyAnalytics) Stop(context.Context) error                      { return nil }
 func (s *spyAnalytics) Send(context.Context, ...analyticstypes.Message) {}
-func (s *spyAnalytics) TrackGroup(context.Context, string, string, map[string]any) {
+func (s *spyAnalytics) TrackUser(_ context.Context, groupID, userID, event string, attrs map[string]any) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	s.trackGroupHits++
-}
-func (s *spyAnalytics) IdentifyGroup(context.Context, string, map[string]any) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	s.identifyGroupHits++
-}
-func (s *spyAnalytics) TrackUser(_ context.Context, group, user, event string, attrs map[string]any) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	s.trackUserCalls = append(s.trackUserCalls, analyticsCall{
-		group: group,
-		user:  user,
-		event: event,
-		attrs: attrs,
+	s.trackCalls = append(s.trackCalls, analyticsCall{
+		groupID: groupID,
+		userID:  userID,
+		event:   event,
+		attrs:   attrs,
 	})
 }
-func (s *spyAnalytics) IdentifyUser(_ context.Context, group, user string, attrs map[string]any) {
+func (s *spyAnalytics) IdentifyUser(_ context.Context, groupID, userID string, attrs map[string]any) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	s.identifyUserCalls = append(s.identifyUserCalls, analyticsCall{
-		group: group,
-		user:  user,
-		attrs: attrs,
+	s.identifyCalls = append(s.identifyCalls, analyticsCall{
+		groupID: groupID,
+		userID:  userID,
+		attrs:   attrs,
 	})
 }
 
-func (s *spyAnalytics) snapshot() (identify []analyticsCall, track []analyticsCall, identifyGroupHits, trackGroupHits int) {
+func (s *spyAnalytics) snapshot() (identify []analyticsCall, track []analyticsCall) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	identify = append([]analyticsCall(nil), s.identifyUserCalls...)
-	track = append([]analyticsCall(nil), s.trackUserCalls...)
-	return identify, track, s.identifyGroupHits, s.trackGroupHits
+	identify = append([]analyticsCall(nil), s.identifyCalls...)
+	track = append([]analyticsCall(nil), s.trackCalls...)
+	return identify, track
 }
 
 var _ analytics.Analytics = (*spyAnalytics)(nil)
@@ -399,26 +387,25 @@ func TestBuildHooks_APIKeyAnalyticsUseServiceAccountIdentity(t *testing.T) {
 	hooks.UnregisterSession(ctx, session)
 
 	waitForCondition(t, time.Second, func() bool {
-		identifyCalls, trackCalls, identifyGroupHits, trackGroupHits := spy.snapshot()
-		return requests.Load() == 2 && identifyGroupHits == 0 && trackGroupHits == 0 && len(identifyCalls) == 1 && len(trackCalls) == 1
+		identifyCalls, trackCalls := spy.snapshot()
+		// Identity caching is exercised directly in the client package; here
+		// we only assert the hooks fire the right analytics events.
+		return requests.Load() >= 1 && len(identifyCalls) == 1 && len(trackCalls) == 1
 	}, "timed out waiting for async API-key analytics")
 
-	identifyCalls, trackCalls, identifyGroupHits, trackGroupHits := spy.snapshot()
-	if identifyGroupHits != 0 || trackGroupHits != 0 {
-		t.Fatalf("expected no group analytics calls, got identify=%d track=%d", identifyGroupHits, trackGroupHits)
-	}
+	identifyCalls, trackCalls := spy.snapshot()
 
 	identify := identifyCalls[0]
-	if identify.group != "org-456" || identify.user != "sa-123" {
-		t.Fatalf("identify user args = (%q, %q), want (%q, %q)", identify.group, identify.user, "org-456", "sa-123")
+	if identify.groupID != "org-456" || identify.userID != "sa-123" {
+		t.Fatalf("identify user args = (%q, %q), want (%q, %q)", identify.groupID, identify.userID, "org-456", "sa-123")
 	}
 	if identify.attrs["org_id"] != "org-456" || identify.attrs["principal"] != "service_account" || identify.attrs["service_email"] != "service@example.com" {
 		t.Fatalf("identify attrs = %#v, want org_id, principal, and service_email", identify.attrs)
 	}
 
 	track := trackCalls[0]
-	if track.group != "org-456" || track.user != "sa-123" || track.event != "MCP Unregistered" {
-		t.Fatalf("track call = (%q, %q, %q), want (%q, %q, %q)", track.group, track.user, track.event, "org-456", "sa-123", "MCP Unregistered")
+	if track.groupID != "org-456" || track.userID != "sa-123" || track.event != "MCP Unregistered" {
+		t.Fatalf("track call = (%q, %q, %q), want (%q, %q, %q)", track.groupID, track.userID, track.event, "org-456", "sa-123", "MCP Unregistered")
 	}
 	if track.attrs[string(telemetry.MCPSessionIDKey)] != "sess-api" {
 		t.Fatalf("session id attr = %v, want %q", track.attrs[string(telemetry.MCPSessionIDKey)], "sess-api")
@@ -477,18 +464,15 @@ func TestUserScopedAnalyticsUseJWTIdentity(t *testing.T) {
 	}
 
 	waitForCondition(t, time.Second, func() bool {
-		identifyCalls, trackCalls, identifyGroupHits, trackGroupHits := spy.snapshot()
-		return requests.Load() == 2 && identifyGroupHits == 0 && trackGroupHits == 0 && len(identifyCalls) == 1 && len(trackCalls) == 2
+		identifyCalls, trackCalls := spy.snapshot()
+		return requests.Load() >= 1 && len(identifyCalls) == 1 && len(trackCalls) == 2
 	}, "timed out waiting for async JWT analytics")
 
-	identifyCalls, trackCalls, identifyGroupHits, trackGroupHits := spy.snapshot()
-	if identifyGroupHits != 0 || trackGroupHits != 0 {
-		t.Fatalf("expected no group analytics calls, got identify=%d track=%d", identifyGroupHits, trackGroupHits)
-	}
+	identifyCalls, trackCalls := spy.snapshot()
 
 	identify := identifyCalls[0]
-	if identify.group != "org-123" || identify.user != "user-123" {
-		t.Fatalf("identify user args = (%q, %q), want (%q, %q)", identify.group, identify.user, "org-123", "user-123")
+	if identify.groupID != "org-123" || identify.userID != "user-123" {
+		t.Fatalf("identify user args = (%q, %q), want (%q, %q)", identify.groupID, identify.userID, "org-123", "user-123")
 	}
 	if identify.attrs["org_id"] != "org-123" || identify.attrs["principal"] != "user" || identify.attrs["user_email"] != "user@example.com" {
 		t.Fatalf("identify attrs = %#v, want org_id, principal, and user_email", identify.attrs)
@@ -505,15 +489,15 @@ func TestUserScopedAnalyticsUseJWTIdentity(t *testing.T) {
 		}
 	}
 
-	if registered.event != "MCP Registered" || registered.group != "org-123" || registered.user != "user-123" {
-		t.Fatalf("registered track call = (%q, %q, %q), want (%q, %q, %q)", registered.group, registered.user, registered.event, "org-123", "user-123", "MCP Registered")
+	if registered.event != "MCP Registered" || registered.groupID != "org-123" || registered.userID != "user-123" {
+		t.Fatalf("registered track call = (%q, %q, %q), want (%q, %q, %q)", registered.groupID, registered.userID, registered.event, "org-123", "user-123", "MCP Registered")
 	}
 	if registered.attrs[string(telemetry.MCPSessionIDKey)] != "sess-jwt" {
 		t.Fatalf("registered session attr = %v, want %q", registered.attrs[string(telemetry.MCPSessionIDKey)], "sess-jwt")
 	}
 
-	if toolCall.event != "Tool Call" || toolCall.group != "org-123" || toolCall.user != "user-123" {
-		t.Fatalf("tool track call = (%q, %q, %q), want (%q, %q, %q)", toolCall.group, toolCall.user, toolCall.event, "org-123", "user-123", "Tool Call")
+	if toolCall.event != "Tool Call" || toolCall.groupID != "org-123" || toolCall.userID != "user-123" {
+		t.Fatalf("tool track call = (%q, %q, %q), want (%q, %q, %q)", toolCall.groupID, toolCall.userID, toolCall.event, "org-123", "user-123", "Tool Call")
 	}
 	if toolCall.attrs[string(telemetry.GenAIToolNameKey)] != "signoz_list_services" {
 		t.Fatalf("tool name attr = %v, want %q", toolCall.attrs[string(telemetry.GenAIToolNameKey)], "signoz_list_services")
@@ -572,12 +556,9 @@ func TestAnalyticsDisabledSkipsIdentityLookup(t *testing.T) {
 	hooks.RegisterSession(ctx, session)
 	hooks.UnregisterSession(ctx, session)
 
-	identifyCalls, trackCalls, identifyGroupHits, trackGroupHits := spy.snapshot()
+	identifyCalls, trackCalls := spy.snapshot()
 	if requests.Load() != 0 {
 		t.Fatalf("identity requests = %d, want %d", requests.Load(), 0)
-	}
-	if identifyGroupHits != 0 || trackGroupHits != 0 {
-		t.Fatalf("expected no group analytics calls, got identify=%d track=%d", identifyGroupHits, trackGroupHits)
 	}
 	if len(identifyCalls) != 0 {
 		t.Fatalf("identify user calls = %d, want %d", len(identifyCalls), 0)
@@ -646,11 +627,11 @@ func TestToolCallReturnsBeforeAsyncAnalyticsCompletes(t *testing.T) {
 	}
 
 	waitForCondition(t, time.Second, func() bool {
-		_, trackCalls, _, _ := spy.snapshot()
+		_, trackCalls := spy.snapshot()
 		return requests.Load() == 1 && len(trackCalls) == 1
 	}, "timed out waiting for async tool analytics")
 
-	_, trackCalls, _, _ := spy.snapshot()
+	_, trackCalls := spy.snapshot()
 	toolCall := trackCalls[0]
 	if toolCall.event != "Tool Call" {
 		t.Fatalf("track event = %q, want %q", toolCall.event, "Tool Call")

--- a/internal/mcp-server/server_test.go
+++ b/internal/mcp-server/server_test.go
@@ -30,12 +30,14 @@ type analyticsCall struct {
 }
 
 type spyAnalytics struct {
+	enabled           bool
 	identifyUserCalls []analyticsCall
 	trackUserCalls    []analyticsCall
 	identifyGroupHits int
 	trackGroupHits    int
 }
 
+func (s *spyAnalytics) Enabled() bool                                  { return s.enabled }
 func (s *spyAnalytics) Start(context.Context) error                     { return nil }
 func (s *spyAnalytics) Stop(context.Context) error                      { return nil }
 func (s *spyAnalytics) Send(context.Context, ...analyticstypes.Message) {}
@@ -349,7 +351,7 @@ func TestBuildHooks_APIKeyAnalyticsUseServiceAccountIdentity(t *testing.T) {
 		ClientCacheTTL:  time.Minute,
 	}
 	handler := tools.NewHandler(zap.NewNop(), cfg)
-	spy := &spyAnalytics{}
+	spy := &spyAnalytics{enabled: true}
 	mcpServer := NewMCPServer(zap.NewNop(), handler, cfg, spy)
 	hooks := mcpServer.buildHooks()
 
@@ -416,7 +418,7 @@ func TestUserScopedAnalyticsUseJWTIdentity(t *testing.T) {
 		ClientCacheTTL:  time.Minute,
 	}
 	handler := tools.NewHandler(zap.NewNop(), cfg)
-	spy := &spyAnalytics{}
+	spy := &spyAnalytics{enabled: true}
 	mcpServer := NewMCPServer(zap.NewNop(), handler, cfg, spy)
 	hooks := mcpServer.buildHooks()
 
@@ -484,5 +486,65 @@ func TestUserScopedAnalyticsUseJWTIdentity(t *testing.T) {
 	}
 	if toolCall.attrs["org_id"] != "org-123" || toolCall.attrs["principal"] != "user" || toolCall.attrs["user_email"] != "user@example.com" {
 		t.Fatalf("tool attrs = %#v, want org_id, principal, and user_email", toolCall.attrs)
+	}
+}
+
+func TestAnalyticsDisabledSkipsIdentityLookup(t *testing.T) {
+	requests := 0
+	sigNoz := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		t.Fatalf("unexpected identity request: %s", r.URL.Path)
+	}))
+	defer sigNoz.Close()
+
+	cfg := &config.Config{
+		URL:             sigNoz.URL,
+		APIKey:          "test-api-key",
+		ClientCacheSize: 1,
+		ClientCacheTTL:  time.Minute,
+	}
+	handler := tools.NewHandler(zap.NewNop(), cfg)
+	spy := &spyAnalytics{enabled: false}
+	mcpServer := NewMCPServer(zap.NewNop(), handler, cfg, spy)
+	hooks := mcpServer.buildHooks()
+
+	ctx := context.Background()
+	ctx = util.SetAPIKey(ctx, "test-api-key")
+	ctx = util.SetAuthHeader(ctx, "SIGNOZ-API-KEY")
+	ctx = util.SetSigNozURL(ctx, sigNoz.URL)
+	ctx = newAnalyticsTestContext(ctx, "sess-disabled")
+
+	hooks.OnAfterInitialize[0](ctx, nil, &mcp.InitializeRequest{}, &mcp.InitializeResult{})
+
+	middleware := mcpServer.loggingMiddleware()
+	_, err := middleware(func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		return &mcp.CallToolResult{}, nil
+	})(ctx, mcp.CallToolRequest{
+		Params: mcp.CallToolParams{
+			Name: "signoz_list_services",
+			Arguments: map[string]any{
+				"searchContext": "list services",
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("middleware error = %v", err)
+	}
+
+	session := fakeSession{id: "sess-disabled", ch: make(chan mcp.JSONRPCNotification, 1)}
+	hooks.RegisterSession(ctx, session)
+	hooks.UnregisterSession(ctx, session)
+
+	if requests != 0 {
+		t.Fatalf("identity requests = %d, want %d", requests, 0)
+	}
+	if spy.identifyGroupHits != 0 || spy.trackGroupHits != 0 {
+		t.Fatalf("expected no group analytics calls, got identify=%d track=%d", spy.identifyGroupHits, spy.trackGroupHits)
+	}
+	if len(spy.identifyUserCalls) != 0 {
+		t.Fatalf("identify user calls = %d, want %d", len(spy.identifyUserCalls), 0)
+	}
+	if len(spy.trackUserCalls) != 0 {
+		t.Fatalf("track user calls = %d, want %d", len(spy.trackUserCalls), 0)
 	}
 }

--- a/internal/mcp-server/server_test.go
+++ b/internal/mcp-server/server_test.go
@@ -1,19 +1,82 @@
 package mcp_server
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/mark3labs/mcp-go/mcp"
+	mcpgoserver "github.com/mark3labs/mcp-go/server"
 	"go.uber.org/zap"
 
 	"github.com/SigNoz/signoz-mcp-server/internal/config"
+	"github.com/SigNoz/signoz-mcp-server/internal/handler/tools"
 	"github.com/SigNoz/signoz-mcp-server/internal/oauth"
+	"github.com/SigNoz/signoz-mcp-server/internal/telemetry"
+	"github.com/SigNoz/signoz-mcp-server/pkg/analytics"
 	"github.com/SigNoz/signoz-mcp-server/pkg/analytics/noopanalytics"
+	"github.com/SigNoz/signoz-mcp-server/pkg/types/analyticstypes"
 	"github.com/SigNoz/signoz-mcp-server/pkg/util"
 )
+
+type analyticsCall struct {
+	group string
+	user  string
+	event string
+	attrs map[string]any
+}
+
+type spyAnalytics struct {
+	identifyUserCalls []analyticsCall
+	trackUserCalls    []analyticsCall
+	identifyGroupHits int
+	trackGroupHits    int
+}
+
+func (s *spyAnalytics) Start(context.Context) error                     { return nil }
+func (s *spyAnalytics) Stop(context.Context) error                      { return nil }
+func (s *spyAnalytics) Send(context.Context, ...analyticstypes.Message) {}
+func (s *spyAnalytics) TrackGroup(context.Context, string, string, map[string]any) {
+	s.trackGroupHits++
+}
+func (s *spyAnalytics) IdentifyGroup(context.Context, string, map[string]any) {
+	s.identifyGroupHits++
+}
+func (s *spyAnalytics) TrackUser(_ context.Context, group, user, event string, attrs map[string]any) {
+	s.trackUserCalls = append(s.trackUserCalls, analyticsCall{
+		group: group,
+		user:  user,
+		event: event,
+		attrs: attrs,
+	})
+}
+func (s *spyAnalytics) IdentifyUser(_ context.Context, group, user string, attrs map[string]any) {
+	s.identifyUserCalls = append(s.identifyUserCalls, analyticsCall{
+		group: group,
+		user:  user,
+		attrs: attrs,
+	})
+}
+
+var _ analytics.Analytics = (*spyAnalytics)(nil)
+
+type fakeSession struct {
+	id string
+	ch chan mcp.JSONRPCNotification
+}
+
+func (f fakeSession) Initialize()                                         {}
+func (f fakeSession) Initialized() bool                                   { return true }
+func (f fakeSession) NotificationChannel() chan<- mcp.JSONRPCNotification { return f.ch }
+func (f fakeSession) SessionID() string                                   { return f.id }
+
+func newAnalyticsTestContext(ctx context.Context, sessionID string) context.Context {
+	base := mcpgoserver.NewMCPServer("test", "1.0.0")
+	return base.WithContext(ctx, fakeSession{id: sessionID, ch: make(chan mcp.JSONRPCNotification, 1)})
+}
 
 func TestNormalizeSigNozURL_RejectsPathQueryFragment(t *testing.T) {
 	tests := []struct {
@@ -261,5 +324,165 @@ func TestAuthMiddlewareReturnsOAuthChallengeWhenMissingAuth(t *testing.T) {
 	wantHeader := `Bearer resource_metadata="https://mcp.example.com/.well-known/oauth-protected-resource"`
 	if rr.Header().Get("WWW-Authenticate") != wantHeader {
 		t.Fatalf("WWW-Authenticate = %q, want %q", rr.Header().Get("WWW-Authenticate"), wantHeader)
+	}
+}
+
+func TestBuildHooks_APIKeyAnalyticsUseServiceAccountIdentity(t *testing.T) {
+	requests := 0
+	sigNoz := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		if r.URL.Path != "/api/v1/service_accounts/me" {
+			t.Fatalf("path = %q, want %q", r.URL.Path, "/api/v1/service_accounts/me")
+		}
+		if r.Header.Get("SIGNOZ-API-KEY") != "test-api-key" {
+			t.Fatalf("SIGNOZ-API-KEY = %q, want %q", r.Header.Get("SIGNOZ-API-KEY"), "test-api-key")
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"status":"success","data":{"id":"sa-123","email":"service@example.com","orgId":"org-456"}}`))
+	}))
+	defer sigNoz.Close()
+
+	cfg := &config.Config{
+		URL:             sigNoz.URL,
+		APIKey:          "test-api-key",
+		ClientCacheSize: 1,
+		ClientCacheTTL:  time.Minute,
+	}
+	handler := tools.NewHandler(zap.NewNop(), cfg)
+	spy := &spyAnalytics{}
+	mcpServer := NewMCPServer(zap.NewNop(), handler, cfg, spy)
+	hooks := mcpServer.buildHooks()
+
+	ctx := context.Background()
+	ctx = util.SetAPIKey(ctx, "test-api-key")
+	ctx = util.SetAuthHeader(ctx, "SIGNOZ-API-KEY")
+	ctx = util.SetSigNozURL(ctx, sigNoz.URL)
+
+	session := fakeSession{id: "sess-api", ch: make(chan mcp.JSONRPCNotification, 1)}
+	hooks.RegisterSession(ctx, session)
+	hooks.UnregisterSession(ctx, session)
+
+	if requests != 2 {
+		t.Fatalf("identity requests = %d, want %d", requests, 2)
+	}
+	if spy.identifyGroupHits != 0 || spy.trackGroupHits != 0 {
+		t.Fatalf("expected no group analytics calls, got identify=%d track=%d", spy.identifyGroupHits, spy.trackGroupHits)
+	}
+	if len(spy.identifyUserCalls) != 1 {
+		t.Fatalf("identify user calls = %d, want %d", len(spy.identifyUserCalls), 1)
+	}
+	if len(spy.trackUserCalls) != 1 {
+		t.Fatalf("track user calls = %d, want %d", len(spy.trackUserCalls), 1)
+	}
+
+	identify := spy.identifyUserCalls[0]
+	if identify.group != "org-456" || identify.user != "sa-123" {
+		t.Fatalf("identify user args = (%q, %q), want (%q, %q)", identify.group, identify.user, "org-456", "sa-123")
+	}
+	if identify.attrs["org_id"] != "org-456" || identify.attrs["principal"] != "service_account" || identify.attrs["service_email"] != "service@example.com" {
+		t.Fatalf("identify attrs = %#v, want org_id, principal, and service_email", identify.attrs)
+	}
+
+	track := spy.trackUserCalls[0]
+	if track.group != "org-456" || track.user != "sa-123" || track.event != "MCP Unregistered" {
+		t.Fatalf("track call = (%q, %q, %q), want (%q, %q, %q)", track.group, track.user, track.event, "org-456", "sa-123", "MCP Unregistered")
+	}
+	if track.attrs[string(telemetry.MCPSessionIDKey)] != "sess-api" {
+		t.Fatalf("session id attr = %v, want %q", track.attrs[string(telemetry.MCPSessionIDKey)], "sess-api")
+	}
+	if track.attrs["org_id"] != "org-456" || track.attrs["principal"] != "service_account" || track.attrs["service_email"] != "service@example.com" {
+		t.Fatalf("track attrs = %#v, want org_id, principal, and service_email", track.attrs)
+	}
+}
+
+func TestUserScopedAnalyticsUseJWTIdentity(t *testing.T) {
+	requests := 0
+	sigNoz := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		if r.URL.Path != "/api/v2/users/me" {
+			t.Fatalf("path = %q, want %q", r.URL.Path, "/api/v2/users/me")
+		}
+		if r.Header.Get("Authorization") != "Bearer jwt-token" {
+			t.Fatalf("Authorization = %q, want %q", r.Header.Get("Authorization"), "Bearer jwt-token")
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"status":"success","data":{"id":"user-123","email":"user@example.com","orgId":"org-123"}}`))
+	}))
+	defer sigNoz.Close()
+
+	cfg := &config.Config{
+		URL:             sigNoz.URL,
+		ClientCacheSize: 1,
+		ClientCacheTTL:  time.Minute,
+	}
+	handler := tools.NewHandler(zap.NewNop(), cfg)
+	spy := &spyAnalytics{}
+	mcpServer := NewMCPServer(zap.NewNop(), handler, cfg, spy)
+	hooks := mcpServer.buildHooks()
+
+	ctx := context.Background()
+	ctx = util.SetAPIKey(ctx, "Bearer jwt-token")
+	ctx = util.SetAuthHeader(ctx, "Authorization")
+	ctx = util.SetSigNozURL(ctx, sigNoz.URL)
+	ctx = newAnalyticsTestContext(ctx, "sess-jwt")
+
+	hooks.OnAfterInitialize[0](ctx, nil, &mcp.InitializeRequest{}, &mcp.InitializeResult{})
+
+	middleware := mcpServer.loggingMiddleware()
+	_, err := middleware(func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		return &mcp.CallToolResult{}, nil
+	})(ctx, mcp.CallToolRequest{
+		Params: mcp.CallToolParams{
+			Name: "signoz_list_services",
+			Arguments: map[string]any{
+				"searchContext": "list services",
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("middleware error = %v", err)
+	}
+
+	if requests != 2 {
+		t.Fatalf("identity requests = %d, want %d", requests, 2)
+	}
+	if spy.identifyGroupHits != 0 || spy.trackGroupHits != 0 {
+		t.Fatalf("expected no group analytics calls, got identify=%d track=%d", spy.identifyGroupHits, spy.trackGroupHits)
+	}
+	if len(spy.identifyUserCalls) != 1 {
+		t.Fatalf("identify user calls = %d, want %d", len(spy.identifyUserCalls), 1)
+	}
+	if len(spy.trackUserCalls) != 2 {
+		t.Fatalf("track user calls = %d, want %d", len(spy.trackUserCalls), 2)
+	}
+
+	identify := spy.identifyUserCalls[0]
+	if identify.group != "org-123" || identify.user != "user-123" {
+		t.Fatalf("identify user args = (%q, %q), want (%q, %q)", identify.group, identify.user, "org-123", "user-123")
+	}
+	if identify.attrs["org_id"] != "org-123" || identify.attrs["principal"] != "user" || identify.attrs["user_email"] != "user@example.com" {
+		t.Fatalf("identify attrs = %#v, want org_id, principal, and user_email", identify.attrs)
+	}
+
+	registered := spy.trackUserCalls[0]
+	if registered.event != "MCP Registered" || registered.group != "org-123" || registered.user != "user-123" {
+		t.Fatalf("registered track call = (%q, %q, %q), want (%q, %q, %q)", registered.group, registered.user, registered.event, "org-123", "user-123", "MCP Registered")
+	}
+	if registered.attrs[string(telemetry.MCPSessionIDKey)] != "sess-jwt" {
+		t.Fatalf("registered session attr = %v, want %q", registered.attrs[string(telemetry.MCPSessionIDKey)], "sess-jwt")
+	}
+
+	toolCall := spy.trackUserCalls[1]
+	if toolCall.event != "Tool Call" || toolCall.group != "org-123" || toolCall.user != "user-123" {
+		t.Fatalf("tool track call = (%q, %q, %q), want (%q, %q, %q)", toolCall.group, toolCall.user, toolCall.event, "org-123", "user-123", "Tool Call")
+	}
+	if toolCall.attrs[string(telemetry.GenAIToolNameKey)] != "signoz_list_services" {
+		t.Fatalf("tool name attr = %v, want %q", toolCall.attrs[string(telemetry.GenAIToolNameKey)], "signoz_list_services")
+	}
+	if toolCall.attrs[string(telemetry.MCPToolIsErrorKey)] != false {
+		t.Fatalf("tool error attr = %v, want false", toolCall.attrs[string(telemetry.MCPToolIsErrorKey)])
+	}
+	if toolCall.attrs["org_id"] != "org-123" || toolCall.attrs["principal"] != "user" || toolCall.attrs["user_email"] != "user@example.com" {
+		t.Fatalf("tool attrs = %#v, want org_id, principal, and user_email", toolCall.attrs)
 	}
 }

--- a/internal/mcp-server/server_test.go
+++ b/internal/mcp-server/server_test.go
@@ -5,6 +5,8 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -30,6 +32,7 @@ type analyticsCall struct {
 }
 
 type spyAnalytics struct {
+	mu                sync.Mutex
 	enabled           bool
 	identifyUserCalls []analyticsCall
 	trackUserCalls    []analyticsCall
@@ -37,17 +40,23 @@ type spyAnalytics struct {
 	trackGroupHits    int
 }
 
-func (s *spyAnalytics) Enabled() bool                                  { return s.enabled }
+func (s *spyAnalytics) Enabled() bool                                   { return s.enabled }
 func (s *spyAnalytics) Start(context.Context) error                     { return nil }
 func (s *spyAnalytics) Stop(context.Context) error                      { return nil }
 func (s *spyAnalytics) Send(context.Context, ...analyticstypes.Message) {}
 func (s *spyAnalytics) TrackGroup(context.Context, string, string, map[string]any) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	s.trackGroupHits++
 }
 func (s *spyAnalytics) IdentifyGroup(context.Context, string, map[string]any) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	s.identifyGroupHits++
 }
 func (s *spyAnalytics) TrackUser(_ context.Context, group, user, event string, attrs map[string]any) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	s.trackUserCalls = append(s.trackUserCalls, analyticsCall{
 		group: group,
 		user:  user,
@@ -56,11 +65,22 @@ func (s *spyAnalytics) TrackUser(_ context.Context, group, user, event string, a
 	})
 }
 func (s *spyAnalytics) IdentifyUser(_ context.Context, group, user string, attrs map[string]any) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	s.identifyUserCalls = append(s.identifyUserCalls, analyticsCall{
 		group: group,
 		user:  user,
 		attrs: attrs,
 	})
+}
+
+func (s *spyAnalytics) snapshot() (identify []analyticsCall, track []analyticsCall, identifyGroupHits, trackGroupHits int) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	identify = append([]analyticsCall(nil), s.identifyUserCalls...)
+	track = append([]analyticsCall(nil), s.trackUserCalls...)
+	return identify, track, s.identifyGroupHits, s.trackGroupHits
 }
 
 var _ analytics.Analytics = (*spyAnalytics)(nil)
@@ -78,6 +98,20 @@ func (f fakeSession) SessionID() string                                   { retu
 func newAnalyticsTestContext(ctx context.Context, sessionID string) context.Context {
 	base := mcpgoserver.NewMCPServer("test", "1.0.0")
 	return base.WithContext(ctx, fakeSession{id: sessionID, ch: make(chan mcp.JSONRPCNotification, 1)})
+}
+
+func waitForCondition(t *testing.T, timeout time.Duration, condition func() bool, failureMessage string) {
+	t.Helper()
+
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if condition() {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	t.Fatal(failureMessage)
 }
 
 func TestNormalizeSigNozURL_RejectsPathQueryFragment(t *testing.T) {
@@ -330,9 +364,9 @@ func TestAuthMiddlewareReturnsOAuthChallengeWhenMissingAuth(t *testing.T) {
 }
 
 func TestBuildHooks_APIKeyAnalyticsUseServiceAccountIdentity(t *testing.T) {
-	requests := 0
+	var requests atomic.Int32
 	sigNoz := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		requests++
+		requests.Add(1)
 		if r.URL.Path != "/api/v1/service_accounts/me" {
 			t.Fatalf("path = %q, want %q", r.URL.Path, "/api/v1/service_accounts/me")
 		}
@@ -364,20 +398,17 @@ func TestBuildHooks_APIKeyAnalyticsUseServiceAccountIdentity(t *testing.T) {
 	hooks.RegisterSession(ctx, session)
 	hooks.UnregisterSession(ctx, session)
 
-	if requests != 2 {
-		t.Fatalf("identity requests = %d, want %d", requests, 2)
-	}
-	if spy.identifyGroupHits != 0 || spy.trackGroupHits != 0 {
-		t.Fatalf("expected no group analytics calls, got identify=%d track=%d", spy.identifyGroupHits, spy.trackGroupHits)
-	}
-	if len(spy.identifyUserCalls) != 1 {
-		t.Fatalf("identify user calls = %d, want %d", len(spy.identifyUserCalls), 1)
-	}
-	if len(spy.trackUserCalls) != 1 {
-		t.Fatalf("track user calls = %d, want %d", len(spy.trackUserCalls), 1)
+	waitForCondition(t, time.Second, func() bool {
+		identifyCalls, trackCalls, identifyGroupHits, trackGroupHits := spy.snapshot()
+		return requests.Load() == 2 && identifyGroupHits == 0 && trackGroupHits == 0 && len(identifyCalls) == 1 && len(trackCalls) == 1
+	}, "timed out waiting for async API-key analytics")
+
+	identifyCalls, trackCalls, identifyGroupHits, trackGroupHits := spy.snapshot()
+	if identifyGroupHits != 0 || trackGroupHits != 0 {
+		t.Fatalf("expected no group analytics calls, got identify=%d track=%d", identifyGroupHits, trackGroupHits)
 	}
 
-	identify := spy.identifyUserCalls[0]
+	identify := identifyCalls[0]
 	if identify.group != "org-456" || identify.user != "sa-123" {
 		t.Fatalf("identify user args = (%q, %q), want (%q, %q)", identify.group, identify.user, "org-456", "sa-123")
 	}
@@ -385,7 +416,7 @@ func TestBuildHooks_APIKeyAnalyticsUseServiceAccountIdentity(t *testing.T) {
 		t.Fatalf("identify attrs = %#v, want org_id, principal, and service_email", identify.attrs)
 	}
 
-	track := spy.trackUserCalls[0]
+	track := trackCalls[0]
 	if track.group != "org-456" || track.user != "sa-123" || track.event != "MCP Unregistered" {
 		t.Fatalf("track call = (%q, %q, %q), want (%q, %q, %q)", track.group, track.user, track.event, "org-456", "sa-123", "MCP Unregistered")
 	}
@@ -398,9 +429,9 @@ func TestBuildHooks_APIKeyAnalyticsUseServiceAccountIdentity(t *testing.T) {
 }
 
 func TestUserScopedAnalyticsUseJWTIdentity(t *testing.T) {
-	requests := 0
+	var requests atomic.Int32
 	sigNoz := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		requests++
+		requests.Add(1)
 		if r.URL.Path != "/api/v2/users/me" {
 			t.Fatalf("path = %q, want %q", r.URL.Path, "/api/v2/users/me")
 		}
@@ -445,20 +476,17 @@ func TestUserScopedAnalyticsUseJWTIdentity(t *testing.T) {
 		t.Fatalf("middleware error = %v", err)
 	}
 
-	if requests != 2 {
-		t.Fatalf("identity requests = %d, want %d", requests, 2)
-	}
-	if spy.identifyGroupHits != 0 || spy.trackGroupHits != 0 {
-		t.Fatalf("expected no group analytics calls, got identify=%d track=%d", spy.identifyGroupHits, spy.trackGroupHits)
-	}
-	if len(spy.identifyUserCalls) != 1 {
-		t.Fatalf("identify user calls = %d, want %d", len(spy.identifyUserCalls), 1)
-	}
-	if len(spy.trackUserCalls) != 2 {
-		t.Fatalf("track user calls = %d, want %d", len(spy.trackUserCalls), 2)
+	waitForCondition(t, time.Second, func() bool {
+		identifyCalls, trackCalls, identifyGroupHits, trackGroupHits := spy.snapshot()
+		return requests.Load() == 2 && identifyGroupHits == 0 && trackGroupHits == 0 && len(identifyCalls) == 1 && len(trackCalls) == 2
+	}, "timed out waiting for async JWT analytics")
+
+	identifyCalls, trackCalls, identifyGroupHits, trackGroupHits := spy.snapshot()
+	if identifyGroupHits != 0 || trackGroupHits != 0 {
+		t.Fatalf("expected no group analytics calls, got identify=%d track=%d", identifyGroupHits, trackGroupHits)
 	}
 
-	identify := spy.identifyUserCalls[0]
+	identify := identifyCalls[0]
 	if identify.group != "org-123" || identify.user != "user-123" {
 		t.Fatalf("identify user args = (%q, %q), want (%q, %q)", identify.group, identify.user, "org-123", "user-123")
 	}
@@ -466,7 +494,17 @@ func TestUserScopedAnalyticsUseJWTIdentity(t *testing.T) {
 		t.Fatalf("identify attrs = %#v, want org_id, principal, and user_email", identify.attrs)
 	}
 
-	registered := spy.trackUserCalls[0]
+	var registered analyticsCall
+	var toolCall analyticsCall
+	for _, call := range trackCalls {
+		switch call.event {
+		case "MCP Registered":
+			registered = call
+		case "Tool Call":
+			toolCall = call
+		}
+	}
+
 	if registered.event != "MCP Registered" || registered.group != "org-123" || registered.user != "user-123" {
 		t.Fatalf("registered track call = (%q, %q, %q), want (%q, %q, %q)", registered.group, registered.user, registered.event, "org-123", "user-123", "MCP Registered")
 	}
@@ -474,7 +512,6 @@ func TestUserScopedAnalyticsUseJWTIdentity(t *testing.T) {
 		t.Fatalf("registered session attr = %v, want %q", registered.attrs[string(telemetry.MCPSessionIDKey)], "sess-jwt")
 	}
 
-	toolCall := spy.trackUserCalls[1]
 	if toolCall.event != "Tool Call" || toolCall.group != "org-123" || toolCall.user != "user-123" {
 		t.Fatalf("tool track call = (%q, %q, %q), want (%q, %q, %q)", toolCall.group, toolCall.user, toolCall.event, "org-123", "user-123", "Tool Call")
 	}
@@ -490,9 +527,9 @@ func TestUserScopedAnalyticsUseJWTIdentity(t *testing.T) {
 }
 
 func TestAnalyticsDisabledSkipsIdentityLookup(t *testing.T) {
-	requests := 0
+	var requests atomic.Int32
 	sigNoz := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		requests++
+		requests.Add(1)
 		t.Fatalf("unexpected identity request: %s", r.URL.Path)
 	}))
 	defer sigNoz.Close()
@@ -535,16 +572,90 @@ func TestAnalyticsDisabledSkipsIdentityLookup(t *testing.T) {
 	hooks.RegisterSession(ctx, session)
 	hooks.UnregisterSession(ctx, session)
 
-	if requests != 0 {
-		t.Fatalf("identity requests = %d, want %d", requests, 0)
+	identifyCalls, trackCalls, identifyGroupHits, trackGroupHits := spy.snapshot()
+	if requests.Load() != 0 {
+		t.Fatalf("identity requests = %d, want %d", requests.Load(), 0)
 	}
-	if spy.identifyGroupHits != 0 || spy.trackGroupHits != 0 {
-		t.Fatalf("expected no group analytics calls, got identify=%d track=%d", spy.identifyGroupHits, spy.trackGroupHits)
+	if identifyGroupHits != 0 || trackGroupHits != 0 {
+		t.Fatalf("expected no group analytics calls, got identify=%d track=%d", identifyGroupHits, trackGroupHits)
 	}
-	if len(spy.identifyUserCalls) != 0 {
-		t.Fatalf("identify user calls = %d, want %d", len(spy.identifyUserCalls), 0)
+	if len(identifyCalls) != 0 {
+		t.Fatalf("identify user calls = %d, want %d", len(identifyCalls), 0)
 	}
-	if len(spy.trackUserCalls) != 0 {
-		t.Fatalf("track user calls = %d, want %d", len(spy.trackUserCalls), 0)
+	if len(trackCalls) != 0 {
+		t.Fatalf("track user calls = %d, want %d", len(trackCalls), 0)
+	}
+}
+
+func TestToolCallReturnsBeforeAsyncAnalyticsCompletes(t *testing.T) {
+	var requests atomic.Int32
+	identityStarted := make(chan struct{}, 1)
+
+	sigNoz := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests.Add(1)
+		select {
+		case identityStarted <- struct{}{}:
+		default:
+		}
+		time.Sleep(200 * time.Millisecond)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"status":"success","data":{"id":"user-123","email":"user@example.com","orgId":"org-123"}}`))
+	}))
+	defer sigNoz.Close()
+
+	cfg := &config.Config{
+		URL:             sigNoz.URL,
+		ClientCacheSize: 1,
+		ClientCacheTTL:  time.Minute,
+	}
+	handler := tools.NewHandler(zap.NewNop(), cfg)
+	spy := &spyAnalytics{enabled: true}
+	mcpServer := NewMCPServer(zap.NewNop(), handler, cfg, spy)
+
+	ctx := context.Background()
+	ctx = util.SetAPIKey(ctx, "Bearer jwt-token")
+	ctx = util.SetAuthHeader(ctx, "Authorization")
+	ctx = util.SetSigNozURL(ctx, sigNoz.URL)
+	ctx = newAnalyticsTestContext(ctx, "sess-jwt")
+
+	middleware := mcpServer.loggingMiddleware()
+
+	start := time.Now()
+	_, err := middleware(func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		return &mcp.CallToolResult{}, nil
+	})(ctx, mcp.CallToolRequest{
+		Params: mcp.CallToolParams{
+			Name: "signoz_list_services",
+			Arguments: map[string]any{
+				"searchContext": "list services",
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("middleware error = %v", err)
+	}
+	elapsed := time.Since(start)
+	if elapsed >= 150*time.Millisecond {
+		t.Fatalf("tool call took %v, want less than %v", elapsed, 150*time.Millisecond)
+	}
+
+	select {
+	case <-identityStarted:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for async identity request to start")
+	}
+
+	waitForCondition(t, time.Second, func() bool {
+		_, trackCalls, _, _ := spy.snapshot()
+		return requests.Load() == 1 && len(trackCalls) == 1
+	}, "timed out waiting for async tool analytics")
+
+	_, trackCalls, _, _ := spy.snapshot()
+	toolCall := trackCalls[0]
+	if toolCall.event != "Tool Call" {
+		t.Fatalf("track event = %q, want %q", toolCall.event, "Tool Call")
+	}
+	if toolCall.attrs["user_email"] != "user@example.com" {
+		t.Fatalf("tool attrs = %#v, want user_email", toolCall.attrs)
 	}
 }

--- a/internal/mcp-server/server_test.go
+++ b/internal/mcp-server/server_test.go
@@ -17,7 +17,6 @@ import (
 	"github.com/SigNoz/signoz-mcp-server/internal/config"
 	"github.com/SigNoz/signoz-mcp-server/internal/handler/tools"
 	"github.com/SigNoz/signoz-mcp-server/internal/oauth"
-	"github.com/SigNoz/signoz-mcp-server/internal/telemetry"
 	"github.com/SigNoz/signoz-mcp-server/pkg/analytics"
 	"github.com/SigNoz/signoz-mcp-server/pkg/analytics/noopanalytics"
 	"github.com/SigNoz/signoz-mcp-server/pkg/types/analyticstypes"
@@ -399,19 +398,19 @@ func TestBuildHooks_APIKeyAnalyticsUseServiceAccountIdentity(t *testing.T) {
 	if identify.groupID != "org-456" || identify.userID != "sa-123" {
 		t.Fatalf("identify user args = (%q, %q), want (%q, %q)", identify.groupID, identify.userID, "org-456", "sa-123")
 	}
-	if identify.attrs["org_id"] != "org-456" || identify.attrs["principal"] != "service_account" || identify.attrs["service_email"] != "service@example.com" {
-		t.Fatalf("identify attrs = %#v, want org_id, principal, and service_email", identify.attrs)
+	if identify.attrs[analytics.AttrOrgID] != "org-456" || identify.attrs[analytics.AttrPrincipal] != "service_account" || identify.attrs[analytics.AttrServiceEmail] != "service@example.com" {
+		t.Fatalf("identify attrs = %#v, want orgId, principal, and serviceEmail", identify.attrs)
 	}
 
 	track := trackCalls[0]
-	if track.groupID != "org-456" || track.userID != "sa-123" || track.event != "MCP Unregistered" {
-		t.Fatalf("track call = (%q, %q, %q), want (%q, %q, %q)", track.groupID, track.userID, track.event, "org-456", "sa-123", "MCP Unregistered")
+	if track.groupID != "org-456" || track.userID != "sa-123" || track.event != analytics.EventSessionUnregistered {
+		t.Fatalf("track call = (%q, %q, %q), want (%q, %q, %q)", track.groupID, track.userID, track.event, "org-456", "sa-123", analytics.EventSessionUnregistered)
 	}
-	if track.attrs[string(telemetry.MCPSessionIDKey)] != "sess-api" {
-		t.Fatalf("session id attr = %v, want %q", track.attrs[string(telemetry.MCPSessionIDKey)], "sess-api")
+	if track.attrs[analytics.AttrSessionID] != "sess-api" {
+		t.Fatalf("session id attr = %v, want %q", track.attrs[analytics.AttrSessionID], "sess-api")
 	}
-	if track.attrs["org_id"] != "org-456" || track.attrs["principal"] != "service_account" || track.attrs["service_email"] != "service@example.com" {
-		t.Fatalf("track attrs = %#v, want org_id, principal, and service_email", track.attrs)
+	if track.attrs[analytics.AttrOrgID] != "org-456" || track.attrs[analytics.AttrPrincipal] != "service_account" || track.attrs[analytics.AttrServiceEmail] != "service@example.com" {
+		t.Fatalf("track attrs = %#v, want orgId, principal, and serviceEmail", track.attrs)
 	}
 }
 
@@ -474,39 +473,42 @@ func TestUserScopedAnalyticsUseJWTIdentity(t *testing.T) {
 	if identify.groupID != "org-123" || identify.userID != "user-123" {
 		t.Fatalf("identify user args = (%q, %q), want (%q, %q)", identify.groupID, identify.userID, "org-123", "user-123")
 	}
-	if identify.attrs["org_id"] != "org-123" || identify.attrs["principal"] != "user" || identify.attrs["user_email"] != "user@example.com" {
-		t.Fatalf("identify attrs = %#v, want org_id, principal, and user_email", identify.attrs)
+	if identify.attrs[analytics.AttrOrgID] != "org-123" || identify.attrs[analytics.AttrPrincipal] != "user" || identify.attrs[analytics.AttrUserEmail] != "user@example.com" {
+		t.Fatalf("identify attrs = %#v, want orgId, principal, and userEmail", identify.attrs)
 	}
 
 	var registered analyticsCall
 	var toolCall analyticsCall
 	for _, call := range trackCalls {
 		switch call.event {
-		case "MCP Registered":
+		case analytics.EventSessionRegistered:
 			registered = call
-		case "Tool Call":
+		case analytics.EventToolCalled:
 			toolCall = call
 		}
 	}
 
-	if registered.event != "MCP Registered" || registered.groupID != "org-123" || registered.userID != "user-123" {
-		t.Fatalf("registered track call = (%q, %q, %q), want (%q, %q, %q)", registered.groupID, registered.userID, registered.event, "org-123", "user-123", "MCP Registered")
+	if registered.event != analytics.EventSessionRegistered || registered.groupID != "org-123" || registered.userID != "user-123" {
+		t.Fatalf("registered track call = (%q, %q, %q), want (%q, %q, %q)", registered.groupID, registered.userID, registered.event, "org-123", "user-123", analytics.EventSessionRegistered)
 	}
-	if registered.attrs[string(telemetry.MCPSessionIDKey)] != "sess-jwt" {
-		t.Fatalf("registered session attr = %v, want %q", registered.attrs[string(telemetry.MCPSessionIDKey)], "sess-jwt")
+	if registered.attrs[analytics.AttrSessionID] != "sess-jwt" {
+		t.Fatalf("registered session attr = %v, want %q", registered.attrs[analytics.AttrSessionID], "sess-jwt")
 	}
 
-	if toolCall.event != "Tool Call" || toolCall.groupID != "org-123" || toolCall.userID != "user-123" {
-		t.Fatalf("tool track call = (%q, %q, %q), want (%q, %q, %q)", toolCall.groupID, toolCall.userID, toolCall.event, "org-123", "user-123", "Tool Call")
+	if toolCall.event != analytics.EventToolCalled || toolCall.groupID != "org-123" || toolCall.userID != "user-123" {
+		t.Fatalf("tool track call = (%q, %q, %q), want (%q, %q, %q)", toolCall.groupID, toolCall.userID, toolCall.event, "org-123", "user-123", analytics.EventToolCalled)
 	}
-	if toolCall.attrs[string(telemetry.GenAIToolNameKey)] != "signoz_list_services" {
-		t.Fatalf("tool name attr = %v, want %q", toolCall.attrs[string(telemetry.GenAIToolNameKey)], "signoz_list_services")
+	if toolCall.attrs[analytics.AttrToolName] != "signoz_list_services" {
+		t.Fatalf("tool name attr = %v, want %q", toolCall.attrs[analytics.AttrToolName], "signoz_list_services")
 	}
-	if toolCall.attrs[string(telemetry.MCPToolIsErrorKey)] != false {
-		t.Fatalf("tool error attr = %v, want false", toolCall.attrs[string(telemetry.MCPToolIsErrorKey)])
+	if toolCall.attrs[analytics.AttrToolIsError] != false {
+		t.Fatalf("tool error attr = %v, want false", toolCall.attrs[analytics.AttrToolIsError])
 	}
-	if toolCall.attrs["org_id"] != "org-123" || toolCall.attrs["principal"] != "user" || toolCall.attrs["user_email"] != "user@example.com" {
-		t.Fatalf("tool attrs = %#v, want org_id, principal, and user_email", toolCall.attrs)
+	if toolCall.attrs[analytics.AttrSearchContext] != "list services" {
+		t.Fatalf("tool searchContext attr = %v, want %q", toolCall.attrs[analytics.AttrSearchContext], "list services")
+	}
+	if toolCall.attrs[analytics.AttrOrgID] != "org-123" || toolCall.attrs[analytics.AttrPrincipal] != "user" || toolCall.attrs[analytics.AttrUserEmail] != "user@example.com" {
+		t.Fatalf("tool attrs = %#v, want orgId, principal, and userEmail", toolCall.attrs)
 	}
 }
 
@@ -633,10 +635,221 @@ func TestToolCallReturnsBeforeAsyncAnalyticsCompletes(t *testing.T) {
 
 	_, trackCalls := spy.snapshot()
 	toolCall := trackCalls[0]
-	if toolCall.event != "Tool Call" {
-		t.Fatalf("track event = %q, want %q", toolCall.event, "Tool Call")
+	if toolCall.event != analytics.EventToolCalled {
+		t.Fatalf("track event = %q, want %q", toolCall.event, analytics.EventToolCalled)
 	}
-	if toolCall.attrs["user_email"] != "user@example.com" {
-		t.Fatalf("tool attrs = %#v, want user_email", toolCall.attrs)
+	if toolCall.attrs[analytics.AttrUserEmail] != "user@example.com" {
+		t.Fatalf("tool attrs = %#v, want userEmail", toolCall.attrs)
+	}
+}
+
+// meEndpointServer stubs the SigNoz /me endpoint with a stable identity.
+func meEndpointServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"status":"success","data":{"id":"sa-1","email":"svc@example.com","orgId":"org-1"}}`))
+	}))
+}
+
+func TestClientInfoAttachesToToolCallEvent(t *testing.T) {
+	sigNoz := meEndpointServer(t)
+	defer sigNoz.Close()
+
+	cfg := &config.Config{
+		URL:             sigNoz.URL,
+		APIKey:          "test-key",
+		ClientCacheSize: 1,
+		ClientCacheTTL:  time.Minute,
+	}
+	handler := tools.NewHandler(zap.NewNop(), cfg)
+	spy := &spyAnalytics{enabled: true}
+	mcpServer := NewMCPServer(zap.NewNop(), handler, cfg, spy)
+	hooks := mcpServer.buildHooks()
+
+	ctx := context.Background()
+	ctx = util.SetAPIKey(ctx, "test-key")
+	ctx = util.SetAuthHeader(ctx, "SIGNOZ-API-KEY")
+	ctx = util.SetSigNozURL(ctx, sigNoz.URL)
+	ctx = newAnalyticsTestContext(ctx, "sess-client")
+
+	hooks.OnAfterInitialize[0](ctx, nil, &mcp.InitializeRequest{
+		Params: mcp.InitializeParams{
+			ClientInfo: mcp.Implementation{Name: "claude-desktop", Version: "1.2.3"},
+		},
+	}, &mcp.InitializeResult{})
+
+	middleware := mcpServer.loggingMiddleware()
+	_, err := middleware(func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		return &mcp.CallToolResult{}, nil
+	})(ctx, mcp.CallToolRequest{
+		Params: mcp.CallToolParams{Name: "signoz_list_services"},
+	})
+	if err != nil {
+		t.Fatalf("middleware error = %v", err)
+	}
+
+	waitForCondition(t, time.Second, func() bool {
+		_, trackCalls := spy.snapshot()
+		return len(trackCalls) == 2
+	}, "timed out waiting for tool analytics")
+
+	_, trackCalls := spy.snapshot()
+	var toolCall analyticsCall
+	for _, c := range trackCalls {
+		if c.event == analytics.EventToolCalled {
+			toolCall = c
+		}
+	}
+	if toolCall.attrs[analytics.AttrClientName] != "claude-desktop" {
+		t.Fatalf("clientName = %v, want claude-desktop", toolCall.attrs[analytics.AttrClientName])
+	}
+	if toolCall.attrs[analytics.AttrClientVersion] != "1.2.3" {
+		t.Fatalf("clientVersion = %v, want 1.2.3", toolCall.attrs[analytics.AttrClientVersion])
+	}
+
+	mcpServer.forgetClientInfo("sess-client")
+	if mcpServer.lookupClientInfo("sess-client").Name != "" {
+		t.Fatalf("expected ClientInfo to be cleared after forgetClientInfo")
+	}
+}
+
+func TestUnregisterSessionHookClearsClientInfo(t *testing.T) {
+	sigNoz := meEndpointServer(t)
+	defer sigNoz.Close()
+
+	cfg := &config.Config{URL: sigNoz.URL, APIKey: "k", ClientCacheSize: 1, ClientCacheTTL: time.Minute}
+	handler := tools.NewHandler(zap.NewNop(), cfg)
+	spy := &spyAnalytics{enabled: true}
+	mcpServer := NewMCPServer(zap.NewNop(), handler, cfg, spy)
+	hooks := mcpServer.buildHooks()
+
+	ctx := context.Background()
+	ctx = util.SetAPIKey(ctx, "k")
+	ctx = util.SetAuthHeader(ctx, "SIGNOZ-API-KEY")
+	ctx = util.SetSigNozURL(ctx, sigNoz.URL)
+	ctx = newAnalyticsTestContext(ctx, "sess-cleanup")
+
+	hooks.OnAfterInitialize[0](ctx, nil,
+		&mcp.InitializeRequest{Params: mcp.InitializeParams{
+			ClientInfo: mcp.Implementation{Name: "cursor", Version: "0.9"},
+		}}, &mcp.InitializeResult{})
+
+	if got := mcpServer.lookupClientInfo("sess-cleanup"); got.Name != "cursor" {
+		t.Fatalf("pre-unregister ClientInfo = %+v, want name=cursor", got)
+	}
+
+	session := fakeSession{id: "sess-cleanup", ch: make(chan mcp.JSONRPCNotification, 1)}
+	hooks.OnUnregisterSession[0](ctx, session)
+
+	if got := mcpServer.lookupClientInfo("sess-cleanup"); got.Name != "" {
+		t.Fatalf("post-unregister ClientInfo = %+v, want empty", got)
+	}
+}
+
+func TestPromptFetchedEvent(t *testing.T) {
+	sigNoz := meEndpointServer(t)
+	defer sigNoz.Close()
+
+	cfg := &config.Config{URL: sigNoz.URL, APIKey: "k", ClientCacheSize: 1, ClientCacheTTL: time.Minute}
+	handler := tools.NewHandler(zap.NewNop(), cfg)
+	spy := &spyAnalytics{enabled: true}
+	mcpServer := NewMCPServer(zap.NewNop(), handler, cfg, spy)
+	hooks := mcpServer.buildHooks()
+
+	ctx := context.Background()
+	ctx = util.SetAPIKey(ctx, "k")
+	ctx = util.SetAuthHeader(ctx, "SIGNOZ-API-KEY")
+	ctx = util.SetSigNozURL(ctx, sigNoz.URL)
+	ctx = newAnalyticsTestContext(ctx, "sess-prompt")
+
+	hooks.OnAfterGetPrompt[0](ctx, nil,
+		&mcp.GetPromptRequest{Params: mcp.GetPromptParams{Name: "rca"}},
+		&mcp.GetPromptResult{})
+
+	waitForCondition(t, time.Second, func() bool {
+		_, trackCalls := spy.snapshot()
+		return len(trackCalls) == 1
+	}, "timed out waiting for prompt analytics")
+
+	_, trackCalls := spy.snapshot()
+	call := trackCalls[0]
+	if call.event != analytics.EventPromptFetched {
+		t.Fatalf("event = %q, want %q", call.event, analytics.EventPromptFetched)
+	}
+	if call.attrs[analytics.AttrPromptName] != "rca" {
+		t.Fatalf("promptName attr = %v, want rca", call.attrs[analytics.AttrPromptName])
+	}
+	if call.attrs[analytics.AttrSessionID] != "sess-prompt" {
+		t.Fatalf("sessionId attr = %v, want sess-prompt", call.attrs[analytics.AttrSessionID])
+	}
+}
+
+func TestResourceFetchedEvent(t *testing.T) {
+	sigNoz := meEndpointServer(t)
+	defer sigNoz.Close()
+
+	cfg := &config.Config{URL: sigNoz.URL, APIKey: "k", ClientCacheSize: 1, ClientCacheTTL: time.Minute}
+	handler := tools.NewHandler(zap.NewNop(), cfg)
+	spy := &spyAnalytics{enabled: true}
+	mcpServer := NewMCPServer(zap.NewNop(), handler, cfg, spy)
+	hooks := mcpServer.buildHooks()
+
+	ctx := context.Background()
+	ctx = util.SetAPIKey(ctx, "k")
+	ctx = util.SetAuthHeader(ctx, "SIGNOZ-API-KEY")
+	ctx = util.SetSigNozURL(ctx, sigNoz.URL)
+	ctx = newAnalyticsTestContext(ctx, "sess-res")
+
+	hooks.OnAfterReadResource[0](ctx, nil,
+		&mcp.ReadResourceRequest{Params: mcp.ReadResourceParams{URI: "signoz://dashboard/abc"}},
+		&mcp.ReadResourceResult{})
+
+	waitForCondition(t, time.Second, func() bool {
+		_, trackCalls := spy.snapshot()
+		return len(trackCalls) == 1
+	}, "timed out waiting for resource analytics")
+
+	_, trackCalls := spy.snapshot()
+	call := trackCalls[0]
+	if call.event != analytics.EventResourceFetched {
+		t.Fatalf("event = %q, want %q", call.event, analytics.EventResourceFetched)
+	}
+	if call.attrs[analytics.AttrResourceURI] != "signoz://dashboard/abc" {
+		t.Fatalf("resourceUri attr = %v, want signoz://dashboard/abc", call.attrs[analytics.AttrResourceURI])
+	}
+}
+
+func TestOAuthEventEmitter_InjectsCredentialsAndDispatches(t *testing.T) {
+	sigNoz := meEndpointServer(t)
+	defer sigNoz.Close()
+
+	cfg := &config.Config{URL: sigNoz.URL, ClientCacheSize: 1, ClientCacheTTL: time.Minute}
+	handler := tools.NewHandler(zap.NewNop(), cfg)
+	spy := &spyAnalytics{enabled: true}
+	mcpServer := NewMCPServer(zap.NewNop(), handler, cfg, spy)
+
+	mcpServer.trackOAuthEvent(context.Background(), analytics.EventOAuthTokenIssued,
+		"oauth-api-key", sigNoz.URL,
+		map[string]any{
+			analytics.AttrTenantURL: sigNoz.URL,
+			analytics.AttrGrantType: "authorization_code",
+		})
+
+	waitForCondition(t, time.Second, func() bool {
+		_, trackCalls := spy.snapshot()
+		return len(trackCalls) == 1
+	}, "timed out waiting for OAuth analytics")
+
+	_, trackCalls := spy.snapshot()
+	call := trackCalls[0]
+	if call.event != analytics.EventOAuthTokenIssued {
+		t.Fatalf("event = %q, want %q", call.event, analytics.EventOAuthTokenIssued)
+	}
+	if call.attrs[analytics.AttrGrantType] != "authorization_code" {
+		t.Fatalf("grantType attr = %v, want authorization_code", call.attrs[analytics.AttrGrantType])
+	}
+	if call.groupID != "org-1" || call.userID != "sa-1" {
+		t.Fatalf("identity (%q, %q), want (org-1, sa-1)", call.groupID, call.userID)
 	}
 }

--- a/internal/oauth/handlers.go
+++ b/internal/oauth/handlers.go
@@ -18,10 +18,16 @@ import (
 
 	"github.com/SigNoz/signoz-mcp-server/internal/client"
 	"github.com/SigNoz/signoz-mcp-server/internal/config"
+	"github.com/SigNoz/signoz-mcp-server/pkg/analytics"
 	"github.com/SigNoz/signoz-mcp-server/pkg/util"
 )
 
 const csrfCookieName = "signoz_mcp_oauth_csrf"
+
+// AnalyticsEmitter publishes OAuth flow events. apiKey and signozURL are
+// the validated tenant credentials the emitter needs to resolve identity
+// (orgId) for the event. Nil disables OAuth analytics.
+type AnalyticsEmitter func(ctx context.Context, event, apiKey, signozURL string, props map[string]any)
 
 //go:embed static/authorize.html
 var authorizeTemplateFS embed.FS
@@ -33,6 +39,7 @@ type Handler struct {
 	config            *config.Config
 	tokenSecret       []byte
 	authorizeTemplate *template.Template
+	emitEvent         AnalyticsEmitter
 }
 
 type registerClientRequest struct {
@@ -71,13 +78,21 @@ type tokenResponse struct {
 	RefreshToken string `json:"refresh_token"`
 }
 
-func NewHandler(logger *zap.Logger, cfg *config.Config) *Handler {
+func NewHandler(logger *zap.Logger, cfg *config.Config, emitEvent AnalyticsEmitter) *Handler {
 	return &Handler{
 		logger:            logger,
 		config:            cfg,
 		tokenSecret:       []byte(cfg.OAuthTokenSecret),
 		authorizeTemplate: authorizePageTemplate,
+		emitEvent:         emitEvent,
 	}
+}
+
+func (h *Handler) emit(ctx context.Context, event, apiKey, signozURL string, props map[string]any) {
+	if h.emitEvent == nil {
+		return
+	}
+	h.emitEvent(ctx, event, apiKey, signozURL, props)
 }
 
 func (h *Handler) HandleProtectedResourceMetadata(w http.ResponseWriter, r *http.Request) {
@@ -261,6 +276,11 @@ func (h *Handler) HandleAuthorizeSubmit(w http.ResponseWriter, r *http.Request) 
 		Secure:   h.isSecure(),
 		MaxAge:   -1,
 	})
+
+	h.emit(r.Context(), analytics.EventOAuthAuthorizationSubmitted, apiKey, normalizedURL, map[string]any{
+		analytics.AttrTenantURL: normalizedURL,
+	})
+
 	http.Redirect(w, r, redirectURL, http.StatusFound)
 }
 
@@ -345,7 +365,7 @@ func (h *Handler) handleAuthorizationCodeGrant(w http.ResponseWriter, r *http.Re
 		return
 	}
 
-	h.issueTokenPair(w, clientID, apiKey, signozURL)
+	h.issueTokenPair(r.Context(), w, clientID, apiKey, signozURL, "authorization_code")
 }
 
 func (h *Handler) handleRefreshTokenGrant(w http.ResponseWriter, r *http.Request) {
@@ -366,10 +386,10 @@ func (h *Handler) handleRefreshTokenGrant(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	h.issueTokenPair(w, refreshClientID, apiKey, signozURL)
+	h.issueTokenPair(r.Context(), w, refreshClientID, apiKey, signozURL, "refresh_token")
 }
 
-func (h *Handler) issueTokenPair(w http.ResponseWriter, clientID, apiKey, signozURL string) {
+func (h *Handler) issueTokenPair(ctx context.Context, w http.ResponseWriter, clientID, apiKey, signozURL, grantType string) {
 	accessTokenExpiresAt := time.Now().UTC().Add(h.config.AccessTokenTTL)
 	accessToken, err := EncryptToken(apiKey, signozURL, clientID, accessTokenExpiresAt, h.tokenSecret)
 	if err != nil {
@@ -394,6 +414,11 @@ func (h *Handler) issueTokenPair(w http.ResponseWriter, clientID, apiKey, signoz
 		TokenType:    "Bearer",
 		ExpiresIn:    int(h.config.AccessTokenTTL.Seconds()),
 		RefreshToken: refreshTokenValue,
+	})
+
+	h.emit(ctx, analytics.EventOAuthTokenIssued, apiKey, signozURL, map[string]any{
+		analytics.AttrTenantURL: signozURL,
+		analytics.AttrGrantType: grantType,
 	})
 }
 

--- a/internal/oauth/handlers_test.go
+++ b/internal/oauth/handlers_test.go
@@ -2,6 +2,7 @@ package oauth
 
 import (
 	"bytes"
+	"context"
 	"crypto/sha256"
 	"encoding/base64"
 	"encoding/json"
@@ -10,12 +11,14 @@ import (
 	"net/url"
 	"regexp"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
 	"go.uber.org/zap"
 
 	"github.com/SigNoz/signoz-mcp-server/internal/config"
+	"github.com/SigNoz/signoz-mcp-server/pkg/analytics"
 )
 
 func TestOAuthAuthorizationFlow(t *testing.T) {
@@ -48,7 +51,7 @@ func TestOAuthAuthorizationFlow(t *testing.T) {
 		AuthCodeTTL:      10 * time.Minute,
 	}
 
-	handler := NewHandler(zap.NewNop(), cfg)
+	handler := NewHandler(zap.NewNop(), cfg, nil)
 	mux := http.NewServeMux()
 	mux.HandleFunc("GET /.well-known/oauth-protected-resource", handler.HandleProtectedResourceMetadata)
 	mux.HandleFunc("GET /.well-known/oauth-authorization-server", handler.HandleAuthorizationServerMetadata)
@@ -235,7 +238,7 @@ func TestOAuthAuthorizationFlowServiceAccountFallback(t *testing.T) {
 		AuthCodeTTL:      10 * time.Minute,
 	}
 
-	handler := NewHandler(zap.NewNop(), cfg)
+	handler := NewHandler(zap.NewNop(), cfg, nil)
 	mux := http.NewServeMux()
 	mux.HandleFunc("POST /oauth/register", handler.HandleRegisterClient)
 	mux.HandleFunc("GET /oauth/authorize", handler.HandleAuthorizePage)
@@ -334,7 +337,7 @@ func TestAuthorizeSubmitRejectsInvalidSigNozCredentials(t *testing.T) {
 		AuthCodeTTL:      10 * time.Minute,
 	}
 
-	handler := NewHandler(zap.NewNop(), cfg)
+	handler := NewHandler(zap.NewNop(), cfg, nil)
 	clientID, err := EncryptClientID([]string{"http://127.0.0.1:4567/callback"}, "Claude", time.Now().UTC(), []byte(cfg.OAuthTokenSecret))
 	if err != nil {
 		t.Fatalf("EncryptClientID() error = %v", err)
@@ -407,7 +410,7 @@ func TestRegisterClientAcceptsIPv6LoopbackRedirectURI(t *testing.T) {
 		OAuthIssuerURL:   "https://mcp.example.com",
 	}
 
-	handler := NewHandler(zap.NewNop(), cfg)
+	handler := NewHandler(zap.NewNop(), cfg, nil)
 	req := httptest.NewRequest(http.MethodPost, "/oauth/register", bytes.NewBufferString(`{"client_name":"Claude","redirect_uris":["http://[::1]:4567/callback"]}`))
 	req.Header.Set("Content-Type", "application/json")
 	rr := httptest.NewRecorder()
@@ -426,7 +429,7 @@ func TestRegisterClientRejectsUnsupportedCustomRedirectScheme(t *testing.T) {
 		OAuthIssuerURL:   "https://mcp.example.com",
 	}
 
-	handler := NewHandler(zap.NewNop(), cfg)
+	handler := NewHandler(zap.NewNop(), cfg, nil)
 	req := httptest.NewRequest(http.MethodPost, "/oauth/register", bytes.NewBufferString(`{"client_name":"Claude","redirect_uris":["javascript:alert(1)"]}`))
 	req.Header.Set("Content-Type", "application/json")
 	rr := httptest.NewRecorder()
@@ -469,7 +472,7 @@ func TestAuthorizePageUsesIssuerPathPrefixForFormAndCSRFCookie(t *testing.T) {
 		AuthCodeTTL:      10 * time.Minute,
 	}
 
-	handler := NewHandler(zap.NewNop(), cfg)
+	handler := NewHandler(zap.NewNop(), cfg, nil)
 	clientID, err := EncryptClientID([]string{"http://127.0.0.1:4567/callback"}, "Claude", time.Now().UTC(), []byte(cfg.OAuthTokenSecret))
 	if err != nil {
 		t.Fatalf("EncryptClientID() error = %v", err)
@@ -528,5 +531,146 @@ func TestAuthorizePageUsesIssuerPathPrefixForFormAndCSRFCookie(t *testing.T) {
 	}
 	if !strings.Contains(submitRR.Header().Get("Set-Cookie"), "Path=/signoz-mcp/oauth/authorize") {
 		t.Fatalf("clearing CSRF cookie missing issuer path prefix: %s", submitRR.Header().Get("Set-Cookie"))
+	}
+}
+
+type capturedEmission struct {
+	event     string
+	apiKey    string
+	signozURL string
+	props     map[string]any
+}
+
+type capturingEmitter struct {
+	mu        sync.Mutex
+	emissions []capturedEmission
+}
+
+func (c *capturingEmitter) emit(_ context.Context, event, apiKey, signozURL string, props map[string]any) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.emissions = append(c.emissions, capturedEmission{event: event, apiKey: apiKey, signozURL: signozURL, props: props})
+}
+
+func (c *capturingEmitter) snapshot() []capturedEmission {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	out := make([]capturedEmission, len(c.emissions))
+	copy(out, c.emissions)
+	return out
+}
+
+func TestOAuthEmitterFiresOnAuthorizeAndTokenIssue(t *testing.T) {
+	signozServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v1/user/me" {
+			http.NotFound(w, r)
+			return
+		}
+		if r.Header.Get("SIGNOZ-API-KEY") != "snz-api-key" {
+			w.WriteHeader(http.StatusUnauthorized)
+			_, _ = w.Write([]byte(`{"status":"error"}`))
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"status":"success","data":[]}`))
+	}))
+	defer signozServer.Close()
+
+	cfg := &config.Config{
+		OAuthEnabled:     true,
+		OAuthTokenSecret: "0123456789abcdef0123456789abcdef",
+		OAuthIssuerURL:   "https://mcp.example.com",
+		AccessTokenTTL:   time.Hour,
+		RefreshTokenTTL:  24 * time.Hour,
+		AuthCodeTTL:      10 * time.Minute,
+	}
+
+	capture := &capturingEmitter{}
+	handler := NewHandler(zap.NewNop(), cfg, capture.emit)
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST /oauth/register", handler.HandleRegisterClient)
+	mux.HandleFunc("GET /oauth/authorize", handler.HandleAuthorizePage)
+	mux.HandleFunc("POST /oauth/authorize", handler.HandleAuthorizeSubmit)
+	mux.HandleFunc("POST /oauth/token", handler.HandleToken)
+
+	registerReq := httptest.NewRequest(http.MethodPost, "/oauth/register",
+		bytes.NewBufferString(`{"client_name":"Claude","redirect_uris":["http://127.0.0.1:4567/callback"]}`))
+	registerReq.Header.Set("Content-Type", "application/json")
+	registerRR := httptest.NewRecorder()
+	mux.ServeHTTP(registerRR, registerReq)
+	var registered registerClientResponse
+	if err := json.Unmarshal(registerRR.Body.Bytes(), &registered); err != nil {
+		t.Fatalf("decode register response: %v", err)
+	}
+
+	verifier := "s3cr3t-pkce-verifier-that-is-long-enough-for-rfc7636"
+	sum := sha256.Sum256([]byte(verifier))
+	challenge := base64.RawURLEncoding.EncodeToString(sum[:])
+
+	authorizeURL := "/oauth/authorize?response_type=code&client_id=" + url.QueryEscape(registered.ClientID) +
+		"&redirect_uri=" + url.QueryEscape("http://127.0.0.1:4567/callback") +
+		"&code_challenge=" + url.QueryEscape(challenge) + "&code_challenge_method=S256"
+
+	authorizeRR := httptest.NewRecorder()
+	mux.ServeHTTP(authorizeRR, httptest.NewRequest(http.MethodGet, authorizeURL, nil))
+	re := regexp.MustCompile(`name="csrf_token" value="([^"]+)"`)
+	csrfToken := re.FindStringSubmatch(authorizeRR.Body.String())[1]
+	csrfCookie := authorizeRR.Result().Cookies()[0]
+
+	form := url.Values{
+		"client_id":             {registered.ClientID},
+		"redirect_uri":          {"http://127.0.0.1:4567/callback"},
+		"code_challenge":        {challenge},
+		"code_challenge_method": {"S256"},
+		"csrf_token":            {csrfToken},
+		"signoz_url":            {signozServer.URL},
+		"api_key":               {"snz-api-key"},
+	}
+	submitReq := httptest.NewRequest(http.MethodPost, "/oauth/authorize", bytes.NewBufferString(form.Encode()))
+	submitReq.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	submitReq.AddCookie(csrfCookie)
+	submitRR := httptest.NewRecorder()
+	mux.ServeHTTP(submitRR, submitReq)
+	location := submitRR.Result().Header.Get("Location")
+	parsedLoc, _ := url.Parse(location)
+	authCode := parsedLoc.Query().Get("code")
+	if authCode == "" {
+		t.Fatalf("no auth code in redirect: %s", location)
+	}
+
+	tokenForm := url.Values{
+		"grant_type":    {"authorization_code"},
+		"client_id":     {registered.ClientID},
+		"code":          {authCode},
+		"redirect_uri":  {"http://127.0.0.1:4567/callback"},
+		"code_verifier": {verifier},
+	}
+	tokenReq := httptest.NewRequest(http.MethodPost, "/oauth/token", bytes.NewBufferString(tokenForm.Encode()))
+	tokenReq.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	tokenRR := httptest.NewRecorder()
+	mux.ServeHTTP(tokenRR, tokenReq)
+	if tokenRR.Code != http.StatusOK {
+		t.Fatalf("token status = %d, body = %s", tokenRR.Code, tokenRR.Body.String())
+	}
+
+	emissions := capture.snapshot()
+	if len(emissions) != 2 {
+		t.Fatalf("expected 2 emissions (authorize submit + token issued), got %d: %+v", len(emissions), emissions)
+	}
+
+	submitted := emissions[0]
+	if submitted.event != analytics.EventOAuthAuthorizationSubmitted {
+		t.Fatalf("first emission event = %q, want %q", submitted.event, analytics.EventOAuthAuthorizationSubmitted)
+	}
+	if submitted.apiKey != "snz-api-key" || submitted.signozURL != signozServer.URL {
+		t.Fatalf("first emission creds = (%q, %q), want (snz-api-key, %q)", submitted.apiKey, submitted.signozURL, signozServer.URL)
+	}
+
+	issued := emissions[1]
+	if issued.event != analytics.EventOAuthTokenIssued {
+		t.Fatalf("second emission event = %q, want %q", issued.event, analytics.EventOAuthTokenIssued)
+	}
+	if issued.props[analytics.AttrGrantType] != "authorization_code" {
+		t.Fatalf("grantType attr = %v, want authorization_code", issued.props[analytics.AttrGrantType])
 	}
 }

--- a/pkg/analytics/analytics.go
+++ b/pkg/analytics/analytics.go
@@ -17,15 +17,8 @@ type Analytics interface {
 	// Send sends raw analytics messages.
 	Send(context.Context, ...analyticstypes.Message)
 
-	// TrackGroup tracks an event at the organization/group level.
-	// The group value is used directly as the userId and associated via Context.Extra groupId.
-	TrackGroup(ctx context.Context, group string, event string, properties map[string]any)
-
 	// TrackUser tracks an event attributed to a specific user within a group.
 	TrackUser(ctx context.Context, group string, user string, event string, properties map[string]any)
-
-	// IdentifyGroup sets traits on an organization/group.
-	IdentifyGroup(ctx context.Context, group string, traits map[string]any)
 
 	// IdentifyUser sets traits on a user and associates them with a group.
 	IdentifyUser(ctx context.Context, group string, user string, traits map[string]any)

--- a/pkg/analytics/analytics.go
+++ b/pkg/analytics/analytics.go
@@ -7,6 +7,8 @@ import (
 )
 
 type Analytics interface {
+	// Enabled reports whether analytics is actively emitting events.
+	Enabled() bool
 	// Start blocks until the analytics backend is stopped.
 	Start(context.Context) error
 	// Stop flushes pending events and closes the client.

--- a/pkg/analytics/analyticstest/provider.go
+++ b/pkg/analytics/analyticstest/provider.go
@@ -17,6 +17,7 @@ func New() *Provider {
 	return &Provider{stopC: make(chan struct{})}
 }
 
+func (p *Provider) Enabled() bool { return false }
 func (p *Provider) Start(_ context.Context) error  { <-p.stopC; return nil }
 func (p *Provider) Stop(_ context.Context) error   { close(p.stopC); return nil }
 func (p *Provider) Send(_ context.Context, _ ...analyticstypes.Message) {}

--- a/pkg/analytics/analyticstest/provider.go
+++ b/pkg/analytics/analyticstest/provider.go
@@ -17,11 +17,9 @@ func New() *Provider {
 	return &Provider{stopC: make(chan struct{})}
 }
 
-func (p *Provider) Enabled() bool { return false }
-func (p *Provider) Start(_ context.Context) error  { <-p.stopC; return nil }
-func (p *Provider) Stop(_ context.Context) error   { close(p.stopC); return nil }
-func (p *Provider) Send(_ context.Context, _ ...analyticstypes.Message) {}
-func (p *Provider) TrackGroup(_ context.Context, _, _ string, _ map[string]any)     {}
-func (p *Provider) TrackUser(_ context.Context, _, _, _ string, _ map[string]any)    {}
-func (p *Provider) IdentifyGroup(_ context.Context, _ string, _ map[string]any)      {}
-func (p *Provider) IdentifyUser(_ context.Context, _, _ string, _ map[string]any)    {}
+func (p *Provider) Enabled() bool                                                 { return false }
+func (p *Provider) Start(_ context.Context) error                                 { <-p.stopC; return nil }
+func (p *Provider) Stop(_ context.Context) error                                  { close(p.stopC); return nil }
+func (p *Provider) Send(_ context.Context, _ ...analyticstypes.Message)           {}
+func (p *Provider) TrackUser(_ context.Context, _, _, _ string, _ map[string]any) {}
+func (p *Provider) IdentifyUser(_ context.Context, _, _ string, _ map[string]any) {}

--- a/pkg/analytics/events.go
+++ b/pkg/analytics/events.go
@@ -1,0 +1,34 @@
+package analytics
+
+// Events follow "MCP <Subsection>: <Action>". The "MCP" prefix keeps these
+// distinct from main-app SigNoz events in shared destinations. IDs go in
+// attributes, never in the event name — cardinality stays bounded.
+const (
+	EventSessionRegistered           = "MCP Session: Registered"
+	EventSessionUnregistered         = "MCP Session: Unregistered"
+	EventToolCalled                  = "MCP Tool: Called"
+	EventPromptFetched               = "MCP Prompt: Fetched"
+	EventResourceFetched             = "MCP Resource: Fetched"
+	EventOAuthAuthorizationSubmitted = "MCP OAuth: Authorization submitted"
+	EventOAuthTokenIssued            = "MCP OAuth: Token issued"
+)
+
+// camelCase for analytics destinations. OTel span attrs use the dotted
+// semantic-convention form and live in internal/telemetry.
+const (
+	AttrOrgID         = "orgId"
+	AttrPrincipal     = "principal"
+	AttrUserEmail     = "userEmail"
+	AttrServiceEmail  = "serviceEmail"
+	AttrTenantURL     = "tenantUrl"
+	AttrSessionID     = "sessionId"
+	AttrClientName    = "clientName"
+	AttrClientVersion = "clientVersion"
+	AttrToolName      = "toolName"
+	AttrToolIsError   = "toolIsError"
+	AttrDurationMs    = "durationMs"
+	AttrSearchContext = "searchContext"
+	AttrPromptName    = "promptName"
+	AttrResourceURI   = "resourceUri"
+	AttrGrantType     = "grantType"
+)

--- a/pkg/analytics/noopanalytics/provider.go
+++ b/pkg/analytics/noopanalytics/provider.go
@@ -15,6 +15,7 @@ func New() analytics.Analytics {
 	return &provider{stopC: make(chan struct{})}
 }
 
+func (p *provider) Enabled() bool { return false }
 func (p *provider) Start(_ context.Context) error  { <-p.stopC; return nil }
 func (p *provider) Stop(_ context.Context) error   { close(p.stopC); return nil }
 func (p *provider) Send(_ context.Context, _ ...analyticstypes.Message) {}

--- a/pkg/analytics/noopanalytics/provider.go
+++ b/pkg/analytics/noopanalytics/provider.go
@@ -15,11 +15,9 @@ func New() analytics.Analytics {
 	return &provider{stopC: make(chan struct{})}
 }
 
-func (p *provider) Enabled() bool { return false }
-func (p *provider) Start(_ context.Context) error  { <-p.stopC; return nil }
-func (p *provider) Stop(_ context.Context) error   { close(p.stopC); return nil }
-func (p *provider) Send(_ context.Context, _ ...analyticstypes.Message) {}
-func (p *provider) TrackGroup(_ context.Context, _, _ string, _ map[string]any)     {}
-func (p *provider) TrackUser(_ context.Context, _, _, _ string, _ map[string]any)    {}
-func (p *provider) IdentifyGroup(_ context.Context, _ string, _ map[string]any)      {}
-func (p *provider) IdentifyUser(_ context.Context, _, _ string, _ map[string]any)    {}
+func (p *provider) Enabled() bool                                                 { return false }
+func (p *provider) Start(_ context.Context) error                                 { <-p.stopC; return nil }
+func (p *provider) Stop(_ context.Context) error                                  { close(p.stopC); return nil }
+func (p *provider) Send(_ context.Context, _ ...analyticstypes.Message)           {}
+func (p *provider) TrackUser(_ context.Context, _, _, _ string, _ map[string]any) {}
+func (p *provider) IdentifyUser(_ context.Context, _, _ string, _ map[string]any) {}

--- a/pkg/analytics/segmentanalytics/provider.go
+++ b/pkg/analytics/segmentanalytics/provider.go
@@ -30,6 +30,8 @@ func New(logger *zap.Logger, cfg analytics.Config) (analytics.Analytics, error) 
 	}, nil
 }
 
+func (p *provider) Enabled() bool { return true }
+
 func (p *provider) Start(_ context.Context) error {
 	<-p.stopC
 	return nil

--- a/pkg/analytics/segmentanalytics/provider.go
+++ b/pkg/analytics/segmentanalytics/provider.go
@@ -53,24 +53,6 @@ func (p *provider) Send(_ context.Context, messages ...analyticstypes.Message) {
 	}
 }
 
-func (p *provider) TrackGroup(_ context.Context, group, event string, properties map[string]any) {
-	if properties == nil {
-		return
-	}
-	if err := p.client.Enqueue(analyticstypes.Track{
-		UserId:     group,
-		Event:      event,
-		Properties: analyticstypes.NewPropertiesFromMap(properties),
-		Context: &analyticstypes.Context{
-			Extra: map[string]interface{}{
-				analyticstypes.KeyGroupID: group,
-			},
-		},
-	}); err != nil {
-		p.logger.Error("failed to enqueue TrackGroup", zap.String("event", event), zap.Error(err))
-	}
-}
-
 func (p *provider) TrackUser(_ context.Context, group, user, event string, properties map[string]any) {
 	if properties == nil {
 		return
@@ -86,25 +68,6 @@ func (p *provider) TrackUser(_ context.Context, group, user, event string, prope
 		},
 	}); err != nil {
 		p.logger.Error("failed to enqueue TrackUser", zap.String("event", event), zap.Error(err))
-	}
-}
-
-func (p *provider) IdentifyGroup(_ context.Context, group string, traits map[string]any) {
-	if traits == nil {
-		return
-	}
-	if err := p.client.Enqueue(analyticstypes.Identify{
-		UserId: group,
-		Traits: analyticstypes.NewTraitsFromMap(traits),
-	}); err != nil {
-		p.logger.Error("failed to enqueue IdentifyGroup Identify", zap.Error(err))
-	}
-	if err := p.client.Enqueue(analyticstypes.Group{
-		UserId:  group,
-		GroupId: group,
-		Traits:  analyticstypes.NewTraitsFromMap(traits),
-	}); err != nil {
-		p.logger.Error("failed to enqueue IdentifyGroup Group", zap.Error(err))
 	}
 }
 

--- a/plans/analytics.md
+++ b/plans/analytics.md
@@ -794,3 +794,48 @@ Based on above doc implement analytics in this repo following pieces from https:
     6. Avg tool calls per tenant
 8. Verify the events and attributes sent using console log and iterate till you do it properly
 9. Remove the console logs from step 8 post verification
+
+---
+
+## Implementation Notes (post-ship)
+
+Sections 1–13 above describe the upstream SigNoz analytics pattern used as a reference. The MCP server's shipped implementation deliberately diverges on a few points — capture them here so future readers aren't misled by the reference.
+
+### Interface surface
+
+- `Analytics` keeps only `TrackUser` and `IdentifyUser` (plus `Enabled`, `Start`, `Stop`, `Send`). The group-scoped `TrackGroup` / `IdentifyGroup` methods from the reference are **not** present — every event carries an identity (orgId, userId) resolved against `/api/v2/users/me` (JWT) or `/api/v1/service_accounts/me` (API key).
+- Identity lookups are cached per-`SigNoz` client with a 10-min TTL and a mutex so concurrent callers share a single roundtrip. Definition: [internal/client/client.go](../internal/client/client.go).
+
+### Event catalog
+
+All event names are defined in [pkg/analytics/events.go](../pkg/analytics/events.go). The naming convention is `Section: Action`, with every MCP-server event prefixed `MCP <Subsection>` so they stay distinct from main-app SigNoz events (Alert, Dashboard, Host Metrics) in shared destinations.
+
+| Event | Fired at | Notable attributes |
+| --- | --- | --- |
+| `MCP Session: Registered` | `AddAfterInitialize` hook (successful initialize) | `tenantUrl`, `sessionId`, `clientName`, `clientVersion` |
+| `MCP Session: Unregistered` | `AddOnUnregisterSession` hook (only fires for long-lived GET listener, not POST-only clients) | `tenantUrl`, `sessionId`, `clientName`, `clientVersion` |
+| `MCP Tool: Called` | tool-handler middleware, post-return | `toolName`, `toolIsError`, `durationMs`, `searchContext`, `sessionId`, `clientName`, `clientVersion` |
+| `MCP Prompt: Fetched` | `AddAfterGetPrompt` (success only) | `promptName`, `sessionId` |
+| `MCP Resource: Fetched` | `AddAfterReadResource` (success only) | `resourceUri`, `sessionId` |
+| `MCP OAuth: Authorization submitted` | `HandleAuthorizeSubmit` after credential validation | `tenantUrl` |
+| `MCP OAuth: Token issued` | `issueTokenPair` for both auth-code and refresh-token grants | `grantType` |
+
+Every event is enriched with identity attributes (`orgId`, `principal`, `userEmail` or `serviceEmail`) by `mergeIdentityAttrs` in [internal/mcp-server/server.go](../internal/mcp-server/server.go). All attribute keys are camelCase (not OTel-dotted) — OTel spans and zap log fields keep the dotted convention for semantic-convention compatibility.
+
+### Async dispatch
+
+All analytics emission runs on a detached goroutine via `trackEventAsync` / `identifyAsync` / `identifyAndTrackAsync` with a 5s budget and its own context carrying credentials, session/tenant context, and the OTel span context (so the identity HTTP request joins the originating tool-call trace). Tool-call latency is never blocked on analytics.
+
+### Client attribution
+
+MCP `ClientInfo` (Name, Version from `InitializeRequest.Params.ClientInfo`) is captured on `AfterInitialize` into an `expirable.LRU[string, mcp.Implementation]` cache keyed by session ID (cap 1024, TTL 30min, sliding window on read). Attribute attach happens synchronously before the async dispatch, so the goroutine snapshots client info correctly even when the session cleanup fires immediately after.
+
+### OAuth
+
+The `oauth.Handler` takes an optional `AnalyticsEmitter` callback (nullable — noop when nil). The MCP server passes a bound method `trackOAuthEvent` that seeds the credentials on the ctx and forwards to `trackEventAsync`. Pre-credential OAuth steps (client registration, authorize GET) are **not** tracked — identity resolution requires credentials in hand.
+
+### Not tracked
+
+- Prompt/Resource errors (routed through the existing `OnError` hook; only success fires an event).
+- Pre-auth OAuth flow steps (no identity yet).
+- Tool-argument payloads (PII risk; `searchContext` conveys intent instead).


### PR DESCRIPTION
## Summary
- resolve analytics identity from `/api/v2/users/me` for auth-token flows and `/api/v1/service_accounts/me` for API-key flows
- send MCP lifecycle and tool analytics as user-scoped events with `groupId=OrgId` and `userId/distinctId` set to the effective identity
- enrich analytics properties with `org_id`, `principal`, and principal-specific email fields (`user_email` or `service_email`)

## Testing
- go test ./...
- Manual E2E test for both auth methods