### PR TITLE
Accept notification channel UUIDs in MCP tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -724,7 +724,7 @@ Create a notification channel and send a test notification.
 Update an existing notification channel and send a test notification.
 
 - **Parameters**:
-  - `id` (required) - Notification channel ID
+  - `id` (required) - Notification channel UUID
   - `type` (required) - Channel type
   - `name` (required) - Channel name
   - Full channel configuration fields for the selected channel type
@@ -734,14 +734,14 @@ Update an existing notification channel and send a test notification.
 Get a single notification channel by ID (`GET /api/v1/channels/{id}`).
 
 - **Parameters**:
-  - `id` (required) - Notification channel ID
+  - `id` (required) - Notification channel UUID
 
 #### `signoz_delete_notification_channel`
 
 Delete a notification channel by ID (`DELETE /api/v1/channels/{id}`). Irreversible — warn if alert rules still reference this channel.
 
 - **Parameters**:
-  - `id` (required) - Notification channel ID
+  - `id` (required) - Notification channel UUID
 
 #### `signoz_execute_builder_query`
 

--- a/internal/handler/tools/notification_channels.go
+++ b/internal/handler/tools/notification_channels.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
-	"strconv"
 
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
@@ -108,7 +107,7 @@ func (h *Handler) RegisterNotificationChannelHandlers(s *server.MCPServer) {
 				"IMPORTANT: This replaces the full channel configuration. All fields must be provided, not just the ones being changed.\n\n"+
 				"SUPPORTED TYPES: slack, webhook, pagerduty, email, opsgenie, msteams\n\n"+
 				"REQUIRED FIELDS:\n"+
-				"- id: The numeric ID of the channel to update\n"+
+				"- id: The UUID of the channel to update\n"+
 				"- type: Channel type (slack, webhook, pagerduty, email, opsgenie, msteams)\n"+
 				"- name: Channel name\n\n"+
 				"REQUIRED FIELDS BY TYPE:\n"+
@@ -122,7 +121,7 @@ func (h *Handler) RegisterNotificationChannelHandlers(s *server.MCPServer) {
 				"The response includes both the channel update result and the test notification outcome.",
 		),
 		// ID field (required for update)
-		mcp.WithString("id", mcp.Required(), mcp.Description("The numeric ID of the notification channel to update")),
+		mcp.WithString("id", mcp.Required(), mcp.Description("The UUID of the notification channel to update")),
 		// Common fields
 		mcp.WithString("type", mcp.Required(), mcp.Description("Channel type. One of: slack, webhook, pagerduty, email, opsgenie, msteams")),
 		mcp.WithString("name", mcp.Required(), mcp.Description("Unique name for the notification channel")),
@@ -167,7 +166,7 @@ func (h *Handler) RegisterNotificationChannelHandlers(s *server.MCPServer) {
 		mcp.WithDestructiveHintAnnotation(false),
 		mcp.WithString("searchContext", mcp.Description("The user's original question or search text that triggered this tool call. Always include the user's raw query here for better results.")),
 		mcp.WithDescription("Get a single notification channel by ID (GET /api/v1/channels/{id}). Returns the full channel configuration including the embedded receiver config (slack/webhook/pagerduty/email/opsgenie/msteams)."),
-		mcp.WithString("id", mcp.Required(), mcp.Description("The numeric ID of the notification channel.")),
+		mcp.WithString("id", mcp.Required(), mcp.Description("The UUID of the notification channel.")),
 	)
 	addTool(s, getChannelTool, h.handleGetNotificationChannel)
 
@@ -175,7 +174,7 @@ func (h *Handler) RegisterNotificationChannelHandlers(s *server.MCPServer) {
 		mcp.WithDestructiveHintAnnotation(true),
 		mcp.WithString("searchContext", mcp.Description("The user's original question or search text that triggered this tool call. Always include the user's raw query here for better results.")),
 		mcp.WithDescription("Delete a notification channel by ID (DELETE /api/v1/channels/{id}). Irreversible. Confirm with the user before calling, and warn if the channel is referenced by existing alert rules."),
-		mcp.WithString("id", mcp.Required(), mcp.Description("The numeric ID of the notification channel to delete.")),
+		mcp.WithString("id", mcp.Required(), mcp.Description("The UUID of the notification channel to delete.")),
 	)
 	addTool(s, deleteChannelTool, h.handleDeleteNotificationChannel)
 }
@@ -375,7 +374,7 @@ func (h *Handler) handleUpdateNotificationChannel(ctx context.Context, req mcp.C
 	// Validate id
 	id, _ := args["id"].(string)
 	if id == "" {
-		return mcp.NewToolResultError(`Parameter validation failed: "id" is required. Provide the numeric ID of the notification channel to update.`), nil
+		return mcp.NewToolResultError(`Parameter validation failed: "id" is required. Provide the UUID of the notification channel to update.`), nil
 	}
 
 	// Validate required fields
@@ -401,27 +400,11 @@ func (h *Handler) handleUpdateNotificationChannel(ctx context.Context, req mcp.C
 		}
 	}
 
-	idInt, err := strconv.Atoi(id)
-	if err != nil {
-		return mcp.NewToolResultError(fmt.Sprintf(`Invalid "id" value: "%s". Must be a numeric ID.`, id)), nil
-	}
-
 	// Build receiver JSON based on type
 	receiverJSON, err := buildReceiverJSON(channelType, name, sendResolved, args)
 	if err != nil {
 		h.logger.WarnContext(ctx, "Failed to build receiver JSON", logpkg.ErrAttr(err))
 		return mcp.NewToolResultError(err.Error()), nil
-	}
-
-	// Inject the channel ID into the receiver JSON for the update request body
-	var receiver types.Receiver
-	if err := json.Unmarshal(receiverJSON, &receiver); err != nil {
-		return mcp.NewToolResultError("failed to parse receiver JSON: " + err.Error()), nil
-	}
-	receiver.ID = idInt
-	receiverJSON, err = types.MarshalReceiver(receiver)
-	if err != nil {
-		return mcp.NewToolResultError("failed to marshal receiver JSON: " + err.Error()), nil
 	}
 
 	client, err := h.GetClient(ctx)

--- a/internal/handler/tools/notification_channels_test.go
+++ b/internal/handler/tools/notification_channels_test.go
@@ -658,6 +658,7 @@ func TestHandleCreateNotificationChannel_InvalidSendResolved(t *testing.T) {
 // --- Update notification channel tests ---
 
 func TestHandleUpdateNotificationChannel_Slack(t *testing.T) {
+	channelID := "019b1af4-3ef5-734d-8ba8-cc12fb5b5978"
 	var capturedID string
 	var capturedBody []byte
 	mock := &client.MockClient{
@@ -667,7 +668,9 @@ func TestHandleUpdateNotificationChannel_Slack(t *testing.T) {
 			return nil
 		},
 		GetNotificationChannelFn: func(ctx context.Context, id string) (json.RawMessage, error) {
-			return json.RawMessage(`{"data":{"id":"1","name":"my-slack","type":"slack"}}`), nil
+			return json.RawMessage(
+				`{"data":{"id":"019b1af4-3ef5-734d-8ba8-cc12fb5b5978","name":"my-slack","type":"slack"}}`,
+			), nil
 		},
 		TestNotificationChannelFn: func(ctx context.Context, receiverJSON []byte) error {
 			return nil
@@ -675,7 +678,7 @@ func TestHandleUpdateNotificationChannel_Slack(t *testing.T) {
 	}
 	h := newTestHandler(mock)
 	req := makeToolRequest("signoz_update_notification_channel", map[string]any{
-		"id":            "1",
+		"id":            channelID,
 		"type":          "slack",
 		"name":          "my-slack",
 		"slack_api_url": "https://hooks.slack.com/services/T123/B456/new",
@@ -690,8 +693,8 @@ func TestHandleUpdateNotificationChannel_Slack(t *testing.T) {
 		t.Fatalf("handler returned error result: %v", result.Content)
 	}
 
-	if capturedID != "1" {
-		t.Errorf("expected id=1, got %v", capturedID)
+	if capturedID != channelID {
+		t.Errorf("expected id=%s, got %v", channelID, capturedID)
 	}
 
 	var receiver map[string]any
@@ -700,6 +703,9 @@ func TestHandleUpdateNotificationChannel_Slack(t *testing.T) {
 	}
 	if receiver["name"] != "my-slack" {
 		t.Errorf("expected name=my-slack, got %v", receiver["name"])
+	}
+	if _, ok := receiver["id"]; ok {
+		t.Errorf("expected receiver body to omit stale numeric id, got %v", receiver["id"])
 	}
 	slackConfigs, ok := receiver["slack_configs"].([]any)
 	if !ok || len(slackConfigs) != 1 {
@@ -801,15 +807,18 @@ func TestHandleUpdateNotificationChannel_TestFails(t *testing.T) {
 // --- Get / Delete notification channel tests ---
 
 func TestHandleGetNotificationChannel(t *testing.T) {
+	channelID := "019b1af4-3ef5-734d-8ba8-cc12fb5b5978"
 	var capturedID string
 	mock := &client.MockClient{
 		GetNotificationChannelFn: func(ctx context.Context, id string) (json.RawMessage, error) {
 			capturedID = id
-			return json.RawMessage(`{"status":"success","data":{"id":"42","name":"primary","type":"slack","data":"{}"}}`), nil
+			return json.RawMessage(
+				`{"status":"success","data":{"id":"019b1af4-3ef5-734d-8ba8-cc12fb5b5978","name":"primary","type":"slack","data":"{}"}}`,
+			), nil
 		},
 	}
 	h := newTestHandler(mock)
-	req := makeToolRequest("signoz_get_notification_channel", map[string]any{"id": "42"})
+	req := makeToolRequest("signoz_get_notification_channel", map[string]any{"id": channelID})
 
 	result, err := h.handleGetNotificationChannel(testCtx(), req)
 	if err != nil {
@@ -818,8 +827,8 @@ func TestHandleGetNotificationChannel(t *testing.T) {
 	if result.IsError {
 		t.Fatalf("unexpected error result: %v", result.Content)
 	}
-	if capturedID != "42" {
-		t.Errorf("expected id=42 forwarded to client, got %s", capturedID)
+	if capturedID != channelID {
+		t.Errorf("expected id=%s forwarded to client, got %s", channelID, capturedID)
 	}
 }
 
@@ -838,6 +847,7 @@ func TestHandleGetNotificationChannel_MissingID(t *testing.T) {
 }
 
 func TestHandleDeleteNotificationChannel(t *testing.T) {
+	channelID := "019b1af4-3ef5-734d-8ba8-cc12fb5b5978"
 	var capturedID string
 	mock := &client.MockClient{
 		DeleteNotificationChannelFn: func(ctx context.Context, id string) error {
@@ -846,7 +856,7 @@ func TestHandleDeleteNotificationChannel(t *testing.T) {
 		},
 	}
 	h := newTestHandler(mock)
-	req := makeToolRequest("signoz_delete_notification_channel", map[string]any{"id": "42"})
+	req := makeToolRequest("signoz_delete_notification_channel", map[string]any{"id": channelID})
 
 	result, err := h.handleDeleteNotificationChannel(testCtx(), req)
 	if err != nil {
@@ -855,8 +865,8 @@ func TestHandleDeleteNotificationChannel(t *testing.T) {
 	if result.IsError {
 		t.Fatalf("unexpected error result: %v", result.Content)
 	}
-	if capturedID != "42" {
-		t.Errorf("expected id=42 forwarded to client, got %s", capturedID)
+	if capturedID != channelID {
+		t.Errorf("expected id=%s forwarded to client, got %s", channelID, capturedID)
 	}
 }
 

--- a/pkg/types/notification_channels.go
+++ b/pkg/types/notification_channels.go
@@ -6,7 +6,6 @@ import "encoding/json"
 // and /api/v1/testChannel endpoints. Only one of the *_configs fields
 // should be populated per receiver.
 type Receiver struct {
-	ID               int               `json:"id,omitempty"`
 	Name             string            `json:"name"`
 	SlackConfigs     []SlackConfig     `json:"slack_configs,omitempty"`
 	WebhookConfigs   []WebhookConfig   `json:"webhook_configs,omitempty"`


### PR DESCRIPTION
## Summary
- Treat notification channel IDs as UUID strings in get/update/delete tool descriptions and validation.
- Stop coercing update IDs to integers and stop injecting stale numeric `id` into the receiver body.
- Update notification-channel tests and README parameter docs to match the `/api/v1/channels/{id}` UUID contract.

## Root Cause
The SigNoz channel API now parses path IDs as UUIDs, and list/create responses expose UUIDs. The MCP update tool still rejected non-numeric IDs before reaching the API, so agents could not update or delete channels using IDs returned by list/create.

## Validation
- `go test ./internal/handler/tools -run 'NotificationChannel'`
- `go test ./...`
