### PR TITLE
fix(dashboard): parse having expression strings into clause arrays

### DIFF
--- a/pkg/dashboard/dashboardbuilder/normalize.go
+++ b/pkg/dashboard/dashboardbuilder/normalize.go
@@ -319,6 +319,54 @@ func splitTopLevelAnd(s string) ([]string, bool) {
 	return parts, true
 }
 
+// stripEnclosingParens removes outer balanced `(...)` wrappers from an
+// expression, preserving inner parentheses. Quoted strings are respected so
+// parentheses inside quotes are not counted. Returns the input unchanged if
+// the leading `(` does not pair with the trailing `)` (e.g. `(a) AND (b)`).
+func stripEnclosingParens(s string) string {
+	for {
+		if len(s) < 2 || s[0] != '(' || s[len(s)-1] != ')' {
+			return s
+		}
+		depth := 0
+		var inQuote byte
+		matched := true
+		for i := 0; i < len(s); i++ {
+			c := s[i]
+			if inQuote != 0 {
+				if c == '\\' && i+1 < len(s) {
+					i++
+					continue
+				}
+				if c == inQuote {
+					inQuote = 0
+				}
+				continue
+			}
+			switch c {
+			case '\'', '"':
+				inQuote = c
+			case '(':
+				depth++
+			case ')':
+				depth--
+				if depth == 0 && i != len(s)-1 {
+					// The opening `(` closes before the end, so the outer
+					// parens are not a single enclosing pair.
+					matched = false
+				}
+			}
+			if !matched {
+				break
+			}
+		}
+		if !matched {
+			return s
+		}
+		s = strings.TrimSpace(s[1 : len(s)-1])
+	}
+}
+
 // isWordChar returns true for ASCII identifier characters (letters, digits,
 // underscore). Used to detect token boundaries around AND/OR keywords so a
 // keyword followed by punctuation (e.g. `OR(`, `AND"x"`) is correctly split,
@@ -330,8 +378,11 @@ func isWordChar(b byte) bool {
 // parseHavingClause parses a single comparison `<columnName> <op> <value>`.
 // Operator detection respects parentheses and quoted strings; the first
 // top-level operator wins. Value is unquoted if it is a fully quoted string,
-// parsed as a number when numeric, or kept verbatim otherwise.
+// parsed as a number when numeric, or kept verbatim otherwise. Repeated
+// balanced enclosing parentheses are stripped first so `(count() > 1000)` is
+// treated the same as `count() > 1000`.
 func parseHavingClause(s string) (map[string]any, bool) {
+	s = stripEnclosingParens(strings.TrimSpace(s))
 	if s == "" {
 		return nil, false
 	}

--- a/pkg/dashboard/dashboardbuilder/normalize.go
+++ b/pkg/dashboard/dashboardbuilder/normalize.go
@@ -290,8 +290,8 @@ func splitTopLevelAnd(s string) ([]string, bool) {
 				return nil, false
 			}
 			if i+2 <= len(s) && (c == 'O' || c == 'o') && strings.EqualFold(s[i:i+2], "OR") {
-				before := i == 0 || isSpace(s[i-1])
-				after := i+2 == len(s) || isSpace(s[i+2])
+				before := i == 0 || !isWordChar(s[i-1])
+				after := i+2 == len(s) || !isWordChar(s[i+2])
 				if before && after {
 					return nil, false
 				}
@@ -303,8 +303,8 @@ func splitTopLevelAnd(s string) ([]string, bool) {
 				continue
 			}
 			if i+3 <= len(s) && (c == 'A' || c == 'a') && strings.EqualFold(s[i:i+3], "AND") {
-				before := i == 0 || isSpace(s[i-1])
-				after := i+3 == len(s) || isSpace(s[i+3])
+				before := i == 0 || !isWordChar(s[i-1])
+				after := i+3 == len(s) || !isWordChar(s[i+3])
 				if before && after {
 					parts = append(parts, s[start:i])
 					i += 3
@@ -321,6 +321,14 @@ func splitTopLevelAnd(s string) ([]string, bool) {
 
 func isSpace(b byte) bool {
 	return b == ' ' || b == '\t' || b == '\n' || b == '\r'
+}
+
+// isWordChar returns true for ASCII identifier characters (letters, digits,
+// underscore). Used to detect token boundaries around AND/OR keywords so a
+// keyword followed by punctuation (e.g. `OR(`, `AND"x"`) is correctly split,
+// while substrings inside identifiers (e.g. `OrderCount`, `expanded`) are not.
+func isWordChar(b byte) bool {
+	return (b >= 'a' && b <= 'z') || (b >= 'A' && b <= 'Z') || (b >= '0' && b <= '9') || b == '_'
 }
 
 // parseHavingClause parses a single comparison `<columnName> <op> <value>`.

--- a/pkg/dashboard/dashboardbuilder/normalize.go
+++ b/pkg/dashboard/dashboardbuilder/normalize.go
@@ -319,10 +319,6 @@ func splitTopLevelAnd(s string) ([]string, bool) {
 	return parts, true
 }
 
-func isSpace(b byte) bool {
-	return b == ' ' || b == '\t' || b == '\n' || b == '\r'
-}
-
 // isWordChar returns true for ASCII identifier characters (letters, digits,
 // underscore). Used to detect token boundaries around AND/OR keywords so a
 // keyword followed by punctuation (e.g. `OR(`, `AND"x"`) is correctly split,

--- a/pkg/dashboard/dashboardbuilder/normalize.go
+++ b/pkg/dashboard/dashboardbuilder/normalize.go
@@ -231,13 +231,28 @@ var havingOps = []string{">=", "<=", "!=", "=", ">", "<"}
 // cannot be parsed; the caller leaves the original object form in place so
 // validation surfaces a clear error.
 func parseHavingExpression(expr string) ([]map[string]any, bool) {
+	// Strip outer balanced parentheses first so a fully wrapped expression
+	// (e.g. `((count() > 1000) AND (count() < 5000))`) splits at the inner
+	// AND rather than parsing as a single clause.
+	expr = stripEnclosingParens(strings.TrimSpace(expr))
 	parts, ok := splitTopLevelAnd(expr)
 	if !ok || len(parts) == 0 {
 		return nil, false
 	}
 	out := make([]map[string]any, 0, len(parts))
 	for _, p := range parts {
-		clause, ok := parseHavingClause(strings.TrimSpace(p))
+		// A part may itself be a wrapped AND group like `(A AND B)`.
+		// Recursively flatten before falling back to clause parsing.
+		trimmed := strings.TrimSpace(p)
+		stripped := stripEnclosingParens(trimmed)
+		if stripped != trimmed {
+			sub, ok := parseHavingExpression(stripped)
+			if ok {
+				out = append(out, sub...)
+				continue
+			}
+		}
+		clause, ok := parseHavingClause(trimmed)
 		if !ok {
 			return nil, false
 		}

--- a/pkg/dashboard/dashboardbuilder/normalize.go
+++ b/pkg/dashboard/dashboardbuilder/normalize.go
@@ -319,6 +319,65 @@ func splitTopLevelAnd(s string) ([]string, bool) {
 	return parts, true
 }
 
+// containsTopLevelBoolean reports whether s contains a top-level (outside
+// parentheses and quoted strings) boolean keyword (`AND`, `OR`) or operator
+// (`&&`, `||`). Used to reject single-clause expressions that secretly carry
+// grouped boolean logic on the RHS, such as `5 OR count() < 1`.
+func containsTopLevelBoolean(s string) bool {
+	depth := 0
+	var inQuote byte
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if inQuote != 0 {
+			if c == '\\' && i+1 < len(s) {
+				i++
+				continue
+			}
+			if c == inQuote {
+				inQuote = 0
+			}
+			continue
+		}
+		switch c {
+		case '\'', '"':
+			inQuote = c
+			continue
+		case '(':
+			depth++
+			continue
+		case ')':
+			if depth > 0 {
+				depth--
+			}
+			continue
+		}
+		if depth != 0 {
+			continue
+		}
+		if c == '|' && i+1 < len(s) && s[i+1] == '|' {
+			return true
+		}
+		if c == '&' && i+1 < len(s) && s[i+1] == '&' {
+			return true
+		}
+		if i+2 <= len(s) && (c == 'O' || c == 'o') && strings.EqualFold(s[i:i+2], "OR") {
+			before := i == 0 || !isWordChar(s[i-1])
+			after := i+2 == len(s) || !isWordChar(s[i+2])
+			if before && after {
+				return true
+			}
+		}
+		if i+3 <= len(s) && (c == 'A' || c == 'a') && strings.EqualFold(s[i:i+3], "AND") {
+			before := i == 0 || !isWordChar(s[i-1])
+			after := i+3 == len(s) || !isWordChar(s[i+3])
+			if before && after {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 // stripEnclosingParens removes outer balanced `(...)` wrappers from an
 // expression, preserving inner parentheses. Quoted strings are respected so
 // parentheses inside quotes are not counted. Returns the input unchanged if
@@ -431,6 +490,14 @@ func parseHavingClause(s string) (map[string]any, bool) {
 				lhs := strings.TrimSpace(s[:i])
 				rhs := strings.TrimSpace(s[i+len(op):])
 				if lhs == "" || rhs == "" {
+					return nil, false
+				}
+				// Reject grouped boolean operands that survived top-level
+				// AND splitting (e.g. `(count() > 5 OR count() < 1)` taken
+				// as a whole AND-operand). Without this guard, the first
+				// operator would be consumed and the remaining boolean
+				// expression silently coerced into the value.
+				if containsTopLevelBoolean(rhs) {
 					return nil, false
 				}
 				return map[string]any{

--- a/pkg/dashboard/dashboardbuilder/normalize.go
+++ b/pkg/dashboard/dashboardbuilder/normalize.go
@@ -226,11 +226,13 @@ var havingOps = []string{">=", "<=", "!=", "=", ">", "<"}
 
 // parseHavingExpression converts a free-form having expression into one or
 // more clause maps `{columnName, op, value}`. Supports AND-joined comparisons.
-// Returns ok=false if any sub-expression cannot be parsed; the caller leaves
-// the original object form in place so validation surfaces a clear error.
+// Returns ok=false if the expression contains a top-level OR (HAVING clause
+// arrays are AND-joined; OR cannot be represented) or if any sub-expression
+// cannot be parsed; the caller leaves the original object form in place so
+// validation surfaces a clear error.
 func parseHavingExpression(expr string) ([]map[string]any, bool) {
-	parts := splitTopLevelAnd(expr)
-	if len(parts) == 0 {
+	parts, ok := splitTopLevelAnd(expr)
+	if !ok || len(parts) == 0 {
 		return nil, false
 	}
 	out := make([]map[string]any, 0, len(parts))
@@ -245,8 +247,10 @@ func parseHavingExpression(expr string) ([]map[string]any, bool) {
 }
 
 // splitTopLevelAnd splits on `AND` (case-insensitive) outside of parentheses
-// and quoted strings. Single `&&` is also treated as AND.
-func splitTopLevelAnd(s string) []string {
+// and quoted strings. Single `&&` is also treated as AND. Returns ok=false if
+// a top-level `OR` / `||` is found, since HAVING coerces to an AND-joined
+// clause array and OR cannot be represented faithfully.
+func splitTopLevelAnd(s string) ([]string, bool) {
 	var parts []string
 	depth := 0
 	var inQuote byte
@@ -282,6 +286,16 @@ func splitTopLevelAnd(s string) []string {
 			continue
 		}
 		if depth == 0 {
+			if c == '|' && i+1 < len(s) && s[i+1] == '|' {
+				return nil, false
+			}
+			if i+2 <= len(s) && (c == 'O' || c == 'o') && strings.EqualFold(s[i:i+2], "OR") {
+				before := i == 0 || isSpace(s[i-1])
+				after := i+2 == len(s) || isSpace(s[i+2])
+				if before && after {
+					return nil, false
+				}
+			}
 			if c == '&' && i+1 < len(s) && s[i+1] == '&' {
 				parts = append(parts, s[start:i])
 				i += 2
@@ -302,7 +316,7 @@ func splitTopLevelAnd(s string) []string {
 		i++
 	}
 	parts = append(parts, s[start:])
-	return parts
+	return parts, true
 }
 
 func isSpace(b byte) bool {

--- a/pkg/dashboard/dashboardbuilder/normalize.go
+++ b/pkg/dashboard/dashboardbuilder/normalize.go
@@ -365,6 +365,16 @@ func parseHavingClause(s string) (map[string]any, bool) {
 		if depth != 0 {
 			continue
 		}
+		// Reject unsupported multi-character comparators (`<>`, `==`, `=<`,
+		// `=>`) before falling through to the single-character match. The
+		// single-char prefix would otherwise consume just the first byte and
+		// silently mis-coerce the remainder into the value.
+		if i+2 <= len(s) {
+			two := s[i : i+2]
+			if two == "<>" || two == "==" || two == "=<" || two == "=>" {
+				return nil, false
+			}
+		}
 		for _, op := range havingOps {
 			if strings.HasPrefix(s[i:], op) {
 				lhs := strings.TrimSpace(s[:i])

--- a/pkg/dashboard/dashboardbuilder/normalize.go
+++ b/pkg/dashboard/dashboardbuilder/normalize.go
@@ -1,6 +1,9 @@
 package dashboardbuilder
 
-import "strings"
+import (
+	"strconv"
+	"strings"
+)
 
 // filterItemsSlice returns the items array from a filters map as []any,
 // regardless of whether the caller constructed the slice as []any (the shape
@@ -172,13 +175,13 @@ func normalizeFilterItem(item map[string]any) {
 }
 
 // coerceHavingInQueryMaps rewrites the `having` field of each query or formula
-// entry from the GET-shape object `{expression: ""}` to the POST/PUT-shape
-// empty array `[]`. Coercion is strictly scoped: the object must have an
-// `expression` key that is a string and is empty/whitespace after trim. Any
-// other shape — `expression` missing, `expression` non-string, non-empty
-// expression, already-array form, nil, absent — is left untouched so
-// downstream strict unmarshalling and validation can surface a clear error
-// rather than silently dropping the HAVING clause.
+// entry from the GET-shape object `{expression: "..."}` to the POST/PUT-shape
+// clause array `[{columnName, op, value}, ...]`. The empty/whitespace
+// expression coerces to `[]`; a parseable expression coerces to a single-clause
+// array (AND-joined expressions become multiple clauses). Shapes that aren't
+// `{expression: <string>}` — missing key, non-string expression, already-array,
+// nil, absent — are left untouched so downstream strict unmarshalling and
+// validation can surface a clear error rather than silent data loss.
 func coerceHavingInQueryMaps(entries []map[string]any) {
 	for _, entry := range entries {
 		if entry == nil {
@@ -200,8 +203,183 @@ func coerceHavingInQueryMaps(entries []map[string]any) {
 		if !isStr {
 			continue
 		}
-		if strings.TrimSpace(exprStr) == "" {
+		trimmed := strings.TrimSpace(exprStr)
+		if trimmed == "" {
 			entry["having"] = []any{}
+			continue
+		}
+		clauses, ok := parseHavingExpression(trimmed)
+		if !ok {
+			continue
+		}
+		out := make([]any, len(clauses))
+		for i, c := range clauses {
+			out[i] = c
+		}
+		entry["having"] = out
+	}
+}
+
+// havingOps lists supported having operators, ordered so multi-character
+// operators are matched before their single-character prefixes.
+var havingOps = []string{">=", "<=", "!=", "=", ">", "<"}
+
+// parseHavingExpression converts a free-form having expression into one or
+// more clause maps `{columnName, op, value}`. Supports AND-joined comparisons.
+// Returns ok=false if any sub-expression cannot be parsed; the caller leaves
+// the original object form in place so validation surfaces a clear error.
+func parseHavingExpression(expr string) ([]map[string]any, bool) {
+	parts := splitTopLevelAnd(expr)
+	if len(parts) == 0 {
+		return nil, false
+	}
+	out := make([]map[string]any, 0, len(parts))
+	for _, p := range parts {
+		clause, ok := parseHavingClause(strings.TrimSpace(p))
+		if !ok {
+			return nil, false
+		}
+		out = append(out, clause)
+	}
+	return out, true
+}
+
+// splitTopLevelAnd splits on `AND` (case-insensitive) outside of parentheses
+// and quoted strings. Single `&&` is also treated as AND.
+func splitTopLevelAnd(s string) []string {
+	var parts []string
+	depth := 0
+	var inQuote byte
+	start := 0
+	i := 0
+	for i < len(s) {
+		c := s[i]
+		if inQuote != 0 {
+			if c == '\\' && i+1 < len(s) {
+				i += 2
+				continue
+			}
+			if c == inQuote {
+				inQuote = 0
+			}
+			i++
+			continue
+		}
+		switch c {
+		case '\'', '"':
+			inQuote = c
+			i++
+			continue
+		case '(':
+			depth++
+			i++
+			continue
+		case ')':
+			if depth > 0 {
+				depth--
+			}
+			i++
+			continue
+		}
+		if depth == 0 {
+			if c == '&' && i+1 < len(s) && s[i+1] == '&' {
+				parts = append(parts, s[start:i])
+				i += 2
+				start = i
+				continue
+			}
+			if i+3 <= len(s) && (c == 'A' || c == 'a') && strings.EqualFold(s[i:i+3], "AND") {
+				before := i == 0 || isSpace(s[i-1])
+				after := i+3 == len(s) || isSpace(s[i+3])
+				if before && after {
+					parts = append(parts, s[start:i])
+					i += 3
+					start = i
+					continue
+				}
+			}
+		}
+		i++
+	}
+	parts = append(parts, s[start:])
+	return parts
+}
+
+func isSpace(b byte) bool {
+	return b == ' ' || b == '\t' || b == '\n' || b == '\r'
+}
+
+// parseHavingClause parses a single comparison `<columnName> <op> <value>`.
+// Operator detection respects parentheses and quoted strings; the first
+// top-level operator wins. Value is unquoted if it is a fully quoted string,
+// parsed as a number when numeric, or kept verbatim otherwise.
+func parseHavingClause(s string) (map[string]any, bool) {
+	if s == "" {
+		return nil, false
+	}
+	depth := 0
+	var inQuote byte
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if inQuote != 0 {
+			if c == '\\' && i+1 < len(s) {
+				i++
+				continue
+			}
+			if c == inQuote {
+				inQuote = 0
+			}
+			continue
+		}
+		switch c {
+		case '\'', '"':
+			inQuote = c
+			continue
+		case '(':
+			depth++
+			continue
+		case ')':
+			if depth > 0 {
+				depth--
+			}
+			continue
+		}
+		if depth != 0 {
+			continue
+		}
+		for _, op := range havingOps {
+			if strings.HasPrefix(s[i:], op) {
+				lhs := strings.TrimSpace(s[:i])
+				rhs := strings.TrimSpace(s[i+len(op):])
+				if lhs == "" || rhs == "" {
+					return nil, false
+				}
+				return map[string]any{
+					"columnName": lhs,
+					"op":         op,
+					"value":      parseHavingValue(rhs),
+				}, true
+			}
 		}
 	}
+	return nil, false
+}
+
+// parseHavingValue best-effort converts an RHS literal to a typed value:
+// stripped quotes for fully quoted strings, int/float for numerics, else the
+// raw trimmed string. Backend tolerates either typed or string values.
+func parseHavingValue(s string) any {
+	if len(s) >= 2 {
+		first, last := s[0], s[len(s)-1]
+		if (first == '\'' || first == '"') && first == last {
+			return s[1 : len(s)-1]
+		}
+	}
+	if i, err := strconv.ParseInt(s, 10, 64); err == nil {
+		return i
+	}
+	if f, err := strconv.ParseFloat(s, 64); err == nil {
+		return f
+	}
+	return s
 }

--- a/pkg/dashboard/dashboardbuilder/normalize_test.go
+++ b/pkg/dashboard/dashboardbuilder/normalize_test.go
@@ -149,6 +149,33 @@ func TestCoerceHavingInQueryMaps_TopLevelOrUntouched(t *testing.T) {
 	}
 }
 
+func TestCoerceHavingInQueryMaps_TopLevelOrPunctuationBoundaryUntouched(t *testing.T) {
+	// OR / AND followed (or preceded) by punctuation rather than whitespace
+	// must still be recognized as a logical operator. Prior to this fix the
+	// boundary check only accepted whitespace, so `OR(` slipped through and
+	// the entire remainder was coerced into a single bogus clause.
+	cases := []string{
+		"count() > 5 OR(count() < 1)",
+		"count() > 5 OR\"x\" = 1",
+		"(count() > 5)OR count() < 1",
+		"count() > 5 AND(count() < 10) OR count() = 0",
+	}
+	for _, expr := range cases {
+		t.Run(expr, func(t *testing.T) {
+			obj := map[string]any{"expression": expr}
+			entries := []map[string]any{{"queryName": "A", "having": obj}}
+			coerceHavingInQueryMaps(entries)
+			got, ok := entries[0]["having"].(map[string]any)
+			if !ok {
+				t.Fatalf("expected map[string]any (untouched), got %T", entries[0]["having"])
+			}
+			if got["expression"] != expr {
+				t.Errorf("expected expression preserved, got %v", got["expression"])
+			}
+		})
+	}
+}
+
 func TestCoerceHavingInQueryMaps_OrInsideQuotesOrParensParsed(t *testing.T) {
 	// `OR` / `||` that is not at the top level (inside quotes or parentheses)
 	// must not trip the OR rejection.

--- a/pkg/dashboard/dashboardbuilder/normalize_test.go
+++ b/pkg/dashboard/dashboardbuilder/normalize_test.go
@@ -123,6 +123,60 @@ func TestCoerceHavingInQueryMaps_UnparseableExpressionUntouched(t *testing.T) {
 	}
 }
 
+func TestCoerceHavingInQueryMaps_TopLevelOrUntouched(t *testing.T) {
+	// HAVING is coerced to an AND-joined clause array; top-level OR (or `||`)
+	// cannot be represented and must NOT be partially parsed. Leave the
+	// original object so downstream validation surfaces a clear error.
+	cases := []string{
+		"count() > 5 OR count() < 1",
+		"count() > 5 or count() < 1",
+		"count() > 5 || count() < 1",
+		"count() > 5 AND count() < 100 OR count() = 0",
+	}
+	for _, expr := range cases {
+		t.Run(expr, func(t *testing.T) {
+			obj := map[string]any{"expression": expr}
+			entries := []map[string]any{{"queryName": "A", "having": obj}}
+			coerceHavingInQueryMaps(entries)
+			got, ok := entries[0]["having"].(map[string]any)
+			if !ok {
+				t.Fatalf("expected map[string]any (untouched), got %T", entries[0]["having"])
+			}
+			if got["expression"] != expr {
+				t.Errorf("expected expression preserved, got %v", got["expression"])
+			}
+		})
+	}
+}
+
+func TestCoerceHavingInQueryMaps_OrInsideQuotesOrParensParsed(t *testing.T) {
+	// `OR` / `||` that is not at the top level (inside quotes or parentheses)
+	// must not trip the OR rejection.
+	entries := []map[string]any{
+		{"queryName": "A", "having": map[string]any{"expression": "count() > 5 AND service.name = 'a OR b'"}},
+		{"queryName": "B", "having": map[string]any{"expression": "OrderCount > 0"}},
+	}
+	coerceHavingInQueryMaps(entries)
+
+	got0, ok := entries[0]["having"].([]any)
+	if !ok || len(got0) != 2 {
+		t.Fatalf("entry 0: expected two-clause []any, got %#v", entries[0]["having"])
+	}
+	c := got0[1].(map[string]any)
+	if c["columnName"] != "service.name" || c["op"] != "=" || c["value"] != "a OR b" {
+		t.Errorf("entry 0 clause[1] = %#v", c)
+	}
+
+	got1, ok := entries[1]["having"].([]any)
+	if !ok || len(got1) != 1 {
+		t.Fatalf("entry 1: expected single-clause []any, got %#v", entries[1]["having"])
+	}
+	c1 := got1[0].(map[string]any)
+	if c1["columnName"] != "OrderCount" {
+		t.Errorf("entry 1 clause = %#v (column with leading 'Or' should not be split)", c1)
+	}
+}
+
 func TestCoerceHavingInQueryMaps_MalformedObjectUntouched(t *testing.T) {
 	// Out-of-contract shapes must NOT be silently coerced to []; they should
 	// be left as-is so downstream strict unmarshal can surface an error.

--- a/pkg/dashboard/dashboardbuilder/normalize_test.go
+++ b/pkg/dashboard/dashboardbuilder/normalize_test.go
@@ -262,6 +262,58 @@ func TestCoerceHavingInQueryMaps_ParenthesizedClausesParsed(t *testing.T) {
 	}
 }
 
+func TestCoerceHavingInQueryMaps_NestedAndGroupsFlattened(t *testing.T) {
+	// AND-only expressions wrapped in outer parentheses (or with nested AND
+	// sub-groups) should flatten into the clause array, not get rejected.
+	cases := []struct {
+		name       string
+		expression string
+		want       []map[string]any
+	}{
+		{
+			name:       "fully wrapped and-pair",
+			expression: "((count() > 1000) AND (count() < 5000))",
+			want: []map[string]any{
+				{"columnName": "count()", "op": ">", "value": int64(1000)},
+				{"columnName": "count()", "op": "<", "value": int64(5000)},
+			},
+		},
+		{
+			name:       "nested and group",
+			expression: "count() > 0 AND (count() > 1000 AND count() < 5000)",
+			want: []map[string]any{
+				{"columnName": "count()", "op": ">", "value": int64(0)},
+				{"columnName": "count()", "op": ">", "value": int64(1000)},
+				{"columnName": "count()", "op": "<", "value": int64(5000)},
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			entries := []map[string]any{{"queryName": "A", "having": map[string]any{"expression": tc.expression}}}
+			coerceHavingInQueryMaps(entries)
+			got, ok := entries[0]["having"].([]any)
+			if !ok {
+				t.Fatalf("expected []any, got %T: %#v", entries[0]["having"], entries[0]["having"])
+			}
+			if len(got) != len(tc.want) {
+				t.Fatalf("len = %d, want %d: %#v", len(got), len(tc.want), got)
+			}
+			for i, w := range tc.want {
+				c, ok := got[i].(map[string]any)
+				if !ok {
+					t.Fatalf("clause[%d]: expected map, got %T", i, got[i])
+				}
+				for k, v := range w {
+					if c[k] != v {
+						t.Errorf("clause[%d][%q] = %#v, want %#v", i, k, c[k], v)
+					}
+				}
+			}
+		})
+	}
+}
+
 func TestCoerceHavingInQueryMaps_GroupedBooleanOperandUntouched(t *testing.T) {
 	// Grouped boolean operands joined by top-level AND must not be silently
 	// mis-coerced. After splitTopLevelAnd, the first AND operand becomes

--- a/pkg/dashboard/dashboardbuilder/normalize_test.go
+++ b/pkg/dashboard/dashboardbuilder/normalize_test.go
@@ -67,16 +67,58 @@ func TestCoerceHavingInQueryMaps_AlreadyArrayUntouched(t *testing.T) {
 	}
 }
 
-func TestCoerceHavingInQueryMaps_NonEmptyExpressionUntouched(t *testing.T) {
-	// Unknown object shape — leave alone so validation surfaces an error.
-	obj := map[string]any{"expression": "count() > 10"}
+func TestCoerceHavingInQueryMaps_NonEmptyExpressionParsedToClauses(t *testing.T) {
+	entries := []map[string]any{
+		{"queryName": "A", "having": map[string]any{"expression": "count() > 10"}},
+		{"queryName": "B", "having": map[string]any{"expression": "sum(system.network.io) > 0"}},
+		{"queryName": "C", "having": map[string]any{"expression": "count() >= 5 AND count() < 100"}},
+	}
+	coerceHavingInQueryMaps(entries)
+
+	got0, ok := entries[0]["having"].([]any)
+	if !ok || len(got0) != 1 {
+		t.Fatalf("entry 0: expected single-clause []any, got %#v", entries[0]["having"])
+	}
+	c0 := got0[0].(map[string]any)
+	if c0["columnName"] != "count()" || c0["op"] != ">" || c0["value"] != int64(10) {
+		t.Errorf("entry 0 clause = %#v", c0)
+	}
+
+	got1, ok := entries[1]["having"].([]any)
+	if !ok || len(got1) != 1 {
+		t.Fatalf("entry 1: expected single-clause []any, got %#v", entries[1]["having"])
+	}
+	c1 := got1[0].(map[string]any)
+	if c1["columnName"] != "sum(system.network.io)" || c1["op"] != ">" || c1["value"] != int64(0) {
+		t.Errorf("entry 1 clause = %#v", c1)
+	}
+
+	got2, ok := entries[2]["having"].([]any)
+	if !ok || len(got2) != 2 {
+		t.Fatalf("entry 2: expected two-clause []any, got %#v", entries[2]["having"])
+	}
+	c2a := got2[0].(map[string]any)
+	c2b := got2[1].(map[string]any)
+	if c2a["op"] != ">=" || c2a["value"] != int64(5) {
+		t.Errorf("entry 2 clause[0] = %#v", c2a)
+	}
+	if c2b["op"] != "<" || c2b["value"] != int64(100) {
+		t.Errorf("entry 2 clause[1] = %#v", c2b)
+	}
+}
+
+func TestCoerceHavingInQueryMaps_UnparseableExpressionUntouched(t *testing.T) {
+	// No recognizable comparison operator at top level — leave the original
+	// shape so downstream validation can surface a clear error rather than
+	// fabricating a bogus clause.
+	obj := map[string]any{"expression": "definitely not a comparison"}
 	entries := []map[string]any{{"queryName": "A", "having": obj}}
 	coerceHavingInQueryMaps(entries)
 	got, ok := entries[0]["having"].(map[string]any)
 	if !ok {
 		t.Fatalf("expected map[string]any (untouched), got %T", entries[0]["having"])
 	}
-	if got["expression"] != "count() > 10" {
+	if got["expression"] != "definitely not a comparison" {
 		t.Errorf("expected expression preserved, got %v", got["expression"])
 	}
 }

--- a/pkg/dashboard/dashboardbuilder/normalize_test.go
+++ b/pkg/dashboard/dashboardbuilder/normalize_test.go
@@ -203,6 +203,65 @@ func TestCoerceHavingInQueryMaps_UnsupportedComparatorUntouched(t *testing.T) {
 	}
 }
 
+func TestCoerceHavingInQueryMaps_ParenthesizedClausesParsed(t *testing.T) {
+	// Clauses wrapped in outer parentheses — either standalone or as
+	// AND-joined operands — must be parsed, not left untouched. The strict
+	// downstream `[]HavingClause` unmarshal would otherwise fail on
+	// otherwise-valid dashboards.
+	cases := []struct {
+		name       string
+		expression string
+		want       []map[string]any
+	}{
+		{
+			name:       "single fully wrapped",
+			expression: "(count() > 1000)",
+			want: []map[string]any{
+				{"columnName": "count()", "op": ">", "value": int64(1000)},
+			},
+		},
+		{
+			name:       "double wrapped",
+			expression: "((count() > 1000))",
+			want: []map[string]any{
+				{"columnName": "count()", "op": ">", "value": int64(1000)},
+			},
+		},
+		{
+			name:       "and-joined with each operand wrapped",
+			expression: "(count() > 1000) AND (count() < 5000)",
+			want: []map[string]any{
+				{"columnName": "count()", "op": ">", "value": int64(1000)},
+				{"columnName": "count()", "op": "<", "value": int64(5000)},
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			entries := []map[string]any{{"queryName": "A", "having": map[string]any{"expression": tc.expression}}}
+			coerceHavingInQueryMaps(entries)
+			got, ok := entries[0]["having"].([]any)
+			if !ok {
+				t.Fatalf("expected []any, got %T: %#v", entries[0]["having"], entries[0]["having"])
+			}
+			if len(got) != len(tc.want) {
+				t.Fatalf("len = %d, want %d: %#v", len(got), len(tc.want), got)
+			}
+			for i, w := range tc.want {
+				c, ok := got[i].(map[string]any)
+				if !ok {
+					t.Fatalf("clause[%d]: expected map, got %T", i, got[i])
+				}
+				for k, v := range w {
+					if c[k] != v {
+						t.Errorf("clause[%d][%q] = %#v, want %#v", i, k, c[k], v)
+					}
+				}
+			}
+		})
+	}
+}
+
 func TestCoerceHavingInQueryMaps_OrInsideQuotesOrParensParsed(t *testing.T) {
 	// `OR` / `||` that is not at the top level (inside quotes or parentheses)
 	// must not trip the OR rejection.

--- a/pkg/dashboard/dashboardbuilder/normalize_test.go
+++ b/pkg/dashboard/dashboardbuilder/normalize_test.go
@@ -176,6 +176,33 @@ func TestCoerceHavingInQueryMaps_TopLevelOrPunctuationBoundaryUntouched(t *testi
 	}
 }
 
+func TestCoerceHavingInQueryMaps_UnsupportedComparatorUntouched(t *testing.T) {
+	// Unsupported two-character comparators (`<>`, `==`, `=<`, `=>`) must NOT
+	// be silently coerced by matching the single-character prefix; the
+	// original object form should be preserved so downstream validation can
+	// surface a clear error.
+	cases := []string{
+		"count() <> 5",
+		"count() == 5",
+		"count() =< 5",
+		"count() => 5",
+	}
+	for _, expr := range cases {
+		t.Run(expr, func(t *testing.T) {
+			obj := map[string]any{"expression": expr}
+			entries := []map[string]any{{"queryName": "A", "having": obj}}
+			coerceHavingInQueryMaps(entries)
+			got, ok := entries[0]["having"].(map[string]any)
+			if !ok {
+				t.Fatalf("expected map[string]any (untouched), got %T", entries[0]["having"])
+			}
+			if got["expression"] != expr {
+				t.Errorf("expected expression preserved, got %v", got["expression"])
+			}
+		})
+	}
+}
+
 func TestCoerceHavingInQueryMaps_OrInsideQuotesOrParensParsed(t *testing.T) {
 	// `OR` / `||` that is not at the top level (inside quotes or parentheses)
 	// must not trip the OR rejection.

--- a/pkg/dashboard/dashboardbuilder/normalize_test.go
+++ b/pkg/dashboard/dashboardbuilder/normalize_test.go
@@ -262,6 +262,34 @@ func TestCoerceHavingInQueryMaps_ParenthesizedClausesParsed(t *testing.T) {
 	}
 }
 
+func TestCoerceHavingInQueryMaps_GroupedBooleanOperandUntouched(t *testing.T) {
+	// Grouped boolean operands joined by top-level AND must not be silently
+	// mis-coerced. After splitTopLevelAnd, the first AND operand becomes
+	// `(count() > 5 OR count() < 1)`, which after outer-paren stripping
+	// would otherwise consume the first `>` and treat the OR'd remainder
+	// as the value. Such expressions should be left as the original object
+	// form for downstream error handling.
+	cases := []string{
+		"(count() > 5 OR count() < 1) AND count() != 0",
+		"(count() > 5 || count() < 1) AND count() != 0",
+		"count() != 0 AND (count() > 5 OR count() < 1)",
+	}
+	for _, expr := range cases {
+		t.Run(expr, func(t *testing.T) {
+			obj := map[string]any{"expression": expr}
+			entries := []map[string]any{{"queryName": "A", "having": obj}}
+			coerceHavingInQueryMaps(entries)
+			got, ok := entries[0]["having"].(map[string]any)
+			if !ok {
+				t.Fatalf("expected map[string]any (untouched), got %T: %#v", entries[0]["having"], entries[0]["having"])
+			}
+			if got["expression"] != expr {
+				t.Errorf("expected expression preserved, got %v", got["expression"])
+			}
+		})
+	}
+}
+
 func TestCoerceHavingInQueryMaps_OrInsideQuotesOrParensParsed(t *testing.T) {
 	// `OR` / `||` that is not at the top level (inside quotes or parentheses)
 	// must not trip the OR rejection.


### PR DESCRIPTION
## Summary
Extends `coerceHavingInQueryMaps` to convert GET-shape `{expression: "..."}` having clauses into the POST/PUT-shape `[{columnName, op, value}, ...]` array. Empty expressions still coerce to `[]`; anything the parser can't safely handle is left untouched so downstream validation surfaces a clear error rather than fabricating a bogus clause.

### What parses
- AND-joined comparisons via top-level `AND` / `&&`, respecting quotes and parentheses.
- Operators `>=`, `<=`, `!=`, `=`, `>`, `<`. RHS values are typed as int/float when numeric, unquoted when fully quoted, else kept as the raw trimmed string.
- Enclosing parens are stripped before operator scanning (`(count() > 1000)` works), and nested AND-only groups like `((a) AND (b))` are flattened recursively.

### What is rejected (preserved as original object)
- Top-level `OR` / `||` anywhere in the expression — including adjacent to punctuation (`OR(...)`, `OR"x"`), via a word-boundary check on logical keywords.
- Unsupported two-character comparators (`<>`, `==`, `=<`, `=>`) that would otherwise match a single-char prefix and swallow the rest as a value.
- Grouped boolean operands such as `(count() > 5 OR count() < 1) AND count() != 0`, where stripping outer parens of an AND-operand would otherwise hide an inner OR.

## Test Plan
- [x] `go test ./pkg/dashboard/dashboardbuilder/...`
- [x] `go test ./...`
- [ ] Round-trip a dashboard with a non-empty `having.expression` (single, AND-joined, parenthesized, nested-AND) through GET → write and confirm the backend accepts the resulting clause array.

🤖 Generated with [Claude Code](https://claude.com/claude-code)