### PR TITLE
[codex] Expose searchContext in MCP schemas

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,7 +27,7 @@ plans/
 
 When adding, renaming, or removing MCP tools/resources/configuration, update docs and metadata in the same PR.
 
-- Every MCP tool input schema must expose a top-level optional `searchContext` string with the user's original question/search text. For tools using `mcp.WithInputSchema[T]()`, put `SearchContext` on `T` itself because typed schemas replace earlier `mcp.WithString("searchContext", ...)` options.
+- Every MCP tool input schema must expose a top-level `searchContext` string with the user's original question/search text. Do not put `searchContext` in the JSON Schema `required` list or describe it as optional. For tools using `mcp.WithInputSchema[T]()`, put `SearchContext` on `T` itself because typed schemas replace earlier `mcp.WithString("searchContext", ...)` options.
 - Update `README.md` tool tables/parameter references to match current behavior.
 - Update `manifest.json` tool metadata (`tools`, descriptions, and related fields) to match registered handlers.
 - Review any user-facing docs under `docs/` for stale references.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,6 +27,7 @@ plans/
 
 When adding, renaming, or removing MCP tools/resources/configuration, update docs and metadata in the same PR.
 
+- Every MCP tool input schema must expose a top-level optional `searchContext` string with the user's original question/search text. For tools using `mcp.WithInputSchema[T]()`, put `SearchContext` on `T` itself because typed schemas replace earlier `mcp.WithString("searchContext", ...)` options.
 - Update `README.md` tool tables/parameter references to match current behavior.
 - Update `manifest.json` tool metadata (`tools`, descriptions, and related fields) to match registered handlers.
 - Review any user-facing docs under `docs/` for stale references.

--- a/README.md
+++ b/README.md
@@ -442,12 +442,13 @@ Updates an existing dashboard.
 
 - **Parameters:**
   - `uuid` (required) – Unique identifier of the dashboard to update
-  - `title` (required) – Dashboard name
-  - `description` (optional) – Short summary of what the dashboard shows
-  - `tags` (optional) – List of tags applied to the dashboard
-  - `layout` (required) – Full widget positioning grid
-  - `variables` (optional) – Map of variables available for use in queries
-  - `widgets` (required) – Complete set of widgets defining the updated dashboard
+  - `dashboard` (required) – Complete dashboard object representing the post-update state
+    - `title` (required) – Dashboard name
+    - `description` (optional) – Short summary of what the dashboard shows
+    - `tags` (optional) – List of tags applied to the dashboard
+    - `layout` (required) – Full widget positioning grid
+    - `variables` (optional) – Map of variables available for use in queries
+    - `widgets` (required) – Complete set of widgets defining the updated dashboard
 
 #### `signoz_list_services`
 

--- a/README.md
+++ b/README.md
@@ -321,6 +321,8 @@ MCP_SERVER_PORT=8000 \
 
 > **SigNoz compatibility:** alert-rule and notification-channel tools target the new convention: `/api/v2/rules/*` for rules and the render-envelope `/api/v1/channels/*` routes. These require a SigNoz release that includes SigNoz/signoz#10941, #10957, #10995, and #10997. Older deployments will see HTTP 404 from the affected tools.
 
+> **Tool metadata:** every tool accepts `searchContext`, the user's original question/search text. It is used for MCP observability and is not forwarded to SigNoz APIs.
+
 | Tool | Description |
 |------|-------------|
 | `signoz_list_metrics` | Search and list available metrics |

--- a/internal/handler/tools/alerts.go
+++ b/internal/handler/tools/alerts.go
@@ -76,7 +76,6 @@ func (h *Handler) RegisterAlertsHandlers(s *server.MCPServer) {
 	createAlertTool := mcp.NewTool(
 		"signoz_create_alert",
 		mcp.WithDestructiveHintAnnotation(true),
-		mcp.WithString("searchContext", mcp.Description("The user's original question or search text that triggered this tool call. Always include the user's raw query here for better results.")),
 		mcp.WithDescription(
 			"Creates a new alert rule in SigNoz (POST /api/v2/rules).\n\n"+
 				"SCHEMA — pick based on ruleType:\n"+
@@ -95,15 +94,13 @@ func (h *Handler) RegisterAlertsHandlers(s *server.MCPServer) {
 				"Supports all alert types (metrics, logs, traces, exceptions) and rule types (threshold, promql, anomaly).\n"+
 				"Labels enable routing policies — always set labels.severity (critical, error, warning, or info) to match your highest threshold tier, and add team/service labels for routing.",
 		),
-		mcp.WithInputSchema[types.AlertRule](),
+		mcp.WithInputSchema[types.CreateAlertInput](),
 	)
 	addTool(s, createAlertTool, h.handleCreateAlert)
 
 	updateAlertTool := mcp.NewTool(
 		"signoz_update_alert",
 		mcp.WithDestructiveHintAnnotation(true),
-		mcp.WithString("searchContext", mcp.Description("The user's original question or search text that triggered this tool call. Always include the user's raw query here for better results.")),
-		mcp.WithString("ruleId", mcp.Required(), mcp.Description("UUIDv7 of the alert rule to update. Obtain it from signoz_list_alert_rules or signoz_get_alert.")),
 		mcp.WithDescription(
 			"Updates an existing alert rule in SigNoz (PUT /api/v2/rules/{ruleId}). Replaces the full rule configuration.\n\n"+
 				"CRITICAL: Read signoz://alert/instructions and signoz://alert/examples before generating the payload. "+
@@ -112,7 +109,7 @@ func (h *Handler) RegisterAlertsHandlers(s *server.MCPServer) {
 				"The rule payload is the same shape as signoz_create_alert. All the same validation rules apply, including "+
 				"the notification-channel presence check.",
 		),
-		mcp.WithInputSchema[types.AlertRule](),
+		mcp.WithInputSchema[types.UpdateAlertInput](),
 	)
 	addTool(s, updateAlertTool, h.handleUpdateAlert)
 

--- a/internal/handler/tools/dashboards.go
+++ b/internal/handler/tools/dashboards.go
@@ -43,7 +43,6 @@ func (h *Handler) RegisterDashboardHandlers(s *server.MCPServer) {
 	createDashboardTool := mcp.NewTool(
 		"signoz_create_dashboard",
 		mcp.WithDestructiveHintAnnotation(true),
-		mcp.WithString("searchContext", mcp.Description("The user's original question or search text that triggered this tool call. Always include the user's raw query here for better results.")),
 		mcp.WithDescription(
 			"Creates a new monitoring dashboard based on the provided title, layout, and widget configuration. "+
 				"CRITICAL: You MUST read these resources BEFORE generating any dashboard output:\n"+
@@ -59,7 +58,7 @@ func (h *Handler) RegisterDashboardHandlers(s *server.MCPServer) {
 				"IMPORTANT: The widgets-examples resource contains complete, working widget configurations. "+
 				"You must consult it to ensure all required fields (id, panelTypes, title, query, selectedLogFields, selectedTracesFields, thresholds, contextLinks) are properly populated.",
 		),
-		mcp.WithInputSchema[types.Dashboard](),
+		mcp.WithInputSchema[types.CreateDashboardInput](),
 	)
 
 	addTool(s, createDashboardTool, h.handleCreateDashboard)
@@ -67,7 +66,6 @@ func (h *Handler) RegisterDashboardHandlers(s *server.MCPServer) {
 	updateDashboardTool := mcp.NewTool(
 		"signoz_update_dashboard",
 		mcp.WithDestructiveHintAnnotation(true),
-		mcp.WithString("searchContext", mcp.Description("The user's original question or search text that triggered this tool call. Always include the user's raw query here for better results.")),
 		mcp.WithDescription(
 			"Update an existing dashboard by supplying its UUID along with a fully assembled dashboard JSON object.\n\n"+
 				"MANDATORY FIRST STEP: Read signoz://dashboard/widgets-examples before doing ANYTHING else. This is NON-NEGOTIABLE.\n\n"+
@@ -172,6 +170,7 @@ func (h *Handler) handleCreateDashboard(ctx context.Context, req mcp.CallToolReq
 		h.logger.WarnContext(ctx, "Received empty or invalid arguments map.")
 		return mcp.NewToolResultError(`Parameter validation failed: The dashboard configuration object is empty or improperly formatted.`), nil
 	}
+	delete(rawConfig, "searchContext")
 
 	// Validate and normalize via the dashboardbuilder + panelbuilder pipeline.
 	cleanJSON, err := dashboard.ValidateFromMap(rawConfig)

--- a/internal/handler/tools/dashboards_test.go
+++ b/internal/handler/tools/dashboards_test.go
@@ -64,6 +64,44 @@ func TestHandleDeleteDashboard_Success(t *testing.T) {
 	}
 }
 
+func TestHandleCreateDashboard_StripsSearchContext(t *testing.T) {
+	var gotBody []byte
+	mock := &client.MockClient{
+		CreateDashboardRawFn: func(ctx context.Context, dashboardJSON []byte) (json.RawMessage, error) {
+			gotBody = append([]byte(nil), dashboardJSON...)
+			return json.RawMessage(`{"status":"success","data":{"uuid":"dashboard-123"}}`), nil
+		},
+	}
+
+	h := newTestHandler(mock)
+	result, err := h.handleCreateDashboard(testCtx(), makeToolRequest("signoz_create_dashboard", map[string]any{
+		"searchContext": "create a dashboard for service latency",
+		"title":         "Latency Dashboard",
+		"widgets":       []any{},
+		"layout":        []any{},
+	}))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("handler returned error result: %v", result.Content)
+	}
+	if len(gotBody) == 0 {
+		t.Fatal("CreateDashboardRawFn was not called")
+	}
+
+	var parsed map[string]any
+	if err := json.Unmarshal(gotBody, &parsed); err != nil {
+		t.Fatalf("dashboard payload should be JSON: %v\n%s", err, gotBody)
+	}
+	if _, hasSearchContext := parsed["searchContext"]; hasSearchContext {
+		t.Errorf("searchContext should be stripped from the API payload: %s", gotBody)
+	}
+	if parsed["title"] != "Latency Dashboard" {
+		t.Errorf("title = %v, want Latency Dashboard", parsed["title"])
+	}
+}
+
 func TestHandleDeleteDashboard_EmptyUUID(t *testing.T) {
 	h := newTestHandler(&client.MockClient{})
 	result, err := h.handleDeleteDashboard(testCtx(), makeToolRequest("signoz_delete_dashboard", map[string]any{

--- a/internal/handler/tools/schema_compat_test.go
+++ b/internal/handler/tools/schema_compat_test.go
@@ -90,6 +90,10 @@ func TestWriteToolInputSchemasExposeSearchContext(t *testing.T) {
 					t.Fatalf("input schema properties missing %q: %#v", field, props)
 				}
 			}
+			required := inputSchemaRequiredFields(t, tt.tool)
+			if containsString(required, "searchContext") {
+				t.Fatalf("input schema required fields should not include searchContext: %#v", required)
+			}
 		})
 	}
 }
@@ -117,4 +121,46 @@ func inputSchemaProperties(t *testing.T, tool mcp.Tool) map[string]any {
 		t.Fatalf("inputSchema.properties = %#v, want object", inputSchema["properties"])
 	}
 	return props
+}
+
+func inputSchemaRequiredFields(t *testing.T, tool mcp.Tool) []string {
+	t.Helper()
+
+	normalizeToolSchemas(&tool)
+	b, err := json.Marshal(tool)
+	if err != nil {
+		t.Fatalf("marshal tool: %v", err)
+	}
+
+	var doc map[string]any
+	if err := json.Unmarshal(b, &doc); err != nil {
+		t.Fatalf("unmarshal tool JSON: %v", err)
+	}
+
+	inputSchema, ok := doc["inputSchema"].(map[string]any)
+	if !ok {
+		t.Fatalf("inputSchema = %#v, want object", doc["inputSchema"])
+	}
+
+	rawRequired, ok := inputSchema["required"].([]any)
+	if !ok {
+		return nil
+	}
+
+	required := make([]string, 0, len(rawRequired))
+	for _, field := range rawRequired {
+		if fieldName, ok := field.(string); ok {
+			required = append(required, fieldName)
+		}
+	}
+	return required
+}
+
+func containsString(values []string, want string) bool {
+	for _, value := range values {
+		if value == want {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/handler/tools/schema_compat_test.go
+++ b/internal/handler/tools/schema_compat_test.go
@@ -3,6 +3,9 @@ package tools
 import (
 	"encoding/json"
 	"testing"
+
+	"github.com/SigNoz/signoz-mcp-server/pkg/types"
+	"github.com/mark3labs/mcp-go/mcp"
 )
 
 func TestNormalizeRawSchemaReplacesSchemaTrueWithEmptyObject(t *testing.T) {
@@ -49,4 +52,69 @@ func TestNormalizeRawSchemaReplacesSchemaTrueWithEmptyObject(t *testing.T) {
 	if len(object["additionalProperties"].(map[string]any)) != 0 {
 		t.Fatalf("object.additionalProperties = %#v, want empty schema object", object["additionalProperties"])
 	}
+}
+
+func TestWriteToolInputSchemasExposeSearchContext(t *testing.T) {
+	tests := []struct {
+		name       string
+		tool       mcp.Tool
+		wantFields []string
+	}{
+		{
+			name:       "create dashboard",
+			tool:       mcp.NewTool("signoz_create_dashboard", mcp.WithInputSchema[types.CreateDashboardInput]()),
+			wantFields: []string{"title", "layout", "widgets", "searchContext"},
+		},
+		{
+			name:       "update dashboard",
+			tool:       mcp.NewTool("signoz_update_dashboard", mcp.WithInputSchema[types.UpdateDashboardInput]()),
+			wantFields: []string{"uuid", "dashboard", "searchContext"},
+		},
+		{
+			name:       "create alert",
+			tool:       mcp.NewTool("signoz_create_alert", mcp.WithInputSchema[types.CreateAlertInput]()),
+			wantFields: []string{"alert", "alertType", "ruleType", "condition", "searchContext"},
+		},
+		{
+			name:       "update alert",
+			tool:       mcp.NewTool("signoz_update_alert", mcp.WithInputSchema[types.UpdateAlertInput]()),
+			wantFields: []string{"ruleId", "alert", "alertType", "ruleType", "condition", "searchContext"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			props := inputSchemaProperties(t, tt.tool)
+			for _, field := range tt.wantFields {
+				if _, ok := props[field]; !ok {
+					t.Fatalf("input schema properties missing %q: %#v", field, props)
+				}
+			}
+		})
+	}
+}
+
+func inputSchemaProperties(t *testing.T, tool mcp.Tool) map[string]any {
+	t.Helper()
+
+	normalizeToolSchemas(&tool)
+	b, err := json.Marshal(tool)
+	if err != nil {
+		t.Fatalf("marshal tool: %v", err)
+	}
+
+	var doc map[string]any
+	if err := json.Unmarshal(b, &doc); err != nil {
+		t.Fatalf("unmarshal tool JSON: %v", err)
+	}
+
+	inputSchema, ok := doc["inputSchema"].(map[string]any)
+	if !ok {
+		t.Fatalf("inputSchema = %#v, want object", doc["inputSchema"])
+	}
+	props, ok := inputSchema["properties"].(map[string]any)
+	if !ok {
+		t.Fatalf("inputSchema.properties = %#v, want object", inputSchema["properties"])
+	}
+	return props
 }

--- a/internal/handler/tools/views.go
+++ b/internal/handler/tools/views.go
@@ -98,9 +98,7 @@ func (h *Handler) RegisterViewHandlers(s *server.MCPServer) {
 			mcp.Required(),
 			mcp.Properties(savedViewSchemaProperties()),
 			mcp.AdditionalProperties(true),
-			func(schema map[string]any) {
-				schema["required"] = []string{"name", "sourcePage", "compositeQuery"}
-			},
+			withRequiredFields("name", "sourcePage", "compositeQuery"),
 			mcp.Description("Full SavedView body representing the complete post-update state. Call signoz_get_view first and pass its data field back here."),
 		),
 	)
@@ -179,6 +177,12 @@ func savedViewSchemaProperties() map[string]any {
 			"type":        "string",
 			"description": "Optional UI-controlled options as a JSON-encoded string (safe to leave empty).",
 		},
+	}
+}
+
+func withRequiredFields(fields ...string) mcp.PropertyOption {
+	return func(schema map[string]any) {
+		schema["required"] = fields
 	}
 }
 

--- a/internal/handler/tools/views.go
+++ b/internal/handler/tools/views.go
@@ -11,7 +11,6 @@ import (
 
 	logpkg "github.com/SigNoz/signoz-mcp-server/pkg/log"
 	"github.com/SigNoz/signoz-mcp-server/pkg/paginate"
-	"github.com/SigNoz/signoz-mcp-server/pkg/types"
 	"github.com/SigNoz/signoz-mcp-server/pkg/views"
 )
 
@@ -62,6 +61,7 @@ func (h *Handler) RegisterViewHandlers(s *server.MCPServer) {
 
 	createTool := mcp.NewTool("signoz_create_view",
 		mcp.WithDestructiveHintAnnotation(true),
+		mcp.WithString("searchContext", mcp.Description("The user's original question or search text that triggered this tool call. Always include the user's raw query here for better results.")),
 		mcp.WithDescription(
 			"Create a new SigNoz saved Explorer view.\n\n"+
 				"CRITICAL: You MUST read these resources BEFORE composing a payload:\n"+
@@ -71,12 +71,18 @@ func (h *Handler) RegisterViewHandlers(s *server.MCPServer) {
 				"Optional: category, tags, extraData. Server populates id, createdAt/By, updatedAt/By — "+
 				"do not send them.",
 		),
-		mcp.WithInputSchema[types.SavedViewInput](),
+		mcp.WithString("name", mcp.Required(), mcp.Description("Display name of the view.")),
+		mcp.WithString("sourcePage", mcp.Required(), mcp.Enum("traces", "logs", "metrics"), mcp.Description(`Which Explorer this view belongs to. One of: "traces", "logs", "metrics".`)),
+		mcp.WithObject("compositeQuery", mcp.Required(), mcp.AdditionalProperties(true), mcp.Description("The Query Builder payload as an object (not a string). Must contain queryType plus matching sub-query. See signoz://view/instructions and signoz://view/examples.")),
+		mcp.WithString("category", mcp.Description("Optional free-form grouping label.")),
+		mcp.WithArray("tags", mcp.WithStringItems(), mcp.Description("Optional free-form tags.")),
+		mcp.WithString("extraData", mcp.Description("Optional UI-controlled options as a JSON-encoded string (safe to leave empty).")),
 	)
 	addTool(s, createTool, h.handleCreateView)
 
 	updateTool := mcp.NewTool("signoz_update_view",
 		mcp.WithDestructiveHintAnnotation(true),
+		mcp.WithString("searchContext", mcp.Description("The user's original question or search text that triggered this tool call. Always include the user's raw query here for better results.")),
 		mcp.WithDescription(
 			"Replace an existing SigNoz saved view (HTTP PUT — full body replace).\n\n"+
 				"CRITICAL: You MUST read these resources BEFORE composing a payload:\n"+
@@ -87,7 +93,16 @@ func (h *Handler) RegisterViewHandlers(s *server.MCPServer) {
 				"and pass that under the `view` field here. Partial bodies will wipe unspecified fields. "+
 				"Do not send id/createdAt/createdBy/updatedAt/updatedBy — the server ignores them.",
 		),
-		mcp.WithInputSchema[types.UpdateViewInput](),
+		mcp.WithString("viewId", mcp.Required(), mcp.Description("UUID of the view to replace.")),
+		mcp.WithObject("view",
+			mcp.Required(),
+			mcp.Properties(savedViewSchemaProperties()),
+			mcp.AdditionalProperties(true),
+			func(schema map[string]any) {
+				schema["required"] = []string{"name", "sourcePage", "compositeQuery"}
+			},
+			mcp.Description("Full SavedView body representing the complete post-update state. Call signoz_get_view first and pass its data field back here."),
+		),
 	)
 	addTool(s, updateTool, h.handleUpdateView)
 
@@ -130,6 +145,41 @@ func (h *Handler) RegisterViewHandlers(s *server.MCPServer) {
 			},
 		}, nil
 	})
+}
+
+// savedViewSchemaProperties is kept manual because mcp.WithInputSchema cannot
+// currently render the SavedView input structs used here without producing an
+// empty effective schema for tools/list clients.
+func savedViewSchemaProperties() map[string]any {
+	return map[string]any{
+		"name": map[string]any{
+			"type":        "string",
+			"description": "Display name of the view.",
+		},
+		"sourcePage": map[string]any{
+			"type":        "string",
+			"enum":        []string{"traces", "logs", "metrics"},
+			"description": `Which Explorer this view belongs to. One of: "traces", "logs", "metrics".`,
+		},
+		"compositeQuery": map[string]any{
+			"type":                 "object",
+			"additionalProperties": true,
+			"description":          "The Query Builder payload as an object (not a string). Must contain queryType plus matching sub-query. See signoz://view/instructions and signoz://view/examples.",
+		},
+		"category": map[string]any{
+			"type":        "string",
+			"description": "Optional free-form grouping label.",
+		},
+		"tags": map[string]any{
+			"type":        "array",
+			"items":       map[string]any{"type": "string"},
+			"description": "Optional free-form tags.",
+		},
+		"extraData": map[string]any{
+			"type":        "string",
+			"description": "Optional UI-controlled options as a JSON-encoded string (safe to leave empty).",
+		},
+	}
 }
 
 // serverPopulatedViewFields are set by the SigNoz API on create/read and

--- a/internal/handler/tools/views_test.go
+++ b/internal/handler/tools/views_test.go
@@ -225,7 +225,7 @@ func TestHandleUpdateView_MissingID(t *testing.T) {
 }
 
 // Back-compat: callers that send SavedView fields flat at the top level
-// (pre-UpdateViewInput schema) should still work.
+// (pre-wrapper schema) should still work.
 func TestHandleUpdateView_FlatFieldsBackCompat(t *testing.T) {
 	var gotBody []byte
 	mock := &client.MockClient{

--- a/internal/mcp-server/integration_test.go
+++ b/internal/mcp-server/integration_test.go
@@ -188,7 +188,7 @@ func TestIntegration_AllToolsExposeSearchContext(t *testing.T) {
 		}
 		for _, field := range schemaRequiredFields(schema) {
 			if field == "searchContext" {
-				t.Errorf("%s searchContext must be optional, but appears in required", tool.Name)
+				t.Errorf("%s searchContext should not be marked required", tool.Name)
 			}
 		}
 	}

--- a/internal/mcp-server/integration_test.go
+++ b/internal/mcp-server/integration_test.go
@@ -149,6 +149,51 @@ func TestIntegration_ListToolsInputSchemasAreOpenAPICompatible(t *testing.T) {
 	}
 }
 
+func TestIntegration_AllToolsExposeSearchContext(t *testing.T) {
+	s := buildTestServer(t)
+	ctx := context.Background()
+
+	c, err := mcpclient.NewInProcessClient(s)
+	if err != nil {
+		t.Fatalf("failed to create in-process client: %v", err)
+	}
+
+	if _, err := c.Initialize(ctx, mcp.InitializeRequest{
+		Params: mcp.InitializeParams{
+			ProtocolVersion: mcp.LATEST_PROTOCOL_VERSION,
+			ClientInfo: mcp.Implementation{
+				Name:    "test-client",
+				Version: version.Version,
+			},
+		},
+	}); err != nil {
+		t.Fatalf("Initialize failed: %v", err)
+	}
+
+	toolsResult, err := c.ListTools(ctx, mcp.ListToolsRequest{})
+	if err != nil {
+		t.Fatalf("ListTools failed: %v", err)
+	}
+
+	for _, tool := range toolsResult.Tools {
+		schema := inputSchema(t, tool)
+		properties := schemaProperties(t, tool.Name, schema)
+		searchContext, ok := properties["searchContext"].(map[string]any)
+		if !ok {
+			t.Errorf("%s inputSchema is missing top-level searchContext", tool.Name)
+			continue
+		}
+		if searchContext["type"] != "string" {
+			t.Errorf("%s searchContext type = %v, want string", tool.Name, searchContext["type"])
+		}
+		for _, field := range schemaRequiredFields(schema) {
+			if field == "searchContext" {
+				t.Errorf("%s searchContext must be optional, but appears in required", tool.Name)
+			}
+		}
+	}
+}
+
 func TestIntegration_PromqlInstructionsResourceRegistered(t *testing.T) {
 	s := buildTestServer(t)
 	ctx := context.Background()
@@ -194,6 +239,41 @@ func TestIntegration_PromqlInstructionsResourceRegistered(t *testing.T) {
 			t.Errorf("resource body missing expected substring %q", want)
 		}
 	}
+}
+
+func inputSchema(t *testing.T, tool mcp.Tool) map[string]any {
+	t.Helper()
+
+	b, err := json.Marshal(tool.InputSchema)
+	if err != nil {
+		t.Fatalf("marshal input schema for %s: %v", tool.Name, err)
+	}
+	var schema map[string]any
+	if err := json.Unmarshal(b, &schema); err != nil {
+		t.Fatalf("unmarshal input schema for %s: %v", tool.Name, err)
+	}
+	return schema
+}
+
+func schemaProperties(t *testing.T, toolName string, schema map[string]any) map[string]any {
+	t.Helper()
+
+	properties, ok := schema["properties"].(map[string]any)
+	if !ok {
+		t.Fatalf("%s inputSchema.properties = %#v, want object", toolName, schema["properties"])
+	}
+	return properties
+}
+
+func schemaRequiredFields(schema map[string]any) []string {
+	rawRequired, _ := schema["required"].([]any)
+	required := make([]string, 0, len(rawRequired))
+	for _, field := range rawRequired {
+		if s, ok := field.(string); ok {
+			required = append(required, s)
+		}
+	}
+	return required
 }
 
 func booleanSubschemaPaths(schema any, path []string) []string {

--- a/pkg/types/alertrule.go
+++ b/pkg/types/alertrule.go
@@ -19,6 +19,17 @@ const (
 	RuleTypeAnomaly   RuleType = "anomaly_rule"
 )
 
+type CreateAlertInput struct {
+	AlertRule
+	SearchContext string `json:"searchContext,omitempty" jsonschema_extras:"description=Optional. The user's original question or search text that triggered this tool call. Always include the user's raw query here for better results."`
+}
+
+type UpdateAlertInput struct {
+	RuleID string `json:"ruleId" jsonschema:"required" jsonschema_extras:"description=UUIDv7 of the alert rule to update. Obtain it from signoz_list_alert_rules or signoz_get_alert."`
+	AlertRule
+	SearchContext string `json:"searchContext,omitempty" jsonschema_extras:"description=Optional. The user's original question or search text that triggered this tool call. Always include the user's raw query here for better results."`
+}
+
 // AlertRule is the payload for creating an alert rule via POST /api/v2/rules.
 // It matches the SigNoz PostableRule structure. Threshold and PromQL rules use
 // the v2alpha1 schema (structured thresholds + evaluation + notificationSettings).
@@ -91,17 +102,17 @@ type AlertQuery struct {
 // For builder_query type this uses the v5 query builder format.
 // For promql/clickhouse_sql types only name query legend and disabled are used.
 type AlertQuerySpec struct {
-	Name         string              `json:"name" jsonschema:"required" jsonschema_extras:"description=Query name (e.g. A or B or C). Used as reference in formulas and selectedQueryName."`
-	Signal       string              `json:"signal,omitempty" jsonschema_extras:"description=Signal type for builder queries: metrics or logs or traces. Required for builder_query type."`
-	StepInterval *int64              `json:"stepInterval,omitempty" jsonschema_extras:"description=Step interval in seconds for time aggregation. Use 60 for metrics alerts."`
-	Disabled     bool                `json:"disabled,omitempty" jsonschema_extras:"description=Whether this query is disabled."`
-	Source       string              `json:"source,omitempty"`
-	Aggregations []AlertAggregation     `json:"aggregations,omitempty" jsonschema_extras:"description=Aggregation expressions for builder queries. For metrics signal use the object shape: [{metricName: k8s.pod.cpu_request_utilization, timeAggregation: avg, spaceAggregation: max}]. For logs/traces use the expression shape: [{expression: count()}] or [{expression: p99(duration_nano)}]."`
-	Filter       *AlertQueryFilter      `json:"filter,omitempty" jsonschema_extras:"description=Filter expression for builder queries. Example: {expression: service.name = frontend AND http.status_code >= 500}."`
-	GroupBy      []AlertGroupByField    `json:"groupBy,omitempty" jsonschema_extras:"description=Fields to group by. Grouped dimensions appear as labels in alert notifications."`
-	Order        []AlertOrderField      `json:"order,omitempty" jsonschema_extras:"description=Order by specification."`
-	Having       *AlertQueryFilter      `json:"having,omitempty" jsonschema_extras:"description=Having clause to filter aggregation results."`
-	Functions    []AlertQueryFunction   `json:"functions,omitempty" jsonschema_extras:"description=Post-query functions applied to the series. Required for anomaly_rule: wrap with {name: anomaly, args: [{name: z_score_threshold, value: 2}]}."`
+	Name         string               `json:"name" jsonschema:"required" jsonschema_extras:"description=Query name (e.g. A or B or C). Used as reference in formulas and selectedQueryName."`
+	Signal       string               `json:"signal,omitempty" jsonschema_extras:"description=Signal type for builder queries: metrics or logs or traces. Required for builder_query type."`
+	StepInterval *int64               `json:"stepInterval,omitempty" jsonschema_extras:"description=Step interval in seconds for time aggregation. Use 60 for metrics alerts."`
+	Disabled     bool                 `json:"disabled,omitempty" jsonschema_extras:"description=Whether this query is disabled."`
+	Source       string               `json:"source,omitempty"`
+	Aggregations []AlertAggregation   `json:"aggregations,omitempty" jsonschema_extras:"description=Aggregation expressions for builder queries. For metrics signal use the object shape: [{metricName: k8s.pod.cpu_request_utilization, timeAggregation: avg, spaceAggregation: max}]. For logs/traces use the expression shape: [{expression: count()}] or [{expression: p99(duration_nano)}]."`
+	Filter       *AlertQueryFilter    `json:"filter,omitempty" jsonschema_extras:"description=Filter expression for builder queries. Example: {expression: service.name = frontend AND http.status_code >= 500}."`
+	GroupBy      []AlertGroupByField  `json:"groupBy,omitempty" jsonschema_extras:"description=Fields to group by. Grouped dimensions appear as labels in alert notifications."`
+	Order        []AlertOrderField    `json:"order,omitempty" jsonschema_extras:"description=Order by specification."`
+	Having       *AlertQueryFilter    `json:"having,omitempty" jsonschema_extras:"description=Having clause to filter aggregation results."`
+	Functions    []AlertQueryFunction `json:"functions,omitempty" jsonschema_extras:"description=Post-query functions applied to the series. Required for anomaly_rule: wrap with {name: anomaly, args: [{name: z_score_threshold, value: 2}]}."`
 
 	// For promql / clickhouse_sql query types
 	Query  string `json:"query,omitempty" jsonschema_extras:"description=PromQL or ClickHouse SQL query string. Used when queryType is promql or clickhouse_sql. PromQL with OTel dotted metric names MUST use the Prometheus 3.x UTF-8 quoted-selector form: {\"metric.name.with.dots\"}. Underscored / __name__ / bare-dotted forms return no data. Read signoz://promql/instructions for the full guide (histogram patterns dotted labels pre-flight checklist)."`

--- a/pkg/types/alertrule.go
+++ b/pkg/types/alertrule.go
@@ -21,13 +21,13 @@ const (
 
 type CreateAlertInput struct {
 	AlertRule
-	SearchContext string `json:"searchContext,omitempty" jsonschema_extras:"description=Optional. The user's original question or search text that triggered this tool call. Always include the user's raw query here for better results."`
+	SearchContext string `json:"searchContext,omitempty" jsonschema_extras:"description=The user's original question or search text that triggered this tool call. Always include the user's raw query here for better results."`
 }
 
 type UpdateAlertInput struct {
 	RuleID string `json:"ruleId" jsonschema:"required" jsonschema_extras:"description=UUIDv7 of the alert rule to update. Obtain it from signoz_list_alert_rules or signoz_get_alert."`
 	AlertRule
-	SearchContext string `json:"searchContext,omitempty" jsonschema_extras:"description=Optional. The user's original question or search text that triggered this tool call. Always include the user's raw query here for better results."`
+	SearchContext string `json:"searchContext,omitempty" jsonschema_extras:"description=The user's original question or search text that triggered this tool call. Always include the user's raw query here for better results."`
 }
 
 // AlertRule is the payload for creating an alert rule via POST /api/v2/rules.

--- a/pkg/types/dashboard.go
+++ b/pkg/types/dashboard.go
@@ -1,8 +1,14 @@
 package types
 
 type UpdateDashboardInput struct {
-	UUID      string    `json:"uuid" jsonschema:"required" jsonschema_extras:"description=Dashboard UUID to update."`
-	Dashboard Dashboard `json:"dashboard" jsonschema:"required" jsonschema_extras:"description=Full dashboard configuration representing the complete post-update state."`
+	UUID          string    `json:"uuid" jsonschema:"required" jsonschema_extras:"description=Dashboard UUID to update."`
+	Dashboard     Dashboard `json:"dashboard" jsonschema:"required" jsonschema_extras:"description=Full dashboard configuration representing the complete post-update state."`
+	SearchContext string    `json:"searchContext,omitempty" jsonschema_extras:"description=Optional. The user's original question or search text that triggered this tool call. Always include the user's raw query here for better results."`
+}
+
+type CreateDashboardInput struct {
+	Dashboard
+	SearchContext string `json:"searchContext,omitempty" jsonschema_extras:"description=Optional. The user's original question or search text that triggered this tool call. Always include the user's raw query here for better results."`
 }
 
 type Dashboard struct {

--- a/pkg/types/dashboard.go
+++ b/pkg/types/dashboard.go
@@ -3,12 +3,12 @@ package types
 type UpdateDashboardInput struct {
 	UUID          string    `json:"uuid" jsonschema:"required" jsonschema_extras:"description=Dashboard UUID to update."`
 	Dashboard     Dashboard `json:"dashboard" jsonschema:"required" jsonschema_extras:"description=Full dashboard configuration representing the complete post-update state."`
-	SearchContext string    `json:"searchContext,omitempty" jsonschema_extras:"description=Optional. The user's original question or search text that triggered this tool call. Always include the user's raw query here for better results."`
+	SearchContext string    `json:"searchContext,omitempty" jsonschema_extras:"description=The user's original question or search text that triggered this tool call. Always include the user's raw query here for better results."`
 }
 
 type CreateDashboardInput struct {
 	Dashboard
-	SearchContext string `json:"searchContext,omitempty" jsonschema_extras:"description=Optional. The user's original question or search text that triggered this tool call. Always include the user's raw query here for better results."`
+	SearchContext string `json:"searchContext,omitempty" jsonschema_extras:"description=The user's original question or search text that triggered this tool call. Always include the user's raw query here for better results."`
 }
 
 type Dashboard struct {

--- a/pkg/types/view.go
+++ b/pkg/types/view.go
@@ -4,8 +4,7 @@ import "encoding/json"
 
 // SavedView mirrors the SigNoz server SavedView model
 // (pkg/query-service/model/v3/v3.go). Used for responses and internal
-// wire formatting; for tool input schemas prefer SavedViewInput so the
-// published schema excludes server-populated fields.
+// wire formatting.
 type SavedView struct {
 	ID             string          `json:"id,omitempty"`
 	Name           string          `json:"name"`
@@ -18,28 +17,4 @@ type SavedView struct {
 	CreatedBy      string          `json:"createdBy,omitempty"`
 	UpdatedAt      string          `json:"updatedAt,omitempty"`
 	UpdatedBy      string          `json:"updatedBy,omitempty"`
-}
-
-// SavedViewInput is the MCP input schema for signoz_create_view and the
-// view field of signoz_update_view. It exposes only caller-settable
-// fields — no id, no audit timestamps — and types CompositeQuery as
-// an object so schema-driven clients know to send a JSON object, not
-// a string.
-type SavedViewInput struct {
-	Name           string         `json:"name" jsonschema:"required" jsonschema_extras:"description=Display name of the view."`
-	Category       string         `json:"category,omitempty" jsonschema_extras:"description=Free-form grouping label."`
-	SourcePage     string         `json:"sourcePage" jsonschema:"required,enum=traces,enum=logs,enum=metrics" jsonschema_extras:"description=Which Explorer this view belongs to."`
-	Tags           []string       `json:"tags,omitempty" jsonschema_extras:"description=Free-form tags."`
-	CompositeQuery map[string]any `json:"compositeQuery" jsonschema:"required" jsonschema_extras:"description=The Query Builder payload as an object (not a string). Must contain queryType plus matching sub-query. See signoz://view/instructions and signoz://view/examples.,type=object,additionalProperties=true"`
-	ExtraData      string         `json:"extraData,omitempty" jsonschema_extras:"description=UI-controlled options as a JSON-encoded string (safe to leave empty)."`
-	SearchContext  string         `json:"searchContext,omitempty" jsonschema_extras:"description=Optional. The user's original question that triggered this tool call."`
-}
-
-// UpdateViewInput is the MCP input schema for signoz_update_view. The path
-// parameter (viewId) and body (view) are bundled so schema-driven clients
-// see both required fields. Mirrors the dashboard update pattern.
-type UpdateViewInput struct {
-	ViewID        string         `json:"viewId" jsonschema:"required" jsonschema_extras:"description=UUID of the view to replace."`
-	View          SavedViewInput `json:"view" jsonschema:"required" jsonschema_extras:"description=Full SavedView body representing the complete post-update state. Call signoz_get_view first and pass its data field back here."`
-	SearchContext string         `json:"searchContext,omitempty" jsonschema_extras:"description=Optional. The user's original question that triggered this tool call."`
 }


### PR DESCRIPTION
## Summary

- Expose top-level `searchContext` across all registered MCP tool schemas so LLM-provided user intent is consistently available for logs, spans, and analytics.
- Keep `searchContext` out of the JSON Schema `required` list and avoid describing it as optional; it is advertised as MCP metadata that clients can provide.
- Replace dashboard and alert write tool schemas with wrapper input types so typed schemas include `searchContext` and `ruleId` where needed.
- Switch saved view create/update schema declarations to explicit MCP schemas because the previous typed view schemas rendered empty effective schemas for `tools/list` clients.
- Add regression coverage that verifies every registered tool exposes string `searchContext` and that write schemas do not mark it required.
- Update README and CLAUDE.md with the schema convention and documented dashboard/alert update shapes.

## Root Cause

`mcp.WithInputSchema[T]()` replaces earlier `mcp.WithString(...)` declarations. Several write tools appeared to declare `searchContext`, but the effective published schemas omitted it. `signoz_update_alert` also relied on a `ruleId` declaration that was replaced by the typed alert schema.

## Validation

- `go test ./...`
- `git diff --check`
