### PR TITLE
[codex] fix internal otel exporter defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -695,6 +695,13 @@ Executes a SigNoz Query Builder v5 query.
 | `OAUTH_REFRESH_TOKEN_TTL_MINUTES` | Refresh token lifetime in minutes (default: 1440 / 24h)       | No                                  |
 | `OAUTH_AUTH_CODE_TTL_SECONDS` | Authorization code lifetime in seconds (default: 600 / 10min)      | No                                  |
 | `SIGNOZ_CUSTOM_HEADERS` | Extra HTTP headers added to every API request, useful when SigNoz is behind a reverse proxy requiring auth (e.g. `CF-Access-Client-Id:id.access,CF-Access-Client-Secret:secret`). Format: `Key1:Value1,Key2:Value2` | No |
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | OTLP gRPC endpoint for the MCP server's own traces and metrics. Internal telemetry export is disabled when no OTLP endpoint/exporter is configured. For plaintext collectors, use an `http://` endpoint such as `http://localhost:4317`. | No |
+| `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` | Trace-specific OTLP gRPC endpoint; overrides `OTEL_EXPORTER_OTLP_ENDPOINT` for traces. | No |
+| `OTEL_EXPORTER_OTLP_METRICS_ENDPOINT` | Metrics-specific OTLP gRPC endpoint; overrides `OTEL_EXPORTER_OTLP_ENDPOINT` for metrics. | No |
+| `OTEL_TRACES_EXPORTER` | Set to `none` to disable internal trace export even when an OTLP endpoint is configured. | No |
+| `OTEL_METRICS_EXPORTER` | Set to `none` to disable internal metrics export and runtime metrics even when an OTLP endpoint is configured. | No |
+
+The MCP server does not run an OTLP log exporter; logs are emitted as JSON to stderr. `OTEL_LOGS_EXPORTER` is therefore not used.
 
 ## Claude Desktop Extension
 

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -55,22 +55,33 @@ func main() {
 		logger.WarnContext(ctx, "OpenTelemetry resource detection partially failed; continuing with available attributes", logpkg.ErrAttr(err))
 	}
 
-	shutdownTracer, err := otelpkg.InitTracerProvider(ctx, res)
+	shutdownTracer, traceStatus, err := otelpkg.InitTracerProvider(ctx, res)
 	if err != nil {
 		logger.WarnContext(ctx, "Failed to initialize OpenTelemetry tracer, continuing without tracing", logpkg.ErrAttr(err))
+	} else if traceStatus == otelpkg.ExporterStatusDisabled {
+		logger.InfoContext(ctx, "OpenTelemetry tracer export disabled", slog.String("env", otelpkg.EnvTracesExporter))
+	} else if traceStatus == otelpkg.ExporterStatusNotConfigured {
+		logger.InfoContext(ctx, "OpenTelemetry tracer export not configured; continuing without tracing export")
 	} else {
 		logger.InfoContext(ctx, "OpenTelemetry tracer initialized successfully")
 	}
 
-	shutdownMeter, err := otelpkg.InitMeterProvider(ctx, res)
+	shutdownMeter, metricStatus, err := otelpkg.InitMeterProvider(ctx, res)
 	if err != nil {
 		logger.WarnContext(ctx, "Failed to initialize OpenTelemetry meter provider, continuing without metrics export", logpkg.ErrAttr(err))
+	} else if metricStatus == otelpkg.ExporterStatusDisabled {
+		logger.InfoContext(ctx, "OpenTelemetry metrics export disabled", slog.String("env", otelpkg.EnvMetricsExporter))
+	} else if metricStatus == otelpkg.ExporterStatusNotConfigured {
+		logger.InfoContext(ctx, "OpenTelemetry metrics export not configured; continuing without metrics export")
 	} else {
 		logger.InfoContext(ctx, "OpenTelemetry meter provider initialized successfully")
 	}
 
-	if err := otelruntime.Start(); err != nil {
-		logger.WarnContext(ctx, "Failed to initialize OpenTelemetry runtime metrics", logpkg.ErrAttr(err))
+	metricsExportEnabled := err == nil && metricStatus == otelpkg.ExporterStatusEnabled
+	if metricsExportEnabled {
+		if err := otelruntime.Start(); err != nil {
+			logger.WarnContext(ctx, "Failed to initialize OpenTelemetry runtime metrics", logpkg.ErrAttr(err))
+		}
 	}
 
 	meters, err := otelpkg.NewMeters(otel.GetMeterProvider())

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -6,11 +6,11 @@
 flowchart TB
 
 subgraph Startup["Server Initialization"]
-    ENV["Env Vars: SIGNOZ_URL, SIGNOZ_API_KEY,<br/>LOG_LEVEL, TRANSPORT_MODE, MCP_SERVER_PORT,<br/>CLIENT_CACHE_SIZE, CLIENT_CACHE_TTL_MINUTES,<br/>OAUTH_ENABLED, OAUTH_TOKEN_SECRET, OAUTH_ISSUER_URL"]
+    ENV["Env Vars: SIGNOZ_URL, SIGNOZ_API_KEY,<br/>LOG_LEVEL, TRANSPORT_MODE, MCP_SERVER_PORT,<br/>CLIENT_CACHE_SIZE, CLIENT_CACHE_TTL_MINUTES,<br/>OAUTH_ENABLED, OAUTH_TOKEN_SECRET, OAUTH_ISSUER_URL,<br/>OTEL_EXPORTER_OTLP_*"]
     ENV --> CFG["config.LoadConfig"]
     CFG --> VALIDATE["config.ValidateConfig"]
-    VALIDATE --> LOG["telemetry.NewLogger"]
-    LOG --> OTEL["Init OpenTelemetry<br/>(Tracer, Meter, Log Provider)"]
+    VALIDATE --> LOG["log.New"]
+    LOG --> OTEL["Init OpenTelemetry<br/>(Tracer, Meter; OTLP export only when configured)"]
     OTEL --> HANDLER["Handler with LRU clientCache"]
     HANDLER --> CHSCHEMA["dashboard.InitClickhouseSchema"]
     CHSCHEMA --> MCPSRV["NewMCPServer"]

--- a/pkg/otel/exporter_config.go
+++ b/pkg/otel/exporter_config.go
@@ -1,0 +1,48 @@
+package otel
+
+import (
+	"os"
+	"strings"
+)
+
+const (
+	EnvExporterOTLPEndpoint        = "OTEL_EXPORTER_OTLP_ENDPOINT"
+	EnvExporterOTLPTracesEndpoint  = "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT"
+	EnvExporterOTLPMetricsEndpoint = "OTEL_EXPORTER_OTLP_METRICS_ENDPOINT"
+	EnvTracesExporter              = "OTEL_TRACES_EXPORTER"
+	EnvMetricsExporter             = "OTEL_METRICS_EXPORTER"
+)
+
+type ExporterStatus string
+
+const (
+	ExporterStatusEnabled       ExporterStatus = "enabled"
+	ExporterStatusDisabled      ExporterStatus = "disabled"
+	ExporterStatusNotConfigured ExporterStatus = "not_configured"
+)
+
+func TraceExporterStatus() ExporterStatus {
+	return exporterStatus(EnvTracesExporter, EnvExporterOTLPTracesEndpoint)
+}
+
+func MetricExporterStatus() ExporterStatus {
+	return exporterStatus(EnvMetricsExporter, EnvExporterOTLPMetricsEndpoint)
+}
+
+func exporterStatus(exporterEnv, signalEndpointEnv string) ExporterStatus {
+	exporter := strings.ToLower(strings.TrimSpace(os.Getenv(exporterEnv)))
+	if exporter == "none" {
+		return ExporterStatusDisabled
+	}
+	if exporter != "" {
+		return ExporterStatusEnabled
+	}
+	if envIsSet(signalEndpointEnv) || envIsSet(EnvExporterOTLPEndpoint) {
+		return ExporterStatusEnabled
+	}
+	return ExporterStatusNotConfigured
+}
+
+func envIsSet(name string) bool {
+	return strings.TrimSpace(os.Getenv(name)) != ""
+}

--- a/pkg/otel/exporter_config_test.go
+++ b/pkg/otel/exporter_config_test.go
@@ -1,0 +1,175 @@
+package otel
+
+import (
+	"context"
+	"testing"
+
+	"go.opentelemetry.io/otel/sdk/resource"
+)
+
+func TestTraceExporterStatus(t *testing.T) {
+	tests := []struct {
+		name string
+		env  map[string]string
+		want ExporterStatus
+	}{
+		{
+			name: "not configured without exporter or endpoint env",
+			want: ExporterStatusNotConfigured,
+		},
+		{
+			name: "enabled by shared OTLP endpoint",
+			env:  map[string]string{EnvExporterOTLPEndpoint: "http://localhost:4317"},
+			want: ExporterStatusEnabled,
+		},
+		{
+			name: "enabled by trace-specific OTLP endpoint",
+			env:  map[string]string{EnvExporterOTLPTracesEndpoint: "http://localhost:4317"},
+			want: ExporterStatusEnabled,
+		},
+		{
+			name: "enabled by explicit trace exporter",
+			env:  map[string]string{EnvTracesExporter: "otlp"},
+			want: ExporterStatusEnabled,
+		},
+		{
+			name: "none disables traces even when endpoint is configured",
+			env: map[string]string{
+				EnvExporterOTLPEndpoint: "http://localhost:4317",
+				EnvTracesExporter:       " none ",
+			},
+			want: ExporterStatusDisabled,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			clearExporterEnv(t)
+			for k, v := range tt.env {
+				t.Setenv(k, v)
+			}
+
+			if got := TraceExporterStatus(); got != tt.want {
+				t.Fatalf("TraceExporterStatus() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestMetricExporterStatus(t *testing.T) {
+	tests := []struct {
+		name string
+		env  map[string]string
+		want ExporterStatus
+	}{
+		{
+			name: "not configured without exporter or endpoint env",
+			want: ExporterStatusNotConfigured,
+		},
+		{
+			name: "enabled by shared OTLP endpoint",
+			env:  map[string]string{EnvExporterOTLPEndpoint: "http://localhost:4317"},
+			want: ExporterStatusEnabled,
+		},
+		{
+			name: "enabled by metrics-specific OTLP endpoint",
+			env:  map[string]string{EnvExporterOTLPMetricsEndpoint: "http://localhost:4317"},
+			want: ExporterStatusEnabled,
+		},
+		{
+			name: "enabled by explicit metrics exporter",
+			env:  map[string]string{EnvMetricsExporter: "otlp"},
+			want: ExporterStatusEnabled,
+		},
+		{
+			name: "none disables metrics even when endpoint is configured",
+			env: map[string]string{
+				EnvExporterOTLPEndpoint: "http://localhost:4317",
+				EnvMetricsExporter:      " none ",
+			},
+			want: ExporterStatusDisabled,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			clearExporterEnv(t)
+			for k, v := range tt.env {
+				t.Setenv(k, v)
+			}
+
+			if got := MetricExporterStatus(); got != tt.want {
+				t.Fatalf("MetricExporterStatus() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestInitProvidersSkipNetworkExportWhenNotConfigured(t *testing.T) {
+	clearExporterEnv(t)
+
+	shutdownTracer, traceStatus, err := InitTracerProvider(context.Background(), resource.Empty())
+	if err != nil {
+		t.Fatalf("InitTracerProvider() error = %v", err)
+	}
+	if shutdownTracer != nil {
+		t.Fatalf("InitTracerProvider() returned a shutdown function, want nil")
+	}
+	if traceStatus != ExporterStatusNotConfigured {
+		t.Fatalf("InitTracerProvider() status = %q, want %q", traceStatus, ExporterStatusNotConfigured)
+	}
+
+	shutdownMeter, metricStatus, err := InitMeterProvider(context.Background(), resource.Empty())
+	if err != nil {
+		t.Fatalf("InitMeterProvider() error = %v", err)
+	}
+	if shutdownMeter != nil {
+		t.Fatalf("InitMeterProvider() returned a shutdown function, want nil")
+	}
+	if metricStatus != ExporterStatusNotConfigured {
+		t.Fatalf("InitMeterProvider() status = %q, want %q", metricStatus, ExporterStatusNotConfigured)
+	}
+}
+
+func TestInitProvidersHonorNoneExporter(t *testing.T) {
+	clearExporterEnv(t)
+	t.Setenv(EnvExporterOTLPEndpoint, "http://localhost:4317")
+	t.Setenv(EnvTracesExporter, "none")
+	t.Setenv(EnvMetricsExporter, "none")
+
+	shutdownTracer, traceStatus, err := InitTracerProvider(context.Background(), resource.Empty())
+	if err != nil {
+		t.Fatalf("InitTracerProvider() error = %v", err)
+	}
+	if shutdownTracer != nil {
+		t.Fatalf("InitTracerProvider() returned a shutdown function, want nil")
+	}
+	if traceStatus != ExporterStatusDisabled {
+		t.Fatalf("InitTracerProvider() status = %q, want %q", traceStatus, ExporterStatusDisabled)
+	}
+
+	shutdownMeter, metricStatus, err := InitMeterProvider(context.Background(), resource.Empty())
+	if err != nil {
+		t.Fatalf("InitMeterProvider() error = %v", err)
+	}
+	if shutdownMeter != nil {
+		t.Fatalf("InitMeterProvider() returned a shutdown function, want nil")
+	}
+	if metricStatus != ExporterStatusDisabled {
+		t.Fatalf("InitMeterProvider() status = %q, want %q", metricStatus, ExporterStatusDisabled)
+	}
+}
+
+func clearExporterEnv(t *testing.T) {
+	t.Helper()
+
+	for _, env := range []string{
+		EnvExporterOTLPEndpoint,
+		EnvExporterOTLPTracesEndpoint,
+		EnvExporterOTLPMetricsEndpoint,
+		EnvTracesExporter,
+		EnvMetricsExporter,
+	} {
+		t.Setenv(env, "")
+	}
+}

--- a/pkg/otel/meter.go
+++ b/pkg/otel/meter.go
@@ -5,14 +5,21 @@ import (
 
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc"
+	metricnoop "go.opentelemetry.io/otel/metric/noop"
 	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
 	"go.opentelemetry.io/otel/sdk/resource"
 )
 
-func InitMeterProvider(ctx context.Context, res *resource.Resource) (func(context.Context) error, error) {
+func InitMeterProvider(ctx context.Context, res *resource.Resource) (func(context.Context) error, ExporterStatus, error) {
+	status := MetricExporterStatus()
+	if status != ExporterStatusEnabled {
+		otel.SetMeterProvider(metricnoop.NewMeterProvider())
+		return nil, status, nil
+	}
+
 	metricExporter, err := otlpmetricgrpc.New(ctx)
 	if err != nil {
-		return nil, err
+		return nil, status, err
 	}
 
 	mp := sdkmetric.NewMeterProvider(
@@ -22,5 +29,5 @@ func InitMeterProvider(ctx context.Context, res *resource.Resource) (func(contex
 
 	otel.SetMeterProvider(mp)
 
-	return mp.Shutdown, nil
+	return mp.Shutdown, status, nil
 }

--- a/pkg/otel/tracer.go
+++ b/pkg/otel/tracer.go
@@ -8,12 +8,21 @@ import (
 	"go.opentelemetry.io/otel/propagation"
 	"go.opentelemetry.io/otel/sdk/resource"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	tracenoop "go.opentelemetry.io/otel/trace/noop"
 )
 
-func InitTracerProvider(ctx context.Context, res *resource.Resource) (func(context.Context) error, error) {
+func InitTracerProvider(ctx context.Context, res *resource.Resource) (func(context.Context) error, ExporterStatus, error) {
+	setTextMapPropagator()
+
+	status := TraceExporterStatus()
+	if status != ExporterStatusEnabled {
+		otel.SetTracerProvider(tracenoop.NewTracerProvider())
+		return nil, status, nil
+	}
+
 	traceExporter, err := otlptracegrpc.New(ctx)
 	if err != nil {
-		return nil, err
+		return nil, status, err
 	}
 
 	tp := sdktrace.NewTracerProvider(
@@ -22,10 +31,12 @@ func InitTracerProvider(ctx context.Context, res *resource.Resource) (func(conte
 	)
 
 	otel.SetTracerProvider(tp)
+	return tp.Shutdown, status, nil
+}
+
+func setTextMapPropagator() {
 	otel.SetTextMapPropagator(propagation.NewCompositeTextMapPropagator(
 		propagation.TraceContext{},
 		propagation.Baggage{},
 	))
-
-	return tp.Shutdown, nil
 }

--- a/plans/observability-refactor.context.md
+++ b/plans/observability-refactor.context.md
@@ -155,5 +155,8 @@ PR review surfaced one remaining transport-safety regression: `pkg/log.New` was 
 
 Fix: move the default slog JSON sink from stdout to stderr. This preserves structured log collection in containerized deployments while keeping stdout protocol-safe for stdio transport. Added a regression test that temporarily redirects both file descriptors and asserts `log.New(...).InfoContext(...)` writes only to stderr.
 
+### 2026-04-24 — Issue #136: opt-in internal OTLP export
+GitHub issue #136 showed the "OTLP always on" decision was too sharp for self-hosted Docker stdio users. With no OTLP env configured, the Go OTLP gRPC exporters default to `https://localhost:4317`; SigNoz Docker exposes plaintext OTLP on `localhost:4317`, so the server repeatedly logged `tls: first record does not look like a TLS handshake` even though `SIGNOZ_URL=http://localhost:8080` was healthy. Decision: internal traces/metrics are still OTel-native, but network export is opt-in by `OTEL_EXPORTER_OTLP_ENDPOINT` or signal-specific endpoints. Also honor `OTEL_TRACES_EXPORTER=none` and `OTEL_METRICS_EXPORTER=none`; `OTEL_LOGS_EXPORTER` remains irrelevant because logs are JSON on stderr, not OTLP logs.
+
 ## Open Questions
 _(none — plan approved by Codex after 3 rounds; post-ship review findings addressed)_

--- a/plans/observability-refactor.plan.md
+++ b/plans/observability-refactor.plan.md
@@ -15,7 +15,7 @@ Goal: match Zeus's shape — slog + ContextHandler + `pkg/otel` — so the MCP s
 ## Cross-Cutting Decisions (apply to all commits)
 
 - **Logs ship as JSON on stderr**. No direct OTLP log exporter. This keeps stdout reserved for MCP stdio protocol frames while remaining compatible with container log collection.
-- **OTLP always on** for traces + metrics — no `deployment.environment` noop gating. Exporters fail gracefully at connect time with a single warning log. (Simpler than Zeus; acceptable because a missing OTLP endpoint just means no data, not crashes.)
+- **OTLP export is opt-in by endpoint/exporter env** for traces + metrics. If no `OTEL_EXPORTER_OTLP_ENDPOINT` / signal-specific endpoint / explicit `OTEL_*_EXPORTER` is configured, the server installs no-op providers and does not attempt network export. `OTEL_TRACES_EXPORTER=none` and `OTEL_METRICS_EXPORTER=none` hard-disable their signals even when an endpoint is set.
 - **Metrics container**: a typed `*otel.Meters` struct instantiated in `main` and injected into `MCPServer`. No package-level globals — simpler to test, explicit dependencies.
 - **Redaction / size caps**: any log field that carries a request body, response body, or error payload is capped at 4 KiB and truncated with a `...(truncated)` suffix. Existing "log detailed errors for LLM" behavior stays (per `feedback_security_scope`), but unbounded bodies don't.
 - **Stacktraces on Error**: `ContextHandler` captures stacktraces, but depth is capped at 64 frames (matches Zeus). Configurable via `LOG_STACKTRACE=false` env to disable entirely for hot error paths.
@@ -30,8 +30,8 @@ Introduce `pkg/otel`, `pkg/version`, and refactor the server for graceful shutdo
 
 **New packages:**
 - `pkg/otel/resource.go` — `NewResource(ctx, serviceVersion)` with `WithFromEnv/Host/Process/Container/TelemetrySDK` + `semconv.ServiceVersion(version.Version)`.
-- `pkg/otel/tracer.go` — `InitTracerProvider(ctx, res)` — OTLP gRPC batched.
-- `pkg/otel/meter.go` — `InitMeterProvider(ctx, res)` — OTLP periodic reader. Runtime metrics polling (`go.opentelemetry.io/contrib/instrumentation/runtime`) is started from `cmd/server/main.go` after the meter provider is installed, so it records against the global provider.
+- `pkg/otel/tracer.go` — `InitTracerProvider(ctx, res)` — OTLP gRPC batched when trace export is configured; otherwise installs a no-op tracer provider while keeping W3C propagation.
+- `pkg/otel/meter.go` — `InitMeterProvider(ctx, res)` — OTLP periodic reader when metrics export is configured; otherwise installs a no-op meter provider. Runtime metrics polling (`go.opentelemetry.io/contrib/instrumentation/runtime`) is started from `cmd/server/main.go` only after a real meter provider is installed, so local stdio runs do not attempt network export.
 - `pkg/otel/attr.go` — moved from `internal/telemetry/genai.go`. Same constants (`GenAISystemKey`, `MCPMethodKey`, …).
 - `pkg/version/version.go` — `var Version = "dev"`. Overridable via `-ldflags "-X github.com/SigNoz/signoz-mcp-server/pkg/version.Version=$VERSION"`.
 
@@ -179,7 +179,7 @@ Specifically:
 - Zeus-style HTTP request/response body logger plugin (adds redaction burden, we already have `otelhttp` traces).
 - Zeus-style separate status server on a second port — `/healthz` already exists.
 - Direct OTLP log exporter (`otelslog`) — stdout JSON is the deliberate Zeus-aligned choice.
-- Noop providers gated on `deployment.environment` — OTLP fails gracefully anyway.
+- Deployment-environment-based noop providers — replaced by endpoint/exporter-env-based opt-in export.
 - `mcp.sessions.active` gauge — see commit 3.
 
 ## Verification


### PR DESCRIPTION
## Summary

- Make internal OTLP trace/metrics export opt-in by endpoint/exporter env instead of falling back to the SDK default `https://localhost:4317`.
- Honor `OTEL_TRACES_EXPORTER=none` and `OTEL_METRICS_EXPORTER=none`, and only start runtime metrics when the metrics exporter initialized.
- Add focused exporter-status regression tests.
- Update `README.md`, `docs/architecture.md`, and the observability plan/context to document the internal telemetry behavior and the issue #136 decision.

Fixes #136

## Root Cause

The server manually initialized OTLP gRPC trace and metric exporters on startup. When no OTLP endpoint was configured, the OpenTelemetry exporter defaulted to `https://localhost:4317`. Self-hosted SigNoz Docker exposes plaintext OTLP on `localhost:4317`, so local stdio users saw repeated TLS handshake failures even though `SIGNOZ_URL=http://localhost:8080` was healthy.

## Validation

- `go test ./...`
- Docker stdio smoke test with no OTLP env configured, waited 70s: no `failed to upload metrics` or TLS handshake error; logs showed export not configured.
- Docker stdio smoke test with `OTEL_METRICS_EXPORTER=none`, `OTEL_TRACES_EXPORTER=none`, `OTEL_LOGS_EXPORTER=none`, waited 70s: no exporter failure; logs showed trace/metrics export disabled.
