### PR TITLE
[codex] Fix OAuth auth form URL normalization

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ Then run `/mcp` inside Codex to verify the connection.
 
 When you add the hosted MCP URL to your client, the client initiates an authentication flow. You will be prompted to enter:
 
-1. Your SigNoz instance URL (for example, `https://your-instance.signoz.cloud`; protocol-less URLs are accepted, and pasted paths, query parameters, and fragments are ignored)
+1. Your SigNoz instance URL (for example, `your-instance.signoz.cloud`). Protocol-less URLs are accepted; paths, query parameters, and fragments are ignored.
 2. Your API key
 
 Create an API key in **Settings → API Keys** in SigNoz. Only **Admin** users can create API keys.

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ Then run `/mcp` inside Codex to verify the connection.
 
 When you add the hosted MCP URL to your client, the client initiates an authentication flow. You will be prompted to enter:
 
-1. Your SigNoz instance URL (for example, `https://your-instance.signoz.cloud`)
+1. Your SigNoz instance URL (for example, `https://your-instance.signoz.cloud`; protocol-less URLs are accepted, and pasted paths, query parameters, and fragments are ignored)
 2. Your API key
 
 Create an API key in **Settings → API Keys** in SigNoz. Only **Admin** users can create API keys.

--- a/internal/oauth/handlers.go
+++ b/internal/oauth/handlers.go
@@ -208,7 +208,7 @@ func (h *Handler) HandleAuthorizeSubmit(w http.ResponseWriter, r *http.Request) 
 		})
 		return
 	}
-	normalizedURL, err := util.NormalizeSigNozURL(signozURL)
+	normalizedURL, err := util.NormalizeSigNozURLFormInput(signozURL)
 	if err != nil {
 		h.renderAuthorizePage(w, r, http.StatusBadRequest, authorizeTemplateData{
 			ClientID:            params.ClientID,
@@ -219,7 +219,7 @@ func (h *Handler) HandleAuthorizeSubmit(w http.ResponseWriter, r *http.Request) 
 			CodeChallengeMethod: params.CodeChallengeMethod,
 			Scope:               params.Scope,
 			SignozURL:           signozURL,
-			ErrorMessage:        "Enter a valid SigNoz base URL, for example https://your-signoz-instance.",
+			ErrorMessage:        "Enter a valid SigNoz URL, for example your-instance.signoz.cloud.",
 			ErrorCode:           "invalid_request",
 		})
 		return

--- a/internal/oauth/handlers_test.go
+++ b/internal/oauth/handlers_test.go
@@ -414,7 +414,7 @@ func TestAuthorizeSubmitRejectsInvalidSigNozCredentials(t *testing.T) {
 	}
 }
 
-func TestAuthorizeSubmitStripsSigNozURLPath(t *testing.T) {
+func TestAuthorizeSubmitStripsSigNozURLPathQueryFragment(t *testing.T) {
 	signozServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/api/v1/user/me" {
 			http.NotFound(w, r)

--- a/internal/oauth/handlers_test.go
+++ b/internal/oauth/handlers_test.go
@@ -414,6 +414,93 @@ func TestAuthorizeSubmitRejectsInvalidSigNozCredentials(t *testing.T) {
 	}
 }
 
+func TestAuthorizeSubmitStripsSigNozURLPath(t *testing.T) {
+	signozServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v1/user/me" {
+			http.NotFound(w, r)
+			return
+		}
+		if r.Header.Get("SIGNOZ-API-KEY") != "snz-api-key" {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"status":"success","data":[]}`))
+	}))
+	defer signozServer.Close()
+
+	cfg := &config.Config{
+		OAuthEnabled:     true,
+		OAuthTokenSecret: "0123456789abcdef0123456789abcdef",
+		OAuthIssuerURL:   "https://mcp.example.com",
+		AuthCodeTTL:      10 * time.Minute,
+	}
+
+	handler := NewHandler(logpkg.New("error"), cfg, nil, nil)
+	clientID, err := EncryptClientID([]string{"http://127.0.0.1:4567/callback"}, "Claude", time.Now().UTC(), []byte(cfg.OAuthTokenSecret))
+	if err != nil {
+		t.Fatalf("EncryptClientID() error = %v", err)
+	}
+
+	authorizeReq := httptest.NewRequest(
+		http.MethodGet,
+		"/oauth/authorize?response_type=code&client_id="+url.QueryEscape(clientID)+
+			"&redirect_uri="+url.QueryEscape("http://127.0.0.1:4567/callback")+
+			"&state=state-123&code_challenge=challenge&code_challenge_method=S256",
+		nil,
+	)
+	authorizeRR := httptest.NewRecorder()
+	handler.HandleAuthorizePage(authorizeRR, authorizeReq)
+
+	re := regexp.MustCompile(`name="csrf_token" value="([^"]+)"`)
+	matches := re.FindStringSubmatch(authorizeRR.Body.String())
+	if len(matches) != 2 {
+		t.Fatalf("csrf token not found in authorize page: %s", authorizeRR.Body.String())
+	}
+	authorizeResult := authorizeRR.Result()
+	if len(authorizeResult.Cookies()) == 0 {
+		t.Fatalf("expected CSRF cookie to be set")
+	}
+
+	form := url.Values{
+		"client_id":             {clientID},
+		"redirect_uri":          {"http://127.0.0.1:4567/callback"},
+		"state":                 {"state-123"},
+		"code_challenge":        {"challenge"},
+		"code_challenge_method": {"S256"},
+		"csrf_token":            {matches[1]},
+		"signoz_url":            {signozServer.URL + "/home?orgId=123#logs"},
+		"api_key":               {"snz-api-key"},
+	}
+
+	submitReq := httptest.NewRequest(http.MethodPost, "/oauth/authorize", bytes.NewBufferString(form.Encode()))
+	submitReq.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	submitReq.AddCookie(authorizeResult.Cookies()[0])
+	submitRR := httptest.NewRecorder()
+	handler.HandleAuthorizeSubmit(submitRR, submitReq)
+
+	if submitRR.Code != http.StatusFound {
+		t.Fatalf("authorize POST status = %d, want %d, body = %s", submitRR.Code, http.StatusFound, submitRR.Body.String())
+	}
+	redirected, err := url.Parse(submitRR.Header().Get("Location"))
+	if err != nil {
+		t.Fatalf("parse redirect location: %v", err)
+	}
+	code := redirected.Query().Get("code")
+	if code == "" {
+		t.Fatalf("authorization code missing from redirect %q", submitRR.Header().Get("Location"))
+	}
+
+	_, signozURL, _, _, _, _, _, err := DecryptAuthorizationCode(code, []byte(cfg.OAuthTokenSecret))
+	if err != nil {
+		t.Fatalf("DecryptAuthorizationCode() error = %v", err)
+	}
+	if signozURL != signozServer.URL {
+		t.Fatalf("authorization code signozURL = %q, want %q", signozURL, signozServer.URL)
+	}
+}
+
 func TestRegisterClientAcceptsIPv6LoopbackRedirectURI(t *testing.T) {
 	cfg := &config.Config{
 		OAuthEnabled:     true,

--- a/internal/oauth/static/authorize.html
+++ b/internal/oauth/static/authorize.html
@@ -415,9 +415,9 @@
         <div class="field">
           <label for="signoz_url">SigNoz Instance URL</label>
           <input id="signoz_url" name="signoz_url" type="text" value="{{.SignozURL}}"
-            placeholder="https://your-signoz-instance" required>
-          <div class="input-note">Use the base URL for your SigNoz deployment. Don’t include a path like
-            <code>/home</code>.</div>
+            placeholder="your-instance.signoz.cloud" required>
+          <div class="input-note">Paste your SigNoz deployment URL. If you omit the protocol, <code>https://</code>
+            is assumed. Paths, query parameters, and fragments are ignored.</div>
         </div>
 
         <div class="field">

--- a/internal/oauth/static/authorize.html
+++ b/internal/oauth/static/authorize.html
@@ -416,8 +416,7 @@
           <label for="signoz_url">SigNoz Instance URL</label>
           <input id="signoz_url" name="signoz_url" type="text" value="{{.SignozURL}}"
             placeholder="your-instance.signoz.cloud" required>
-          <div class="input-note">Paste your SigNoz deployment URL. If you omit the protocol, <code>https://</code>
-            is assumed. Paths, query parameters, and fragments are ignored.</div>
+          <div class="input-note">Paste your SigNoz deployment URL.</div>
         </div>
 
         <div class="field">

--- a/pkg/util/url.go
+++ b/pkg/util/url.go
@@ -28,6 +28,9 @@ func NormalizeSigNozURL(rawURL string) (string, error) {
 	if parsed.Fragment != "" {
 		return "", fmt.Errorf("URL must be an origin (scheme://host[:port]) without a fragment")
 	}
+	if parsed.User != nil {
+		return "", fmt.Errorf("URL must not include user info")
+	}
 
 	host := strings.ToLower(parsed.Hostname())
 	if host == "" {
@@ -52,4 +55,50 @@ func NormalizeSigNozURL(rawURL string) (string, error) {
 		origin += ":" + port
 	}
 	return origin, nil
+}
+
+// NormalizeSigNozURLFormInput normalizes URLs entered by humans in auth forms. It
+// accepts protocol-less hosts by assuming HTTPS and strips path/query/fragment
+// suffixes before delegating to the strict origin validator.
+func NormalizeSigNozURLFormInput(rawURL string) (string, error) {
+	trimmed := strings.TrimSpace(rawURL)
+	if trimmed == "" {
+		return "", fmt.Errorf("URL is required")
+	}
+
+	normalized := trimmed
+	if strings.HasPrefix(normalized, "//") {
+		normalized = "https:" + normalized
+	} else if hasMalformedHTTPScheme(normalized) {
+		return "", fmt.Errorf("malformed URL: http and https URLs must start with // after the scheme")
+	} else if !hasExplicitScheme(normalized) {
+		normalized = "https://" + normalized
+	}
+
+	parsed, err := url.Parse(normalized)
+	if err != nil {
+		return "", fmt.Errorf("malformed URL: %w", err)
+	}
+	parsed.Path = ""
+	parsed.RawQuery = ""
+	parsed.ForceQuery = false
+	parsed.Fragment = ""
+
+	return NormalizeSigNozURL(parsed.String())
+}
+
+func hasExplicitScheme(rawURL string) bool {
+	schemeSep := strings.Index(rawURL, "://")
+	if schemeSep < 0 {
+		return false
+	}
+
+	pathStart := strings.IndexAny(rawURL, "/?#")
+	return pathStart < 0 || schemeSep < pathStart
+}
+
+func hasMalformedHTTPScheme(rawURL string) bool {
+	lower := strings.ToLower(rawURL)
+	return strings.HasPrefix(lower, "http:") && !strings.HasPrefix(lower, "http://") ||
+		strings.HasPrefix(lower, "https:") && !strings.HasPrefix(lower, "https://")
 }

--- a/pkg/util/url.go
+++ b/pkg/util/url.go
@@ -68,6 +68,9 @@ func NormalizeSigNozURLFormInput(rawURL string) (string, error) {
 
 	normalized := trimmed
 	if strings.HasPrefix(normalized, "//") {
+		if hasHTTPishPrefix(strings.TrimPrefix(normalized, "//")) {
+			return "", fmt.Errorf("malformed URL: http and https URLs must start with // after the scheme")
+		}
 		normalized = "https:" + normalized
 	} else if hasMalformedHTTPScheme(normalized) {
 		return "", fmt.Errorf("malformed URL: http and https URLs must start with // after the scheme")
@@ -99,6 +102,11 @@ func hasExplicitScheme(rawURL string) bool {
 
 func hasMalformedHTTPScheme(rawURL string) bool {
 	lower := strings.ToLower(rawURL)
-	return strings.HasPrefix(lower, "http:") && !strings.HasPrefix(lower, "http://") ||
-		strings.HasPrefix(lower, "https:") && !strings.HasPrefix(lower, "https://")
+	return hasHTTPishPrefix(lower) && !strings.HasPrefix(lower, "http://") &&
+		!strings.HasPrefix(lower, "https://")
+}
+
+func hasHTTPishPrefix(rawURL string) bool {
+	lower := strings.ToLower(rawURL)
+	return strings.HasPrefix(lower, "http:") || strings.HasPrefix(lower, "https:")
 }

--- a/pkg/util/url_test.go
+++ b/pkg/util/url_test.go
@@ -1,0 +1,96 @@
+package util
+
+import "testing"
+
+func TestNormalizeSigNozURLFormInput(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  string
+		want string
+	}{
+		{
+			name: "adds https for protocol-less cloud host",
+			raw:  "tough-gecko.us.signoz.cloud",
+			want: "https://tough-gecko.us.signoz.cloud",
+		},
+		{
+			name: "strips path from full URL",
+			raw:  "https://tough-gecko.us.signoz.cloud/home",
+			want: "https://tough-gecko.us.signoz.cloud",
+		},
+		{
+			name: "adds https and strips path query and fragment",
+			raw:  "tough-gecko.us.signoz.cloud/home?orgId=123#logs",
+			want: "https://tough-gecko.us.signoz.cloud",
+		},
+		{
+			name: "adds https when stripped query contains absolute URL",
+			raw:  "tough-gecko.us.signoz.cloud/home?next=https://example.com",
+			want: "https://tough-gecko.us.signoz.cloud",
+		},
+		{
+			name: "preserves explicit http and custom port",
+			raw:  "http://tenant.example.com:8080/dashboard",
+			want: "http://tenant.example.com:8080",
+		},
+		{
+			name: "strips default https port after path removal",
+			raw:  "https://tenant.example.com:443/home",
+			want: "https://tenant.example.com",
+		},
+		{
+			name: "accepts protocol-relative URL",
+			raw:  "//tenant.example.com/home",
+			want: "https://tenant.example.com",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := NormalizeSigNozURLFormInput(tt.raw)
+			if err != nil {
+				t.Fatalf("NormalizeSigNozURLFormInput(%q) error = %v", tt.raw, err)
+			}
+			if got != tt.want {
+				t.Fatalf("NormalizeSigNozURLFormInput(%q) = %q, want %q", tt.raw, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNormalizeSigNozURLFormInputRejectsInvalidHosts(t *testing.T) {
+	tests := []string{
+		"",
+		"ftp://tenant.example.com/home",
+		"http:/tenant.example.com/home",
+		"https:/tenant.example.com/home",
+		"http:tenant.example.com/home",
+		"https:tenant.example.com/home",
+		"https://tough-gecko.us.signoz.cloud@evil.example/home",
+		"tough-gecko.us.signoz.cloud@evil.example/home",
+		"localhost/home",
+		"0.0.0.0/home",
+	}
+
+	for _, raw := range tests {
+		t.Run(raw, func(t *testing.T) {
+			if got, err := NormalizeSigNozURLFormInput(raw); err == nil {
+				t.Fatalf("NormalizeSigNozURLFormInput(%q) = %q, want error", raw, got)
+			}
+		})
+	}
+}
+
+func TestNormalizeSigNozURLRejectsUserinfo(t *testing.T) {
+	tests := []string{
+		"https://tenant.example.com@evil.example",
+	}
+
+	for _, raw := range tests {
+		t.Run(raw, func(t *testing.T) {
+			if got, err := NormalizeSigNozURL(raw); err == nil {
+				t.Fatalf("NormalizeSigNozURL(%q) = %q, want error", raw, got)
+			}
+		})
+	}
+}

--- a/pkg/util/url_test.go
+++ b/pkg/util/url_test.go
@@ -66,6 +66,8 @@ func TestNormalizeSigNozURLFormInputRejectsInvalidHosts(t *testing.T) {
 		"https:/tenant.example.com/home",
 		"http:tenant.example.com/home",
 		"https:tenant.example.com/home",
+		"//http:tenant.example.com/home",
+		"//https:tenant.example.com/home",
 		"https://tough-gecko.us.signoz.cloud@evil.example/home",
 		"tough-gecko.us.signoz.cloud@evil.example/home",
 		"localhost/home",

--- a/plans/oauth-auth-form-url-normalization.context.md
+++ b/plans/oauth-auth-form-url-normalization.context.md
@@ -20,6 +20,11 @@
 - Kept broader private-network SSRF policy out of scope because existing local/self-hosted tests and workflows rely on loopback URLs.
 - Updated UI and README copy to describe protocol-less HTTPS assumption and path/query/fragment stripping.
 
+### 2026-05-06 - Claude PR review cleanup
+- Rejected protocol-relative malformed HTTP-like inputs such as `//http:tenant`.
+- Renamed the OAuth submit integration test to mention path, query, and fragment stripping.
+- Changed the README auth example to use the protocol-less form as the canonical example.
+
 ## Open Questions
 - [x] Should protocol-less auth-form input default to HTTPS? Answer: yes.
 - [x] Should `/home` and similar suffixes be rejected or stripped? Answer: strip path, query, and fragment in the auth-form path.

--- a/plans/oauth-auth-form-url-normalization.context.md
+++ b/plans/oauth-auth-form-url-normalization.context.md
@@ -1,0 +1,27 @@
+# Feature: OAuth Auth Form URL Normalization - Context & Discussion
+
+## Original Prompt
+> auth screen should accept protocol-less URLs imo
+> also it should do path stripping for things like https://tough-gecko.us.signoz.cloud/home
+
+## Reference Links
+- None
+
+## Key Decisions & Discussion Log
+### 2026-05-06 - Initial implementation
+- Added a form-specific URL normalizer for the OAuth authorize screen.
+- Protocol-less entries assume `https://`.
+- Path, query, and fragment suffixes are stripped before credential validation and token storage.
+- Strict `NormalizeSigNozURL` remains in use for non-form paths such as `X-SigNoz-URL`.
+
+### 2026-05-06 - Review feedback
+- Rejected URL userinfo so entries such as `https://tenant@evil.example/home` cannot normalize to the host after `@`.
+- Rejected malformed explicit schemes such as `http:/tenant` and `https:/tenant`.
+- Kept broader private-network SSRF policy out of scope because existing local/self-hosted tests and workflows rely on loopback URLs.
+- Updated UI and README copy to describe protocol-less HTTPS assumption and path/query/fragment stripping.
+
+## Open Questions
+- [x] Should protocol-less auth-form input default to HTTPS? Answer: yes.
+- [x] Should `/home` and similar suffixes be rejected or stripped? Answer: strip path, query, and fragment in the auth-form path.
+- [x] Should this lenient behavior replace strict origin validation everywhere? Answer: no, keep it scoped to auth-form input.
+- [ ] Should OAuth credential validation block private, loopback, link-local, or redirect targets? Out of scope for this change; needs a separate self-hosted-compatible security policy.

--- a/plans/oauth-auth-form-url-normalization.plan.md
+++ b/plans/oauth-auth-form-url-normalization.plan.md
@@ -1,0 +1,33 @@
+# Plan: OAuth Auth Form URL Normalization
+
+## Status
+Done
+
+## Context
+Users can paste either a SigNoz Cloud hostname or a deep link from their SigNoz UI into the hosted MCP OAuth auth screen. The form previously required a strict base URL with a scheme and rejected useful inputs such as `tough-gecko.us.signoz.cloud` or `https://tough-gecko.us.signoz.cloud/home`.
+
+## Approach
+Add a form-specific normalization helper that:
+
+- Trims whitespace.
+- Assumes `https://` when the pasted value has no explicit scheme.
+- Preserves explicit `http://` for self-hosted deployments.
+- Rejects malformed `http:` or `https:` prefixes that do not use `//`.
+- Strips path, query, and fragment suffixes before delegating to strict origin validation.
+- Rejects userinfo through the strict validator.
+
+Keep existing strict normalization for non-form callers.
+
+## Files to Modify
+- `pkg/util/url.go` - add form-specific normalization and userinfo rejection.
+- `pkg/util/url_test.go` - cover protocol-less input, suffix stripping, malformed scheme input, userinfo rejection, and absolute URLs inside stripped query values.
+- `internal/oauth/handlers.go` - use the form-specific normalizer in `HandleAuthorizeSubmit`.
+- `internal/oauth/handlers_test.go` - verify a deep-link auth-form URL stores the stripped origin in the authorization code.
+- `internal/oauth/static/authorize.html` - update form helper text.
+- `README.md` - document hosted auth-form URL input behavior.
+
+## Verification
+- `git diff --check`
+- `go test ./pkg/util ./internal/oauth ./internal/mcp-server`
+- `go test ./...`
+- Independent agent review of security, tests/docs/UX, and implementation compatibility.


### PR DESCRIPTION
## Summary

- Accept protocol-less SigNoz URLs in the OAuth auth form by assuming HTTPS.
- Strip path, query, and fragment suffixes before credential validation and token storage.
- Reject URL userinfo and malformed `http:/` / `https:/` inputs to avoid surprising host normalization.
- Update auth form copy, README hosted-auth guidance, tests, and the local planning notes.

## Why

Users often paste either a SigNoz Cloud hostname or a deep link from the SigNoz UI, such as `https://tough-gecko.us.signoz.cloud/home`. The auth screen should normalize those human-entered values to the deployment origin instead of rejecting them.

## Validation

- `git diff --check`
- `go test ./pkg/util ./internal/oauth ./internal/mcp-server`
- `go test ./...`
- Independent agent review for security, UX/docs/tests, and implementation compatibility

## Notes

No MCP tool, resource, or config metadata changed. `manifest.json` does not need a matching update.