### PR TITLE
feat(dashboard): add signoz_create_dashboard_from_template MCP tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -353,6 +353,7 @@ HTTP mode exposes unauthenticated probe endpoints. New Kubernetes deployments sh
 | `signoz_create_dashboard` | Create a new dashboard |
 | `signoz_update_dashboard` | Update an existing dashboard |
 | `signoz_delete_dashboard` | Delete a dashboard by UUID |
+| `signoz_create_dashboard_from_template` | Create a dashboard from a curated SigNoz/dashboards template by path |
 | `signoz_list_services` | List services within a time range |
 | `signoz_get_service_top_operations` | Get top operations for a service |
 | `signoz_list_views` | List saved Explorer views for a sourcePage (traces/logs/metrics) |
@@ -457,6 +458,13 @@ Creates a dashboard.
   - `layout` (required) – Widget positioning grid
   - `variables` (optional) – Map of variables available for use in queries
   - `widgets` (required) – List of widgets added to the dashboard
+
+#### `signoz_create_dashboard_from_template`
+
+Creates a dashboard from a curated template hosted in the [SigNoz/dashboards](https://github.com/SigNoz/dashboards) repo (pinned commit). The server fetches the template JSON, validates it, and creates the dashboard in one call.
+
+- **Parameters:**
+  - `path` (required) – Template path within the SigNoz/dashboards repo, e.g. `hostmetrics/hostmetrics.json`
 
 #### `signoz_update_dashboard`
 

--- a/README.md
+++ b/README.md
@@ -354,6 +354,7 @@ HTTP mode exposes unauthenticated probe endpoints. New Kubernetes deployments sh
 | `signoz_update_dashboard` | Update an existing dashboard |
 | `signoz_delete_dashboard` | Delete a dashboard by UUID |
 | `signoz_import_dashboard` | Create a dashboard from a curated SigNoz/dashboards template by path |
+| `signoz_list_dashboard_templates` | List the bundled curated SigNoz dashboard template catalog so the model can pick a template |
 | `signoz_list_services` | List services within a time range |
 | `signoz_get_service_top_operations` | Get top operations for a service |
 | `signoz_list_views` | List saved Explorer views for a sourcePage (traces/logs/metrics) |
@@ -463,8 +464,17 @@ Creates a dashboard.
 
 Creates a dashboard from a curated template hosted in the [SigNoz/dashboards](https://github.com/SigNoz/dashboards) repo (pinned commit). The server fetches the template JSON, validates it, and creates the dashboard in one call.
 
+To discover available paths, call `signoz_list_dashboard_templates` first and let the model pick the best match.
+
 - **Parameters:**
   - `path` (required) – Template path within the SigNoz/dashboards repo, e.g. `hostmetrics/hostmetrics.json`
+
+#### `signoz_list_dashboard_templates`
+
+Returns the full bundled catalog of curated SigNoz dashboard templates (id, title, path, description, category, keywords) as a JSON array. Pair with `signoz_import_dashboard`: have the model read the catalog, choose the entry that best matches the user's intent, then import it by its `path`.
+
+- **Parameters:**
+  - `category` (optional) – Restrict results to a single catalog category (case-insensitive), e.g. `Apm`, `K8S Infra Metrics`
 
 #### `signoz_update_dashboard`
 

--- a/README.md
+++ b/README.md
@@ -353,7 +353,7 @@ HTTP mode exposes unauthenticated probe endpoints. New Kubernetes deployments sh
 | `signoz_create_dashboard` | Create a new dashboard |
 | `signoz_update_dashboard` | Update an existing dashboard |
 | `signoz_delete_dashboard` | Delete a dashboard by UUID |
-| `signoz_create_dashboard_from_template` | Create a dashboard from a curated SigNoz/dashboards template by path |
+| `signoz_import_dashboard` | Create a dashboard from a curated SigNoz/dashboards template by path |
 | `signoz_list_services` | List services within a time range |
 | `signoz_get_service_top_operations` | Get top operations for a service |
 | `signoz_list_views` | List saved Explorer views for a sourcePage (traces/logs/metrics) |
@@ -459,7 +459,7 @@ Creates a dashboard.
   - `variables` (optional) – Map of variables available for use in queries
   - `widgets` (required) – List of widgets added to the dashboard
 
-#### `signoz_create_dashboard_from_template`
+#### `signoz_import_dashboard`
 
 Creates a dashboard from a curated template hosted in the [SigNoz/dashboards](https://github.com/SigNoz/dashboards) repo (pinned commit). The server fetches the template JSON, validates it, and creates the dashboard in one call.
 

--- a/internal/handler/tools/dashboard_templates.go
+++ b/internal/handler/tools/dashboard_templates.go
@@ -1,0 +1,48 @@
+package tools
+
+import (
+	_ "embed"
+	"encoding/json"
+	"strings"
+)
+
+//go:embed dashboard_templates.json
+var dashboardTemplateCatalogJSON []byte
+
+// dashboardTemplateEntry mirrors one entry in the bundled catalog.
+type dashboardTemplateEntry struct {
+	ID          string   `json:"id"`
+	Title       string   `json:"title"`
+	Path        string   `json:"path"`
+	Keywords    []string `json:"keywords"`
+	Description string   `json:"description"`
+	Category    string   `json:"category"`
+}
+
+var dashboardTemplateCatalog []dashboardTemplateEntry
+
+func init() {
+	if err := json.Unmarshal(dashboardTemplateCatalogJSON, &dashboardTemplateCatalog); err != nil {
+		// The catalog is committed alongside this code; failure here means the
+		// embedded JSON is malformed. Fall back to empty so the tool still loads.
+		dashboardTemplateCatalog = nil
+	}
+}
+
+// listDashboardTemplates returns the embedded catalog. When category is
+// non-empty, results are restricted to that catalog category (case-insensitive).
+func listDashboardTemplates(category string) []dashboardTemplateEntry {
+	if category == "" {
+		out := make([]dashboardTemplateEntry, len(dashboardTemplateCatalog))
+		copy(out, dashboardTemplateCatalog)
+		return out
+	}
+	want := strings.ToLower(category)
+	out := make([]dashboardTemplateEntry, 0, len(dashboardTemplateCatalog))
+	for _, e := range dashboardTemplateCatalog {
+		if strings.ToLower(e.Category) == want {
+			out = append(out, e)
+		}
+	}
+	return out
+}

--- a/internal/handler/tools/dashboard_templates.json
+++ b/internal/handler/tools/dashboard_templates.json
@@ -1,0 +1,1151 @@
+[
+  {
+    "id": "agno",
+    "title": "Agno",
+    "path": "agno/agno-dashboard.json",
+    "keywords": [
+      "agno"
+    ],
+    "description": "",
+    "category": "Agno"
+  },
+  {
+    "id": "anthropic",
+    "title": "Anthropic API",
+    "path": "anthropic/anthropic-dashboard.json",
+    "keywords": [
+      "anthropic",
+      "api"
+    ],
+    "description": "",
+    "category": "Anthropic"
+  },
+  {
+    "id": "apache-web-server",
+    "title": "Apache Monitoring Dashboard",
+    "path": "apache-web-server/apache.json",
+    "keywords": [
+      "apache",
+      "web",
+      "server",
+      "monitoring"
+    ],
+    "description": "",
+    "category": "Apache Web Server"
+  },
+  {
+    "id": "apm",
+    "title": "APM Metrics",
+    "path": "apm/apm-metrics.json",
+    "keywords": [
+      "apm",
+      "metrics",
+      "latency",
+      "error",
+      "rate",
+      "throughput"
+    ],
+    "description": "",
+    "category": "Apm"
+  },
+  {
+    "id": "apm",
+    "title": "DB Calls Monitoring",
+    "path": "apm/db-calls-monitoring.json",
+    "keywords": [
+      "apm",
+      "db",
+      "calls",
+      "monitoring"
+    ],
+    "description": "Built on top of available DB attributes from opentelemetry: https://opentelemetry.io/docs/specs/semconv/attributes-registry/db/",
+    "category": "Apm"
+  },
+  {
+    "id": "apm",
+    "title": "HTTP API Monitoring",
+    "path": "apm/http-api-monitoring.json",
+    "keywords": [
+      "apm",
+      "http",
+      "api",
+      "monitoring"
+    ],
+    "description": "Built on top of available HTTP attributes from opentelemetry: https://opentelemetry.io/docs/specs/semconv/attributes-registry/http/",
+    "category": "Apm"
+  },
+  {
+    "id": "argocd",
+    "title": "Argocd Dashboard",
+    "path": "argocd/argocd.json",
+    "keywords": [
+      "argocd"
+    ],
+    "description": "",
+    "category": "Argocd"
+  },
+  {
+    "id": "autogen",
+    "title": "Autogen",
+    "path": "autogen/autogen-dashboard.json",
+    "keywords": [
+      "autogen"
+    ],
+    "description": "",
+    "category": "Autogen"
+  },
+  {
+    "id": "aws-sqs-prometheus",
+    "title": "AWS SQS Prometheus",
+    "path": "aws-sqs-prometheus/aws-sqs-prometheus.json",
+    "keywords": [
+      "aws",
+      "sqs",
+      "prometheus"
+    ],
+    "description": "Dashboard is built on the provided metrics by Third-party prometheus exporters \n( https://github.com/jmal98/sqs-exporter )",
+    "category": "Aws Sqs Prometheus"
+  },
+  {
+    "id": "azure-openai",
+    "title": "Azure OpenAI API",
+    "path": "azure-openai/azure-openai-dashboard.json",
+    "keywords": [
+      "azure",
+      "openai",
+      "api"
+    ],
+    "description": "",
+    "category": "Azure Openai"
+  },
+  {
+    "id": "baseten",
+    "title": "Baseten",
+    "path": "baseten/baseten-dashboard.json",
+    "keywords": [
+      "baseten"
+    ],
+    "description": "",
+    "category": "Baseten"
+  },
+  {
+    "id": "bedrock",
+    "title": "Amazon Bedrock",
+    "path": "bedrock/bedrock-dashboard.json",
+    "keywords": [
+      "bedrock",
+      "amazon"
+    ],
+    "description": "",
+    "category": "Bedrock"
+  },
+  {
+    "id": "cicd",
+    "title": "CI/CD Observability",
+    "path": "cicd/cicd.json",
+    "keywords": [
+      "cicd",
+      "ci",
+      "cd",
+      "observability",
+      "vcs"
+    ],
+    "description": "Dashboard displaying metrics from CI and CD systems.",
+    "category": "Cicd"
+  },
+  {
+    "id": "claude-agent-sdk",
+    "title": "Claude Agent SDK",
+    "path": "claude-agent-sdk/claude-agent-sdk-dashboard.json",
+    "keywords": [
+      "claude",
+      "agent",
+      "sdk"
+    ],
+    "description": "",
+    "category": "Claude Agent Sdk"
+  },
+  {
+    "id": "claude-code",
+    "title": "Claude Code Metrics",
+    "path": "claude-code/claude-code-dashboard.json",
+    "keywords": [
+      "claude",
+      "code",
+      "metrics",
+      "ai",
+      "opentelemetry"
+    ],
+    "description": "Monitor Claude Code usage, costs, tokens, and productivity metrics",
+    "category": "Claude Code"
+  },
+  {
+    "id": "clickhouse",
+    "title": "Clickhouse Overview",
+    "path": "clickhouse/clickhouse-overview.json",
+    "keywords": [
+      "clickhouse",
+      "overview"
+    ],
+    "description": "This dashboard provides a high-level overview of your Clickhouse Server hosts.",
+    "category": "Clickhouse"
+  },
+  {
+    "id": "codex",
+    "title": "Codex",
+    "path": "codex/codex-dashboard.json",
+    "keywords": [
+      "codex"
+    ],
+    "description": "",
+    "category": "Codex"
+  },
+  {
+    "id": "couchdb",
+    "title": "CouchDB",
+    "path": "couchdb/couchdb.json",
+    "keywords": [
+      "couchdb"
+    ],
+    "description": "Basic metrics to monitor around CouchDB",
+    "category": "Couchdb"
+  },
+  {
+    "id": "crewai",
+    "title": "Crew AI",
+    "path": "crewai/crewai-dashboard.json",
+    "keywords": [
+      "crewai",
+      "crew",
+      "ai"
+    ],
+    "description": "",
+    "category": "Crewai"
+  },
+  {
+    "id": "deepseek",
+    "title": "Deepseek API",
+    "path": "deepseek/deepseek-dashboard.json",
+    "keywords": [
+      "deepseek",
+      "api"
+    ],
+    "description": "",
+    "category": "Deepseek"
+  },
+  {
+    "id": "ecs-infra-metrics",
+    "title": "Container Metrics - ECS",
+    "path": "ecs-infra-metrics/container-metrics.json",
+    "keywords": [
+      "ecs",
+      "infra",
+      "metrics",
+      "container",
+      "ec2",
+      "sidecar"
+    ],
+    "description": "Container Metrics Dashboard of ECS using sidecar",
+    "category": "Ecs Infra Metrics"
+  },
+  {
+    "id": "ecs-infra-metrics",
+    "title": "Instance Metrics - ECS",
+    "path": "ecs-infra-metrics/instance-metrics.json",
+    "keywords": [
+      "ecs",
+      "infra",
+      "metrics",
+      "instance",
+      "daemon",
+      "ec2"
+    ],
+    "description": "Instance Metrics Dashboard of ECS EC2",
+    "category": "Ecs Infra Metrics"
+  },
+  {
+    "id": "elasticsearch",
+    "title": "Elasticsearch Monitoring Dashboard",
+    "path": "elasticsearch/elasticsearch-dashboard-detailed.json",
+    "keywords": [
+      "elasticsearch",
+      "detailed",
+      "monitoring"
+    ],
+    "description": "Elasticsearch monitoring dashboard built on the OpenTelemetry Collector elasticsearch receiver, covering cluster health & shard state, node-level CPU/disk/HTTP metrics, etc.",
+    "category": "Elasticsearch"
+  },
+  {
+    "id": "envoy",
+    "title": "Envoy Monitoring Dasboard",
+    "path": "envoy/envoy-otlp-v1.json",
+    "keywords": [
+      "envoy",
+      "otlp",
+      "v1",
+      "monitoring",
+      "dasboard",
+      "proxy"
+    ],
+    "description": "",
+    "category": "Envoy"
+  },
+  {
+    "id": "flask-monitoring",
+    "title": "Flask monitoring",
+    "path": "flask-monitoring/flask-monitoring.json",
+    "keywords": [
+      "flask",
+      "monitoring"
+    ],
+    "description": "",
+    "category": "Flask Monitoring"
+  },
+  {
+    "id": "fly",
+    "title": "Fly.io — Fly App (SigNoz)",
+    "path": "fly/fly-prometheus-v1.json",
+    "keywords": [
+      "fly",
+      "prometheus",
+      "v1",
+      "io",
+      "app",
+      "(signoz)",
+      "federate"
+    ],
+    "description": "",
+    "category": "Fly"
+  },
+  {
+    "id": "go-runtime",
+    "title": "Go Runtime Metrics",
+    "path": "go-runtime/go-runtime-metrics.json",
+    "keywords": [
+      "go",
+      "runtime",
+      "metrics",
+      "golang"
+    ],
+    "description": "Go runtime metrics dashboard for monitoring memory, goroutines, and scheduler performance",
+    "category": "Go Runtime"
+  },
+  {
+    "id": "google-adk",
+    "title": "Google ADK",
+    "path": "google-adk/google-adk-dashboard.json",
+    "keywords": [
+      "google",
+      "adk"
+    ],
+    "description": "",
+    "category": "Google Adk"
+  },
+  {
+    "id": "google-gemini",
+    "title": "Gemini Dashboard",
+    "path": "google-gemini/google-gemini-template.json",
+    "keywords": [
+      "google",
+      "gemini"
+    ],
+    "description": "",
+    "category": "Google Gemini"
+  },
+  {
+    "id": "grok",
+    "title": "Grok",
+    "path": "grok/grok-dashboard.json",
+    "keywords": [
+      "grok"
+    ],
+    "description": "",
+    "category": "Grok"
+  },
+  {
+    "id": "groq",
+    "title": "Groq",
+    "path": "groq/groq-dashboard.json",
+    "keywords": [
+      "groq"
+    ],
+    "description": "",
+    "category": "Groq"
+  },
+  {
+    "id": "hadoop",
+    "title": "Hadoop Dashboard",
+    "path": "hadoop/hadoop-otlp-v1.json",
+    "keywords": [
+      "hadoop",
+      "otlp",
+      "v1"
+    ],
+    "description": "",
+    "category": "Hadoop"
+  },
+  {
+    "id": "haproxy",
+    "title": "HAProxy dashboard",
+    "path": "haproxy/haproxy.json",
+    "keywords": [
+      "haproxy"
+    ],
+    "description": "",
+    "category": "Haproxy"
+  },
+  {
+    "id": "haystack",
+    "title": "Haystack",
+    "path": "haystack/haystack-dashboard.json",
+    "keywords": [
+      "haystack"
+    ],
+    "description": "",
+    "category": "Haystack"
+  },
+  {
+    "id": "hostmetrics",
+    "title": "Host Metrics",
+    "path": "hostmetrics/hostmetrics.json",
+    "keywords": [
+      "hostmetrics",
+      "host",
+      "metrics",
+      "cpu",
+      "memory",
+      "network"
+    ],
+    "description": "This dashboard uses the system metrics collected from the `hostmetrics` receiver to show CPU, Memory, Disk, Network and Filesystem usage",
+    "category": "Hostmetrics"
+  },
+  {
+    "id": "hostmetrics",
+    "title": "Host Metrics (k8s)",
+    "path": "hostmetrics/hostmetrics-k8s.json",
+    "keywords": [
+      "hostmetrics",
+      "k8s",
+      "host",
+      "metrics",
+      "(k8s)",
+      "node"
+    ],
+    "description": "This dashboard uses the system metrics collected from the `hostmetrics` receiver to show CPU, Memory, Disk, Network and Filesystem usage",
+    "category": "Hostmetrics"
+  },
+  {
+    "id": "huggingface",
+    "title": "HuggingFace",
+    "path": "huggingface/huggingface-dashboard.json",
+    "keywords": [
+      "huggingface"
+    ],
+    "description": "",
+    "category": "Huggingface"
+  },
+  {
+    "id": "inkeep",
+    "title": "Inkeep",
+    "path": "inkeep/inkeep-dashboard.json",
+    "keywords": [
+      "inkeep"
+    ],
+    "description": "",
+    "category": "Inkeep"
+  },
+  {
+    "id": "jenkins",
+    "title": "Jenkins",
+    "path": "jenkins/jenkins-metrics.json",
+    "keywords": [
+      "jenkins",
+      "metrics",
+      "admin",
+      "devops"
+    ],
+    "description": "Monitor: Scale from 0 or to 0\nSpecific Instance type based on request\nResource Usage of jobs",
+    "category": "Jenkins"
+  },
+  {
+    "id": "jmx",
+    "title": "Cassandra metrics",
+    "path": "jmx/cassandra.json",
+    "keywords": [
+      "jmx",
+      "cassandra",
+      "metrics"
+    ],
+    "description": "",
+    "category": "Jmx"
+  },
+  {
+    "id": "jvm",
+    "title": "JVM Metrics",
+    "path": "jvm/jvm-metrics-by-service.json",
+    "keywords": [
+      "jvm",
+      "metrics",
+      "by",
+      "service",
+      "runtime"
+    ],
+    "description": "JVM Runtime metrics for service",
+    "category": "Jvm"
+  },
+  {
+    "id": "k8s-infra-metrics",
+    "title": "Host Metrics (k8s)",
+    "path": "k8s-infra-metrics/host-metrics.json",
+    "keywords": [
+      "k8s",
+      "infra",
+      "metrics",
+      "host",
+      "(k8s)",
+      "hostmetrics",
+      "node"
+    ],
+    "description": "This dashboard uses the system metrics collected from the `hostmetrics` receiver to show CPU, Memory, Disk, Network and Filesystem usage",
+    "category": "K8S Infra Metrics"
+  },
+  {
+    "id": "k8s-infra-metrics",
+    "title": "Kubernetes Cluster Events",
+    "path": "k8s-infra-metrics/k8s-events-receiver.json",
+    "keywords": [
+      "k8s",
+      "infra",
+      "metrics",
+      "events",
+      "receiver",
+      "kubernetes",
+      "cluster",
+      "cloud"
+    ],
+    "description": "This dashboard displays specific event and object kind counts, as well as their respective time-series charts, allowing the viewer to understand what's happening inside a cluster at a glance.",
+    "category": "K8S Infra Metrics"
+  },
+  {
+    "id": "k8s-infra-metrics",
+    "title": "Kubernetes Cluster Metrics",
+    "path": "k8s-infra-metrics/kubernetes-cluster-metrics.json",
+    "keywords": [
+      "k8s",
+      "infra",
+      "metrics",
+      "kubernetes",
+      "cluster",
+      "k8sclusterreceiver"
+    ],
+    "description": "This dashboard uses the metrics sent using `k8sclusterreceiver` to show the desired and currently running pods for deployments, daemonsets, statefulset, replicasets and pods count by phase.",
+    "category": "K8S Infra Metrics"
+  },
+  {
+    "id": "k8s-infra-metrics",
+    "title": "Kubernetes Node Metrics - Detailed",
+    "path": "k8s-infra-metrics/kubernetes-node-metrics-detailed.json",
+    "keywords": [
+      "k8s",
+      "infra",
+      "metrics",
+      "kubernetes",
+      "node",
+      "detailed",
+      "kubelet"
+    ],
+    "description": "",
+    "category": "K8S Infra Metrics"
+  },
+  {
+    "id": "k8s-infra-metrics",
+    "title": "Kubernetes Node Metrics - Overall",
+    "path": "k8s-infra-metrics/kubernetes-node-metrics-overall.json",
+    "keywords": [
+      "k8s",
+      "infra",
+      "metrics",
+      "kubernetes",
+      "node",
+      "overall",
+      "kubelet"
+    ],
+    "description": "",
+    "category": "K8S Infra Metrics"
+  },
+  {
+    "id": "k8s-infra-metrics",
+    "title": "Kubernetes Pod Metrics - Detailed",
+    "path": "k8s-infra-metrics/kubernetes-pod-metrics-detailed.json",
+    "keywords": [
+      "k8s",
+      "infra",
+      "metrics",
+      "kubernetes",
+      "pod",
+      "detailed"
+    ],
+    "description": "",
+    "category": "K8S Infra Metrics"
+  },
+  {
+    "id": "k8s-infra-metrics",
+    "title": "Kubernetes Pod Metrics - Overall",
+    "path": "k8s-infra-metrics/kubernetes-pod-metrics-overall.json",
+    "keywords": [
+      "k8s",
+      "infra",
+      "metrics",
+      "kubernetes",
+      "pod",
+      "overall"
+    ],
+    "description": "",
+    "category": "K8S Infra Metrics"
+  },
+  {
+    "id": "k8s-infra-metrics",
+    "title": "Kubernetes PVC Metrics",
+    "path": "k8s-infra-metrics/kubernetes-pvc-metrics.json",
+    "keywords": [
+      "k8s",
+      "infra",
+      "metrics",
+      "kubernetes",
+      "pvc",
+      "pod",
+      "volume"
+    ],
+    "description": "",
+    "category": "K8S Infra Metrics"
+  },
+  {
+    "id": "keda",
+    "title": "KEDA Dashboard",
+    "path": "keda/keda-otlp-v1.json",
+    "keywords": [
+      "keda",
+      "otlp",
+      "v1"
+    ],
+    "description": "",
+    "category": "Keda"
+  },
+  {
+    "id": "key-operations",
+    "title": "Key operations",
+    "path": "key-operations/key-operations.json",
+    "keywords": [
+      "key",
+      "operations",
+      "apm",
+      "latency",
+      "error",
+      "rate",
+      "throughput"
+    ],
+    "description": "",
+    "category": "Key Operations"
+  },
+  {
+    "id": "litellm",
+    "title": "LiteLLM Proxy",
+    "path": "litellm/litellm-proxy-dashboard.json",
+    "keywords": [
+      "litellm",
+      "proxy"
+    ],
+    "description": "",
+    "category": "Litellm"
+  },
+  {
+    "id": "litellm",
+    "title": "LiteLLM SDK",
+    "path": "litellm/litellm-sdk-dashboard.json",
+    "keywords": [
+      "litellm",
+      "sdk"
+    ],
+    "description": "",
+    "category": "Litellm"
+  },
+  {
+    "id": "livekit",
+    "title": "LiveKit",
+    "path": "livekit/livekit-dashboard.json",
+    "keywords": [
+      "livekit"
+    ],
+    "description": "",
+    "category": "Livekit"
+  },
+  {
+    "id": "llm-observability",
+    "title": "SigNoz Chat PDF Performance Metrics",
+    "path": "llm-observability/sample-chatpdf-performance-metrics.json",
+    "keywords": [
+      "llm",
+      "observability",
+      "sample",
+      "chatpdf",
+      "performance",
+      "metrics",
+      "signoz",
+      "chat",
+      "pdf",
+      "langchain"
+    ],
+    "description": "",
+    "category": "Llm Observability"
+  },
+  {
+    "id": "llm-observability",
+    "title": "SigNoz ChatPDF Cost Dashboard",
+    "path": "llm-observability/sample-chatpdf-cost-dashboard.json",
+    "keywords": [
+      "llm",
+      "observability",
+      "sample",
+      "chatpdf",
+      "cost",
+      "signoz"
+    ],
+    "description": "",
+    "category": "Llm Observability"
+  },
+  {
+    "id": "mastra",
+    "title": "Mastra",
+    "path": "mastra/mastra-dashboard.json",
+    "keywords": [
+      "mastra"
+    ],
+    "description": "",
+    "category": "Mastra"
+  },
+  {
+    "id": "memcached",
+    "title": "Memcached",
+    "path": "memcached/memcached.json",
+    "keywords": [
+      "memcached"
+    ],
+    "description": "Dashboard to monitor Memcached",
+    "category": "Memcached"
+  },
+  {
+    "id": "meter",
+    "title": "Meter Breakdown",
+    "path": "meter/meter.json",
+    "keywords": [
+      "meter",
+      "breakdown",
+      "cost",
+      "ingestion"
+    ],
+    "description": "Provides breakdown of meter by service and environment. Please use time range greater than 1 hour as meter data is aggregated over 1 hour intervals. ",
+    "category": "Meter"
+  },
+  {
+    "id": "mistral",
+    "title": "Mistral AI",
+    "path": "mistral/mistral-dashboard.json",
+    "keywords": [
+      "mistral",
+      "ai"
+    ],
+    "description": "",
+    "category": "Mistral"
+  },
+  {
+    "id": "mongodb",
+    "title": "Mongo overview",
+    "path": "mongodb/mongodb.json",
+    "keywords": [
+      "mongodb",
+      "mongo",
+      "overview",
+      "database"
+    ],
+    "description": "This dashboard provides a high-level overview of your MongoDB. It includes read/write performance, most-used replicas, collection metrics etc...",
+    "category": "Mongodb"
+  },
+  {
+    "id": "mysql",
+    "title": "MySQL (OTEL)",
+    "path": "mysql/mysql-otlp-v1.json",
+    "keywords": [
+      "mysql",
+      "otlp",
+      "v1",
+      "(otel)",
+      "otel"
+    ],
+    "description": "",
+    "category": "Mysql"
+  },
+  {
+    "id": "n8n",
+    "title": "n8n",
+    "path": "n8n/n8n-dashboard.json",
+    "keywords": [
+      "n8n"
+    ],
+    "description": "",
+    "category": "N8N"
+  },
+  {
+    "id": "nginx",
+    "title": "Ingress Nginx - Request Handling Performance",
+    "path": "nginx/nginx-ingress-request-handling-performance.json",
+    "keywords": [
+      "nginx",
+      "ingress",
+      "request",
+      "handling",
+      "performance"
+    ],
+    "description": "",
+    "category": "Nginx"
+  },
+  {
+    "id": "nginx",
+    "title": "NGINX (OTEL)",
+    "path": "nginx/nginx.json",
+    "keywords": [
+      "nginx",
+      "(otel)",
+      "otel"
+    ],
+    "description": "",
+    "category": "Nginx"
+  },
+  {
+    "id": "nginx",
+    "title": "NGINX Ingress controller [WIP by SigNoz] ",
+    "path": "nginx/ingress-nginx-controller.json",
+    "keywords": [
+      "nginx",
+      "ingress",
+      "controller",
+      "[wip",
+      "by",
+      "signoz]"
+    ],
+    "description": "",
+    "category": "Nginx"
+  },
+  {
+    "id": "nomad",
+    "title": "Nomad Metrics",
+    "path": "nomad/nomad-metrics-by-host.json",
+    "keywords": [
+      "nomad",
+      "metrics",
+      "by",
+      "host"
+    ],
+    "description": "",
+    "category": "Nomad"
+  },
+  {
+    "id": "nvidia-dcgm",
+    "title": "NVIDIA DCGM",
+    "path": "nvidia-dcgm/nvidia-dcgm.json",
+    "keywords": [
+      "nvidia",
+      "dcgm"
+    ],
+    "description": "",
+    "category": "Nvidia Dcgm"
+  },
+  {
+    "id": "ollama",
+    "title": "Ollama",
+    "path": "ollama/ollama-dashboard.json",
+    "keywords": [
+      "ollama"
+    ],
+    "description": "",
+    "category": "Ollama"
+  },
+  {
+    "id": "openai",
+    "title": "OpenAI",
+    "path": "openai/openai-dashboard.json",
+    "keywords": [
+      "openai"
+    ],
+    "description": "",
+    "category": "Openai"
+  },
+  {
+    "id": "openclaw",
+    "title": "Openclaw Overview",
+    "path": "openclaw/openclaw-dashboard.json",
+    "keywords": [
+      "openclaw",
+      "overview"
+    ],
+    "description": "",
+    "category": "Openclaw"
+  },
+  {
+    "id": "openrouter",
+    "title": "Openrouter",
+    "path": "openrouter/openrouter-dashboard.json",
+    "keywords": [
+      "openrouter"
+    ],
+    "description": "",
+    "category": "Openrouter"
+  },
+  {
+    "id": "pipecat",
+    "title": "Pipecat",
+    "path": "pipecat/pipecat-dashboard.json",
+    "keywords": [
+      "pipecat"
+    ],
+    "description": "",
+    "category": "Pipecat"
+  },
+  {
+    "id": "postgresql",
+    "title": "Postgres overview",
+    "path": "postgresql/postgresql.json",
+    "keywords": [
+      "postgresql",
+      "postgres",
+      "overview",
+      "database"
+    ],
+    "description": "This dashboard provides a high-level overview of your PostgreSQL databases. It includes replication, locks, and throughput etc...",
+    "category": "Postgresql"
+  },
+  {
+    "id": "pydantic-ai",
+    "title": "Pydantic",
+    "path": "pydantic-ai/pydantic-dashboard.json",
+    "keywords": [
+      "pydantic",
+      "ai"
+    ],
+    "description": "",
+    "category": "Pydantic Ai"
+  },
+  {
+    "id": "qwen",
+    "title": "Qwen",
+    "path": "qwen/qwen-dashboard.json",
+    "keywords": [
+      "qwen"
+    ],
+    "description": "",
+    "category": "Qwen"
+  },
+  {
+    "id": "rabbitmq",
+    "title": "RabbitMQ Metricsl (OTEL)",
+    "path": "rabbitmq/rabbitmq.json",
+    "keywords": [
+      "rabbitmq",
+      "metricsl",
+      "(otel)",
+      "otel",
+      "queue"
+    ],
+    "description": "Dashboard for rabbitmq metrics provided by (rabbitmqreceiver)[https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/receiver/rabbitmqreceiver]",
+    "category": "Rabbitmq"
+  },
+  {
+    "id": "redis",
+    "title": "Redis overview",
+    "path": "redis/redis-overview.json",
+    "keywords": [
+      "redis",
+      "overview",
+      "database"
+    ],
+    "description": "This dashboard shows the Redis instance overview. It includes latency, hit/miss rate, connections, and memory information.\n",
+    "category": "Redis"
+  },
+  {
+    "id": "render",
+    "title": "Render Test",
+    "path": "render/render-dashboard.json",
+    "keywords": [
+      "render",
+      "test"
+    ],
+    "description": "",
+    "category": "Render"
+  },
+  {
+    "id": "semantic-kernel",
+    "title": "Semantic Kernel",
+    "path": "semantic-kernel/semantic-kernel-dashboard.json",
+    "keywords": [
+      "semantic",
+      "kernel"
+    ],
+    "description": "",
+    "category": "Semantic Kernel"
+  },
+  {
+    "id": "signoz-ingestion-analysis",
+    "title": "Ingestion",
+    "path": "signoz-ingestion-analysis/signoz-ingestion-analysis-v1.json",
+    "keywords": [
+      "signoz",
+      "ingestion",
+      "analysis",
+      "v1"
+    ],
+    "description": "This dashboard shows the metrics, traces and logs ingested.  Please follow the following guides to control your data sent to SigNoz. Only last 15 minutes of data is shown as this is mainly intended to help you understand the recent volume. \n\nMetrics: https://signoz.io/docs/userguide/drop-metrics/\n\n\nLogs: https://signoz.io/docs/logs-management/guides/drop-logs/\n\n\nTraces: https://signoz.io/docs/traces-management/guides/drop-spans/",
+    "category": "Signoz Ingestion Analysis"
+  },
+  {
+    "id": "signoz-ingestion-analysis",
+    "title": "IngestionV2",
+    "path": "signoz-ingestion-analysis/signoz-ingestion-analysis-v2.json",
+    "keywords": [
+      "signoz",
+      "ingestion",
+      "analysis",
+      "v2",
+      "ingestionv2",
+      "usage"
+    ],
+    "description": "This dashboard shows the metrics, traces and logs ingested.  Please follow the following guides to control your data sent to SigNoz. Only last 15 minutes of data is shown as this is mainly intended to help you understand the recent volume. \n\nMetrics: https://signoz.io/docs/userguide/drop-metrics/\n\n\nLogs: https://signoz.io/docs/logs-management/guides/drop-logs/\n\n\nTraces: https://signoz.io/docs/traces-management/guides/drop-spans/",
+    "category": "Signoz Ingestion Analysis"
+  },
+  {
+    "id": "slurm",
+    "title": "SLURM ",
+    "path": "slurm/slurm.json",
+    "keywords": [
+      "slurm"
+    ],
+    "description": "",
+    "category": "Slurm"
+  },
+  {
+    "id": "snowflake",
+    "title": "Snowflake Dashboard",
+    "path": "snowflake/snowflake-otlp-v1.json",
+    "keywords": [
+      "snowflake",
+      "otlp",
+      "v1"
+    ],
+    "description": "This dashboard plots all the important metrics for Snowflake.",
+    "category": "Snowflake"
+  },
+  {
+    "id": "supabase",
+    "title": "Supabase Monitoring Dashboard",
+    "path": "supabase/supabase-dashboard-detailed.json",
+    "keywords": [
+      "supabase",
+      "detailed",
+      "monitoring"
+    ],
+    "description": "",
+    "category": "Supabase"
+  },
+  {
+    "id": "temporal-agents",
+    "title": "Temporal for AI",
+    "path": "temporal-agents/temporal-dashboard.json",
+    "keywords": [
+      "temporal",
+      "agents",
+      "for",
+      "ai"
+    ],
+    "description": "",
+    "category": "Temporal Agents"
+  },
+  {
+    "id": "temporal.io",
+    "title": "Temporal Cloud Metrics",
+    "path": "temporal.io/Temporal Cloud Metrics.json",
+    "keywords": [
+      "temporal",
+      "io",
+      "cloud",
+      "metrics"
+    ],
+    "description": "",
+    "category": "Temporal.Io"
+  },
+  {
+    "id": "temporal.io",
+    "title": "Temporal SDK Metrics",
+    "path": "temporal.io/Temporal SDK Metrics - golang.json",
+    "keywords": [
+      "temporal",
+      "io",
+      "sdk",
+      "metrics",
+      "golang"
+    ],
+    "description": "",
+    "category": "Temporal.Io"
+  },
+  {
+    "id": "temporal.io",
+    "title": "Temporal SDK Metrics",
+    "path": "temporal.io/Temporal SDK Metrics - typescript.json",
+    "keywords": [
+      "temporal",
+      "io",
+      "sdk",
+      "metrics",
+      "typescript"
+    ],
+    "description": "",
+    "category": "Temporal.Io"
+  },
+  {
+    "id": "vercel-ai-sdk",
+    "title": "Vercel AI SDK Template",
+    "path": "vercel-ai-sdk/vercel-ai-sdk-template.json",
+    "keywords": [
+      "vercel",
+      "ai",
+      "sdk"
+    ],
+    "description": "",
+    "category": "Vercel Ai Sdk"
+  },
+  {
+    "id": "web-vitals-monitoring",
+    "title": "Web Vitals Monitoring",
+    "path": "web-vitals-monitoring/web-vitals-monitoring-with-metrics.json",
+    "keywords": [
+      "web",
+      "vitals",
+      "monitoring",
+      "with",
+      "metrics"
+    ],
+    "description": "Real-time monitoring of key Web Vitals metrics to track user experience and page performance.",
+    "category": "Web Vitals Monitoring"
+  },
+  {
+    "id": "web-vitals-monitoring",
+    "title": "Web Vitals Monitoring",
+    "path": "web-vitals-monitoring/web-vitals-monitoring-with-traces.json",
+    "keywords": [
+      "web",
+      "vitals",
+      "monitoring",
+      "with",
+      "traces"
+    ],
+    "description": "Real-time monitoring of key Web Vitals using traces to track user experience and page performance.\n\n",
+    "category": "Web Vitals Monitoring"
+  }
+]

--- a/internal/handler/tools/dashboards.go
+++ b/internal/handler/tools/dashboards.go
@@ -4,7 +4,12 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"log/slog"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
 
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
@@ -14,6 +19,20 @@ import (
 	"github.com/SigNoz/signoz-mcp-server/pkg/paginate"
 	"github.com/SigNoz/signoz-mcp-server/pkg/promql"
 	"github.com/SigNoz/signoz-mcp-server/pkg/types"
+)
+
+// Template fetch configuration for signoz_create_dashboard_from_template.
+// templateRepoBaseURLVar is a var (not const) so tests can point it at a
+// local httptest server. Kept in sync with the agent-skills
+// import_template.py PINNED_SHA.
+const (
+	templateRepoPinnedSHA = "61d374c50f9e1383e0eba3584fb81498f38c1f8d"
+	templateFetchTimeout  = 30 * time.Second
+)
+
+var (
+	templateRepoBaseURLVar = "https://raw.githubusercontent.com/SigNoz/dashboards"
+	templateHTTPClient     = &http.Client{Timeout: templateFetchTimeout}
 )
 
 func (h *Handler) RegisterDashboardHandlers(s *server.MCPServer) {
@@ -96,6 +115,22 @@ func (h *Handler) RegisterDashboardHandlers(s *server.MCPServer) {
 	)
 
 	addTool(s, deleteDashboardTool, h.handleDeleteDashboard)
+
+	createFromTemplateTool := mcp.NewTool(
+		"signoz_create_dashboard_from_template",
+		mcp.WithDestructiveHintAnnotation(true),
+		mcp.WithDescription(
+			"Create a new SigNoz dashboard from a curated template hosted in the SigNoz/dashboards GitHub repo. "+
+				"Takes a single 'path' argument (e.g. 'hostmetrics/hostmetrics.json' or 'postgresql/postgresql.json') "+
+				"that points to a template file under the pinned commit. The server fetches the JSON, validates it, "+
+				"and creates the dashboard in one call — the client does not need to inline the template body. "+
+				"Use this for any official SigNoz dashboard template; for custom dashboards, use signoz_create_dashboard.",
+		),
+		mcp.WithString("path", mcp.Required(), mcp.Description("Template path within the SigNoz/dashboards repo, e.g. 'hostmetrics/hostmetrics.json'.")),
+		mcp.WithString("searchContext", mcp.Description("The user's original question or search text that triggered this tool call. Always include the user's raw query here for better results.")),
+	)
+
+	addTool(s, createFromTemplateTool, h.handleCreateDashboardFromTemplate)
 
 	// resources for create and update dashboard
 	h.registerDashboardResources(s)
@@ -192,6 +227,87 @@ func (h *Handler) handleCreateDashboard(ctx context.Context, req mcp.CallToolReq
 	}
 
 	return mcp.NewToolResultText(string(data)), nil
+}
+
+func (h *Handler) handleCreateDashboardFromTemplate(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	args, ok := req.Params.Arguments.(map[string]any)
+	if !ok {
+		return mcp.NewToolResultError(`Parameter validation failed: arguments must be an object with a "path" string field.`), nil
+	}
+	path, ok := args["path"].(string)
+	if !ok || strings.TrimSpace(path) == "" {
+		return mcp.NewToolResultError(`Parameter validation failed: "path" must be a non-empty string, e.g. "hostmetrics/hostmetrics.json".`), nil
+	}
+	path = strings.TrimSpace(path)
+	if strings.Contains(path, "..") || strings.HasPrefix(path, "/") || strings.HasPrefix(path, "http://") || strings.HasPrefix(path, "https://") {
+		return mcp.NewToolResultError(`Parameter validation failed: "path" must be a relative template path within the SigNoz/dashboards repo (e.g. "hostmetrics/hostmetrics.json"), not an absolute path or URL.`), nil
+	}
+
+	h.logger.DebugContext(ctx, "Tool called: signoz_create_dashboard_from_template", slog.String("path", path))
+
+	body, err := fetchTemplate(ctx, path)
+	if err != nil {
+		h.logger.ErrorContext(ctx, "Failed to fetch dashboard template", slog.String("path", path), logpkg.ErrAttr(err))
+		return mcp.NewToolResultError(fmt.Sprintf("Template fetch error: %s", err.Error())), nil
+	}
+
+	var rawConfig map[string]any
+	if err := json.Unmarshal(body, &rawConfig); err != nil {
+		h.logger.ErrorContext(ctx, "Failed to parse template JSON", slog.String("path", path), logpkg.ErrAttr(err))
+		return mcp.NewToolResultError(fmt.Sprintf("Template parse error: %s", err.Error())), nil
+	}
+	if len(rawConfig) == 0 {
+		return mcp.NewToolResultError("Template is empty after parsing."), nil
+	}
+
+	cleanJSON, err := dashboard.ValidateFromMap(rawConfig)
+	if err != nil {
+		h.logger.WarnContext(ctx, "Template validation failed", slog.String("path", path), logpkg.ErrAttr(err))
+		return mcp.NewToolResultError(fmt.Sprintf("Template validation error: %s", err.Error())), nil
+	}
+
+	client, err := h.GetClient(ctx)
+	if err != nil {
+		return mcp.NewToolResultError(err.Error()), nil
+	}
+	data, err := client.CreateDashboardRaw(ctx, cleanJSON)
+	if err != nil {
+		h.logger.ErrorContext(ctx, "Failed to create dashboard from template", slog.String("path", path), logpkg.ErrAttr(err))
+		return mcp.NewToolResultError(fmt.Sprintf("SigNoz API Error: %s", err.Error())), nil
+	}
+
+	return mcp.NewToolResultText(string(data)), nil
+}
+
+// fetchTemplate downloads a dashboard template JSON from the pinned
+// SigNoz/dashboards commit. Returns the raw response body.
+func fetchTemplate(ctx context.Context, path string) ([]byte, error) {
+	rel := strings.TrimPrefix(path, "/")
+	// Preserve "/" separators between path segments while encoding each.
+	segments := strings.Split(rel, "/")
+	for i, seg := range segments {
+		segments[i] = url.PathEscape(seg)
+	}
+	fullURL := fmt.Sprintf("%s/%s/%s", templateRepoBaseURLVar, templateRepoPinnedSHA, strings.Join(segments, "/"))
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, fullURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("build request: %w", err)
+	}
+	resp, err := templateHTTPClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("fetch %s: %w", fullURL, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusNotFound {
+		return nil, fmt.Errorf("template not found at %s (HTTP 404). Verify the path exists in the SigNoz/dashboards repo at the pinned commit", path)
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, fmt.Errorf("HTTP %d fetching %s", resp.StatusCode, path)
+	}
+
+	return io.ReadAll(resp.Body)
 }
 
 func (h *Handler) handleUpdateDashboard(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {

--- a/internal/handler/tools/dashboards.go
+++ b/internal/handler/tools/dashboards.go
@@ -124,13 +124,31 @@ func (h *Handler) RegisterDashboardHandlers(s *server.MCPServer) {
 				"Takes a single 'path' argument (e.g. 'hostmetrics/hostmetrics.json' or 'postgresql/postgresql.json') "+
 				"that points to a template file under the pinned commit. The server fetches the JSON, validates it, "+
 				"and creates the dashboard in one call — the client does not need to inline the template body. "+
-				"Use this for any official SigNoz dashboard template; for custom dashboards, use signoz_create_dashboard.",
+				"To discover the available paths, call signoz_list_dashboard_templates first and let the model pick the best match. "+
+				"For custom dashboards, use signoz_create_dashboard.",
 		),
 		mcp.WithString("path", mcp.Required(), mcp.Description("Template path within the SigNoz/dashboards repo, e.g. 'hostmetrics/hostmetrics.json'.")),
 		mcp.WithString("searchContext", mcp.Description("The user's original question or search text that triggered this tool call. Always include the user's raw query here for better results.")),
 	)
 
 	addTool(s, importDashboardTool, h.handleImportDashboard)
+
+	listTemplatesTool := mcp.NewTool(
+		"signoz_list_dashboard_templates",
+		mcp.WithReadOnlyHintAnnotation(true),
+		mcp.WithDestructiveHintAnnotation(false),
+		mcp.WithDescription(
+			"List all curated SigNoz dashboard templates bundled with this server. "+
+				"Returns the full catalog as a JSON array — each entry includes 'id', 'title', 'path', 'description', 'category', and 'keywords'. "+
+				"Use this to discover which template fits the user's intent, then pass the chosen 'path' to signoz_import_dashboard. "+
+				"The catalog is small enough to read in full; let the model decide the best match rather than relying on keyword scoring. "+
+				"Optional 'category' narrows the result to a single catalog category (case-insensitive), e.g. 'Apm', 'K8S Infra Metrics'.",
+		),
+		mcp.WithString("category", mcp.Description("Optional catalog category to restrict results to (case-insensitive), e.g. 'Apm', 'K8S Infra Metrics'.")),
+		mcp.WithString("searchContext", mcp.Description("The user's original question or search text that triggered this tool call. Always include the user's raw query here for better results.")),
+	)
+
+	addTool(s, listTemplatesTool, h.handleListDashboardTemplates)
 
 	// resources for create and update dashboard
 	h.registerDashboardResources(s)
@@ -236,7 +254,7 @@ func (h *Handler) handleImportDashboard(ctx context.Context, req mcp.CallToolReq
 	}
 	path, ok := args["path"].(string)
 	if !ok || strings.TrimSpace(path) == "" {
-		return mcp.NewToolResultError(`Parameter validation failed: "path" must be a non-empty string, e.g. "hostmetrics/hostmetrics.json".`), nil
+		return mcp.NewToolResultError(`Parameter validation failed: "path" must be a non-empty string, e.g. "hostmetrics/hostmetrics.json". Use signoz_list_dashboard_templates to discover available paths.`), nil
 	}
 	path = strings.TrimSpace(path)
 	if strings.Contains(path, "..") || strings.HasPrefix(path, "/") || strings.HasPrefix(path, "http://") || strings.HasPrefix(path, "https://") {
@@ -308,6 +326,21 @@ func fetchTemplate(ctx context.Context, path string) ([]byte, error) {
 	}
 
 	return io.ReadAll(resp.Body)
+}
+
+func (h *Handler) handleListDashboardTemplates(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	args, _ := req.Params.Arguments.(map[string]any)
+	category, _ := args["category"].(string)
+	category = strings.TrimSpace(category)
+
+	h.logger.DebugContext(ctx, "Tool called: signoz_list_dashboard_templates", slog.String("category", category))
+
+	entries := listDashboardTemplates(category)
+	body, err := json.Marshal(entries)
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("failed to encode templates: %s", err.Error())), nil
+	}
+	return mcp.NewToolResultText(string(body)), nil
 }
 
 func (h *Handler) handleUpdateDashboard(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {

--- a/internal/handler/tools/dashboards.go
+++ b/internal/handler/tools/dashboards.go
@@ -298,7 +298,7 @@ func fetchTemplate(ctx context.Context, path string) ([]byte, error) {
 	if err != nil {
 		return nil, fmt.Errorf("fetch %s: %w", fullURL, err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode == http.StatusNotFound {
 		return nil, fmt.Errorf("template not found at %s (HTTP 404). Verify the path exists in the SigNoz/dashboards repo at the pinned commit", path)

--- a/internal/handler/tools/dashboards.go
+++ b/internal/handler/tools/dashboards.go
@@ -21,7 +21,7 @@ import (
 	"github.com/SigNoz/signoz-mcp-server/pkg/types"
 )
 
-// Template fetch configuration for signoz_create_dashboard_from_template.
+// Template fetch configuration for signoz_import_dashboard.
 // templateRepoBaseURLVar is a var (not const) so tests can point it at a
 // local httptest server. Kept in sync with the agent-skills
 // import_template.py PINNED_SHA.
@@ -116,8 +116,8 @@ func (h *Handler) RegisterDashboardHandlers(s *server.MCPServer) {
 
 	addTool(s, deleteDashboardTool, h.handleDeleteDashboard)
 
-	createFromTemplateTool := mcp.NewTool(
-		"signoz_create_dashboard_from_template",
+	importDashboardTool := mcp.NewTool(
+		"signoz_import_dashboard",
 		mcp.WithDestructiveHintAnnotation(true),
 		mcp.WithDescription(
 			"Create a new SigNoz dashboard from a curated template hosted in the SigNoz/dashboards GitHub repo. "+
@@ -130,7 +130,7 @@ func (h *Handler) RegisterDashboardHandlers(s *server.MCPServer) {
 		mcp.WithString("searchContext", mcp.Description("The user's original question or search text that triggered this tool call. Always include the user's raw query here for better results.")),
 	)
 
-	addTool(s, createFromTemplateTool, h.handleCreateDashboardFromTemplate)
+	addTool(s, importDashboardTool, h.handleImportDashboard)
 
 	// resources for create and update dashboard
 	h.registerDashboardResources(s)
@@ -229,7 +229,7 @@ func (h *Handler) handleCreateDashboard(ctx context.Context, req mcp.CallToolReq
 	return mcp.NewToolResultText(string(data)), nil
 }
 
-func (h *Handler) handleCreateDashboardFromTemplate(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+func (h *Handler) handleImportDashboard(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	args, ok := req.Params.Arguments.(map[string]any)
 	if !ok {
 		return mcp.NewToolResultError(`Parameter validation failed: arguments must be an object with a "path" string field.`), nil
@@ -243,7 +243,7 @@ func (h *Handler) handleCreateDashboardFromTemplate(ctx context.Context, req mcp
 		return mcp.NewToolResultError(`Parameter validation failed: "path" must be a relative template path within the SigNoz/dashboards repo (e.g. "hostmetrics/hostmetrics.json"), not an absolute path or URL.`), nil
 	}
 
-	h.logger.DebugContext(ctx, "Tool called: signoz_create_dashboard_from_template", slog.String("path", path))
+	h.logger.DebugContext(ctx, "Tool called: signoz_import_dashboard", slog.String("path", path))
 
 	body, err := fetchTemplate(ctx, path)
 	if err != nil {

--- a/internal/handler/tools/dashboards_test.go
+++ b/internal/handler/tools/dashboards_test.go
@@ -9,6 +9,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/mark3labs/mcp-go/mcp"
+
 	"github.com/SigNoz/signoz-mcp-server/internal/client"
 )
 
@@ -235,6 +237,102 @@ func TestHandleImportDashboard_RejectsAbsoluteAndURL(t *testing.T) {
 		if !result.IsError {
 			t.Errorf("expected error result for path %q", bad)
 		}
+	}
+}
+
+func TestHandleListDashboardTemplates_FullCatalog(t *testing.T) {
+	h := newTestHandler(&client.MockClient{})
+	result, err := h.handleListDashboardTemplates(testCtx(), makeToolRequest(
+		"signoz_list_dashboard_templates",
+		map[string]any{},
+	))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("handler returned error: %v", result.Content)
+	}
+	textContent, ok := result.Content[0].(mcp.TextContent)
+	if !ok {
+		t.Fatalf("expected TextContent, got %T", result.Content[0])
+	}
+	var entries []map[string]any
+	if err := json.Unmarshal([]byte(textContent.Text), &entries); err != nil {
+		t.Fatalf("response should be a JSON array: %v\n%s", err, textContent.Text)
+	}
+	if len(entries) < 50 {
+		t.Errorf("expected the full catalog (>=50 entries), got %d", len(entries))
+	}
+	// Spot-check that a known template is present and well-formed.
+	foundPostgres := false
+	for _, e := range entries {
+		if e["path"] == "postgresql/postgresql.json" {
+			foundPostgres = true
+			for _, key := range []string{"id", "title", "path", "category"} {
+				if _, ok := e[key]; !ok {
+					t.Errorf("postgres entry missing %q field: %#v", key, e)
+				}
+			}
+			break
+		}
+	}
+	if !foundPostgres {
+		t.Error("expected postgresql/postgresql.json to be in the bundled catalog")
+	}
+}
+
+func TestHandleListDashboardTemplates_CategoryFilter(t *testing.T) {
+	h := newTestHandler(&client.MockClient{})
+	result, err := h.handleListDashboardTemplates(testCtx(), makeToolRequest(
+		"signoz_list_dashboard_templates",
+		map[string]any{"category": "apm"},
+	))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("handler returned error: %v", result.Content)
+	}
+	textContent, ok := result.Content[0].(mcp.TextContent)
+	if !ok {
+		t.Fatalf("expected TextContent, got %T", result.Content[0])
+	}
+	var entries []map[string]any
+	if err := json.Unmarshal([]byte(textContent.Text), &entries); err != nil {
+		t.Fatalf("response should be a JSON array: %v\n%s", err, textContent.Text)
+	}
+	if len(entries) == 0 {
+		t.Fatal("expected at least one Apm template")
+	}
+	for _, e := range entries {
+		if !strings.EqualFold(e["category"].(string), "Apm") {
+			t.Errorf("category filter leaked entry from %q", e["category"])
+		}
+	}
+}
+
+func TestHandleListDashboardTemplates_UnknownCategory(t *testing.T) {
+	h := newTestHandler(&client.MockClient{})
+	result, err := h.handleListDashboardTemplates(testCtx(), makeToolRequest(
+		"signoz_list_dashboard_templates",
+		map[string]any{"category": "no-such-category-zzz"},
+	))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("handler returned error: %v", result.Content)
+	}
+	textContent, ok := result.Content[0].(mcp.TextContent)
+	if !ok {
+		t.Fatalf("expected TextContent, got %T", result.Content[0])
+	}
+	var entries []map[string]any
+	if err := json.Unmarshal([]byte(textContent.Text), &entries); err != nil {
+		t.Fatalf("response should be a JSON array: %v\n%s", err, textContent.Text)
+	}
+	if len(entries) != 0 {
+		t.Errorf("expected empty result for unknown category, got %d entries", len(entries))
 	}
 }
 

--- a/internal/handler/tools/dashboards_test.go
+++ b/internal/handler/tools/dashboards_test.go
@@ -156,7 +156,7 @@ func withTemplateServer(t *testing.T, srv *httptest.Server) {
 	t.Cleanup(func() { templateHTTPClient = origClient })
 }
 
-func TestHandleCreateDashboardFromTemplate_Success(t *testing.T) {
+func TestHandleImportDashboard_Success(t *testing.T) {
 	template := `{"title":"Host Metrics","tags":["hostmetrics"],"layout":[],"widgets":[]}`
 
 	var receivedPath string
@@ -183,8 +183,8 @@ func TestHandleCreateDashboardFromTemplate_Success(t *testing.T) {
 	}
 
 	h := newTestHandler(mock)
-	result, err := h.handleCreateDashboardFromTemplate(testCtx(), makeToolRequest(
-		"signoz_create_dashboard_from_template",
+	result, err := h.handleImportDashboard(testCtx(), makeToolRequest(
+		"signoz_import_dashboard",
 		map[string]any{"path": "hostmetrics/hostmetrics.json"},
 	))
 	if err != nil {
@@ -208,10 +208,10 @@ func TestHandleCreateDashboardFromTemplate_Success(t *testing.T) {
 	}
 }
 
-func TestHandleCreateDashboardFromTemplate_MissingPath(t *testing.T) {
+func TestHandleImportDashboard_MissingPath(t *testing.T) {
 	h := newTestHandler(&client.MockClient{})
-	result, err := h.handleCreateDashboardFromTemplate(testCtx(), makeToolRequest(
-		"signoz_create_dashboard_from_template",
+	result, err := h.handleImportDashboard(testCtx(), makeToolRequest(
+		"signoz_import_dashboard",
 		map[string]any{},
 	))
 	if err != nil {
@@ -222,11 +222,11 @@ func TestHandleCreateDashboardFromTemplate_MissingPath(t *testing.T) {
 	}
 }
 
-func TestHandleCreateDashboardFromTemplate_RejectsAbsoluteAndURL(t *testing.T) {
+func TestHandleImportDashboard_RejectsAbsoluteAndURL(t *testing.T) {
 	h := newTestHandler(&client.MockClient{})
 	for _, bad := range []string{"/etc/passwd", "https://example.com/x.json", "..\\windows", "../escape.json"} {
-		result, err := h.handleCreateDashboardFromTemplate(testCtx(), makeToolRequest(
-			"signoz_create_dashboard_from_template",
+		result, err := h.handleImportDashboard(testCtx(), makeToolRequest(
+			"signoz_import_dashboard",
 			map[string]any{"path": bad},
 		))
 		if err != nil {
@@ -238,7 +238,7 @@ func TestHandleCreateDashboardFromTemplate_RejectsAbsoluteAndURL(t *testing.T) {
 	}
 }
 
-func TestHandleCreateDashboardFromTemplate_NotFound(t *testing.T) {
+func TestHandleImportDashboard_NotFound(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		http.NotFound(w, r)
 	}))
@@ -250,8 +250,8 @@ func TestHandleCreateDashboardFromTemplate_NotFound(t *testing.T) {
 	withTemplateServer(t, srv)
 
 	h := newTestHandler(&client.MockClient{})
-	result, err := h.handleCreateDashboardFromTemplate(testCtx(), makeToolRequest(
-		"signoz_create_dashboard_from_template",
+	result, err := h.handleImportDashboard(testCtx(), makeToolRequest(
+		"signoz_import_dashboard",
 		map[string]any{"path": "no/such/template.json"},
 	))
 	if err != nil {

--- a/internal/handler/tools/dashboards_test.go
+++ b/internal/handler/tools/dashboards_test.go
@@ -4,6 +4,9 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/SigNoz/signoz-mcp-server/internal/client"
@@ -141,5 +144,120 @@ func TestHandleDeleteDashboard_ClientError(t *testing.T) {
 	}
 	if !result.IsError {
 		t.Error("expected error result when client returns error")
+	}
+}
+
+// withTemplateServer swaps the package HTTP client for the test server's
+// client and restores it on cleanup.
+func withTemplateServer(t *testing.T, srv *httptest.Server) {
+	t.Helper()
+	origClient := templateHTTPClient
+	templateHTTPClient = srv.Client()
+	t.Cleanup(func() { templateHTTPClient = origClient })
+}
+
+func TestHandleCreateDashboardFromTemplate_Success(t *testing.T) {
+	template := `{"title":"Host Metrics","tags":["hostmetrics"],"layout":[],"widgets":[]}`
+
+	var receivedPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedPath = r.URL.Path
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(template))
+	}))
+	defer srv.Close()
+
+	// Point the package fetcher at our test server.
+	origBase := templateRepoBaseURLVar
+	templateRepoBaseURLVar = srv.URL
+	t.Cleanup(func() { templateRepoBaseURLVar = origBase })
+
+	withTemplateServer(t, srv)
+
+	var gotBody []byte
+	mock := &client.MockClient{
+		CreateDashboardRawFn: func(ctx context.Context, dashboardJSON []byte) (json.RawMessage, error) {
+			gotBody = append([]byte(nil), dashboardJSON...)
+			return json.RawMessage(`{"status":"success","data":{"uuid":"created-uuid"}}`), nil
+		},
+	}
+
+	h := newTestHandler(mock)
+	result, err := h.handleCreateDashboardFromTemplate(testCtx(), makeToolRequest(
+		"signoz_create_dashboard_from_template",
+		map[string]any{"path": "hostmetrics/hostmetrics.json"},
+	))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("handler returned error: %v", result.Content)
+	}
+	if !strings.HasSuffix(receivedPath, "/hostmetrics/hostmetrics.json") {
+		t.Errorf("unexpected fetch path: %s", receivedPath)
+	}
+	if len(gotBody) == 0 {
+		t.Fatal("CreateDashboardRawFn was not called")
+	}
+	var parsed map[string]any
+	if err := json.Unmarshal(gotBody, &parsed); err != nil {
+		t.Fatalf("payload should be JSON: %v", err)
+	}
+	if parsed["title"] != "Host Metrics" {
+		t.Errorf("title = %v, want Host Metrics", parsed["title"])
+	}
+}
+
+func TestHandleCreateDashboardFromTemplate_MissingPath(t *testing.T) {
+	h := newTestHandler(&client.MockClient{})
+	result, err := h.handleCreateDashboardFromTemplate(testCtx(), makeToolRequest(
+		"signoz_create_dashboard_from_template",
+		map[string]any{},
+	))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !result.IsError {
+		t.Error("expected error result for missing path")
+	}
+}
+
+func TestHandleCreateDashboardFromTemplate_RejectsAbsoluteAndURL(t *testing.T) {
+	h := newTestHandler(&client.MockClient{})
+	for _, bad := range []string{"/etc/passwd", "https://example.com/x.json", "..\\windows", "../escape.json"} {
+		result, err := h.handleCreateDashboardFromTemplate(testCtx(), makeToolRequest(
+			"signoz_create_dashboard_from_template",
+			map[string]any{"path": bad},
+		))
+		if err != nil {
+			t.Fatalf("unexpected error for %q: %v", bad, err)
+		}
+		if !result.IsError {
+			t.Errorf("expected error result for path %q", bad)
+		}
+	}
+}
+
+func TestHandleCreateDashboardFromTemplate_NotFound(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.NotFound(w, r)
+	}))
+	defer srv.Close()
+
+	origBase := templateRepoBaseURLVar
+	templateRepoBaseURLVar = srv.URL
+	t.Cleanup(func() { templateRepoBaseURLVar = origBase })
+	withTemplateServer(t, srv)
+
+	h := newTestHandler(&client.MockClient{})
+	result, err := h.handleCreateDashboardFromTemplate(testCtx(), makeToolRequest(
+		"signoz_create_dashboard_from_template",
+		map[string]any{"path": "no/such/template.json"},
+	))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !result.IsError {
+		t.Error("expected error result on 404")
 	}
 }

--- a/internal/mcp-server/integration_test.go
+++ b/internal/mcp-server/integration_test.go
@@ -89,7 +89,7 @@ func TestIntegration_InitializeAndListTools(t *testing.T) {
 		t.Fatalf("ListTools failed: %v", err)
 	}
 
-	const expectedToolCount = 35
+	const expectedToolCount = 36
 	if len(toolsResult.Tools) != expectedToolCount {
 		t.Errorf("expected %d tools, got %d", expectedToolCount, len(toolsResult.Tools))
 		for _, tool := range toolsResult.Tools {

--- a/internal/mcp-server/integration_test.go
+++ b/internal/mcp-server/integration_test.go
@@ -89,7 +89,7 @@ func TestIntegration_InitializeAndListTools(t *testing.T) {
 		t.Fatalf("ListTools failed: %v", err)
 	}
 
-	const expectedToolCount = 34
+	const expectedToolCount = 35
 	if len(toolsResult.Tools) != expectedToolCount {
 		t.Errorf("expected %d tools, got %d", expectedToolCount, len(toolsResult.Tools))
 		for _, tool := range toolsResult.Tools {

--- a/manifest.json
+++ b/manifest.json
@@ -90,6 +90,10 @@
       "description": "Delete a dashboard by UUID"
     },
     {
+      "name": "signoz_create_dashboard_from_template",
+      "description": "Create a dashboard from a curated template in the SigNoz/dashboards GitHub repo"
+    },
+    {
       "name": "signoz_list_services",
       "description": "List services within a given time range"
     },

--- a/manifest.json
+++ b/manifest.json
@@ -91,7 +91,11 @@
     },
     {
       "name": "signoz_import_dashboard",
-      "description": "Create a dashboard from a curated template in the SigNoz/dashboards GitHub repo"
+      "description": "Create a dashboard from a curated template in the SigNoz/dashboards GitHub repo by path"
+    },
+    {
+      "name": "signoz_list_dashboard_templates",
+      "description": "List the bundled curated SigNoz dashboard template catalog so the model can pick a template by intent"
     },
     {
       "name": "signoz_list_services",

--- a/manifest.json
+++ b/manifest.json
@@ -90,7 +90,7 @@
       "description": "Delete a dashboard by UUID"
     },
     {
-      "name": "signoz_create_dashboard_from_template",
+      "name": "signoz_import_dashboard",
       "description": "Create a dashboard from a curated template in the SigNoz/dashboards GitHub repo"
     },
     {


### PR DESCRIPTION
## Summary
Adds two MCP tools for working with the curated SigNoz dashboard template catalog:

- **`signoz_import_dashboard`** — fetches a curated template from the [SigNoz/dashboards](https://github.com/SigNoz/dashboards) repo (pinned SHA), validates it, and creates the dashboard in one call. Clients pass only a relative `path` (e.g. `hostmetrics/hostmetrics.json`) — no need to inline the template body. Path is sanitized: absolute paths, URLs, and `..` traversal are rejected. Fetch uses a 30s timeout and surfaces 404s with a helpful message.
  - (Originally introduced as `signoz_create_dashboard_from_template`; renamed to `signoz_import_dashboard` during review.)
- **`signoz_list_dashboard_templates`** — exposes the bundled curated catalog so the model can pick a template by intent and pass its path to `signoz_import_dashboard`. Supports an optional case-insensitive category filter.

The bundled catalog (`internal/handler/tools/dashboard_templates.json`) ships with the server so listing does not require a network call.

`manifest.json` and `README.md` (tool table + per-tool sections) are updated to match.

## Test plan
- [x] `go build ./...`
- [x] `go test ./internal/handler/tools/...` — covers success, missing path, rejected absolute/URL/traversal paths, and upstream 404 for `signoz_import_dashboard`
- [x] Integration test `expectedToolCount` bumped to reflect the two new tools
- [ ] Manual smoke: list templates, then call `signoz_import_dashboard` with one of the returned paths against a real SigNoz instance

🤖 Generated with [Claude Code](https://claude.com/claude-code)