### PR TITLE
docs(dashboard): clarify threshold format and operator constraints

### DIFF
--- a/pkg/dashboard/dashboardbuilder/types.go
+++ b/pkg/dashboard/dashboardbuilder/types.go
@@ -153,15 +153,23 @@ type PanelMapEntry struct {
 
 // Threshold represents a visual threshold on a chart.
 // Fields match the SigNoz frontend schema (types.Threshold).
+//
+// thresholdFormat: only "Text" or "Background" are accepted by SigNoz.
+//   - "Text"       colors the threshold value label.
+//   - "Background" tints the panel area when the operator+value condition holds.
+//
+// SigNoz does NOT support a Grafana-style "Line" marker on timeseries panels.
+//
+// thresholdOperator: one of ">", "<", ">=", "<=", "=".
 type Threshold struct {
 	Index                 string `json:"index,omitempty"`
 	IsEditEnabled         bool   `json:"isEditEnabled,omitempty"`
 	KeyIndex              int    `json:"keyIndex,omitempty"`
 	SelectedGraph         string `json:"selectedGraph,omitempty"`
 	ThresholdColor        string `json:"thresholdColor,omitempty"`
-	ThresholdFormat       string `json:"thresholdFormat,omitempty"`
+	ThresholdFormat       string `json:"thresholdFormat,omitempty"` // "Text" | "Background" (NOT "Line")
 	ThresholdLabel        string `json:"thresholdLabel,omitempty"`
-	ThresholdOperator     string `json:"thresholdOperator,omitempty"`
+	ThresholdOperator     string `json:"thresholdOperator,omitempty"` // ">" | "<" | ">=" | "<=" | "="
 	ThresholdTableOptions string `json:"thresholdTableOptions,omitempty"`
 	ThresholdUnit         string `json:"thresholdUnit,omitempty"`
 	ThresholdValue        any    `json:"thresholdValue,omitempty"`

--- a/pkg/dashboard/widgets.go
+++ b/pkg/dashboard/widgets.go
@@ -70,7 +70,7 @@ Note: This panel is best used when you need to compare discrete categories (e.g.
 - Bar Chart displays frequency or aggregated values for one or more categories over time or across categories.
 - It supports data from logs, traces, or metrics.
 - You can configure the Y-axis unit, and optionally set "Soft Min/Max" to control vertical scale so small values aren't exaggerated.
-- You can add thresholds (value + optional color) to draw reference lines on the Y-axis, useful for highlighting important limits.
+- You can add thresholds (value + operator + optional color) to highlight important limits. thresholdFormat must be 'Text' (color the threshold label) or 'Background' (tint the panel when the condition holds). SigNoz does not support a Grafana-style 'Line' marker — do not set thresholdFormat to 'Line'. thresholdOperator must be one of '>', '<', '>=', '<=', '='.
 
 Histogram panel [CRITICAL]:
 Note: This panel is best used to understand distribution patterns, detect skew, and analyze how values cluster across ranges.
@@ -109,7 +109,7 @@ Note: This panel is best used for any metric whose meaning depends on temporal e
 - Fill Gaps converts missing timestamps into zeros, useful when sparse data must be interpreted as absence of activity rather than missing samples.
 - Y-axis Unit formats numerical values for readability and domain correctness (bytes, durations, percentages, counts).
 - Soft Min/Max constrains the y-axis so small fluctuations aren't visually amplified or drowned out, stabilizing interpretation across charts.
-- Thresholds add horizontal reference lines for limits, SLOs, warning levels, or expected baselines, improving anomaly recognition.
+- Thresholds highlight limits, SLOs, warning levels, or expected baselines. thresholdFormat must be 'Text' (color the threshold label) or 'Background' (tint the panel when the condition holds). SigNoz timeseries panels do NOT render a Grafana-style horizontal line at the threshold value — do not set thresholdFormat to 'Line'. thresholdOperator must be one of '>', '<', '>=', '<=', '='.
 
 Value panel [CRITICAL]:
 - Value Panel reduces a time series to a single representative number, exposing a point-in-time or aggregated metric such as current throughput, average latency, error count, or any computed summary.

--- a/pkg/types/dashboard.go
+++ b/pkg/types/dashboard.go
@@ -93,17 +93,17 @@ type ContextLinks struct {
 }
 
 type Threshold struct {
-	Index                 string      `json:"index,omitempty"`
+	Index                 string      `json:"index,omitempty" jsonschema_extras:"description=Stable identifier for this threshold within the widget."`
 	IsEditEnabled         bool        `json:"isEditEnabled,omitempty"`
 	KeyIndex              int         `json:"keyIndex,omitempty"`
 	SelectedGraph         string      `json:"selectedGraph,omitempty"`
-	ThresholdColor        string      `json:"thresholdColor,omitempty"`
-	ThresholdFormat       string      `json:"thresholdFormat,omitempty"`
-	ThresholdLabel        string      `json:"thresholdLabel,omitempty"`
-	ThresholdOperator     string      `json:"thresholdOperator,omitempty"`
+	ThresholdColor        string      `json:"thresholdColor,omitempty" jsonschema_extras:"description=Hex color for the threshold (e.g. #FF0000)."`
+	ThresholdFormat       string      `json:"thresholdFormat,omitempty" jsonschema_extras:"description=How the threshold is rendered. Allowed values: 'Text' or 'Background'. SigNoz does NOT support a Grafana-style 'Line' marker; do not use 'Line'. 'Background' tints the panel area when the operator+value condition holds; 'Text' colors the threshold value label only."`
+	ThresholdLabel        string      `json:"thresholdLabel,omitempty" jsonschema_extras:"description=Optional display label for the threshold."`
+	ThresholdOperator     string      `json:"thresholdOperator,omitempty" jsonschema_extras:"description=Comparison operator. Allowed values: '>', '<', '>=', '<=', '='."`
 	ThresholdTableOptions string      `json:"thresholdTableOptions,omitempty"`
-	ThresholdUnit         string      `json:"thresholdUnit,omitempty"`
-	ThresholdValue        interface{} `json:"thresholdValue,omitempty"`
+	ThresholdUnit         string      `json:"thresholdUnit,omitempty" jsonschema_extras:"description=Unit for the threshold value (should match the panel's yAxisUnit)."`
+	ThresholdValue        interface{} `json:"thresholdValue,omitempty" jsonschema_extras:"description=Numeric value the operator is compared against."`
 }
 
 type SelectedLogField struct {


### PR DESCRIPTION
## Summary
- Document that SigNoz `thresholdFormat` accepts only `Text` or `Background` (not Grafana-style `Line`).
- Document supported `thresholdOperator` values: `>`, `<`, `>=`, `<=`, `=`.
- Add `jsonschema_extras` descriptions on `pkg/types.Threshold` so MCP clients surface these constraints inline; mirror the guidance in bar chart and timeseries widget instructions.

## Test plan
- [x] `go test ./...` passes
- [ ] Verify MCP clients see the new threshold field descriptions in tool schemas
- [ ] Confirm dashboard creation with `thresholdFormat: "Background"` and `"Text"` still works end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)