### PR TITLE
[codex] Normalize advertised MCP tool schemas

### DIFF
--- a/internal/handler/tools/alerts.go
+++ b/internal/handler/tools/alerts.go
@@ -36,7 +36,7 @@ func (h *Handler) RegisterAlertsHandlers(s *server.MCPServer) {
 		mcp.WithString("filter", mcp.Description("Comma-separated matcher expressions to filter alerts. Example: 'alertname=\"HighCPU\"' or 'alertname=\"HighCPU\",severity=\"critical\"'. Uses Prometheus matcher syntax.")),
 		mcp.WithString("receiver", mcp.Description("Regex to filter alerts by receiver name. Example: 'slack-.*' to match all Slack receivers.")),
 	)
-	s.AddTool(alertsTool, h.handleListAlerts)
+	addTool(s, alertsTool, h.handleListAlerts)
 
 	getAlertTool := mcp.NewTool("signoz_get_alert",
 		mcp.WithReadOnlyHintAnnotation(true),
@@ -45,7 +45,7 @@ func (h *Handler) RegisterAlertsHandlers(s *server.MCPServer) {
 		mcp.WithDescription("Get the rule definition for a specific alert rule by ruleId (GET /api/v2/rules/{ruleId}).\n\nResponse shape depends on the SigNoz server version. Post-#10997 servers return the canonical Rule type with audit fields createdAt/updatedAt/createdBy/updatedBy; older servers return GettableRule with createAt/updateAt/createBy/updateBy (no 'd')."),
 		mcp.WithString("ruleId", mcp.Required(), mcp.Description("Alert rule ID (UUIDv7 on v2 servers).")),
 	)
-	s.AddTool(getAlertTool, h.handleGetAlert)
+	addTool(s, getAlertTool, h.handleGetAlert)
 
 	alertHistoryTool := mcp.NewTool("signoz_get_alert_history",
 		mcp.WithReadOnlyHintAnnotation(true),
@@ -61,7 +61,7 @@ func (h *Handler) RegisterAlertsHandlers(s *server.MCPServer) {
 		mcp.WithString("limit", mcp.Description("Limit number of results (default: 20)")),
 		mcp.WithString("order", mcp.Description("Sort order: 'asc' or 'desc' (default: 'asc')")),
 	)
-	s.AddTool(alertHistoryTool, h.handleGetAlertHistory)
+	addTool(s, alertHistoryTool, h.handleGetAlertHistory)
 
 	createAlertTool := mcp.NewTool(
 		"signoz_create_alert",
@@ -87,7 +87,7 @@ func (h *Handler) RegisterAlertsHandlers(s *server.MCPServer) {
 		),
 		mcp.WithInputSchema[types.AlertRule](),
 	)
-	s.AddTool(createAlertTool, h.handleCreateAlert)
+	addTool(s, createAlertTool, h.handleCreateAlert)
 
 	updateAlertTool := mcp.NewTool(
 		"signoz_update_alert",
@@ -104,7 +104,7 @@ func (h *Handler) RegisterAlertsHandlers(s *server.MCPServer) {
 		),
 		mcp.WithInputSchema[types.AlertRule](),
 	)
-	s.AddTool(updateAlertTool, h.handleUpdateAlert)
+	addTool(s, updateAlertTool, h.handleUpdateAlert)
 
 	deleteAlertTool := mcp.NewTool(
 		"signoz_delete_alert",
@@ -113,7 +113,7 @@ func (h *Handler) RegisterAlertsHandlers(s *server.MCPServer) {
 		mcp.WithString("ruleId", mcp.Required(), mcp.Description("UUIDv7 of the alert rule to delete. The server validates the UUID format and returns invalid_input on bad values.")),
 		mcp.WithDescription("Deletes an alert rule by ID (DELETE /api/v2/rules/{ruleId}). Irreversible. Confirm with the user before calling."),
 	)
-	s.AddTool(deleteAlertTool, h.handleDeleteAlert)
+	addTool(s, deleteAlertTool, h.handleDeleteAlert)
 
 	// Register alert resources for create alert
 	h.registerAlertResources(s)

--- a/internal/handler/tools/dashboards.go
+++ b/internal/handler/tools/dashboards.go
@@ -28,7 +28,7 @@ func (h *Handler) RegisterDashboardHandlers(s *server.MCPServer) {
 		mcp.WithString("offset", mcp.Description("Number of results to skip before returning results. Use for pagination: offset=0 for first page, offset=50 for second page (if limit=50), offset=100 for third page, etc. Check 'pagination.nextOffset' in the response to get the next page offset. Default: 0. Must be >= 0.")),
 	)
 
-	s.AddTool(tool, h.handleListDashboards)
+	addTool(s, tool, h.handleListDashboards)
 
 	getDashboardTool := mcp.NewTool("signoz_get_dashboard",
 		mcp.WithReadOnlyHintAnnotation(true),
@@ -38,7 +38,7 @@ func (h *Handler) RegisterDashboardHandlers(s *server.MCPServer) {
 		mcp.WithString("uuid", mcp.Required(), mcp.Description("Dashboard UUID")),
 	)
 
-	s.AddTool(getDashboardTool, h.handleGetDashboard)
+	addTool(s, getDashboardTool, h.handleGetDashboard)
 
 	createDashboardTool := mcp.NewTool(
 		"signoz_create_dashboard",
@@ -62,7 +62,7 @@ func (h *Handler) RegisterDashboardHandlers(s *server.MCPServer) {
 		mcp.WithInputSchema[types.Dashboard](),
 	)
 
-	s.AddTool(createDashboardTool, h.handleCreateDashboard)
+	addTool(s, createDashboardTool, h.handleCreateDashboard)
 
 	updateDashboardTool := mcp.NewTool(
 		"signoz_update_dashboard",
@@ -88,7 +88,7 @@ func (h *Handler) RegisterDashboardHandlers(s *server.MCPServer) {
 		mcp.WithInputSchema[types.UpdateDashboardInput](),
 	)
 
-	s.AddTool(updateDashboardTool, h.handleUpdateDashboard)
+	addTool(s, updateDashboardTool, h.handleUpdateDashboard)
 
 	deleteDashboardTool := mcp.NewTool("signoz_delete_dashboard",
 		mcp.WithDestructiveHintAnnotation(true),
@@ -97,7 +97,7 @@ func (h *Handler) RegisterDashboardHandlers(s *server.MCPServer) {
 		mcp.WithString("uuid", mcp.Required(), mcp.Description("Dashboard UUID to delete")),
 	)
 
-	s.AddTool(deleteDashboardTool, h.handleDeleteDashboard)
+	addTool(s, deleteDashboardTool, h.handleDeleteDashboard)
 
 	// resources for create and update dashboard
 	h.registerDashboardResources(s)

--- a/internal/handler/tools/fields.go
+++ b/internal/handler/tools/fields.go
@@ -26,7 +26,7 @@ func (h *Handler) RegisterFieldsHandlers(s *server.MCPServer) {
 		mcp.WithString("source", mcp.Description("Source filter (optional).")),
 	)
 
-	s.AddTool(getFieldKeysTool, h.handleGetFieldKeys)
+	addTool(s, getFieldKeysTool, h.handleGetFieldKeys)
 
 	getFieldValuesTool := mcp.NewTool("signoz_get_field_values",
 		mcp.WithReadOnlyHintAnnotation(true),
@@ -40,7 +40,7 @@ func (h *Handler) RegisterFieldsHandlers(s *server.MCPServer) {
 		mcp.WithString("source", mcp.Description("Source filter (optional).")),
 	)
 
-	s.AddTool(getFieldValuesTool, h.handleGetFieldValues)
+	addTool(s, getFieldValuesTool, h.handleGetFieldValues)
 }
 
 func (h *Handler) handleGetFieldKeys(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {

--- a/internal/handler/tools/logs.go
+++ b/internal/handler/tools/logs.go
@@ -38,7 +38,7 @@ func (h *Handler) RegisterLogsHandlers(s *server.MCPServer) {
 		mcp.WithString("stepInterval", mcp.Description("Time bucket size in seconds for time_series mode (optional). When omitted, the backend auto-selects an appropriate interval. Only set this if the user explicitly requests a specific granularity. Examples: \"60\" (1 min), \"3600\" (1 hour), \"86400\" (1 day).")),
 	)
 
-	s.AddTool(aggregateLogsTool, h.handleAggregateLogs)
+	addTool(s, aggregateLogsTool, h.handleAggregateLogs)
 
 	// search_logs: log search with optional filters
 	// ToDo: use this function for error logs or logs by service
@@ -60,7 +60,7 @@ func (h *Handler) RegisterLogsHandlers(s *server.MCPServer) {
 		mcp.WithString("offset", mcp.Description("Offset for pagination (default: 0)")),
 	)
 
-	s.AddTool(searchLogsTool, h.handleSearchLogs)
+	addTool(s, searchLogsTool, h.handleSearchLogs)
 }
 
 func (h *Handler) handleAggregateLogs(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {

--- a/internal/handler/tools/logs_test.go
+++ b/internal/handler/tools/logs_test.go
@@ -196,4 +196,3 @@ func TestHandleAggregateLogs_WithGroupBy(t *testing.T) {
 		t.Fatal("QueryBuilderV5 was not called")
 	}
 }
-

--- a/internal/handler/tools/metrics.go
+++ b/internal/handler/tools/metrics.go
@@ -27,7 +27,7 @@ func (h *Handler) RegisterMetricsHandlers(s *server.MCPServer) {
 		mcp.WithString("source", mcp.Description("Filter by source (optional).")),
 	)
 
-	s.AddTool(listMetricsTool, h.handleListMetrics)
+	addTool(s, listMetricsTool, h.handleListMetrics)
 
 	// signoz_query_metrics — smart metrics query tool with aggregation validation and defaults
 	queryMetricsTool := mcp.NewTool("signoz_query_metrics",
@@ -59,7 +59,7 @@ func (h *Handler) RegisterMetricsHandlers(s *server.MCPServer) {
 		mcp.WithString("formulaQueries", mcp.Description("JSON array of additional named metric queries for formula. Each object: {\"name\":\"B\", \"metricName\":\"...\", \"metricType\":\"...\", \"isMonotonic\":true, \"temporality\":\"...\", \"timeAggregation\":\"...\", \"spaceAggregation\":\"...\", \"groupBy\":[\"...\"], \"filter\":\"...\"}. All fields except name and metricName are optional.")),
 	)
 
-	s.AddTool(queryMetricsTool, func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	addTool(s, queryMetricsTool, func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 		return h.handleQueryMetrics(ctx, req)
 	})
 

--- a/internal/handler/tools/notification_channels.go
+++ b/internal/handler/tools/notification_channels.go
@@ -43,7 +43,7 @@ func (h *Handler) RegisterNotificationChannelHandlers(s *server.MCPServer) {
 		mcp.WithString("offset", mcp.Description("Number of results to skip before returning results. Use for pagination: offset=0 for first page, offset=50 for second page (if limit=50). Check 'pagination.nextOffset' in the response to get the next page offset. Default: 0.")),
 	)
 
-	s.AddTool(listChannelsTool, h.handleListNotificationChannels)
+	addTool(s, listChannelsTool, h.handleListNotificationChannels)
 
 	createChannelTool := mcp.NewTool("signoz_create_notification_channel",
 		mcp.WithDestructiveHintAnnotation(true),
@@ -98,7 +98,7 @@ func (h *Handler) RegisterNotificationChannelHandlers(s *server.MCPServer) {
 		mcp.WithString("msteams_text", mcp.Description("Message body template (Go template syntax supported)")),
 	)
 
-	s.AddTool(createChannelTool, h.handleCreateNotificationChannel)
+	addTool(s, createChannelTool, h.handleCreateNotificationChannel)
 
 	updateChannelTool := mcp.NewTool("signoz_update_notification_channel",
 		mcp.WithDestructiveHintAnnotation(true),
@@ -160,7 +160,7 @@ func (h *Handler) RegisterNotificationChannelHandlers(s *server.MCPServer) {
 		mcp.WithString("msteams_text", mcp.Description("Message body template (Go template syntax supported)")),
 	)
 
-	s.AddTool(updateChannelTool, h.handleUpdateNotificationChannel)
+	addTool(s, updateChannelTool, h.handleUpdateNotificationChannel)
 
 	getChannelTool := mcp.NewTool("signoz_get_notification_channel",
 		mcp.WithReadOnlyHintAnnotation(true),
@@ -169,7 +169,7 @@ func (h *Handler) RegisterNotificationChannelHandlers(s *server.MCPServer) {
 		mcp.WithDescription("Get a single notification channel by ID (GET /api/v1/channels/{id}). Returns the full channel configuration including the embedded receiver config (slack/webhook/pagerduty/email/opsgenie/msteams)."),
 		mcp.WithString("id", mcp.Required(), mcp.Description("The numeric ID of the notification channel.")),
 	)
-	s.AddTool(getChannelTool, h.handleGetNotificationChannel)
+	addTool(s, getChannelTool, h.handleGetNotificationChannel)
 
 	deleteChannelTool := mcp.NewTool("signoz_delete_notification_channel",
 		mcp.WithDestructiveHintAnnotation(true),
@@ -177,7 +177,7 @@ func (h *Handler) RegisterNotificationChannelHandlers(s *server.MCPServer) {
 		mcp.WithDescription("Delete a notification channel by ID (DELETE /api/v1/channels/{id}). Irreversible. Confirm with the user before calling, and warn if the channel is referenced by existing alert rules."),
 		mcp.WithString("id", mcp.Required(), mcp.Description("The numeric ID of the notification channel to delete.")),
 	)
-	s.AddTool(deleteChannelTool, h.handleDeleteNotificationChannel)
+	addTool(s, deleteChannelTool, h.handleDeleteNotificationChannel)
 }
 
 func (h *Handler) handleGetNotificationChannel(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {

--- a/internal/handler/tools/query_builder.go
+++ b/internal/handler/tools/query_builder.go
@@ -34,7 +34,7 @@ func (h *Handler) RegisterQueryBuilderV5Handlers(s *server.MCPServer) {
 		mcp.WithObject("query", mcp.Required(), mcp.Description("Complete SigNoz Query Builder v5 JSON object with schemaVersion, start, end, requestType, compositeQuery, formatOptions, and variables")),
 	)
 
-	s.AddTool(executeQuery, h.handleExecuteBuilderQuery)
+	addTool(s, executeQuery, h.handleExecuteBuilderQuery)
 
 	tracesQueryBuilderGuide := mcp.NewResource(
 		"signoz://traces/query-builder-guide",

--- a/internal/handler/tools/schema_compat.go
+++ b/internal/handler/tools/schema_compat.go
@@ -1,0 +1,150 @@
+package tools
+
+import (
+	"encoding/json"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
+)
+
+var schemaMapFields = map[string]struct{}{
+	"$defs":             {},
+	"definitions":       {},
+	"dependentSchemas":  {},
+	"patternProperties": {},
+	"properties":        {},
+}
+
+var schemaValueFields = map[string]struct{}{
+	"additionalItems":       {},
+	"additionalProperties":  {},
+	"contains":              {},
+	"else":                  {},
+	"if":                    {},
+	"items":                 {},
+	"not":                   {},
+	"propertyNames":         {},
+	"then":                  {},
+	"unevaluatedItems":      {},
+	"unevaluatedProperties": {},
+}
+
+var schemaArrayFields = map[string]struct{}{
+	"allOf":       {},
+	"anyOf":       {},
+	"oneOf":       {},
+	"prefixItems": {},
+}
+
+func addTool(s *server.MCPServer, tool mcp.Tool, handler server.ToolHandlerFunc) {
+	normalizeToolSchemas(&tool)
+	s.AddTool(tool, handler)
+}
+
+func normalizeToolSchemas(tool *mcp.Tool) {
+	if len(tool.RawInputSchema) > 0 {
+		tool.RawInputSchema = normalizeRawSchema(tool.RawInputSchema)
+	} else {
+		normalizeToolArgumentsSchema(&tool.InputSchema)
+	}
+
+	if len(tool.RawOutputSchema) > 0 {
+		tool.RawOutputSchema = normalizeRawSchema(tool.RawOutputSchema)
+	} else if tool.OutputSchema.Type != "" {
+		normalizeToolOutputSchema(&tool.OutputSchema)
+	}
+}
+
+func normalizeRawSchema(raw json.RawMessage) json.RawMessage {
+	var schema any
+	if err := json.Unmarshal(raw, &schema); err != nil {
+		return raw
+	}
+	normalized := normalizeJSONSchema(schema)
+	b, err := json.Marshal(normalized)
+	if err != nil {
+		return raw
+	}
+	return b
+}
+
+func normalizeToolArgumentsSchema(schema *mcp.ToolInputSchema) {
+	for name, propertySchema := range schema.Properties {
+		schema.Properties[name] = normalizeJSONSchema(propertySchema)
+	}
+	for name, defSchema := range schema.Defs {
+		schema.Defs[name] = normalizeJSONSchema(defSchema)
+	}
+	if schema.AdditionalProperties != nil {
+		schema.AdditionalProperties = normalizeJSONSchema(schema.AdditionalProperties)
+	}
+}
+
+func normalizeToolOutputSchema(schema *mcp.ToolOutputSchema) {
+	for name, propertySchema := range schema.Properties {
+		schema.Properties[name] = normalizeJSONSchema(propertySchema)
+	}
+	for name, defSchema := range schema.Defs {
+		schema.Defs[name] = normalizeJSONSchema(defSchema)
+	}
+	if schema.AdditionalProperties != nil {
+		schema.AdditionalProperties = normalizeJSONSchema(schema.AdditionalProperties)
+	}
+}
+
+func normalizeJSONSchema(schema any) any {
+	switch typed := schema.(type) {
+	case bool:
+		if typed {
+			return map[string]any{}
+		}
+		return typed
+	case map[string]any:
+		for key, value := range typed {
+			switch {
+			case isSchemaMapField(key):
+				normalizeSchemaMap(value)
+			case isSchemaValueField(key):
+				typed[key] = normalizeJSONSchema(value)
+			case isSchemaArrayField(key):
+				normalizeSchemaArray(value)
+			}
+		}
+	}
+	return schema
+}
+
+func normalizeSchemaMap(value any) {
+	schemas, ok := value.(map[string]any)
+	if !ok {
+		return
+	}
+	for name, schema := range schemas {
+		schemas[name] = normalizeJSONSchema(schema)
+	}
+}
+
+func normalizeSchemaArray(value any) {
+	schemas, ok := value.([]any)
+	if !ok {
+		return
+	}
+	for i, schema := range schemas {
+		schemas[i] = normalizeJSONSchema(schema)
+	}
+}
+
+func isSchemaMapField(key string) bool {
+	_, ok := schemaMapFields[key]
+	return ok
+}
+
+func isSchemaValueField(key string) bool {
+	_, ok := schemaValueFields[key]
+	return ok
+}
+
+func isSchemaArrayField(key string) bool {
+	_, ok := schemaArrayFields[key]
+	return ok
+}

--- a/internal/handler/tools/schema_compat_test.go
+++ b/internal/handler/tools/schema_compat_test.go
@@ -1,0 +1,52 @@
+package tools
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestNormalizeRawSchemaReplacesSchemaTrueWithEmptyObject(t *testing.T) {
+	raw := json.RawMessage(`{
+		"type": "object",
+		"properties": {
+			"anything": true,
+			"flag": {
+				"type": "boolean",
+				"default": true
+			},
+			"list": {
+				"type": "array",
+				"items": true
+			},
+			"object": {
+				"type": "object",
+				"additionalProperties": true
+			}
+		}
+	}`)
+
+	var got map[string]any
+	if err := json.Unmarshal(normalizeRawSchema(raw), &got); err != nil {
+		t.Fatalf("normalized schema should remain JSON: %v", err)
+	}
+
+	properties := got["properties"].(map[string]any)
+	if len(properties["anything"].(map[string]any)) != 0 {
+		t.Fatalf("properties.anything = %#v, want empty schema object", properties["anything"])
+	}
+
+	flag := properties["flag"].(map[string]any)
+	if flag["type"] != "boolean" || flag["default"] != true {
+		t.Fatalf("flag schema = %#v, want boolean schema with default true preserved", flag)
+	}
+
+	list := properties["list"].(map[string]any)
+	if len(list["items"].(map[string]any)) != 0 {
+		t.Fatalf("list.items = %#v, want empty schema object", list["items"])
+	}
+
+	object := properties["object"].(map[string]any)
+	if len(object["additionalProperties"].(map[string]any)) != 0 {
+		t.Fatalf("object.additionalProperties = %#v, want empty schema object", object["additionalProperties"])
+	}
+}

--- a/internal/handler/tools/services.go
+++ b/internal/handler/tools/services.go
@@ -28,7 +28,7 @@ func (h *Handler) RegisterServiceHandlers(s *server.MCPServer) {
 		mcp.WithString("offset", mcp.Description("Number of results to skip before returning results. Use for pagination: offset=0 for first page, offset=50 for second page (if limit=50), offset=100 for third page, etc. Check 'pagination.nextOffset' in the response to get the next page offset. Default: 0. Must be >= 0.")),
 	)
 
-	s.AddTool(listTool, h.handleListServices)
+	addTool(s, listTool, h.handleListServices)
 
 	getOpsTool := mcp.NewTool("signoz_get_service_top_operations",
 		mcp.WithReadOnlyHintAnnotation(true),
@@ -42,7 +42,7 @@ func (h *Handler) RegisterServiceHandlers(s *server.MCPServer) {
 		mcp.WithString("tags", mcp.Description("Optional tags JSON array")),
 	)
 
-	s.AddTool(getOpsTool, h.handleGetServiceTopOperations)
+	addTool(s, getOpsTool, h.handleGetServiceTopOperations)
 }
 
 func (h *Handler) handleListServices(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {

--- a/internal/handler/tools/traces.go
+++ b/internal/handler/tools/traces.go
@@ -44,7 +44,7 @@ func (h *Handler) RegisterTracesHandlers(s *server.MCPServer) {
 		mcp.WithString("stepInterval", mcp.Description("Time bucket size in seconds for time_series mode (optional). When omitted, the backend auto-selects an appropriate interval. Only set this if the user explicitly requests a specific granularity. Examples: \"60\" (1 min), \"3600\" (1 hour), \"86400\" (1 day).")),
 	)
 
-	s.AddTool(aggregateTracesTool, h.handleAggregateTraces)
+	addTool(s, aggregateTracesTool, h.handleAggregateTraces)
 
 	searchTracesTool := mcp.NewTool("signoz_search_traces",
 		mcp.WithReadOnlyHintAnnotation(true),
@@ -66,7 +66,7 @@ func (h *Handler) RegisterTracesHandlers(s *server.MCPServer) {
 		mcp.WithString("offset", mcp.Description("Offset for pagination (default: 0)")),
 	)
 
-	s.AddTool(searchTracesTool, h.handleSearchTraces)
+	addTool(s, searchTracesTool, h.handleSearchTraces)
 
 	getTraceDetailsTool := mcp.NewTool("signoz_get_trace_details",
 		mcp.WithReadOnlyHintAnnotation(true),
@@ -80,7 +80,7 @@ func (h *Handler) RegisterTracesHandlers(s *server.MCPServer) {
 		mcp.WithString("includeSpans", mcp.Description("Include detailed span information (true/false, default: true)")),
 	)
 
-	s.AddTool(getTraceDetailsTool, h.handleGetTraceDetails)
+	addTool(s, getTraceDetailsTool, h.handleGetTraceDetails)
 }
 
 func (h *Handler) handleAggregateTraces(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {

--- a/internal/handler/tools/views.go
+++ b/internal/handler/tools/views.go
@@ -49,7 +49,7 @@ func (h *Handler) RegisterViewHandlers(s *server.MCPServer) {
 		mcp.WithString("limit", mcp.Description("Maximum number of views to return per page. Default: 50.")),
 		mcp.WithString("offset", mcp.Description("Number of results to skip before returning results. Use 'pagination.nextOffset' from the previous page. Default: 0.")),
 	)
-	s.AddTool(listTool, h.handleListViews)
+	addTool(s, listTool, h.handleListViews)
 
 	getTool := mcp.NewTool("signoz_get_view",
 		mcp.WithReadOnlyHintAnnotation(true),
@@ -58,7 +58,7 @@ func (h *Handler) RegisterViewHandlers(s *server.MCPServer) {
 		mcp.WithDescription("Fetch a single SigNoz saved view by UUID. Use the returned object as the base for signoz_update_view — the update is a full-body replace."),
 		mcp.WithString("viewId", mcp.Required(), mcp.Description("Saved view UUID. Use signoz_list_views to discover IDs.")),
 	)
-	s.AddTool(getTool, h.handleGetView)
+	addTool(s, getTool, h.handleGetView)
 
 	createTool := mcp.NewTool("signoz_create_view",
 		mcp.WithDestructiveHintAnnotation(true),
@@ -73,7 +73,7 @@ func (h *Handler) RegisterViewHandlers(s *server.MCPServer) {
 		),
 		mcp.WithInputSchema[types.SavedViewInput](),
 	)
-	s.AddTool(createTool, h.handleCreateView)
+	addTool(s, createTool, h.handleCreateView)
 
 	updateTool := mcp.NewTool("signoz_update_view",
 		mcp.WithDestructiveHintAnnotation(true),
@@ -89,7 +89,7 @@ func (h *Handler) RegisterViewHandlers(s *server.MCPServer) {
 		),
 		mcp.WithInputSchema[types.UpdateViewInput](),
 	)
-	s.AddTool(updateTool, h.handleUpdateView)
+	addTool(s, updateTool, h.handleUpdateView)
 
 	deleteTool := mcp.NewTool("signoz_delete_view",
 		mcp.WithDestructiveHintAnnotation(true),
@@ -97,7 +97,7 @@ func (h *Handler) RegisterViewHandlers(s *server.MCPServer) {
 		mcp.WithDescription("Permanently delete a SigNoz saved view by UUID. This cannot be undone."),
 		mcp.WithString("viewId", mcp.Required(), mcp.Description("UUID of the view to delete.")),
 	)
-	s.AddTool(deleteTool, h.handleDeleteView)
+	addTool(s, deleteTool, h.handleDeleteView)
 
 	viewInstructions := mcp.NewResource(
 		"signoz://view/instructions",

--- a/internal/mcp-server/integration_test.go
+++ b/internal/mcp-server/integration_test.go
@@ -2,6 +2,8 @@ package mcp_server
 
 import (
 	"context"
+	"encoding/json"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -96,6 +98,47 @@ func TestIntegration_InitializeAndListTools(t *testing.T) {
 	}
 }
 
+func TestIntegration_ListToolsInputSchemasAreOpenAPICompatible(t *testing.T) {
+	s := buildTestServer(t)
+	ctx := context.Background()
+
+	c, err := mcpclient.NewInProcessClient(s)
+	if err != nil {
+		t.Fatalf("failed to create in-process client: %v", err)
+	}
+
+	if _, err := c.Initialize(ctx, mcp.InitializeRequest{
+		Params: mcp.InitializeParams{
+			ProtocolVersion: mcp.LATEST_PROTOCOL_VERSION,
+			ClientInfo: mcp.Implementation{
+				Name:    "test-client",
+				Version: version.Version,
+			},
+		},
+	}); err != nil {
+		t.Fatalf("Initialize failed: %v", err)
+	}
+
+	toolsResult, err := c.ListTools(ctx, mcp.ListToolsRequest{})
+	if err != nil {
+		t.Fatalf("ListTools failed: %v", err)
+	}
+
+	for _, tool := range toolsResult.Tools {
+		b, err := json.Marshal(tool.InputSchema)
+		if err != nil {
+			t.Fatalf("marshal input schema for %s: %v", tool.Name, err)
+		}
+		var schema any
+		if err := json.Unmarshal(b, &schema); err != nil {
+			t.Fatalf("unmarshal input schema for %s: %v", tool.Name, err)
+		}
+		if paths := booleanSubschemaPaths(schema, nil); len(paths) > 0 {
+			t.Errorf("%s inputSchema has OpenAPI-incompatible boolean subschemas: %s", tool.Name, strings.Join(paths, ", "))
+		}
+	}
+}
+
 func TestIntegration_PromqlInstructionsResourceRegistered(t *testing.T) {
 	s := buildTestServer(t)
 	ctx := context.Background()
@@ -141,6 +184,44 @@ func TestIntegration_PromqlInstructionsResourceRegistered(t *testing.T) {
 			t.Errorf("resource body missing expected substring %q", want)
 		}
 	}
+}
+
+func booleanSubschemaPaths(schema any, path []string) []string {
+	switch typed := schema.(type) {
+	case bool:
+		return []string{strings.Join(path, ".")}
+	case map[string]any:
+		var paths []string
+		for _, field := range []string{"$defs", "definitions", "dependentSchemas", "patternProperties", "properties"} {
+			if schemas, ok := typed[field].(map[string]any); ok {
+				for name, child := range schemas {
+					paths = append(paths, booleanSubschemaPaths(child, appendPath(path, field, name))...)
+				}
+			}
+		}
+		for _, field := range []string{"additionalItems", "contains", "else", "if", "items", "not", "propertyNames", "then", "unevaluatedItems", "unevaluatedProperties"} {
+			if child, ok := typed[field]; ok {
+				paths = append(paths, booleanSubschemaPaths(child, appendPath(path, field))...)
+			}
+		}
+		for _, field := range []string{"allOf", "anyOf", "oneOf", "prefixItems"} {
+			if schemas, ok := typed[field].([]any); ok {
+				for i, child := range schemas {
+					paths = append(paths, booleanSubschemaPaths(child, appendPath(path, field, strconv.Itoa(i)))...)
+				}
+			}
+		}
+		return paths
+	default:
+		return nil
+	}
+}
+
+func appendPath(path []string, parts ...string) []string {
+	next := make([]string, 0, len(path)+len(parts))
+	next = append(next, path...)
+	next = append(next, parts...)
+	return next
 }
 
 func TestIntegration_ListPrompts(t *testing.T) {

--- a/plans/openapi-schema-compat.context.md
+++ b/plans/openapi-schema-compat.context.md
@@ -1,0 +1,37 @@
+# Feature: OpenAPI-Compatible Tool Schemas — Context & Discussion
+
+## Original Prompt
+> Help me triage this issue: https://github.com/SigNoz/signoz-mcp-server/issues/118
+>
+> Is it really a bug on signoz mcp server or client specific issue?
+>
+> If we fix it Will it have any other consequences as well? Is it safe to fix?
+>
+> Let's implement it and create PR
+
+## Reference Links
+- [GitHub Issue #118](https://github.com/SigNoz/signoz-mcp-server/issues/118)
+- [MCP schema reference](https://modelcontextprotocol.io/specification/draft/schema)
+- [JSON Schema boolean schemas](https://json-schema.org/draft/2020-12/draft-bhutton-json-schema-00#section-4.3.2)
+- [OpenAPI 3.0 Schema Object](https://spec.openapis.org/oas/v3.0.3.html#schema-object)
+
+## Key Decisions & Discussion Log
+### 2026-04-24 — triage
+- hiAgent fails tool synchronization because some advertised MCP input schemas contain JSON Schema boolean subschemas (`true`) under schema-bearing fields.
+- JSON Schema allows `true` as an accept-anything schema, but OpenAPI 3.0 `properties` entries must be Schema Objects.
+- Treat this as a SigNoz MCP server compatibility bug exposed by an OpenAPI-shaped client, not a SigNoz backend runtime bug.
+- Local `tools/list` inspection found affected schemas on `signoz_create_alert`, `signoz_update_alert`, `signoz_create_dashboard`, and `signoz_update_dashboard`.
+
+### 2026-04-24 — implementation choice
+- Normalize generated tool schemas at registration time instead of changing runtime argument parsing or tightening SigNoz payload structs.
+- Replace only schema-position `true` subschemas with `{}` so semantics remain accept-anything.
+- Do not rewrite real boolean-valued metadata such as tool annotations or schema fields like `{ "type": "boolean" }`.
+
+### 2026-04-24 — implementation complete
+- Added shared tool registration helper that normalizes raw and structured MCP input/output schemas before they are advertised.
+- Added unit coverage for schema-position `true` conversion and integration coverage over `tools/list`.
+- Verified with focused package tests and full `go test ./...`.
+
+## Open Questions
+- [x] Is this server-side or client-specific? Answer: server-side compatibility bug; permissive JSON Schema clients may work, but MCP clients reasonably expect object-valued tool property schemas.
+- [x] Is the fix safe? Answer: yes if limited to schema-position `true` to `{}` normalization, because those are semantically equivalent.

--- a/plans/openapi-schema-compat.plan.md
+++ b/plans/openapi-schema-compat.plan.md
@@ -1,0 +1,20 @@
+# Plan: OpenAPI-Compatible Tool Schemas
+
+## Status
+Done
+
+## Context
+hiAgent cannot synchronize SigNoz MCP tools because it parses advertised `inputSchema` data through an OpenAPI 3 parser. The current generated schemas include JSON Schema boolean subschemas (`true`) for open-ended `interface{}` fields, which are legal JSON Schema but invalid as OpenAPI 3 `properties` entries.
+
+## Approach
+Normalize advertised MCP tool schemas after each tool is built and before registration. Walk only schema-bearing positions and replace `true` subschemas with empty schema objects `{}`. Leave normal boolean fields and annotations unchanged.
+
+## Files to Modify
+- `internal/handler/tools/schema_compat.go` — helper to normalize MCP tool schemas and register tools.
+- `internal/handler/tools/*` — use the helper for tool registration.
+- `internal/mcp-server/integration_test.go` — regression test over `tools/list` advertised schemas.
+
+## Verification
+- Run targeted tests for tool discovery and schema normalization.
+- Confirm no `inputSchema.properties.*` boolean subschemas remain in `tools/list`.
+- Run `go test ./...`.


### PR DESCRIPTION
## Summary

- Normalize advertised MCP tool input/output schemas before registration so schema-position `true` subschemas are emitted as `{}`.
- Route tool registration through the shared compatibility helper without changing runtime tool argument handling or SigNoz payload validation.
- Add unit and integration coverage that guards `tools/list` against OpenAPI-incompatible boolean subschemas.

## Root Cause

Some generated schemas for open-ended Go fields (`interface{}` / `[]interface{}`) used JSON Schema boolean subschemas such as `true`. That is valid JSON Schema, but OpenAPI 3 parsers expect schema-bearing fields like `properties.*` and `items` to be objects, so hiAgent failed tool synchronization.

Fixes #118.

## Docs / Metadata

No README or manifest update was needed because this does not add, rename, or remove tools/resources/configuration. It only normalizes the advertised schema representation.

## Validation

- `go test ./internal/handler/tools -run 'TestNormalizeRawSchemaReplacesSchemaTrueWithEmptyObject' -count=1`
- `go test ./internal/mcp-server -run 'TestIntegration_(InitializeAndListTools|ListToolsInputSchemasAreOpenAPICompatible)' -count=1`
- `go test ./internal/handler/tools ./internal/mcp-server`
- `go test ./...`