### PR TITLE
fix(dashboard): accept typed-slice filter items in normalizers and co…

### DIFF
--- a/pkg/dashboard/dashboardbuilder/normalize.go
+++ b/pkg/dashboard/dashboardbuilder/normalize.go
@@ -2,6 +2,32 @@ package dashboardbuilder
 
 import "strings"
 
+// filterItemsSlice returns the items array from a filters map as []any,
+// regardless of whether the caller constructed the slice as []any (the shape
+// Go's JSON decoder produces when unmarshalling into map[string]any) or as
+// []map[string]any (an idiomatic Go literal for a typed array of maps).
+// Returns nil for any other type — missing key, wrong concrete type, or non-
+// slice value — so callers that range over the result naturally no-op.
+//
+// This exists because filter-related helpers (normalizers and the expression
+// consistency check) need to walk filter items regardless of which code path
+// built the payload. Asserting on []any alone silently skips the whole items
+// array when the caller happens to use the typed-slice literal, defeating
+// the purpose of the helper.
+func filterItemsSlice(items any) []any {
+	switch v := items.(type) {
+	case []any:
+		return v
+	case []map[string]any:
+		out := make([]any, len(v))
+		for i, m := range v {
+			out[i] = m
+		}
+		return out
+	}
+	return nil
+}
+
 // canonicalDynamicSource maps an incoming dynamicVariablesSource value to the
 // canonical form written by the current SigNoz UI dropdown
 // (frontend AttributeSource enum): "Traces", "Logs", "Metrics", "All telemetry".
@@ -45,8 +71,8 @@ func uppercaseFilterOpsInQueryMaps(entries []map[string]any) {
 		if !ok {
 			continue
 		}
-		items, ok := filters["items"].([]any)
-		if !ok {
+		items := filterItemsSlice(filters["items"])
+		if items == nil {
 			continue
 		}
 		for _, it := range items {
@@ -95,8 +121,8 @@ func normalizeFilterItemsInQueryMaps(entries []map[string]any) {
 		if !ok {
 			continue
 		}
-		items, ok := filters["items"].([]any)
-		if !ok {
+		items := filterItemsSlice(filters["items"])
+		if items == nil {
 			continue
 		}
 		for _, it := range items {

--- a/pkg/dashboard/dashboardbuilder/normalize_test.go
+++ b/pkg/dashboard/dashboardbuilder/normalize_test.go
@@ -330,6 +330,89 @@ func TestNormalizeFilterItems_MissingOrNil(t *testing.T) {
 	normalizeFilterItemsInQueryMaps(entries)
 }
 
+func TestFilterItemsSlice(t *testing.T) {
+	cases := []struct {
+		name string
+		in   any
+		want int // length; nil → 0
+		nilExpected bool
+	}{
+		{"nil input", nil, 0, true},
+		{"empty []any", []any{}, 0, false},
+		{"populated []any", []any{map[string]any{"op": "IN"}}, 1, false},
+		{"[]map[string]any", []map[string]any{{"op": "IN"}, {"op": "=" }}, 2, false},
+		{"wrong type string", "oops", 0, true},
+		{"wrong type map", map[string]any{"a": 1}, 0, true},
+		{"empty []map[string]any", []map[string]any{}, 0, false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := filterItemsSlice(c.in)
+			if c.nilExpected && got != nil {
+				t.Errorf("expected nil, got %v", got)
+			}
+			if !c.nilExpected && got == nil {
+				t.Errorf("expected non-nil slice")
+			}
+			if len(got) != c.want {
+				t.Errorf("len = %d, want %d", len(got), c.want)
+			}
+		})
+	}
+}
+
+func TestUppercaseFilterOpsInQueryMaps_TypedSliceLiteral(t *testing.T) {
+	// Go-idiomatic []map[string]any literal (not []any). Must still be
+	// processed by the normalizer, same as the JSON-unmarshalled shape.
+	entries := []map[string]any{
+		{
+			"filters": map[string]any{
+				"op": "AND",
+				"items": []map[string]any{
+					{"op": "in", "value": "x"},
+					{"op": "not_in", "value": "y"},
+				},
+			},
+		},
+	}
+	uppercaseFilterOpsInQueryMaps(entries)
+	items := entries[0]["filters"].(map[string]any)["items"].([]map[string]any)
+	if items[0]["op"] != "IN" || items[1]["op"] != "NOT_IN" {
+		t.Errorf("expected uppercase, got %v / %v", items[0]["op"], items[1]["op"])
+	}
+}
+
+func TestNormalizeFilterItemsInQueryMaps_TypedSliceLiteral(t *testing.T) {
+	// Same Go-idiomatic shape — must heal the malformed key even though
+	// items is []map[string]any rather than []any.
+	entries := []map[string]any{
+		{
+			"filters": map[string]any{
+				"op": "AND",
+				"items": []map[string]any{
+					{
+						"key":   map[string]any{"id": "k8s.node.name", "key": "k8s.node.name", "type": ""},
+						"op":    "IN",
+						"value": []any{"$k8s.node.name"},
+					},
+				},
+			},
+		},
+	}
+	normalizeFilterItemsInQueryMaps(entries)
+	item := entries[0]["filters"].(map[string]any)["items"].([]map[string]any)[0]
+	key := item["key"].(map[string]any)
+	if key["dataType"] != "string" {
+		t.Errorf("dataType not filled: %v", key["dataType"])
+	}
+	if key["id"] != "k8s.node.name--string--" {
+		t.Errorf("id not rebuilt: %v", key["id"])
+	}
+	if item["value"] != "$k8s.node.name" {
+		t.Errorf("value not unwrapped: %v", item["value"])
+	}
+}
+
 func TestUppercaseFilterOpsInQueryMaps_MissingOrNil(t *testing.T) {
 	entries := []map[string]any{
 		nil,                               // nil entry

--- a/pkg/dashboard/dashboardbuilder/validate.go
+++ b/pkg/dashboard/dashboardbuilder/validate.go
@@ -204,7 +204,7 @@ func validateFilterExpressionConsistency(prefix string, qd map[string]any, errs 
 		return
 	}
 	filtersMap, _ := qd["filters"].(map[string]any)
-	itemsAny, _ := filtersMap["items"].([]any)
+	itemsAny := filterItemsSlice(filtersMap["items"])
 	if len(itemsAny) == 0 {
 		return
 	}

--- a/pkg/dashboard/dashboardbuilder/validate_test.go
+++ b/pkg/dashboard/dashboardbuilder/validate_test.go
@@ -720,6 +720,54 @@ func TestValidate_FilterExpressionAcceptsStandaloneVarReference(t *testing.T) {
 	}
 }
 
+func TestValidate_FilterExpressionConsistencyHandlesTypedSliceLiteral(t *testing.T) {
+	// Go-native []map[string]any literal (not []any). Consistency guard must
+	// still detect the missing key and reject, matching the behavior on the
+	// JSON-unmarshalled []any path.
+	d := &DashboardData{
+		Title:     "Test",
+		Version:   DashboardVersion,
+		Variables: map[string]*DashboardVariable{},
+		Widgets: []WidgetOrRow{
+			{
+				ID: "w1", PanelTypes: PanelTypeGraph, Title: "W1",
+				Query: &Query{
+					QueryType: QueryTypeBuilder,
+					Builder: &BuilderData{
+						QueryData: []map[string]any{
+							{
+								"queryName":  "A",
+								"dataSource": "metrics",
+								"expression": "A",
+								"filter": map[string]any{
+									"expression": "service.name IN $service_name",
+								},
+								"filters": map[string]any{
+									"op": "AND",
+									// Typed slice literal, not []any.
+									"items": []map[string]any{
+										{"key": map[string]any{"key": "service.name"}, "op": "IN", "value": "$service_name"},
+										{"key": map[string]any{"key": "region"}, "op": "=", "value": "us-east"},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		Layout: []LayoutItem{{I: "w1", X: 0, Y: 0, W: 6, H: 6}},
+	}
+	verr := Validate(d)
+	if verr == nil {
+		t.Fatal("expected rejection: region item missing from expression, regardless of slice concrete type")
+	}
+	assertHasFieldError(t, verr, "filter.expression")
+	if !strings.Contains(verr.Error(), "region") {
+		t.Errorf("error should name the missing key, got: %v", verr)
+	}
+}
+
 func TestContainsKeyAsIdentifier(t *testing.T) {
 	// Direct unit coverage of the boundary logic for clarity.
 	cases := []struct {


### PR DESCRIPTION
…nsistency check

The three filter-item helpers asserted `filters["items"].([]any)` to walk the items array. That assertion only succeeds for the JSON-unmarshal shape (where arrays decode to []any inside map[string]any); it silently fails for the idiomatic Go literal []map[string]any, causing the whole items block to be skipped.

In practice the JSON ingest path is the only one we ship today, so the bug is latent. But fluent-builder code, tests, or any future Go-native construction would bypass:
- uppercaseFilterOpsInQueryMaps — ops would not be uppercased
- normalizeFilterItemsInQueryMaps — malformed key shapes not healed
- validateFilterExpressionConsistency — expression/items mismatch not rejected, defeating the whole point of the guard

Extract filterItemsSlice(any) []any in normalize.go that handles both concrete slice types and returns nil for everything else. Swap the assertion at all three sites. Codex flagged only the consistency check on PR #144; fixing the class covers the two normalizers that share the same pattern.

Tests:
- TestFilterItemsSlice — 7-row table test covering nil, empty and populated []any, []map[string]any, empty []map[string]any, and two wrong-type inputs.
- TestUppercaseFilterOpsInQueryMaps_TypedSliceLiteral — verifies lowercase ops are uppercased even when items is []map[string]any.
- TestNormalizeFilterItemsInQueryMaps_TypedSliceLiteral — verifies the key.dataType / key.id / value-unwrap heals run on []map[string]any.
- TestValidate_FilterExpressionConsistencyHandlesTypedSliceLiteral — end-to-end rejection of mismatched expression/items when items is constructed as []map[string]any.

Refs #144 review comment
https://github.com/SigNoz/signoz-mcp-server/pull/144#discussion_r3137220056