### PR TITLE
[codex] add alert rules listing tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -328,6 +328,7 @@ MCP_SERVER_PORT=8000 \
 | `signoz_get_field_keys` | Discover available field keys for metrics, traces, or logs |
 | `signoz_get_field_values` | Get possible values for a field key |
 | `signoz_list_alerts` | List firing/silenced/inhibited Alertmanager alert *instances* (not rule definitions) |
+| `signoz_list_alert_rules` | List configured alert rules, including inactive/OK and disabled rules |
 | `signoz_get_alert` | Get an alert rule definition by ID via GET /api/v2/rules/{ruleId} |
 | `signoz_get_alert_history` | Get alert state history timeline for a rule |
 | `signoz_create_alert` | Create an alert rule via POST /api/v2/rules; v2alpha1 for threshold/promql, v1 for anomaly |
@@ -396,7 +397,15 @@ Query metrics with smart aggregation defaults and validation. Automatically appl
 
 #### `signoz_list_alerts`
 
-Lists currently firing/silenced/inhibited alert *instances* from Alertmanager — **not** rule definitions. Use `signoz_get_alert` with a `ruleId` for rule definitions, or `signoz_get_alert_history` for the state timeline.
+Lists currently firing/silenced/inhibited alert *instances* from Alertmanager — **not** rule definitions. Use `signoz_list_alert_rules` for configured rules, `signoz_get_alert` with a `ruleId` for one full rule definition, or `signoz_get_alert_history` for the state timeline.
+
+#### `signoz_list_alert_rules`
+
+Lists configured alert rules from `GET /api/v2/rules`, including inactive/OK and disabled rules. Returns compact summaries with `ruleId`, `alert`, `alertType`, `ruleType`, `state`, `disabled`, `severity`, `labels`, `createdAt`, and `updatedAt`.
+
+- **Parameters**:
+  - `limit` (optional) - Maximum number of rules to return (default: 50)
+  - `offset` (optional) - Number of rules to skip for pagination (default: 0)
 
 #### `signoz_get_alert`
 
@@ -613,7 +622,7 @@ Create a new alert rule in SigNoz via `POST /api/v2/rules`.
 Update an existing alert rule via `PUT /api/v2/rules/{ruleId}`. Replaces the full rule configuration — fetch the current rule with `signoz_get_alert` first and merge changes on top of it.
 
 - **Parameters**:
-  - `ruleId` (required) - UUIDv7 of the rule to update (obtain from `signoz_list_alerts` / `signoz_get_alert`).
+  - `ruleId` (required) - UUIDv7 of the rule to update (obtain from `signoz_list_alert_rules` / `signoz_get_alert`).
   - Plus all fields of the alert rule schema (same shape as `signoz_create_alert`).
 
 #### `signoz_delete_alert`

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -456,6 +456,12 @@ func (s *SigNoz) ListAlerts(ctx context.Context, params types.ListAlertsParams) 
 	return s.doRequest(ctx, http.MethodGet, reqURL, nil, DefaultQueryTimeout)
 }
 
+func (s *SigNoz) ListAlertRules(ctx context.Context) (json.RawMessage, error) {
+	reqURL := fmt.Sprintf("%s/api/v2/rules", s.baseURL)
+	s.logger.DebugContext(s.ensureTenantContext(ctx), "Fetching alert rules from SigNoz", slog.String("url", reqURL))
+	return s.doRequest(ctx, http.MethodGet, reqURL, nil, DefaultQueryTimeout)
+}
+
 func (s *SigNoz) GetAlertByRuleID(ctx context.Context, ruleID string) (json.RawMessage, error) {
 	reqURL := fmt.Sprintf("%s/api/v2/rules/%s", s.baseURL, url.PathEscape(ruleID))
 	s.logger.DebugContext(s.ensureTenantContext(ctx), "Fetching alert rule details", slog.String("ruleID", ruleID))

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -128,6 +128,27 @@ func TestGetAlertByRuleID(t *testing.T) {
 	}
 }
 
+func TestListAlertRules(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, "/api/v2/rules", r.URL.Path)
+		assert.Equal(t, "", r.URL.RawQuery)
+		assert.Equal(t, "application/json", r.Header.Get("Content-Type"))
+		assert.Equal(t, "test-api-key", r.Header.Get("SIGNOZ-API-KEY"))
+
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"status":"success","data":[{"id":"rule-1","alert":"High CPU","state":"inactive"}]}`))
+	}))
+	defer server.Close()
+
+	logger := logpkg.New("debug")
+	client := NewClient(logger, server.URL, "test-api-key", "SIGNOZ-API-KEY", nil)
+
+	result, err := client.ListAlertRules(context.Background())
+	require.NoError(t, err)
+	assert.Contains(t, string(result), `"id":"rule-1"`)
+}
+
 func TestValidateCredentials(t *testing.T) {
 	tests := []struct {
 		name            string

--- a/internal/client/interface.go
+++ b/internal/client/interface.go
@@ -13,6 +13,7 @@ type Client interface {
 	GetAnalyticsIdentity(ctx context.Context) (*AnalyticsIdentity, error)
 	ListMetrics(ctx context.Context, start, end int64, limit int, searchText, source string) (json.RawMessage, error)
 	ListAlerts(ctx context.Context, params types.ListAlertsParams) (json.RawMessage, error)
+	ListAlertRules(ctx context.Context) (json.RawMessage, error)
 	GetAlertByRuleID(ctx context.Context, ruleID string) (json.RawMessage, error)
 	GetAlertHistory(ctx context.Context, ruleID string, req types.AlertHistoryRequest) (json.RawMessage, error)
 	ListDashboards(ctx context.Context) (json.RawMessage, error)

--- a/internal/client/mock.go
+++ b/internal/client/mock.go
@@ -14,6 +14,7 @@ type MockClient struct {
 	GetAnalyticsIdentityFn      func(ctx context.Context) (*AnalyticsIdentity, error)
 	ListMetricsFn               func(ctx context.Context, start, end int64, limit int, searchText, source string) (json.RawMessage, error)
 	ListAlertsFn                func(ctx context.Context, params types.ListAlertsParams) (json.RawMessage, error)
+	ListAlertRulesFn            func(ctx context.Context) (json.RawMessage, error)
 	GetAlertByRuleIDFn          func(ctx context.Context, ruleID string) (json.RawMessage, error)
 	GetAlertHistoryFn           func(ctx context.Context, ruleID string, req types.AlertHistoryRequest) (json.RawMessage, error)
 	ListDashboardsFn            func(ctx context.Context) (json.RawMessage, error)
@@ -65,6 +66,13 @@ func (m *MockClient) ListMetrics(ctx context.Context, start, end int64, limit in
 func (m *MockClient) ListAlerts(ctx context.Context, params types.ListAlertsParams) (json.RawMessage, error) {
 	if m.ListAlertsFn != nil {
 		return m.ListAlertsFn(ctx, params)
+	}
+	return json.RawMessage(`{}`), nil
+}
+
+func (m *MockClient) ListAlertRules(ctx context.Context) (json.RawMessage, error) {
+	if m.ListAlertRulesFn != nil {
+		return m.ListAlertRulesFn(ctx)
 	}
 	return json.RawMessage(`{}`), nil
 }

--- a/internal/handler/tools/alerts.go
+++ b/internal/handler/tools/alerts.go
@@ -27,7 +27,7 @@ func (h *Handler) RegisterAlertsHandlers(s *server.MCPServer) {
 		mcp.WithReadOnlyHintAnnotation(true),
 		mcp.WithDestructiveHintAnnotation(false),
 		mcp.WithString("searchContext", mcp.Description("The user's original question or search text that triggered this tool call. Always include the user's raw query here for better results.")),
-		mcp.WithDescription("Lists currently firing/silenced/inhibited alert *instances* from Alertmanager — not rule definitions. Use signoz_get_alert with a ruleId to fetch the rule definition itself, or signoz_get_alert_history for the state timeline.\n\nReturns alert name, rule ID, severity, start time, end time, and state.\n\nFILTERING: Use server-side filters to narrow results BEFORE paginating.\n- To find a specific alert by name: filter='alertname=\"HighCPU\"'\n- To find alerts by severity: filter='severity=\"critical\"'\n- Combine matchers: filter='alertname=\"HighCPU\",severity=\"critical\"'\n- To see only firing alerts: active='true', silenced='false', inhibited='false'\n- To see only silenced alerts: silenced='true', active='false'\n- To filter by notification receiver: receiver='slack-.*'\nBy default all alert states (active, silenced, inhibited) are included.\n\nPAGINATION: Supports 'limit' and 'offset'. Response includes 'pagination' with 'total', 'hasMore', and 'nextOffset'. Prefer 'filter' to find specific alerts instead of paginating all pages. Default: limit=50, offset=0."),
+		mcp.WithDescription("Lists currently firing/silenced/inhibited alert *instances* from Alertmanager — not rule definitions. Use signoz_list_alert_rules for configured rules, signoz_get_alert with a ruleId for one full rule definition, or signoz_get_alert_history for the state timeline.\n\nReturns alert name, rule ID, severity, start time, end time, and state.\n\nFILTERING: Use server-side filters to narrow results BEFORE paginating.\n- To find a specific alert by name: filter='alertname=\"HighCPU\"'\n- To find alerts by severity: filter='severity=\"critical\"'\n- Combine matchers: filter='alertname=\"HighCPU\",severity=\"critical\"'\n- To see only firing alerts: active='true', silenced='false', inhibited='false'\n- To see only silenced alerts: silenced='true', active='false'\n- To filter by notification receiver: receiver='slack-.*'\nBy default all alert states (active, silenced, inhibited) are included.\n\nPAGINATION: Supports 'limit' and 'offset'. Response includes 'pagination' with 'total', 'hasMore', and 'nextOffset'. Prefer 'filter' to find specific alerts instead of paginating all pages. Default: limit=50, offset=0."),
 		mcp.WithString("limit", mcp.Description("Maximum number of alerts to return per page. Default: 50.")),
 		mcp.WithString("offset", mcp.Description("Number of results to skip for pagination. Default: 0.")),
 		mcp.WithString("active", mcp.Description("Include active (firing) alerts. Values: 'true' or 'false'. Default: true.")),
@@ -37,6 +37,16 @@ func (h *Handler) RegisterAlertsHandlers(s *server.MCPServer) {
 		mcp.WithString("receiver", mcp.Description("Regex to filter alerts by receiver name. Example: 'slack-.*' to match all Slack receivers.")),
 	)
 	addTool(s, alertsTool, h.handleListAlerts)
+
+	alertRulesTool := mcp.NewTool("signoz_list_alert_rules",
+		mcp.WithReadOnlyHintAnnotation(true),
+		mcp.WithDestructiveHintAnnotation(false),
+		mcp.WithString("searchContext", mcp.Description("The user's original question or search text that triggered this tool call. Always include the user's raw query here for better results.")),
+		mcp.WithDescription("Lists configured alert rules from GET /api/v2/rules, including inactive/OK and disabled rules. Use signoz_list_alerts for current Alertmanager alert instances.\n\nReturns ruleId, alert, alertType, ruleType, state, disabled, severity, labels, createdAt, and updatedAt. Use signoz_get_alert for the full rule definition.\n\nPAGINATION: Supports 'limit' and 'offset'. Response includes 'pagination' with 'total', 'hasMore', and 'nextOffset'. Default: limit=50, offset=0."),
+		mcp.WithString("limit", mcp.Description("Maximum number of alert rules to return per page. Default: 50.")),
+		mcp.WithString("offset", mcp.Description("Number of results to skip for pagination. Default: 0.")),
+	)
+	addTool(s, alertRulesTool, h.handleListAlertRules)
 
 	getAlertTool := mcp.NewTool("signoz_get_alert",
 		mcp.WithReadOnlyHintAnnotation(true),
@@ -93,7 +103,7 @@ func (h *Handler) RegisterAlertsHandlers(s *server.MCPServer) {
 		"signoz_update_alert",
 		mcp.WithDestructiveHintAnnotation(true),
 		mcp.WithString("searchContext", mcp.Description("The user's original question or search text that triggered this tool call. Always include the user's raw query here for better results.")),
-		mcp.WithString("ruleId", mcp.Required(), mcp.Description("UUIDv7 of the alert rule to update. Obtain it from signoz_get_alert or signoz_list_alerts.")),
+		mcp.WithString("ruleId", mcp.Required(), mcp.Description("UUIDv7 of the alert rule to update. Obtain it from signoz_list_alert_rules or signoz_get_alert.")),
 		mcp.WithDescription(
 			"Updates an existing alert rule in SigNoz (PUT /api/v2/rules/{ruleId}). Replaces the full rule configuration.\n\n"+
 				"CRITICAL: Read signoz://alert/instructions and signoz://alert/examples before generating the payload. "+
@@ -189,6 +199,68 @@ func (h *Handler) handleListAlerts(ctx context.Context, req mcp.CallToolRequest)
 	resultJSON, err := paginate.Wrap(pagedAlerts, total, offset, limit)
 	if err != nil {
 		h.logger.ErrorContext(ctx, "Failed to wrap alerts with pagination", logpkg.ErrAttr(err))
+		return mcp.NewToolResultError("failed to marshal response: " + err.Error()), nil
+	}
+
+	return mcp.NewToolResultText(string(resultJSON)), nil
+}
+
+func (h *Handler) handleListAlertRules(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	h.logger.DebugContext(ctx, "Tool called: signoz_list_alert_rules")
+	limit, offset := paginate.ParseParams(req.Params.Arguments)
+
+	client, err := h.GetClient(ctx)
+	if err != nil {
+		return mcp.NewToolResultError(err.Error()), nil
+	}
+	rules, err := client.ListAlertRules(ctx)
+	if err != nil {
+		h.logger.ErrorContext(ctx, "Failed to list alert rules", logpkg.ErrAttr(err))
+		return mcp.NewToolResultError(err.Error()), nil
+	}
+
+	var apiResponse types.APIAlertRulesResponse
+	if err := json.Unmarshal(rules, &apiResponse); err != nil {
+		h.logger.ErrorContext(ctx, "Failed to parse alert rules response", logpkg.ErrAttr(err), slog.String("response", logpkg.TruncBody(rules)))
+		return mcp.NewToolResultError("failed to parse alert rules response: " + err.Error()), nil
+	}
+
+	ruleSummaries := make([]types.AlertRuleSummary, 0, len(apiResponse.Data))
+	for _, apiRule := range apiResponse.Data {
+		createdAt := apiRule.CreatedAt
+		if createdAt == "" {
+			createdAt = apiRule.CreateAt
+		}
+		updatedAt := apiRule.UpdatedAt
+		if updatedAt == "" {
+			updatedAt = apiRule.UpdateAt
+		}
+
+		ruleSummaries = append(ruleSummaries, types.AlertRuleSummary{
+			RuleID:      apiRule.ID,
+			Alert:       apiRule.Alert,
+			AlertType:   apiRule.AlertType,
+			RuleType:    apiRule.RuleType,
+			State:       apiRule.State,
+			Disabled:    apiRule.Disabled,
+			Severity:    apiRule.Labels["severity"],
+			Description: apiRule.Description,
+			Labels:      apiRule.Labels,
+			CreatedAt:   createdAt,
+			UpdatedAt:   updatedAt,
+		})
+	}
+
+	total := len(ruleSummaries)
+	rulesArray := make([]any, len(ruleSummaries))
+	for i, v := range ruleSummaries {
+		rulesArray[i] = v
+	}
+	pagedRules := paginate.Array(rulesArray, offset, limit)
+
+	resultJSON, err := paginate.Wrap(pagedRules, total, offset, limit)
+	if err != nil {
+		h.logger.ErrorContext(ctx, "Failed to wrap alert rules with pagination", logpkg.ErrAttr(err))
 		return mcp.NewToolResultError("failed to marshal response: " + err.Error()), nil
 	}
 
@@ -347,7 +419,7 @@ func (h *Handler) handleUpdateAlert(ctx context.Context, req mcp.CallToolRequest
 		return mcp.NewToolResultError(`Parameter validation failed: "ruleId" is required. Provide the UUIDv7 of the rule to update.`), nil
 	}
 	if !util.IsUUIDv7(ruleID) {
-		return mcp.NewToolResultError(fmt.Sprintf(`Invalid "ruleId": %q is not a UUIDv7. Obtain the rule ID from signoz_list_alerts or signoz_get_alert.`, ruleID)), nil
+		return mcp.NewToolResultError(fmt.Sprintf(`Invalid "ruleId": %q is not a UUIDv7. Obtain the rule ID from signoz_list_alert_rules or signoz_get_alert.`, ruleID)), nil
 	}
 	delete(rawConfig, "ruleId")
 

--- a/internal/handler/tools/alerts_test.go
+++ b/internal/handler/tools/alerts_test.go
@@ -93,6 +93,129 @@ func TestHandleListAlerts_ClientError(t *testing.T) {
 	}
 }
 
+func TestHandleListAlertRules(t *testing.T) {
+	mock := &client.MockClient{
+		ListAlertRulesFn: func(ctx context.Context) (json.RawMessage, error) {
+			return json.RawMessage(`{
+				"status": "success",
+				"data": [
+					{
+						"id": "rule-1",
+						"alert": "HighCPU",
+						"alertType": "METRIC_BASED_ALERT",
+						"ruleType": "threshold_rule",
+						"state": "firing",
+						"disabled": false,
+						"labels": {"severity": "critical", "team": "infra"},
+						"createdAt": "2026-04-01T00:00:00Z",
+						"updatedAt": "2026-04-02T00:00:00Z"
+					},
+					{
+						"id": "rule-2",
+						"alert": "HighMemory",
+						"alertType": "METRIC_BASED_ALERT",
+						"ruleType": "threshold_rule",
+						"state": "inactive",
+						"disabled": false,
+						"labels": {"severity": "warning"},
+						"createAt": "2026-03-01T00:00:00Z",
+						"updateAt": "2026-03-02T00:00:00Z"
+					},
+					{
+						"id": "rule-3",
+						"alert": "DisabledRule",
+						"alertType": "LOGS_BASED_ALERT",
+						"ruleType": "threshold_rule",
+						"state": "disabled",
+						"disabled": true
+					}
+				]
+			}`), nil
+		},
+	}
+	h := newTestHandler(mock)
+	req := makeToolRequest("signoz_list_alert_rules", map[string]any{
+		"limit":  "2",
+		"offset": "1",
+	})
+
+	result, err := h.handleListAlertRules(testCtx(), req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("handler returned error result: %v", result.Content)
+	}
+
+	var resp struct {
+		Data       []types.AlertRuleSummary `json:"data"`
+		Pagination struct {
+			Total      int  `json:"total"`
+			Offset     int  `json:"offset"`
+			Limit      int  `json:"limit"`
+			HasMore    bool `json:"hasMore"`
+			NextOffset int  `json:"nextOffset"`
+		} `json:"pagination"`
+	}
+	text := result.Content[0].(mcp.TextContent).Text
+	if err := json.Unmarshal([]byte(text), &resp); err != nil {
+		t.Fatalf("failed to parse response: %v", err)
+	}
+	if resp.Pagination.Total != 3 {
+		t.Fatalf("total = %d, want 3", resp.Pagination.Total)
+	}
+	if len(resp.Data) != 2 {
+		t.Fatalf("len(data) = %d, want 2", len(resp.Data))
+	}
+	if resp.Data[0].RuleID != "rule-2" || resp.Data[0].State != "inactive" || resp.Data[0].Severity != "warning" {
+		t.Fatalf("unexpected first rule summary: %+v", resp.Data[0])
+	}
+	if resp.Data[0].CreatedAt != "2026-03-01T00:00:00Z" || resp.Data[0].UpdatedAt != "2026-03-02T00:00:00Z" {
+		t.Fatalf("legacy timestamps were not preserved: %+v", resp.Data[0])
+	}
+	if !resp.Data[1].Disabled || resp.Data[1].RuleID != "rule-3" {
+		t.Fatalf("unexpected second rule summary: %+v", resp.Data[1])
+	}
+}
+
+func TestHandleListAlertRules_NoArguments(t *testing.T) {
+	mock := &client.MockClient{
+		ListAlertRulesFn: func(ctx context.Context) (json.RawMessage, error) {
+			return json.RawMessage(`{"status":"success","data":[]}`), nil
+		},
+	}
+	h := newTestHandler(mock)
+	req := mcp.CallToolRequest{
+		Params: mcp.CallToolParams{Name: "signoz_list_alert_rules"},
+	}
+
+	result, err := h.handleListAlertRules(testCtx(), req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("handler returned error result: %v", result.Content)
+	}
+}
+
+func TestHandleListAlertRules_ClientError(t *testing.T) {
+	mock := &client.MockClient{
+		ListAlertRulesFn: func(ctx context.Context) (json.RawMessage, error) {
+			return nil, fmt.Errorf("connection refused")
+		},
+	}
+	h := newTestHandler(mock)
+	req := makeToolRequest("signoz_list_alert_rules", map[string]any{})
+
+	result, err := h.handleListAlertRules(testCtx(), req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !result.IsError {
+		t.Error("expected error result when client returns error")
+	}
+}
+
 func TestHandleGetAlert(t *testing.T) {
 	var capturedRuleID string
 	mock := &client.MockClient{

--- a/internal/mcp-server/integration_test.go
+++ b/internal/mcp-server/integration_test.go
@@ -89,12 +89,22 @@ func TestIntegration_InitializeAndListTools(t *testing.T) {
 		t.Fatalf("ListTools failed: %v", err)
 	}
 
-	const expectedToolCount = 33
+	const expectedToolCount = 34
 	if len(toolsResult.Tools) != expectedToolCount {
 		t.Errorf("expected %d tools, got %d", expectedToolCount, len(toolsResult.Tools))
 		for _, tool := range toolsResult.Tools {
 			t.Logf("  tool: %s", tool.Name)
 		}
+	}
+	foundAlertRulesTool := false
+	for _, tool := range toolsResult.Tools {
+		if tool.Name == "signoz_list_alert_rules" {
+			foundAlertRulesTool = true
+			break
+		}
+	}
+	if !foundAlertRulesTool {
+		t.Error("expected signoz_list_alert_rules tool to be registered")
 	}
 }
 

--- a/manifest.json
+++ b/manifest.json
@@ -46,6 +46,10 @@
       "description": "List firing/silenced/inhibited Alertmanager alert *instances* (not rule definitions) with optional matcher/receiver filtering"
     },
     {
+      "name": "signoz_list_alert_rules",
+      "description": "List configured alert rules via GET /api/v2/rules, including inactive/OK and disabled rules"
+    },
+    {
       "name": "signoz_get_alert",
       "description": "Get an alert rule definition by ID via GET /api/v2/rules/{ruleId}. Response shape differs by server version (v2 Rule vs v1 GettableRule)"
     },

--- a/pkg/types/alerts.go
+++ b/pkg/types/alerts.go
@@ -54,6 +54,42 @@ type APIAlertsResponse struct {
 	Data   []APIAlert `json:"data"`
 }
 
+// AlertRuleSummary contains the fields needed to discover configured rules.
+type AlertRuleSummary struct {
+	RuleID      string            `json:"ruleId"`
+	Alert       string            `json:"alert"`
+	AlertType   string            `json:"alertType"`
+	RuleType    string            `json:"ruleType"`
+	State       string            `json:"state"`
+	Disabled    bool              `json:"disabled"`
+	Severity    string            `json:"severity,omitempty"`
+	Description string            `json:"description,omitempty"`
+	Labels      map[string]string `json:"labels,omitempty"`
+	CreatedAt   string            `json:"createdAt,omitempty"`
+	UpdatedAt   string            `json:"updatedAt,omitempty"`
+}
+
+// APIAlertRule mirrors the compact fields used from GET /api/v2/rules.
+type APIAlertRule struct {
+	ID          string            `json:"id"`
+	Alert       string            `json:"alert"`
+	AlertType   string            `json:"alertType"`
+	RuleType    string            `json:"ruleType"`
+	State       string            `json:"state"`
+	Disabled    bool              `json:"disabled"`
+	Description string            `json:"description"`
+	Labels      map[string]string `json:"labels"`
+	CreatedAt   string            `json:"createdAt"`
+	UpdatedAt   string            `json:"updatedAt"`
+	CreateAt    string            `json:"createAt"`
+	UpdateAt    string            `json:"updateAt"`
+}
+
+type APIAlertRulesResponse struct {
+	Status string         `json:"status"`
+	Data   []APIAlertRule `json:"data"`
+}
+
 // ListAlertsParams contains query parameters for the GET /api/v1/alerts endpoint.
 type ListAlertsParams struct {
 	Active    *bool


### PR DESCRIPTION
## Summary
- Add `signoz_list_alert_rules`, a read-only MCP tool backed by `GET /api/v2/rules`, to list configured alert rules including inactive/OK and disabled rules.
- Keep `signoz_list_alerts` scoped to current Alertmanager alert instances, and update rule-ID guidance to point at `signoz_list_alert_rules`.
- Return compact paginated rule summaries and preserve both current `createdAt`/`updatedAt` and legacy `createAt`/`updateAt` timestamp shapes.

## Why
`signoz_list_alerts` maps to `/api/v1/alerts`, which returns current Alertmanager alert instances and can be empty when all configured rules are inactive. Users need a separate tool for inventorying configured alert rules from `/api/v2/rules`.

## Docs and metadata
- Updated `README.md` tool table and parameter reference.
- Updated `manifest.json` tool metadata for the new MCP tool.

## Validation
- `go test ./internal/client ./internal/handler/tools ./internal/mcp-server`
- `go test ./...`
- GitHub commit verification: `verified=true`, reason `valid` for `4f421b5cfdcac0236c9c95523f82e6108316d5b8`.

Addresses #119.