### PR TITLE
feat(dashboard): normalize GET/write shape quirks and reject filter i…

### DIFF
--- a/pkg/dashboard/basics.go
+++ b/pkg/dashboard/basics.go
@@ -64,7 +64,7 @@ Variables [Critical]:
 
 Default to DYNAMIC Variables:
 - ALWAYS prefer DYNAMIC type variables. They auto-derive dropdown values from OpenTelemetry resource/tag attributes using DynamicVariablesAttribute and DynamicVariablesSource, require no manual SQL, and stay in sync with backend state automatically.
-- Set DynamicVariablesSource to one of: "Traces", "Logs", "Metrics", or "all sources".
+- Set DynamicVariablesSource to one of: "Traces", "Logs", "Metrics", or "All telemetry" (matches the values written by the SigNoz UI dropdown). Note: GET responses may return these in any casing (e.g. "metrics") and older SigNoz versions used the legacy alias "all sources" in place of "All telemetry"; the server normalizes case and aliases on write so echoing a GET payload back is safe.
 - Set DynamicVariablesAttribute to the attribute key (e.g., "service.name", "deployment.environment", "k8s.namespace.name").
 - When you know the attribute (e.g., the user says "filter by service" → use service.name, "filter by environment" → use deployment.environment), create the DYNAMIC variable directly without extra API calls.
 - When the right attribute is NOT obvious, call signoz_get_field_keys with the relevant signal and fieldContext=resource to discover available resource attributes, then pick the best match. Optionally call signoz_get_field_values to preview values and confirm the attribute is populated. Use the discovered attribute as DynamicVariablesAttribute.
@@ -83,6 +83,13 @@ Variable Configuration:
 - Interpret ALL in dynamic variables as no filter, not select everything.
 - Reference variables using $var syntax across Query Builder, ClickHouse SQL, and PromQL; use IN for multi-select inputs.
 - Chain variables by constraining one variable using another, but rely on dynamic variables for automatic dependency handling.
+
+Applying Variables to Panels [Critical — MUST prompt the user]:
+- Before wiring a new variable into panel queries, ALWAYS ask the user which panels it should apply to. Never silently inject a variable reference into every panel.
+- Present the current panels as a list (id + title, grouped by row if rows exist) and offer two choices: (a) apply to all panels, or (b) pick a subset. Wait for the user's selection before generating any queries that reference the variable.
+- Only inject $<var_name> into the filter expressions / queries of panels the user selected; leave the rest untouched.
+- Rationale: variables often apply to a subset of panels (e.g., a service.name filter belongs on RED panels but not on a global latency heatmap). Silent auto-injection produces dashboards that look valid syntactically but over-filter unrelated panels.
+- This applies to both signoz_create_dashboard (introducing a variable at creation time) and signoz_update_dashboard (adding a variable to an existing dashboard).
 
 Links:
 - Dashboard: https://signoz.io/docs/userguide/manage-dashboards/

--- a/pkg/dashboard/dashboardbuilder/builder.go
+++ b/pkg/dashboard/dashboardbuilder/builder.go
@@ -151,7 +151,7 @@ func (b *DashboardBuilder) BuildMap() (map[string]any, error) {
 
 // NewDynamicVariable creates a DYNAMIC type variable.
 // attribute is the field to query (e.g., "service.name").
-// source is one of "Traces", "Logs", "Metrics", or "all sources".
+// source is one of "Traces", "Logs", "Metrics", or "All telemetry".
 func NewDynamicVariable(attribute, source string) *DashboardVariable {
 	return &DashboardVariable{
 		Type:                      VariableTypeDynamic,

--- a/pkg/dashboard/dashboardbuilder/convert.go
+++ b/pkg/dashboard/dashboardbuilder/convert.go
@@ -67,7 +67,7 @@ func ParseFromJSON(data []byte) (*DashboardData, error) {
 			SelectedValue:             rv.SelectedValue,
 			DefaultValue:              rv.DefaultValue,
 			DynamicVariablesAttribute: rv.DynamicVariablesAttribute,
-			DynamicVariablesSource:    rv.DynamicVariablesSource,
+			DynamicVariablesSource:    canonicalDynamicSource(rv.DynamicVariablesSource),
 			Order:                     rv.Order,
 		}
 		if rv.MultiSelect != nil {

--- a/pkg/dashboard/dashboardbuilder/defaults.go
+++ b/pkg/dashboard/dashboardbuilder/defaults.go
@@ -49,7 +49,7 @@ const (
 	DynamicSourceTraces     = "Traces"
 	DynamicSourceLogs       = "Logs"
 	DynamicSourceMetrics    = "Metrics"
-	DynamicSourceAllSources = "all sources"
+	DynamicSourceAllSources = "All telemetry"
 )
 
 // Legend positions.
@@ -227,6 +227,12 @@ func ApplyDefaults(d *DashboardData, multiSelectSet, showALLSet map[string]bool)
 			if w.Query.Builder.QueryFormulas == nil {
 				w.Query.Builder.QueryFormulas = []map[string]any{}
 			}
+			coerceHavingInQueryMaps(w.Query.Builder.QueryData)
+			coerceHavingInQueryMaps(w.Query.Builder.QueryFormulas)
+			uppercaseFilterOpsInQueryMaps(w.Query.Builder.QueryData)
+			uppercaseFilterOpsInQueryMaps(w.Query.Builder.QueryFormulas)
+			normalizeFilterItemsInQueryMaps(w.Query.Builder.QueryData)
+			normalizeFilterItemsInQueryMaps(w.Query.Builder.QueryFormulas)
 		}
 		// Ensure clickhouse_sql and promql are not nil.
 		if w.Query != nil {
@@ -330,6 +336,12 @@ func applyBuilderDefaults(d *DashboardData) {
 			if w.Query.Builder.QueryFormulas == nil {
 				w.Query.Builder.QueryFormulas = []map[string]any{}
 			}
+			coerceHavingInQueryMaps(w.Query.Builder.QueryData)
+			coerceHavingInQueryMaps(w.Query.Builder.QueryFormulas)
+			uppercaseFilterOpsInQueryMaps(w.Query.Builder.QueryData)
+			uppercaseFilterOpsInQueryMaps(w.Query.Builder.QueryFormulas)
+			normalizeFilterItemsInQueryMaps(w.Query.Builder.QueryData)
+			normalizeFilterItemsInQueryMaps(w.Query.Builder.QueryFormulas)
 		}
 		if w.Query != nil {
 			if w.Query.ClickhouseSQL == nil {

--- a/pkg/dashboard/dashboardbuilder/normalize.go
+++ b/pkg/dashboard/dashboardbuilder/normalize.go
@@ -147,10 +147,12 @@ func normalizeFilterItem(item map[string]any) {
 
 // coerceHavingInQueryMaps rewrites the `having` field of each query or formula
 // entry from the GET-shape object `{expression: ""}` to the POST/PUT-shape
-// empty array `[]`. An empty/whitespace expression is treated as "no HAVING"
-// and normalized to an empty array. Any other shape (non-empty expression,
-// already-array form, nil, absent) is left untouched so downstream strict
-// unmarshalling and validation can surface a clear error.
+// empty array `[]`. Coercion is strictly scoped: the object must have an
+// `expression` key that is a string and is empty/whitespace after trim. Any
+// other shape — `expression` missing, `expression` non-string, non-empty
+// expression, already-array form, nil, absent — is left untouched so
+// downstream strict unmarshalling and validation can surface a clear error
+// rather than silently dropping the HAVING clause.
 func coerceHavingInQueryMaps(entries []map[string]any) {
 	for _, entry := range entries {
 		if entry == nil {
@@ -164,8 +166,15 @@ func coerceHavingInQueryMaps(entries []map[string]any) {
 		if !isObj {
 			continue
 		}
-		expr, _ := obj["expression"].(string)
-		if strings.TrimSpace(expr) == "" {
+		rawExpr, hasExpr := obj["expression"]
+		if !hasExpr {
+			continue
+		}
+		exprStr, isStr := rawExpr.(string)
+		if !isStr {
+			continue
+		}
+		if strings.TrimSpace(exprStr) == "" {
 			entry["having"] = []any{}
 		}
 	}

--- a/pkg/dashboard/dashboardbuilder/normalize.go
+++ b/pkg/dashboard/dashboardbuilder/normalize.go
@@ -1,0 +1,172 @@
+package dashboardbuilder
+
+import "strings"
+
+// canonicalDynamicSource maps an incoming dynamicVariablesSource value to the
+// canonical form written by the current SigNoz UI dropdown
+// (frontend AttributeSource enum): "Traces", "Logs", "Metrics", "All telemetry".
+// The GET API and older payloads may return any casing of these values, plus
+// the legacy alias "all sources" which earlier versions of the SigNoz
+// frontend used in place of "All telemetry". LLMs that echo a GET payload
+// back on update would otherwise fail validation unnecessarily.
+//
+// Unknown values pass through untouched so Validate can emit a clear error.
+func canonicalDynamicSource(s string) string {
+	if s == "" {
+		return s
+	}
+	lower := strings.ToLower(strings.TrimSpace(s))
+	if lower == "all sources" {
+		return DynamicSourceAllSources
+	}
+	for _, valid := range ValidDynamicVariableSources {
+		if strings.ToLower(valid) == lower {
+			return valid
+		}
+	}
+	return s
+}
+
+// uppercaseFilterOpsInQueryMaps normalizes `filters.items[].op` within each
+// query or formula entry to uppercase. The SigNoz write API only accepts the
+// Capitalized operator forms in validFilterOperators (IN, NOT_IN, LIKE, ILIKE,
+// EXISTS, CONTAINS, =, !=, ...), while the GET API may return either case.
+// Without this, an LLM that echoes a GET payload back on update trips panel
+// validation for a trivially-fixable case mismatch.
+//
+// Symbol operators (=, !=, >=, >, <=, <) are unaffected by ToUpper. Unknown
+// operators are still rejected downstream by the panel validator.
+func uppercaseFilterOpsInQueryMaps(entries []map[string]any) {
+	for _, entry := range entries {
+		if entry == nil {
+			continue
+		}
+		filters, ok := entry["filters"].(map[string]any)
+		if !ok {
+			continue
+		}
+		items, ok := filters["items"].([]any)
+		if !ok {
+			continue
+		}
+		for _, it := range items {
+			item, ok := it.(map[string]any)
+			if !ok {
+				continue
+			}
+			op, ok := item["op"].(string)
+			if !ok {
+				continue
+			}
+			item["op"] = strings.ToUpper(strings.TrimSpace(op))
+		}
+	}
+}
+
+// normalizeFilterItemsInQueryMaps walks each `filters.items[]` entry on a
+// query or formula and heals two read/write shape quirks that stop the SigNoz
+// UI edit modal from hydrating the filter row — even though the list/render
+// path and the ClickHouse query path both accept the broken shape via the
+// top-level `filter.expression` string:
+//
+//  1. `key.dataType` missing and `key.id` non-canonical. The edit modal
+//     reverse-maps the filter key back to the autocomplete dropdown by id,
+//     which must be `<key>--<dataType>--<type>` (a trailing `--` when type
+//     is empty). Items with an id like `"k8s.node.name"` (missing the whole
+//     suffix) fail to hydrate. We fill `dataType` (inferring from a
+//     well-formed id when possible, else defaulting to `"string"`) and
+//     rebuild `id` only when it is clearly malformed (empty or missing
+//     `--`). Well-formed 3-part and 4-part ids pass through untouched.
+//
+//  2. `value` wrapped in a single-element array around a `$var` reference.
+//     The canonical shape on every other IN-with-variable filter is a plain
+//     string; `["$var"]` causes the form row to misrender. We unwrap only
+//     when the sole element is a `$`-prefixed string, so genuine
+//     single-element arrays of real values are preserved.
+//
+// Everything else (nil items, missing filters, wrong types, non-map keys) is
+// skipped safely.
+func normalizeFilterItemsInQueryMaps(entries []map[string]any) {
+	for _, entry := range entries {
+		if entry == nil {
+			continue
+		}
+		filters, ok := entry["filters"].(map[string]any)
+		if !ok {
+			continue
+		}
+		items, ok := filters["items"].([]any)
+		if !ok {
+			continue
+		}
+		for _, it := range items {
+			item, ok := it.(map[string]any)
+			if !ok {
+				continue
+			}
+			normalizeFilterItem(item)
+		}
+	}
+}
+
+func normalizeFilterItem(item map[string]any) {
+	if key, ok := item["key"].(map[string]any); ok {
+		keyName, _ := key["key"].(string)
+		dataType, _ := key["dataType"].(string)
+		keyType, _ := key["type"].(string)
+		existingID, _ := key["id"].(string)
+
+		// Fill dataType — prefer the value from a well-formed id if present.
+		if dataType == "" && strings.Contains(existingID, "--") {
+			if parts := strings.Split(existingID, "--"); len(parts) >= 2 && parts[1] != "" {
+				dataType = parts[1]
+				key["dataType"] = dataType
+			}
+		}
+		if dataType == "" && keyName != "" {
+			dataType = "string"
+			key["dataType"] = dataType
+		}
+
+		// Rebuild id only when clearly malformed (empty or no `--` separator).
+		// Leaves canonical 3-part (`key--dataType--type`) and richer 4-part
+		// forms (e.g. trailing `--true` for isColumn) alone.
+		if keyName != "" && (existingID == "" || !strings.Contains(existingID, "--")) {
+			key["id"] = keyName + "--" + dataType + "--" + keyType
+		}
+	}
+
+	// Unwrap `["$var"]` → `"$var"`. Preserves multi-element arrays and
+	// single-element arrays of non-variable values.
+	if arr, isArr := item["value"].([]any); isArr && len(arr) == 1 {
+		if s, isStr := arr[0].(string); isStr && strings.HasPrefix(s, "$") {
+			item["value"] = s
+		}
+	}
+}
+
+// coerceHavingInQueryMaps rewrites the `having` field of each query or formula
+// entry from the GET-shape object `{expression: ""}` to the POST/PUT-shape
+// empty array `[]`. An empty/whitespace expression is treated as "no HAVING"
+// and normalized to an empty array. Any other shape (non-empty expression,
+// already-array form, nil, absent) is left untouched so downstream strict
+// unmarshalling and validation can surface a clear error.
+func coerceHavingInQueryMaps(entries []map[string]any) {
+	for _, entry := range entries {
+		if entry == nil {
+			continue
+		}
+		h, ok := entry["having"]
+		if !ok {
+			continue
+		}
+		obj, isObj := h.(map[string]any)
+		if !isObj {
+			continue
+		}
+		expr, _ := obj["expression"].(string)
+		if strings.TrimSpace(expr) == "" {
+			entry["having"] = []any{}
+		}
+	}
+}

--- a/pkg/dashboard/dashboardbuilder/normalize_test.go
+++ b/pkg/dashboard/dashboardbuilder/normalize_test.go
@@ -81,6 +81,34 @@ func TestCoerceHavingInQueryMaps_NonEmptyExpressionUntouched(t *testing.T) {
 	}
 }
 
+func TestCoerceHavingInQueryMaps_MalformedObjectUntouched(t *testing.T) {
+	// Out-of-contract shapes must NOT be silently coerced to []; they should
+	// be left as-is so downstream strict unmarshal can surface an error.
+	cases := []struct {
+		name string
+		obj  map[string]any
+	}{
+		{"no expression key", map[string]any{"foo": "bar"}},
+		{"expression is int", map[string]any{"expression": 123}},
+		{"expression is nil", map[string]any{"expression": nil}},
+		{"expression is array", map[string]any{"expression": []any{"count() > 10"}}},
+		{"expression is map", map[string]any{"expression": map[string]any{"k": "v"}}},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			entries := []map[string]any{{"queryName": "A", "having": c.obj}}
+			coerceHavingInQueryMaps(entries)
+			got, ok := entries[0]["having"].(map[string]any)
+			if !ok {
+				t.Fatalf("expected map[string]any (untouched), got %T", entries[0]["having"])
+			}
+			if !reflect.DeepEqual(got, c.obj) {
+				t.Errorf("having should be preserved unchanged, got %#v", got)
+			}
+		})
+	}
+}
+
 func TestCoerceHavingInQueryMaps_MissingOrNil(t *testing.T) {
 	entries := []map[string]any{
 		{"queryName": "A"},                    // no having key

--- a/pkg/dashboard/dashboardbuilder/normalize_test.go
+++ b/pkg/dashboard/dashboardbuilder/normalize_test.go
@@ -1,0 +1,344 @@
+package dashboardbuilder
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+)
+
+func TestCanonicalDynamicSource(t *testing.T) {
+	cases := []struct {
+		in, out string
+	}{
+		{"", ""},
+		{"Traces", "Traces"},
+		{"Logs", "Logs"},
+		{"Metrics", "Metrics"},
+		{"All telemetry", "All telemetry"},
+		{"traces", "Traces"},
+		{"logs", "Logs"},
+		{"metrics", "Metrics"},
+		{"METRICS", "Metrics"},
+		{"  Logs  ", "Logs"},
+		{"all telemetry", "All telemetry"},
+		{"ALL TELEMETRY", "All telemetry"},
+		{"  All telemetry  ", "All telemetry"},
+		{"all sources", "All telemetry"},
+		{"All Sources", "All telemetry"},
+		{"ALL SOURCES", "All telemetry"},
+		{"  all sources  ", "All telemetry"},
+		{"foobar", "foobar"},
+	}
+	for _, c := range cases {
+		got := canonicalDynamicSource(c.in)
+		if got != c.out {
+			t.Errorf("canonicalDynamicSource(%q) = %q, want %q", c.in, got, c.out)
+		}
+	}
+}
+
+func TestCoerceHavingInQueryMaps_EmptyObjectToEmptyArray(t *testing.T) {
+	entries := []map[string]any{
+		{"queryName": "A", "having": map[string]any{"expression": ""}},
+		{"queryName": "B", "having": map[string]any{"expression": "   "}},
+	}
+	coerceHavingInQueryMaps(entries)
+	for i, entry := range entries {
+		got, ok := entry["having"].([]any)
+		if !ok {
+			t.Fatalf("entry %d: expected []any, got %T", i, entry["having"])
+		}
+		if len(got) != 0 {
+			t.Errorf("entry %d: expected empty array, got %v", i, got)
+		}
+	}
+}
+
+func TestCoerceHavingInQueryMaps_AlreadyArrayUntouched(t *testing.T) {
+	original := []any{map[string]any{"columnName": "count", "op": ">", "value": 10}}
+	entries := []map[string]any{{"queryName": "A", "having": original}}
+	coerceHavingInQueryMaps(entries)
+	got, ok := entries[0]["having"].([]any)
+	if !ok {
+		t.Fatalf("expected []any, got %T", entries[0]["having"])
+	}
+	if !reflect.DeepEqual(got, original) {
+		t.Errorf("expected %v, got %v", original, got)
+	}
+}
+
+func TestCoerceHavingInQueryMaps_NonEmptyExpressionUntouched(t *testing.T) {
+	// Unknown object shape — leave alone so validation surfaces an error.
+	obj := map[string]any{"expression": "count() > 10"}
+	entries := []map[string]any{{"queryName": "A", "having": obj}}
+	coerceHavingInQueryMaps(entries)
+	got, ok := entries[0]["having"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected map[string]any (untouched), got %T", entries[0]["having"])
+	}
+	if got["expression"] != "count() > 10" {
+		t.Errorf("expected expression preserved, got %v", got["expression"])
+	}
+}
+
+func TestCoerceHavingInQueryMaps_MissingOrNil(t *testing.T) {
+	entries := []map[string]any{
+		{"queryName": "A"},                    // no having key
+		{"queryName": "B", "having": nil},     // explicit nil
+		nil,                                   // nil entry
+	}
+	coerceHavingInQueryMaps(entries)
+	if _, exists := entries[0]["having"]; exists {
+		t.Errorf("entry 0: should not add having key when missing")
+	}
+	if entries[1]["having"] != nil {
+		t.Errorf("entry 1: nil having should remain nil, got %v", entries[1]["having"])
+	}
+}
+
+func TestUppercaseFilterOpsInQueryMaps(t *testing.T) {
+	entries := []map[string]any{
+		{
+			"queryName": "A",
+			"filters": map[string]any{
+				"op": "AND",
+				"items": []any{
+					map[string]any{"op": "in", "value": "x"},
+					map[string]any{"op": "Not_In", "value": "y"},
+					map[string]any{"op": "  like  ", "value": "%z%"},
+					map[string]any{"op": "=", "value": 1},
+					map[string]any{"op": "!=", "value": 2},
+					map[string]any{"op": "EXISTS"},
+				},
+			},
+		},
+	}
+	uppercaseFilterOpsInQueryMaps(entries)
+	items := entries[0]["filters"].(map[string]any)["items"].([]any)
+	want := []string{"IN", "NOT_IN", "LIKE", "=", "!=", "EXISTS"}
+	for i, w := range want {
+		got := items[i].(map[string]any)["op"]
+		if got != w {
+			t.Errorf("items[%d].op = %q, want %q", i, got, w)
+		}
+	}
+}
+
+func TestNormalizeFilterItems_HealsMalformedKey(t *testing.T) {
+	// Mirrors the real CPU Used dashboard bug: key.dataType missing,
+	// key.id collapsed to just the key name, value wrapped in a
+	// single-element `$var` array.
+	entries := []map[string]any{
+		{
+			"queryName": "A",
+			"filters": map[string]any{
+				"op": "AND",
+				"items": []any{
+					map[string]any{
+						"id":  "f52f479c-f6ad-41b4-951f-9a03d982d30c",
+						"key": map[string]any{
+							"id":   "k8s.node.name",
+							"key":  "k8s.node.name",
+							"type": "",
+						},
+						"op":    "IN",
+						"value": []any{"$k8s.node.name"},
+					},
+				},
+			},
+		},
+	}
+	normalizeFilterItemsInQueryMaps(entries)
+
+	item := entries[0]["filters"].(map[string]any)["items"].([]any)[0].(map[string]any)
+	key := item["key"].(map[string]any)
+	if key["dataType"] != "string" {
+		t.Errorf("dataType: want %q, got %v", "string", key["dataType"])
+	}
+	if key["id"] != "k8s.node.name--string--" {
+		t.Errorf("id: want %q, got %v", "k8s.node.name--string--", key["id"])
+	}
+	if item["value"] != "$k8s.node.name" {
+		t.Errorf("value: want unwrapped string, got %v (%T)", item["value"], item["value"])
+	}
+}
+
+func TestNormalizeFilterItems_PreservesCanonical(t *testing.T) {
+	// 3-part canonical id, dataType present, scalar string value — untouched.
+	entries := []map[string]any{
+		{
+			"filters": map[string]any{
+				"op": "AND",
+				"items": []any{
+					map[string]any{
+						"key": map[string]any{
+							"id":       "k8s.cluster.name--string--",
+							"key":      "k8s.cluster.name",
+							"type":     "",
+							"dataType": "string",
+						},
+						"op":    "IN",
+						"value": "$k8s.cluster.name",
+					},
+				},
+			},
+		},
+	}
+	before := fmt.Sprintf("%#v", entries[0]["filters"])
+	normalizeFilterItemsInQueryMaps(entries)
+	after := fmt.Sprintf("%#v", entries[0]["filters"])
+	if before != after {
+		t.Errorf("canonical filter item mutated:\n before: %s\n after:  %s", before, after)
+	}
+}
+
+func TestNormalizeFilterItems_PreservesFourPartID(t *testing.T) {
+	// 4-part id (e.g. with trailing isColumn segment) has `--` — should pass through.
+	entries := []map[string]any{
+		{
+			"filters": map[string]any{
+				"op": "AND",
+				"items": []any{
+					map[string]any{
+						"key": map[string]any{
+							"id":       "serviceName--string--tag--true",
+							"key":      "serviceName",
+							"type":     "tag",
+							"dataType": "string",
+						},
+						"op":    "=",
+						"value": "frontend",
+					},
+				},
+			},
+		},
+	}
+	normalizeFilterItemsInQueryMaps(entries)
+	key := entries[0]["filters"].(map[string]any)["items"].([]any)[0].(map[string]any)["key"].(map[string]any)
+	if key["id"] != "serviceName--string--tag--true" {
+		t.Errorf("4-part id should be preserved, got %v", key["id"])
+	}
+}
+
+func TestNormalizeFilterItems_InfersDataTypeFromID(t *testing.T) {
+	// dataType missing but id is well-formed → infer dataType from id.
+	entries := []map[string]any{
+		{
+			"filters": map[string]any{
+				"op": "AND",
+				"items": []any{
+					map[string]any{
+						"key": map[string]any{
+							"id":   "http.status_code--int64--tag",
+							"key":  "http.status_code",
+							"type": "tag",
+						},
+						"op":    "=",
+						"value": 500,
+					},
+				},
+			},
+		},
+	}
+	normalizeFilterItemsInQueryMaps(entries)
+	key := entries[0]["filters"].(map[string]any)["items"].([]any)[0].(map[string]any)["key"].(map[string]any)
+	if key["dataType"] != "int64" {
+		t.Errorf("dataType inferred from id: want %q, got %v", "int64", key["dataType"])
+	}
+	if key["id"] != "http.status_code--int64--tag" {
+		t.Errorf("id should be preserved, got %v", key["id"])
+	}
+}
+
+func TestNormalizeFilterItems_ValueUnwrapOnlyForVariables(t *testing.T) {
+	// Single-element arrays of non-variable values must NOT be unwrapped.
+	entries := []map[string]any{
+		{
+			"filters": map[string]any{
+				"op": "AND",
+				"items": []any{
+					map[string]any{
+						"key": map[string]any{
+							"id":       "env--string--tag",
+							"key":      "env",
+							"type":     "tag",
+							"dataType": "string",
+						},
+						"op":    "IN",
+						"value": []any{"production"}, // single real value — keep as array
+					},
+					map[string]any{
+						"key": map[string]any{
+							"id":       "env--string--tag",
+							"key":      "env",
+							"type":     "tag",
+							"dataType": "string",
+						},
+						"op":    "IN",
+						"value": []any{"production", "staging"}, // multi — keep
+					},
+				},
+			},
+		},
+	}
+	normalizeFilterItemsInQueryMaps(entries)
+	items := entries[0]["filters"].(map[string]any)["items"].([]any)
+	if _, isArr := items[0].(map[string]any)["value"].([]any); !isArr {
+		t.Errorf("single non-var value should stay as array, got %T", items[0].(map[string]any)["value"])
+	}
+	if arr, _ := items[1].(map[string]any)["value"].([]any); len(arr) != 2 {
+		t.Errorf("multi-element array should be preserved, got %v", items[1].(map[string]any)["value"])
+	}
+}
+
+func TestNormalizeFilterItems_MissingOrNil(t *testing.T) {
+	entries := []map[string]any{
+		nil,
+		{"queryName": "A"},
+		{"queryName": "B", "filters": nil},
+		{"queryName": "C", "filters": map[string]any{"items": []any{"not-a-map", map[string]any{}}}},
+	}
+	// Should not panic.
+	normalizeFilterItemsInQueryMaps(entries)
+}
+
+func TestUppercaseFilterOpsInQueryMaps_MissingOrNil(t *testing.T) {
+	entries := []map[string]any{
+		nil,                               // nil entry
+		{"queryName": "A"},                // no filters key
+		{"queryName": "B", "filters": nil}, // explicit nil
+		{"queryName": "C", "filters": "oops"}, // wrong type
+		{"queryName": "D", "filters": map[string]any{"op": "AND"}}, // no items
+		{"queryName": "E", "filters": map[string]any{"items": "oops"}}, // wrong items type
+		{"queryName": "F", "filters": map[string]any{"items": []any{
+			"not-a-map",                        // non-map item
+			map[string]any{},                   // item without op
+			map[string]any{"op": 123},          // non-string op
+		}}},
+	}
+	// Should not panic and should leave non-normalizable entries untouched.
+	uppercaseFilterOpsInQueryMaps(entries)
+
+	if _, exists := entries[1]["filters"]; exists {
+		t.Errorf("entry 1: should not add filters key when missing")
+	}
+	if entries[2]["filters"] != nil {
+		t.Errorf("entry 2: nil filters should remain nil")
+	}
+	if entries[3]["filters"] != "oops" {
+		t.Errorf("entry 3: non-map filters should be untouched")
+	}
+	if _, exists := entries[4]["filters"].(map[string]any)["items"]; exists {
+		t.Errorf("entry 4: should not add items key when missing")
+	}
+	fItems := entries[6]["filters"].(map[string]any)["items"].([]any)
+	if fItems[0] != "not-a-map" {
+		t.Errorf("entry 6 items[0]: non-map should be untouched")
+	}
+	if _, exists := fItems[1].(map[string]any)["op"]; exists {
+		t.Errorf("entry 6 items[1]: missing op should not be added")
+	}
+	if fItems[2].(map[string]any)["op"] != 123 {
+		t.Errorf("entry 6 items[2]: non-string op should be untouched")
+	}
+}

--- a/pkg/dashboard/dashboardbuilder/validate.go
+++ b/pkg/dashboard/dashboardbuilder/validate.go
@@ -174,6 +174,62 @@ func validateBuilderQuery(prefix string, q *Query, errs *ValidationError) {
 		if expr == "" {
 			errs.Add(qPrefix+".expression", "is required and must be a non-empty string")
 		}
+
+		validateFilterExpressionConsistency(qPrefix, qd, errs)
+	}
+
+	for i, qf := range q.Builder.QueryFormulas {
+		qPrefix := fmt.Sprintf("%s.builder.queryFormulas[%d]", prefix, i)
+		validateFilterExpressionConsistency(qPrefix, qf, errs)
+	}
+}
+
+// validateFilterExpressionConsistency rejects builder queries whose
+// `filter.expression` string omits any key present in `filters.items[]`. Both
+// the SigNoz list/graph renderer (which reads `filter.expression` directly)
+// and the edit-modal expression-reconstruction path (which walks
+// `filters.items[]`) must agree, or the two produce different query payloads:
+// the list view silently drops predicates, and the edit modal trips on an
+// item it cannot find a home for. The SigNoz backend tolerates this
+// inconsistency on write (it does not reject mismatched payloads), so we
+// enforce it here — permissive upstream does not mean correct.
+//
+// Only runs when both sides are non-empty: an empty `filter.expression` lets
+// SigNoz build from items, and an empty `filters.items[]` means
+// expression-only is intentional.
+func validateFilterExpressionConsistency(prefix string, qd map[string]any, errs *ValidationError) {
+	filterMap, _ := qd["filter"].(map[string]any)
+	expression, _ := filterMap["expression"].(string)
+	if strings.TrimSpace(expression) == "" {
+		return
+	}
+	filtersMap, _ := qd["filters"].(map[string]any)
+	itemsAny, _ := filtersMap["items"].([]any)
+	if len(itemsAny) == 0 {
+		return
+	}
+	var missing []string
+	for _, it := range itemsAny {
+		item, ok := it.(map[string]any)
+		if !ok {
+			continue
+		}
+		keyObj, ok := item["key"].(map[string]any)
+		if !ok {
+			continue
+		}
+		keyName, _ := keyObj["key"].(string)
+		if keyName == "" {
+			continue
+		}
+		if !strings.Contains(expression, keyName) {
+			missing = append(missing, keyName)
+		}
+	}
+	if len(missing) > 0 {
+		errs.Addf(prefix+".filter.expression",
+			"is inconsistent with filters.items[]: keys %v are present in items but missing from expression %q. Every filter item key must appear in filter.expression so the list view and edit modal render the same predicates.",
+			missing, expression)
 	}
 }
 

--- a/pkg/dashboard/dashboardbuilder/validate.go
+++ b/pkg/dashboard/dashboardbuilder/validate.go
@@ -222,7 +222,7 @@ func validateFilterExpressionConsistency(prefix string, qd map[string]any, errs 
 		if keyName == "" {
 			continue
 		}
-		if !strings.Contains(expression, keyName) {
+		if !containsKeyAsIdentifier(expression, keyName) {
 			missing = append(missing, keyName)
 		}
 	}
@@ -231,6 +231,53 @@ func validateFilterExpressionConsistency(prefix string, qd map[string]any, errs 
 			"is inconsistent with filters.items[]: keys %v are present in items but missing from expression %q. Every filter item key must appear in filter.expression so the list view and edit modal render the same predicates.",
 			missing, expression)
 	}
+}
+
+// containsKeyAsIdentifier reports whether `key` appears in `expression` as a
+// standalone identifier — that is, flanked by characters that cannot be part
+// of a SigNoz attribute name, or by the start/end of the expression. This
+// avoids false positives where a shorter key substring-matches inside a
+// longer identifier (e.g. key "service.name" appearing in "service.name_v2",
+// or key "k8s.namespace" appearing in "k8s.namespace.name").
+//
+// Attribute names are ASCII and may contain [a-zA-Z0-9_.] — the dot is part
+// of the identifier because OpenTelemetry semantic convention names like
+// "k8s.namespace.name" are a single attribute, not three. Anything outside
+// that set (whitespace, operators, variable prefixes, quotes, parentheses)
+// is a valid boundary.
+func containsKeyAsIdentifier(expression, key string) bool {
+	if key == "" {
+		return false
+	}
+	for idx := 0; idx <= len(expression)-len(key); {
+		i := strings.Index(expression[idx:], key)
+		if i < 0 {
+			return false
+		}
+		pos := idx + i
+		endPos := pos + len(key)
+		beforeOK := pos == 0 || !isAttributeNameByte(expression[pos-1])
+		afterOK := endPos == len(expression) || !isAttributeNameByte(expression[endPos])
+		if beforeOK && afterOK {
+			return true
+		}
+		idx = pos + 1
+	}
+	return false
+}
+
+func isAttributeNameByte(b byte) bool {
+	switch {
+	case b >= 'a' && b <= 'z':
+		return true
+	case b >= 'A' && b <= 'Z':
+		return true
+	case b >= '0' && b <= '9':
+		return true
+	case b == '_' || b == '.':
+		return true
+	}
+	return false
 }
 
 func validateClickHouseQueries(prefix string, q *Query, errs *ValidationError) {

--- a/pkg/dashboard/dashboardbuilder/validate_test.go
+++ b/pkg/dashboard/dashboardbuilder/validate_test.go
@@ -606,6 +606,145 @@ func TestValidate_FilterExpressionMismatchOnFormulas(t *testing.T) {
 	assertHasFieldError(t, verr, "widgets[0].query.builder.queryFormulas[0].filter.expression")
 }
 
+func TestValidate_FilterExpressionRejectsSubstringMatch(t *testing.T) {
+	// key "service.name" should NOT match substring inside "service.name_v2".
+	// The consistency guard must flag the key as missing.
+	d := &DashboardData{
+		Title:     "Test",
+		Version:   DashboardVersion,
+		Variables: map[string]*DashboardVariable{},
+		Widgets: []WidgetOrRow{
+			{
+				ID: "w1", PanelTypes: PanelTypeGraph, Title: "W1",
+				Query: &Query{
+					QueryType: QueryTypeBuilder,
+					Builder: &BuilderData{
+						QueryData: []map[string]any{
+							{
+								"queryName":  "A",
+								"dataSource": "metrics",
+								"expression": "A",
+								"filter":     map[string]any{"expression": "service.name_v2 = 'x'"},
+								"filters": map[string]any{
+									"op":    "AND",
+									"items": []any{map[string]any{"key": map[string]any{"key": "service.name"}, "op": "=", "value": "frontend"}},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		Layout: []LayoutItem{{I: "w1", X: 0, Y: 0, W: 6, H: 6}},
+	}
+	verr := Validate(d)
+	if verr == nil {
+		t.Fatal("expected rejection: service.name should not match substring of service.name_v2")
+	}
+	assertHasFieldError(t, verr, "filter.expression")
+}
+
+func TestValidate_FilterExpressionRejectsShorterKeyPrefix(t *testing.T) {
+	// key "k8s.namespace" should NOT match inside "k8s.namespace.name"
+	// because the following "." is a valid identifier char, not a boundary.
+	d := &DashboardData{
+		Title:     "Test",
+		Version:   DashboardVersion,
+		Variables: map[string]*DashboardVariable{},
+		Widgets: []WidgetOrRow{
+			{
+				ID: "w1", PanelTypes: PanelTypeGraph, Title: "W1",
+				Query: &Query{
+					QueryType: QueryTypeBuilder,
+					Builder: &BuilderData{
+						QueryData: []map[string]any{
+							{
+								"queryName":  "A",
+								"dataSource": "metrics",
+								"expression": "A",
+								"filter":     map[string]any{"expression": "k8s.namespace.name IN $k8s.namespace.name"},
+								"filters": map[string]any{
+									"op":    "AND",
+									"items": []any{map[string]any{"key": map[string]any{"key": "k8s.namespace"}, "op": "IN", "value": "$k8s.namespace"}},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		Layout: []LayoutItem{{I: "w1", X: 0, Y: 0, W: 6, H: 6}},
+	}
+	verr := Validate(d)
+	if verr == nil {
+		t.Fatal("expected rejection: k8s.namespace is not a valid identifier inside k8s.namespace.name")
+	}
+	assertHasFieldError(t, verr, "filter.expression")
+}
+
+func TestValidate_FilterExpressionAcceptsStandaloneVarReference(t *testing.T) {
+	// key "name" should match the `$name` reference (preceded by `$` which
+	// is a non-attribute char, followed by end-of-string). This verifies
+	// legitimate standalone references aren't over-rejected by the boundary
+	// check.
+	d := &DashboardData{
+		Title:     "Test",
+		Version:   DashboardVersion,
+		Variables: map[string]*DashboardVariable{},
+		Widgets: []WidgetOrRow{
+			{
+				ID: "w1", PanelTypes: PanelTypeGraph, Title: "W1",
+				Query: &Query{
+					QueryType: QueryTypeBuilder,
+					Builder: &BuilderData{
+						QueryData: []map[string]any{
+							{
+								"queryName":  "A",
+								"dataSource": "metrics",
+								"expression": "A",
+								"filter":     map[string]any{"expression": "name IN $name"},
+								"filters": map[string]any{
+									"op":    "AND",
+									"items": []any{map[string]any{"key": map[string]any{"key": "name"}, "op": "IN", "value": "$name"}},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		Layout: []LayoutItem{{I: "w1", X: 0, Y: 0, W: 6, H: 6}},
+	}
+	if verr := Validate(d); verr != nil {
+		t.Fatalf("expected no errors for standalone identifier match, got: %v", verr)
+	}
+}
+
+func TestContainsKeyAsIdentifier(t *testing.T) {
+	// Direct unit coverage of the boundary logic for clarity.
+	cases := []struct {
+		expression, key string
+		want            bool
+	}{
+		{"", "name", false},
+		{"name", "", false},
+		{"name", "name", true},
+		{"service.name IN $service_name", "service.name", true},
+		{"service.name_v2 = 'x'", "service.name", false},
+		{"k8s.namespace.name IN $k8s.namespace.name", "k8s.namespace", false},
+		{"k8s.namespace.name IN $k8s.namespace.name", "k8s.namespace.name", true},
+		{"(service.name = 'x')", "service.name", true},
+		{"xservice.name = 'x'", "service.name", false},
+		{"service.names = 'x'", "service.name", false},
+	}
+	for _, c := range cases {
+		got := containsKeyAsIdentifier(c.expression, c.key)
+		if got != c.want {
+			t.Errorf("containsKeyAsIdentifier(%q, %q) = %v, want %v", c.expression, c.key, got, c.want)
+		}
+	}
+}
+
 // --- helpers ---
 
 func validBuilderQuery() *Query {

--- a/pkg/dashboard/dashboardbuilder/validate_test.go
+++ b/pkg/dashboard/dashboardbuilder/validate_test.go
@@ -411,6 +411,201 @@ func TestValidate_InvalidLegendPosition(t *testing.T) {
 	assertHasFieldError(t, verr, "widgets[0].legendPosition")
 }
 
+// --- filter.expression / filters.items[] consistency ---
+
+func TestValidate_FilterExpressionMissingItemKey(t *testing.T) {
+	// The CPU Used bug pattern: filter.expression has two predicates but
+	// filters.items[] has three entries (namespace missing from expression).
+	d := &DashboardData{
+		Title:     "Test",
+		Version:   DashboardVersion,
+		Variables: map[string]*DashboardVariable{},
+		Widgets: []WidgetOrRow{
+			{
+				ID: "w1", PanelTypes: PanelTypeGraph, Title: "W1",
+				Query: &Query{
+					QueryType: QueryTypeBuilder,
+					Builder: &BuilderData{
+						QueryData: []map[string]any{
+							{
+								"queryName":  "A",
+								"dataSource": "metrics",
+								"expression": "A",
+								"filter": map[string]any{
+									"expression": "k8s.cluster.name IN $k8s.cluster.name AND k8s.node.name IN $k8s.node.name",
+								},
+								"filters": map[string]any{
+									"op": "AND",
+									"items": []any{
+										map[string]any{"key": map[string]any{"key": "k8s.cluster.name"}, "op": "IN", "value": "$k8s.cluster.name"},
+										map[string]any{"key": map[string]any{"key": "k8s.node.name"}, "op": "IN", "value": "$k8s.node.name"},
+										map[string]any{"key": map[string]any{"key": "k8s.namespace.name"}, "op": "IN", "value": "$k8s.namespace.name"},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		Layout: []LayoutItem{{I: "w1", X: 0, Y: 0, W: 6, H: 6}},
+	}
+	verr := Validate(d)
+	if verr == nil {
+		t.Fatal("expected validation error for filter.expression missing item key")
+	}
+	assertHasFieldError(t, verr, "widgets[0].query.builder.queryData[0].filter.expression")
+	if !strings.Contains(verr.Error(), "k8s.namespace.name") {
+		t.Errorf("error should name the missing key, got: %v", verr)
+	}
+}
+
+func TestValidate_FilterExpressionConsistent(t *testing.T) {
+	// All three item keys appear in the expression — should pass.
+	d := &DashboardData{
+		Title:     "Test",
+		Version:   DashboardVersion,
+		Variables: map[string]*DashboardVariable{},
+		Widgets: []WidgetOrRow{
+			{
+				ID: "w1", PanelTypes: PanelTypeGraph, Title: "W1",
+				Query: &Query{
+					QueryType: QueryTypeBuilder,
+					Builder: &BuilderData{
+						QueryData: []map[string]any{
+							{
+								"queryName":  "A",
+								"dataSource": "metrics",
+								"expression": "A",
+								"filter": map[string]any{
+									"expression": "k8s.cluster.name IN $k8s.cluster.name AND k8s.node.name IN $k8s.node.name AND k8s.namespace.name IN $k8s.namespace.name",
+								},
+								"filters": map[string]any{
+									"op": "AND",
+									"items": []any{
+										map[string]any{"key": map[string]any{"key": "k8s.cluster.name"}, "op": "IN", "value": "$k8s.cluster.name"},
+										map[string]any{"key": map[string]any{"key": "k8s.node.name"}, "op": "IN", "value": "$k8s.node.name"},
+										map[string]any{"key": map[string]any{"key": "k8s.namespace.name"}, "op": "IN", "value": "$k8s.namespace.name"},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		Layout: []LayoutItem{{I: "w1", X: 0, Y: 0, W: 6, H: 6}},
+	}
+	if verr := Validate(d); verr != nil {
+		t.Fatalf("expected no errors for consistent expression/items, got: %v", verr)
+	}
+}
+
+func TestValidate_FilterExpressionEmptySkipped(t *testing.T) {
+	// Empty filter.expression: SigNoz builds from items, no consistency check needed.
+	d := &DashboardData{
+		Title:     "Test",
+		Version:   DashboardVersion,
+		Variables: map[string]*DashboardVariable{},
+		Widgets: []WidgetOrRow{
+			{
+				ID: "w1", PanelTypes: PanelTypeGraph, Title: "W1",
+				Query: &Query{
+					QueryType: QueryTypeBuilder,
+					Builder: &BuilderData{
+						QueryData: []map[string]any{
+							{
+								"queryName":  "A",
+								"dataSource": "metrics",
+								"expression": "A",
+								"filter":     map[string]any{"expression": ""},
+								"filters": map[string]any{
+									"op":    "AND",
+									"items": []any{map[string]any{"key": map[string]any{"key": "service.name"}, "op": "IN", "value": "frontend"}},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		Layout: []LayoutItem{{I: "w1", X: 0, Y: 0, W: 6, H: 6}},
+	}
+	if verr := Validate(d); verr != nil {
+		t.Fatalf("expected no errors when filter.expression is empty, got: %v", verr)
+	}
+}
+
+func TestValidate_FilterItemsEmptySkipped(t *testing.T) {
+	// Expression-only filter (no items array): nothing to cross-check.
+	d := &DashboardData{
+		Title:     "Test",
+		Version:   DashboardVersion,
+		Variables: map[string]*DashboardVariable{},
+		Widgets: []WidgetOrRow{
+			{
+				ID: "w1", PanelTypes: PanelTypeGraph, Title: "W1",
+				Query: &Query{
+					QueryType: QueryTypeBuilder,
+					Builder: &BuilderData{
+						QueryData: []map[string]any{
+							{
+								"queryName":  "A",
+								"dataSource": "metrics",
+								"expression": "A",
+								"filter":     map[string]any{"expression": "service.name = 'frontend'"},
+							},
+						},
+					},
+				},
+			},
+		},
+		Layout: []LayoutItem{{I: "w1", X: 0, Y: 0, W: 6, H: 6}},
+	}
+	if verr := Validate(d); verr != nil {
+		t.Fatalf("expected no errors when filters.items is empty, got: %v", verr)
+	}
+}
+
+func TestValidate_FilterExpressionMismatchOnFormulas(t *testing.T) {
+	// queryFormulas can also carry filters (rare); same consistency rule applies.
+	d := &DashboardData{
+		Title:     "Test",
+		Version:   DashboardVersion,
+		Variables: map[string]*DashboardVariable{},
+		Widgets: []WidgetOrRow{
+			{
+				ID: "w1", PanelTypes: PanelTypeGraph, Title: "W1",
+				Query: &Query{
+					QueryType: QueryTypeBuilder,
+					Builder: &BuilderData{
+						QueryData: []map[string]any{
+							{"queryName": "A", "dataSource": "metrics", "expression": "A"},
+						},
+						QueryFormulas: []map[string]any{
+							{
+								"queryName":  "F1",
+								"expression": "A",
+								"filter":     map[string]any{"expression": "service.name = 'frontend'"},
+								"filters": map[string]any{
+									"op":    "AND",
+									"items": []any{map[string]any{"key": map[string]any{"key": "region"}, "op": "=", "value": "us-east"}},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		Layout: []LayoutItem{{I: "w1", X: 0, Y: 0, W: 6, H: 6}},
+	}
+	verr := Validate(d)
+	if verr == nil {
+		t.Fatal("expected error for formula filter mismatch")
+	}
+	assertHasFieldError(t, verr, "widgets[0].query.builder.queryFormulas[0].filter.expression")
+}
+
 // --- helpers ---
 
 func validBuilderQuery() *Query {

--- a/pkg/dashboard/pipeline_test.go
+++ b/pkg/dashboard/pipeline_test.go
@@ -175,6 +175,220 @@ func TestValidate_DynamicVariableExplicitFalse(t *testing.T) {
 	assert.Equal(t, false, svcVar["multiSelect"])
 }
 
+// --- GET-shape normalization (the two API asymmetries) ---
+
+func TestValidate_NormalizesGetShapePayload(t *testing.T) {
+	// Mirrors a real round-trip: fetch via GET (lowercase dynamicVariablesSource,
+	// object-form having, lowercase filter op, legacy "all sources" alias),
+	// mutate nothing, send back via PUT. Without normalization this would fail
+	// at panel unmarshal (strict []HavingClause), variable validation (strict
+	// canonical-form enum), and panel-validator filter operator check.
+	data := toJSON(t, map[string]any{
+		"title": "Round-trip",
+		"variables": map[string]any{
+			"service_name": map[string]any{
+				"type":                      "DYNAMIC",
+				"dynamicVariablesAttribute": "service.name",
+				"dynamicVariablesSource":    "metrics", // lowercase as returned by GET
+			},
+			"any_attr": map[string]any{
+				"type":                      "DYNAMIC",
+				"dynamicVariablesAttribute": "deployment.environment",
+				"dynamicVariablesSource":    "all sources", // legacy alias from older SigNoz versions
+			},
+		},
+		"widgets": []map[string]any{
+			{
+				"id": "w1", "panelTypes": "value", "title": "Requests",
+				"query": map[string]any{
+					"queryType": "builder",
+					"builder": map[string]any{
+						"queryData": []map[string]any{
+							{
+								"queryName":  "A",
+								"dataSource": "traces",
+								"expression": "A",
+								"having":     map[string]any{"expression": ""}, // object form as returned by GET
+								"filters": map[string]any{
+									"op": "AND",
+									"items": []any{
+										map[string]any{
+											"key":   map[string]any{"key": "service.name", "dataType": "string"},
+											"op":    "in", // lowercase as returned by GET
+											"value": "$service_name",
+										},
+									},
+								},
+							},
+						},
+						"queryFormulas": []map[string]any{
+							{"queryName": "F1", "expression": "A", "having": map[string]any{"expression": ""}},
+						},
+					},
+				},
+			},
+		},
+	})
+
+	out, err := Validate(data)
+	require.NoError(t, err)
+
+	var result map[string]any
+	require.NoError(t, json.Unmarshal(out, &result))
+
+	// Source normalized to Capitalized form.
+	svc := result["variables"].(map[string]any)["service_name"].(map[string]any)
+	assert.Equal(t, "Metrics", svc["dynamicVariablesSource"])
+
+	// Legacy "all sources" aliased to canonical "All telemetry".
+	anyAttr := result["variables"].(map[string]any)["any_attr"].(map[string]any)
+	assert.Equal(t, "All telemetry", anyAttr["dynamicVariablesSource"])
+
+	// having coerced to empty array on both queryData and queryFormulas.
+	widgets := result["widgets"].([]any)
+	builder := widgets[0].(map[string]any)["query"].(map[string]any)["builder"].(map[string]any)
+
+	qd := builder["queryData"].([]any)
+	qdHaving, ok := qd[0].(map[string]any)["having"].([]any)
+	require.True(t, ok, "queryData[0].having must be an array, got %T", qd[0].(map[string]any)["having"])
+	assert.Empty(t, qdHaving)
+
+	// filters.items[].op normalized to uppercase.
+	filters := qd[0].(map[string]any)["filters"].(map[string]any)
+	items := filters["items"].([]any)
+	assert.Equal(t, "IN", items[0].(map[string]any)["op"])
+
+	qf := builder["queryFormulas"].([]any)
+	qfHaving, ok := qf[0].(map[string]any)["having"].([]any)
+	require.True(t, ok, "queryFormulas[0].having must be an array, got %T", qf[0].(map[string]any)["having"])
+	assert.Empty(t, qfHaving)
+}
+
+func TestValidate_InvalidDynamicSourceStillRejected(t *testing.T) {
+	// Normalization must not silently accept garbage — truly invalid values
+	// should still produce a validation error.
+	data := toJSON(t, map[string]any{
+		"title": "Test",
+		"variables": map[string]any{
+			"svc": map[string]any{
+				"type":                      "DYNAMIC",
+				"dynamicVariablesAttribute": "service.name",
+				"dynamicVariablesSource":    "foobar",
+			},
+		},
+		"widgets": []map[string]any{
+			{
+				"id": "w1", "panelTypes": "value", "title": "T",
+				"query": map[string]any{
+					"queryType": "builder",
+					"builder":   map[string]any{"queryData": []map[string]any{{"queryName": "A", "dataSource": "traces", "expression": "A"}}},
+				},
+			},
+		},
+	})
+	_, err := Validate(data)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "dynamicVariablesSource")
+}
+
+func TestValidate_RejectsFilterExpressionMismatch(t *testing.T) {
+	// Payload with 3 items but a 2-clause expression must be rejected
+	// regardless of whether SigNoz would accept it — the list view and edit
+	// modal see different predicates otherwise.
+	data := toJSON(t, map[string]any{
+		"title": "Mismatch",
+		"widgets": []map[string]any{
+			{
+				"id": "w1", "panelTypes": "value", "title": "T",
+				"query": map[string]any{
+					"queryType": "builder",
+					"builder": map[string]any{
+						"queryData": []map[string]any{
+							{
+								"queryName":  "A",
+								"dataSource": "metrics",
+								"expression": "A",
+								"filter": map[string]any{
+									"expression": "k8s.cluster.name IN $k8s.cluster.name AND k8s.node.name IN $k8s.node.name",
+								},
+								"filters": map[string]any{
+									"op": "AND",
+									"items": []any{
+										map[string]any{"key": map[string]any{"key": "k8s.cluster.name", "dataType": "string", "id": "k8s.cluster.name--string--", "type": ""}, "op": "IN", "value": "$k8s.cluster.name"},
+										map[string]any{"key": map[string]any{"key": "k8s.node.name", "dataType": "string", "id": "k8s.node.name--string--", "type": ""}, "op": "IN", "value": "$k8s.node.name"},
+										map[string]any{"key": map[string]any{"key": "k8s.namespace.name", "dataType": "string", "id": "k8s.namespace.name--string--", "type": ""}, "op": "IN", "value": "$k8s.namespace.name"},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	})
+	_, err := Validate(data)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "k8s.namespace.name")
+	assert.Contains(t, err.Error(), "filter.expression")
+}
+
+func TestValidate_NormalizesMalformedFilterItem(t *testing.T) {
+	// Mirrors the "CPU Used" dashboard bug: the k8s.node.name filter item
+	// has a missing key.dataType, non-canonical key.id, and a value wrapped
+	// in a single-element $var array. List/render tolerates this (ClickHouse
+	// uses filter.expression) but the edit modal fails to hydrate. Our
+	// normalizer should heal all three deviations before the payload leaves
+	// Validate.
+	data := toJSON(t, map[string]any{
+		"title": "Fixture",
+		"widgets": []map[string]any{
+			{
+				"id": "w1", "panelTypes": "value", "title": "CPU Used",
+				"query": map[string]any{
+					"queryType": "builder",
+					"builder": map[string]any{
+						"queryData": []map[string]any{
+							{
+								"queryName":  "A",
+								"dataSource": "metrics",
+								"expression": "A",
+								"filters": map[string]any{
+									"op": "AND",
+									"items": []any{
+										map[string]any{
+											"id":  "broken-item",
+											"key": map[string]any{
+												"id":   "k8s.node.name",
+												"key":  "k8s.node.name",
+												"type": "",
+											},
+											"op":    "IN",
+											"value": []any{"$k8s.node.name"},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	})
+
+	out, err := Validate(data)
+	require.NoError(t, err)
+
+	var result map[string]any
+	require.NoError(t, json.Unmarshal(out, &result))
+
+	item := result["widgets"].([]any)[0].(map[string]any)["query"].(map[string]any)["builder"].(map[string]any)["queryData"].([]any)[0].(map[string]any)["filters"].(map[string]any)["items"].([]any)[0].(map[string]any)
+	key := item["key"].(map[string]any)
+
+	assert.Equal(t, "string", key["dataType"], "dataType should be filled")
+	assert.Equal(t, "k8s.node.name--string--", key["id"], "id should be canonicalized")
+	assert.Equal(t, "$k8s.node.name", item["value"], "value should be unwrapped")
+}
+
 // --- Auto-layout ---
 
 func TestValidate_AutoLayoutGenerated(t *testing.T) {

--- a/pkg/dashboard/widgets_examples.go
+++ b/pkg/dashboard/widgets_examples.go
@@ -40,6 +40,14 @@ INCORRECT: groupBy: - name: llm.model_name # ERROR: Should be 'key' dataType: st
 
 ERROR: Using 'name' instead of 'key' in groupBy causes query errors. SOLUTION: Always use 'key' field in groupBy.
 
+--- having (write-shape) ---
+
+CORRECT (write): having: []  OR  having: [{columnName: count, op: '>', value: 10}]
+
+INCORRECT (write): having: {expression: ""}  # this is the GET-response shape; sending it back on write fails.
+
+ERROR: Sending the object form {expression: ""} to POST/PUT is rejected. SOLUTION: Use the array form. The server auto-coerces the empty object form to [] when round-tripping a GET payload, but prefer sending [] directly.
+
 --- filters.items (structured filters) ---
 
 CORRECT: filters: op: AND items: - key: key: service.name # Use 'key' not 'name' dataType: string op: IN value: $service_name
@@ -47,6 +55,31 @@ CORRECT: filters: op: AND items: - key: key: service.name # Use 'key' not 'name'
 INCORRECT: filters: items: - key: name: service.name # ERROR: Should be 'key' op: IN value: $service_name
 
 ERROR: Using 'name' in filter items causes filter parsing errors. SOLUTION: Always use 'key' field in filters.items[].key.
+
+--- filters.items[].key (write-shape for edit-modal hydration) ---
+
+CORRECT (write):
+  filters.items[0].key = {key: k8s.node.name, dataType: string, type: "", id: "k8s.node.name--string--"}
+
+INCORRECT (write):
+  filters.items[0].key = {key: k8s.node.name, type: ""}                              # missing dataType, malformed id
+  filters.items[0].key = {key: k8s.node.name, dataType: string, id: "k8s.node.name"}  # id missing --<dataType>--<type> suffix
+
+Canonical id form is <key>--<dataType>--<type> (trailing "--" is correct when type is empty). The SigNoz edit modal reverse-maps the key back to the autocomplete dropdown by this id; a malformed id makes the filter row fail to hydrate even though the list/graph renders fine (it uses the top-level filter.expression string).
+
+For variable references on IN filters, always send value as a plain string like "$var", not a single-element array like ["$var"]. The array form causes the form row to misrender.
+
+The server auto-heals all three cases (fills dataType, rebuilds malformed id, unwraps single-$var arrays) so a GET-echoed payload round-trips cleanly — but prefer sending the canonical shape directly.
+
+--- filters.items[].op (write-shape casing) ---
+
+CORRECT (write): op: IN  OR  op: NOT_IN  OR  op: LIKE  OR  op: EXISTS  OR  op: =  OR  op: !=
+
+INCORRECT (write): op: in  OR  op: Not_In  OR  op: like  # lowercase/mixed-case as returned by some GET responses
+
+Canonical operators (uppercase word ops; symbol ops unaffected by case): IN, NOT_IN, LIKE, NOT_LIKE, ILIKE, NOT_ILIKE, REGEX, NOT_REGEX, EXISTS, NOT_EXISTS, CONTAINS, NOT_CONTAINS, HAS, NHAS, =, !=, >=, >, <=, <.
+
+ERROR: Sending lowercase or mixed-case word operators to POST/PUT is rejected by panel validation. SOLUTION: Use uppercase. The server trims + uppercases filter operators when round-tripping a GET payload, but prefer sending uppercase directly.
 
 === PANEL TYPE REQUIREMENTS ===
 
@@ -162,7 +195,7 @@ Existence Check: filter: expression: llm.model_name EXISTS
 
 filters: op: AND items: - key: key: service.name dataType: string op: IN value: $service_name - key: key: has_error op: = value: true
 
-NOTE: You can use BOTH filter.expression AND filters.items together for compatibility.
+NOTE: You can use BOTH filter.expression AND filters.items together for compatibility. When you do, they MUST stay consistent: every key.key in filters.items must appear in filter.expression. The MCP server REJECTS dashboards where a filter item's key is missing from the expression — even though the SigNoz backend would accept the payload. Rationale: the list/graph renderer reads filter.expression directly, while the edit-modal's expression-reconstruction path walks filters.items[]. A mismatch causes the two to execute different queries, silently dropping predicates in the list view and breaking edit-modal hydration. If the two must differ intentionally, send only one side (leave filter.expression empty OR leave filters.items unset).
 
 ERROR: Invalid operators cause filter errors. ERROR: Missing $ prefix for variables causes literal string matching. ERROR: Typo in field names causes no data.
 

--- a/plans/dashboard-normalize-get-write-shapes.context.md
+++ b/plans/dashboard-normalize-get-write-shapes.context.md
@@ -1,0 +1,84 @@
+# Feature: Normalize dashboard GET vs write shapes — Context & Discussion
+
+## Original Prompt
+> Two API gotchas worth noting (the first update attempt failed and needed retries):
+> 1. `variables.*.dynamicVariablesSource` must be capitalized ("Metrics", not "metrics") on write — even though GET returns lowercase.
+> 2. `queryData[].having` must be sent as an array (`[]`), not the `{expression: ""}` object the GET returns.
+>
+> Aren't these part of resources?
+>
+> Follow-up: "how to fix these? Should you expose these as input schema via resource so that mcp client or agent is able to construct these correctly in the 1st pass OR adding these in resource as info is good enough?"
+>
+> Resolution: "fix both"
+
+## Reference Links
+- Validation entry point: `internal/handler/tools/dashboards.go:177,220`
+- Existing constants: `pkg/dashboard/dashboardbuilder/defaults.go:116` (`ValidDynamicVariableSources`)
+- Strict having validator (where unmarshal fails today): `pkg/dashboard/pipeline.go:90`
+
+## Key Decisions & Discussion Log
+### 2026-04-24 — design choice: server-side coercion over schema tightening or doc-only
+- Rejected: tightening MCP tool input schema (`types.Dashboard` / `types.UpdateDashboardInput`) with enums/unions. Reason: the LLM's natural flow is GET → mutate → PUT, so rejecting echoed GET shapes just causes retries. Union-typing `having` in JSON Schema is also awkward and clients handle it inconsistently.
+- Rejected: documentation-only fix. Reason: LLMs frequently miss subtle casing/shape rules in resource text; the GET → PUT echo pattern is the path of least resistance.
+- Accepted: permissive-in / strict-out normalization inside the existing `pkg/dashboard/dashboardbuilder` pipeline, with docs updated as a secondary safety net.
+
+### 2026-04-24 — `having` coercion scope
+- Decided to coerce only the empty/whitespace-expression object form (`{expression: ""}` → `[]`). Non-empty expression object forms are left untouched so validation can surface a clear error if they ever appear — in practice the GET API only emits the empty form.
+- Applied to both `QueryData` and `QueryFormulas`. `QueryTraceOperator` skipped (not observed to carry `having`).
+
+### 2026-04-24 — source casing normalization
+- Case-insensitive lookup against `ValidDynamicVariableSources` with trim; unknown values pass through so the existing `validate.go:68-70` enum error still fires.
+- Applied in `convert.go` during `rawDashboardVariable → DashboardVariable` conversion (JSON ingest path only). The fluent `builder.go` path sets the source via constants directly, so no change needed there.
+
+### 2026-04-24 — third asymmetry discovered: filter operator casing
+- GET responses may return lowercase or mixed-case operators for `queryData[].filters.items[].op` / `queryFormulas[].filters.items[].op` (e.g. `"in"`, `"Not_In"`, `"like"`), but the write API's `validFilterOperators` map (`pkg/dashboard/panelbuilder/panel_validator.go:218-228`) is strictly uppercase (`IN`, `NOT_IN`, `LIKE`, `EXISTS`, ...).
+- Added `uppercaseFilterOpsInQueryMaps` in `normalize.go` that trims whitespace and uppercases each item's `op`. Symbol operators (`=`, `!=`, `>=`, `>`, `<=`, `<`) are unaffected by `strings.ToUpper`. Unknown operators still surface via the downstream `validFilterOperators` check, so we retain error quality.
+- Wired into both `ApplyDefaults` and `applyBuilderDefaults` for parity (same pattern as `coerceHavingInQueryMaps`).
+
+### 2026-04-24 — `"All telemetry"` UI-label alias
+- Some SigNoz versions return the UI-facing label `"All telemetry"` for the all-sources variant, while the write enum is `"all sources"`. Added a dedicated alias inside `canonicalDynamicSource` (case-insensitive, trim-tolerant) that maps `"all telemetry"` → `DynamicSourceAllSources`. Kept alongside the lowercase-echo normalization rather than splitting into a separate helper.
+
+### 2026-04-24 — `applyBuilderDefaults` parity resolved
+- Earlier plan flagged a risk that only `ApplyDefaults` called the new normalizers. Confirmed both `coerceHavingInQueryMaps` and `uppercaseFilterOpsInQueryMaps` are now called in `applyBuilderDefaults` too (`defaults.go:337-340`), matching the JSON-ingest path. Fluent-builder callers that pass constants directly are unaffected, but the parity keeps the two code paths behaviorally identical.
+
+### 2026-04-24 — docs kept as secondary safety net
+- `basics.go:67` now mentions both the lowercase-source normalization and the `"All telemetry"` alias.
+- `widgets_examples.go` has the `having (write-shape)` block plus a new `filters.items[].op (write-shape casing)` block listing the canonical operator set and noting server-side normalization.
+- Docs are deliberately framed as "prefer canonical form; server normalizes" — not load-bearing, but they keep an LLM that reads resources before writing from producing obviously-wrong payloads.
+
+### 2026-04-24 — canonical all-sources value flipped: `"all sources"` → `"All telemetry"`
+- Verified upstream against `SigNoz/signoz` (commit `156459e`). `frontend/src/container/DashboardContainer/DashboardSettings/DashboardVariableSettings/VariableItem/DynamicVariable/DynamicVariable.tsx` defines the dropdown enum:
+  ```
+  enum AttributeSource {
+      ALL_TELEMETRY = 'All telemetry',
+      LOGS          = 'Logs',
+      METRICS       = 'Metrics',
+      TRACES        = 'Traces',
+  }
+  ```
+  The UI dropdown writes `'All telemetry'` to `dynamicVariablesSource`; `'all sources'` only survives in two older hooks (`useDashboardVariableUpdate.ts`, `useDashboardVarConfig.tsx`) and the SigNoz frontend tolerates both on read (`.toLowerCase() === 'all telemetry'`).
+- The SigNoz Go backend has zero references to any of these strings (`gh search code repo:SigNoz/signoz language:Go` for `dynamicVariablesSource`, `"all sources"`, `"All telemetry"` all return empty); dashboards are stored as opaque JSON, so backend acceptance is unconstrained. The frontend is the sole enforcer.
+- Action: flipped `DynamicSourceAllSources` from `"all sources"` to `"All telemetry"` (`defaults.go:52`); reversed the alias in `canonicalDynamicSource` so legacy `"all sources"` (any case) now normalizes *to* `"All telemetry"`. Updated `normalize_test.go`, `pipeline_test.go`, `basics.go`, and the `builder.go:154` doc comment to match. All tests green.
+- Reason: matches what the live SigNoz UI writes today, so dashboards we emit round-trip cleanly through the SigNoz frontend; the legacy alias keeps backward compatibility with older payloads.
+
+## Open Questions
+- [x] Should `{expression: "<non-empty>"}` be coerced? Decided: no — leave for validation error. If SigNoz later supports expression-form HAVING, revisit.
+- [x] Should MCP input schema be tightened? Decided: no — server coercion is sufficient and more ergonomic.
+- [x] Should `applyBuilderDefaults` also call the new normalizers? Decided: yes — parity with the JSON-ingest path, zero downside for fluent-builder callers.
+- [x] Should we alias `"All telemetry"` → `"all sources"`? Decided: yes — observed in the wild from some GET responses; the canonical form is unambiguous.
+
+### 2026-04-24 — fourth asymmetry: malformed filter-item key / wrapped $var values
+- Discovered while triaging dashboard `019dbe7e-c0bd-70fc-b863-86950b526a48` ("CPU Used" value panel rendering fine on the dashboard list but failing to hydrate in the edit modal). Root cause: a `filters.items[]` entry for `k8s.node.name` with `key.dataType` missing, `key.id` collapsed to just `"k8s.node.name"` (no `--<dataType>--<type>` suffix), and `value` wrapped in a single-element `$var` array. Two sibling widgets on the same dashboard (CPU Usage by Pod, CPU Usage by namespace) had the same shape.
+- Why our pipeline missed it: `dashboardbuilder` uses `[]map[string]any` for queryData (no strict typing on filter items), and `panelvalidator.validateTagFilter` (`pkg/dashboard/panelbuilder/panel_validator.go:526`) only checks `filter.Op` and `item.Op` against a whitelist — it never inspects `item.Key` structure or `item.Value` shape. `TagFilterItem.Value` is typed `any`, so scalar vs. single-element-array both unmarshal cleanly. SigNoz backend is also lenient (ClickHouse only consumes `filter.expression`); only the React edit-modal filter-row component is strict.
+- Action: added `normalizeFilterItemsInQueryMaps` in `normalize.go`, wired into both `ApplyDefaults` and `applyBuilderDefaults` (parity). It (a) fills `key.dataType` (inferring from a well-formed id when possible, defaulting to `"string"` otherwise), (b) rebuilds `key.id` to `<key>--<dataType>--<type>` only when clearly malformed (empty or missing `--`), leaving canonical 3-part and 4-part ids alone, (c) unwraps `["$var"]` → `"$var"` only when the sole element is a `$`-prefixed string, preserving multi-element arrays and single-element arrays of real values.
+- Tests: six `TestNormalizeFilterItems_*` cases in `normalize_test.go` (heal, preserve canonical, preserve 4-part, infer from id, selective value unwrap, nil/missing safety) plus one end-to-end `TestValidate_NormalizesMalformedFilterItem` in `pipeline_test.go`.
+- Docs: added a `filters.items[].key (write-shape for edit-modal hydration)` block in `widgets_examples.go` showing canonical vs. broken forms and flagging the server-side auto-heal.
+- Permissive-in / strict-out preserved: rejecting would have been user-hostile (GET returns this shape, legacy dashboards have it, echoing back is natural). Unknown/ambiguous inputs still pass through for downstream validators to surface.
+
+### 2026-04-24 — strict validation: reject `filter.expression` / `filters.items[]` mismatch
+- Scenario: CPU Used widget was eventually traced to the SigNoz backend server-authoritatively rewriting `temporality` (`null` → `""`) and `filter.expression` (3-clause → 2-clause) for Sum-type metrics (`k8s.node.cpu.usage`, `k8s.pod.cpu.usage`). Neither field survives a PUT through our MCP tool, which means we cannot *normalize* them into consistency. Separately, during diagnosis it became clear that an inconsistent payload — where `filter.expression` has fewer predicates than `filters.items[]` — is something an LLM-authored dashboard could produce at creation time, and the SigNoz backend accepts it silently, letting the list view and edit modal drift.
+- Decision: add a strict **reject** check for `filter.expression` / `filters.items[]` mismatches, even though SigNoz accepts them. Permissive-upstream does not mean correct. Only runs when both sides are non-empty; expression-only or items-only payloads pass through unchanged (either is a deliberate single-source-of-truth configuration).
+- Implementation: `validateFilterExpressionConsistency` in `pkg/dashboard/dashboardbuilder/validate.go`, called per queryData and queryFormula entry from `validateBuilderQuery`. For each `filters.items[i].key.key`, requires the key string to appear in `filter.expression`; on any miss, emits a field error naming the missing keys and showing the offending expression.
+- Scope decision: this is the one case where we tighten validation rather than permissively normalize. The earlier normalizers (source, having, op, filter-item shape) fix *shape* drift where the canonical repair is unambiguous. Here the "repair" would be rebuilding the expression — but SigNoz rewrites expression on save, so any rebuild we do is cosmetic. Rejecting forces the agent to produce coherent payloads at generation time, which is both sides' intent and the only layer where coherence is actually enforceable.
+- Tests: five unit cases in `validate_test.go` (mismatch rejected, consistent passes, empty expression skipped, empty items skipped, formula-side mismatch rejected) plus an end-to-end `TestValidate_RejectsFilterExpressionMismatch` in `pipeline_test.go`.
+- Docs: `widgets_examples.go` NOTE updated to state the rejection rule and the rationale (list view vs. edit modal drift).

--- a/plans/dashboard-normalize-get-write-shapes.plan.md
+++ b/plans/dashboard-normalize-get-write-shapes.plan.md
@@ -1,0 +1,56 @@
+# Plan: Normalize dashboard GET vs write shapes
+
+## Status
+Done
+
+## Context
+SigNoz dashboard GET and write APIs accept subtly different shapes for several fields. An agent that fetched a dashboard and echoed fields back on PUT would hit one of three rejections:
+
+1. `variables.*.dynamicVariablesSource` — GET may return any casing (e.g. `"metrics"`) or the legacy alias `"all sources"`; the canonical write form (matching the SigNoz UI dropdown's `AttributeSource` enum) is `"Traces"`, `"Logs"`, `"Metrics"`, or `"All telemetry"`.
+2. `queryData[].having` / `queryFormulas[].having` — GET returns `{expression: ""}`; write requires `[]HavingClause` (empty `[]` for no HAVING). Strict unmarshal into `panelvalidator.BuilderQuery.Having` at `pkg/dashboard/pipeline.go:90` fails with an opaque error.
+3. `queryData[].filters.items[].op` / `queryFormulas[].filters.items[].op` — GET may return lowercase/mixed-case (e.g. `"in"`, `"Not_In"`); write's `validFilterOperators` (`pkg/dashboard/panelbuilder/panel_validator.go:218-228`) is strictly uppercase.
+4. `queryData[].filters.items[].key` shape — some dashboards (including ones authored via the SigNoz UI) have items with missing `key.dataType`, non-canonical `key.id` (collapsed to just `<key>` instead of `<key>--<dataType>--<type>`), and `value` wrapped in a single-element `$var` array. The list renderer tolerates this via the top-level `filter.expression` string, but the edit modal's autocomplete hydration fails.
+
+All three are fixed at the `dashboardbuilder` layer with a *permissive-in / strict-out* normalization pass: accept either shape from the LLM, emit the canonical form to SigNoz.
+
+## Approach
+
+Three helpers in `pkg/dashboard/dashboardbuilder/normalize.go`, all pass-through on unknown/absent input:
+
+- `canonicalDynamicSource(s)` — case-insensitive, trim-tolerant lookup against `ValidDynamicVariableSources`, with a dedicated alias mapping the legacy `"all sources"` (any case) → canonical `"All telemetry"`. Unknown values pass through so `validate.go:68-70` still surfaces a clear enum error.
+- `coerceHavingInQueryMaps(entries)` — rewrites `having: {expression: ""}` (empty/whitespace only) to `having: []`. Array form, nil, missing, and non-empty-expression object forms are left untouched.
+- `uppercaseFilterOpsInQueryMaps(entries)` — trims whitespace and uppercases each `filters.items[].op`. Symbol operators are unaffected by `strings.ToUpper`; unknown operators still surface via the downstream `validFilterOperators` check.
+- `normalizeFilterItemsInQueryMaps(entries)` — heals filter-item key/value shape: fills `key.dataType` (inferring from a well-formed id when possible, else defaulting to `"string"`), rebuilds `key.id` to `<key>--<dataType>--<type>` only when clearly malformed (empty or missing `--`), and unwraps `["$var"]` → `"$var"` only when the sole element is a `$`-prefixed string. Canonical 3-part/4-part ids and genuine multi-/single-value arrays pass through untouched.
+
+One strict check (not a normalizer):
+- `validateFilterExpressionConsistency` in `validate.go` — rejects builder queryData and queryFormula entries whose `filter.expression` omits any `filters.items[].key.key`. Enforced even though the SigNoz backend accepts the mismatch, because the list/graph renderer and the edit-modal's expression-reconstruction disagree otherwise. Only runs when both sides are non-empty — single-source-of-truth configurations (expression-only or items-only) pass through.
+
+Wiring:
+- `convert.go` — apply `canonicalDynamicSource` during `rawDashboardVariable → DashboardVariable` conversion (JSON ingest path).
+- `defaults.go` — call `coerceHavingInQueryMaps` and `uppercaseFilterOpsInQueryMaps` on both `QueryData` and `QueryFormulas` inside the builder-nil-init block of **both** `ApplyDefaults` (JSON-ingest path) and `applyBuilderDefaults` (fluent-builder path). Fluent-builder callers that pass constants directly are unaffected; parity keeps the two paths behaviorally identical.
+
+Because `dashboardbuilder` owns serialization to SigNoz via `DashboardData.ToJSON()`, the normalized shape reaches the API. Because normalization runs before `widgetToPanel` in `pipeline.go`, the strict `panelvalidator` types see the canonical form and unmarshal cleanly.
+
+## Files Modified
+
+- `pkg/dashboard/dashboardbuilder/normalize.go` — new; the three helpers.
+- `pkg/dashboard/dashboardbuilder/normalize_test.go` — new; unit coverage for all three helpers including `"All telemetry"` aliases, uppercase-with-trim, nil/missing/wrong-type edge cases.
+- `pkg/dashboard/dashboardbuilder/convert.go` — call `canonicalDynamicSource` at the variable-conversion site.
+- `pkg/dashboard/dashboardbuilder/defaults.go` — call `coerceHavingInQueryMaps` and `uppercaseFilterOpsInQueryMaps` on `QueryData` and `QueryFormulas` in both defaults paths.
+- `pkg/dashboard/pipeline_test.go` — `TestValidate_NormalizesGetShapePayload` covers source case, `having` shape, `"All telemetry"` alias, and filter-op casing in a single round-trip; `TestValidate_InvalidDynamicSourceStillRejected` guards the negative path.
+- `pkg/dashboard/basics.go` — clarifies that the server normalizes lowercase source and the `"All telemetry"` alias on write.
+- `pkg/dashboard/widgets_examples.go` — adds `having (write-shape)` and `filters.items[].op (write-shape casing)` notes so LLMs reading the resource see both asymmetries in one place.
+
+## Verification
+
+- `go test ./pkg/dashboard/...` — all green, including new unit tests and the end-to-end `TestValidate_NormalizesGetShapePayload`.
+- `go test ./...` — no regressions across the repo.
+- `go build ./...` — clean.
+- Negative-path check: `TestValidate_InvalidDynamicSourceStillRejected` + existing `validate_test.go` negative case confirm truly invalid values still surface the enum error.
+- Read-through sanity check on `widgets_examples.go`: an LLM reading the resource sees the `having` and `filters.items[].op` write-shape notes adjacent to each other, making the GET → write asymmetries discoverable without separate tool calls.
+
+## Out of Scope
+- Tightening MCP tool input schemas (`types.Dashboard` / `types.UpdateDashboardInput`) — server coercion makes it unnecessary.
+- Changes to alerts, views, or other entities.
+- `README.md` / `manifest.json` updates — the fix is transparent and adds no user-visible tool metadata.
+- Any additional API-shape normalizations not yet observed in the wild.


### PR DESCRIPTION
…nconsistencies

Heal four GET-vs-write shape asymmetries so LLM-authored or GET-echoed dashboards round-trip cleanly through signoz_create_dashboard and signoz_update_dashboard:

- canonicalDynamicSource: case-insensitive lookup against ValidDynamicVariableSources plus a legacy "all sources" -> "All telemetry" alias. Flips DynamicSourceAllSources to match the current SigNoz UI dropdown enum (frontend AttributeSource.ALL_TELEMETRY).
- coerceHavingInQueryMaps: empty {expression: ""} objects -> [].
- uppercaseFilterOpsInQueryMaps: trims + uppercases filters.items[].op so lowercase/mixed-case ops from GET responses pass the strict validFilterOperators check.
- normalizeFilterItemsInQueryMaps: fills key.dataType, rebuilds malformed key.id to <key>--<dataType>--<type>, and unwraps single-element $var arrays. Heals the CPU Used / edit-modal hydration bug class.

Add a strict consistency check — validateFilterExpressionConsistency — that rejects builder queries whose filter.expression omits any filters.items[].key.key. The SigNoz backend accepts the mismatch silently, but the list/graph renderer reads filter.expression while the edit-modal reconstructs from items, so inconsistent payloads cause the two views to execute different queries. Tool-level rejection forces agent-authored dashboards to be coherent at generation time, the only layer where coherence is actually enforceable (SigNoz rewrites expression server-side on save).

Docs: widgets_examples.go now documents the write-shape quirks (having array form, filter op casing, filter-item key shape, expression/items consistency rule); basics.go flags the dynamicVariablesSource canonicalization and aliasing, and adds the "prompt before adding a variable to all panels" guidance.

Tests:
- normalize_test.go covers all four helpers including "All telemetry" aliases, uppercase-with-trim, canonical-id preservation, $var-only value unwrap, and nil/missing/wrong-type safety.
- validate_test.go adds five cases for filter.expression / items consistency (mismatch rejected, consistent passes, empty-expression skipped, empty-items skipped, formula-side mismatch rejected).
- pipeline_test.go adds end-to-end coverage for the GET-shape round trip, invalid-source negative path, filter-item heal, and expression/items mismatch rejection.