### PR TITLE
docs: document alert rule version floor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - migrate to v2 rules API and refresh schema per SigNoz P… ([#140](https://github.com/SigNoz/signoz-mcp-server/pull/140))
 - add CRUD MCP tools for saved explorer views ([#138](https://github.com/SigNoz/signoz-mcp-server/pull/138))
 
+### Changed
+- Self-hosted SigNoz users must run SigNoz v0.120.0 or newer for alert rule tools that use the `/api/v2/rules` APIs.
+
 ### Fixed
 - accept typed-slice filter items in normalizers and co… ([#148](https://github.com/SigNoz/signoz-mcp-server/pull/148))
 

--- a/README.md
+++ b/README.md
@@ -206,6 +206,7 @@ The binary is at `./bin/signoz-mcp-server`.
 ### Prerequisites
 
 - A running [SigNoz](https://signoz.io) instance
+- SigNoz v0.120.0 or newer for alert rule tools that use the `/api/v2/rules` APIs
 - A SigNoz API key (Settings → API Keys in the SigNoz UI)
 - The `signoz-mcp-server` binary (see [Self-Hosted Installation](#self-hosted-installation))
 
@@ -330,7 +331,7 @@ HTTP mode exposes unauthenticated probe endpoints. New Kubernetes deployments sh
 
 ## Available Tools
 
-> **SigNoz compatibility:** alert-rule and notification-channel tools target the new convention: `/api/v2/rules/*` for rules and the render-envelope `/api/v1/channels/*` routes. These require a SigNoz release that includes SigNoz/signoz#10941, #10957, #10995, and #10997. Older deployments will see HTTP 404 from the affected tools.
+> **SigNoz compatibility:** alert-rule tools target `/api/v2/rules/*`, which is available in SigNoz v0.120.0 and newer. Self-hosted deployments on older SigNoz versions will see HTTP 404 from the affected alert-rule tools. Notification-channel tools target the render-envelope `/api/v1/channels/*` routes introduced by SigNoz/signoz#10941, #10957, #10995, and #10997.
 
 > **Tool metadata:** every tool accepts `searchContext`, the user's original question/search text. It is used for MCP observability and is not forwarded to SigNoz APIs.
 


### PR DESCRIPTION
## Summary
- Document that alert-rule tools using `/api/v2/rules` require SigNoz v0.120.0 or newer for self-hosted deployments.
- Add the same compatibility note to `CHANGELOG.md`.
- Split the README compatibility note so alert-rule and notification-channel version requirements stay precise.

## Validation
- `git diff --check`