### PR TITLE
fix(dashboard): omit null tags and drop unused category filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -473,8 +473,7 @@ To discover available paths, call `signoz_list_dashboard_templates` first and le
 
 Returns the full bundled catalog of curated SigNoz dashboard templates (id, title, path, description, category, keywords) as a JSON array. Pair with `signoz_import_dashboard`: have the model read the catalog, choose the entry that best matches the user's intent, then import it by its `path`.
 
-- **Parameters:**
-  - `category` (optional) – Restrict results to a single catalog category (case-insensitive), e.g. `Apm`, `K8S Infra Metrics`
+- **Parameters:** none
 
 #### `signoz_update_dashboard`
 

--- a/internal/handler/tools/dashboard_templates.go
+++ b/internal/handler/tools/dashboard_templates.go
@@ -3,7 +3,6 @@ package tools
 import (
 	_ "embed"
 	"encoding/json"
-	"strings"
 )
 
 //go:embed dashboard_templates.json
@@ -29,20 +28,9 @@ func init() {
 	}
 }
 
-// listDashboardTemplates returns the embedded catalog. When category is
-// non-empty, results are restricted to that catalog category (case-insensitive).
-func listDashboardTemplates(category string) []dashboardTemplateEntry {
-	if category == "" {
-		out := make([]dashboardTemplateEntry, len(dashboardTemplateCatalog))
-		copy(out, dashboardTemplateCatalog)
-		return out
-	}
-	want := strings.ToLower(category)
-	out := make([]dashboardTemplateEntry, 0, len(dashboardTemplateCatalog))
-	for _, e := range dashboardTemplateCatalog {
-		if strings.ToLower(e.Category) == want {
-			out = append(out, e)
-		}
-	}
+// listDashboardTemplates returns a copy of the embedded catalog.
+func listDashboardTemplates() []dashboardTemplateEntry {
+	out := make([]dashboardTemplateEntry, len(dashboardTemplateCatalog))
+	copy(out, dashboardTemplateCatalog)
 	return out
 }

--- a/internal/handler/tools/dashboards.go
+++ b/internal/handler/tools/dashboards.go
@@ -142,10 +142,8 @@ func (h *Handler) RegisterDashboardHandlers(s *server.MCPServer) {
 			"List all curated SigNoz dashboard templates bundled with this server. "+
 				"Returns the full catalog as a JSON array — each entry includes 'id', 'title', 'path', 'description', 'category', and 'keywords'. "+
 				"Use this to discover which template fits the user's intent, then pass the chosen 'path' to signoz_import_dashboard. "+
-				"The catalog is small enough to read in full; let the model decide the best match rather than relying on keyword scoring. "+
-				"Optional 'category' narrows the result to a single catalog category (case-insensitive), e.g. 'Apm', 'K8S Infra Metrics'.",
+				"The catalog is small enough to read in full; let the model decide the best match rather than relying on keyword scoring.",
 		),
-		mcp.WithString("category", mcp.Description("Optional catalog category to restrict results to (case-insensitive), e.g. 'Apm', 'K8S Infra Metrics'.")),
 		mcp.WithString("searchContext", mcp.Description("The user's original question or search text that triggered this tool call. Always include the user's raw query here for better results.")),
 	)
 
@@ -330,13 +328,9 @@ func fetchTemplate(ctx context.Context, path string) ([]byte, error) {
 }
 
 func (h *Handler) handleListDashboardTemplates(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-	args, _ := req.Params.Arguments.(map[string]any)
-	category, _ := args["category"].(string)
-	category = strings.TrimSpace(category)
+	h.logger.DebugContext(ctx, "Tool called: signoz_list_dashboard_templates")
 
-	h.logger.DebugContext(ctx, "Tool called: signoz_list_dashboard_templates", slog.String("category", category))
-
-	entries := listDashboardTemplates(category)
+	entries := listDashboardTemplates()
 	body, err := json.Marshal(entries)
 	if err != nil {
 		return mcp.NewToolResultError(fmt.Sprintf("failed to encode templates: %s", err.Error())), nil

--- a/internal/handler/tools/dashboards_test.go
+++ b/internal/handler/tools/dashboards_test.go
@@ -281,61 +281,6 @@ func TestHandleListDashboardTemplates_FullCatalog(t *testing.T) {
 	}
 }
 
-func TestHandleListDashboardTemplates_CategoryFilter(t *testing.T) {
-	h := newTestHandler(&client.MockClient{})
-	result, err := h.handleListDashboardTemplates(testCtx(), makeToolRequest(
-		"signoz_list_dashboard_templates",
-		map[string]any{"category": "apm"},
-	))
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if result.IsError {
-		t.Fatalf("handler returned error: %v", result.Content)
-	}
-	textContent, ok := result.Content[0].(mcp.TextContent)
-	if !ok {
-		t.Fatalf("expected TextContent, got %T", result.Content[0])
-	}
-	var entries []map[string]any
-	if err := json.Unmarshal([]byte(textContent.Text), &entries); err != nil {
-		t.Fatalf("response should be a JSON array: %v\n%s", err, textContent.Text)
-	}
-	if len(entries) == 0 {
-		t.Fatal("expected at least one Apm template")
-	}
-	for _, e := range entries {
-		if !strings.EqualFold(e["category"].(string), "Apm") {
-			t.Errorf("category filter leaked entry from %q", e["category"])
-		}
-	}
-}
-
-func TestHandleListDashboardTemplates_UnknownCategory(t *testing.T) {
-	h := newTestHandler(&client.MockClient{})
-	result, err := h.handleListDashboardTemplates(testCtx(), makeToolRequest(
-		"signoz_list_dashboard_templates",
-		map[string]any{"category": "no-such-category-zzz"},
-	))
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if result.IsError {
-		t.Fatalf("handler returned error: %v", result.Content)
-	}
-	textContent, ok := result.Content[0].(mcp.TextContent)
-	if !ok {
-		t.Fatalf("expected TextContent, got %T", result.Content[0])
-	}
-	var entries []map[string]any
-	if err := json.Unmarshal([]byte(textContent.Text), &entries); err != nil {
-		t.Fatalf("response should be a JSON array: %v\n%s", err, textContent.Text)
-	}
-	if len(entries) != 0 {
-		t.Errorf("expected empty result for unknown category, got %d entries", len(entries))
-	}
-}
-
 func TestHandleImportDashboard_NotFound(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		http.NotFound(w, r)

--- a/pkg/types/dashboard.go
+++ b/pkg/types/dashboard.go
@@ -14,7 +14,7 @@ type CreateDashboardInput struct {
 type Dashboard struct {
 	Title       string              `json:"title" jsonschema:"required" jsonschema_extras:"description=The display name of the dashboard."`
 	Description string              `json:"description,omitempty" jsonschema_extras:"description=A brief explanation of what the dashboard shows."`
-	Tags        []string            `json:"tags" jsonschema_extras:"description=Keywords for categorization e.g performance latency."`
+	Tags        []string            `json:"tags,omitempty" jsonschema_extras:"description=Keywords for categorization e.g performance latency."`
 	Layout      []LayoutItem        `json:"layout" jsonschema:"required" jsonschema_extras:"description=Defines the grid positioning and size for each widget."`
 	Variables   map[string]Variable `json:"variables,omitempty" jsonschema_extras:"description=Key-value map of template variables available for queries."`
 	Widgets     []Widget            `json:"widgets" jsonschema:"required" jsonschema_extras:"description=The list of all graphical components displayed on the dashboard."`


### PR DESCRIPTION
## Summary
- Fix `Tags` JSON tag on the dashboard input type to use `omitempty`, so the create/update payload no longer sends `"tags": null` when the caller omits tags. The SigNoz backend stores dashboard data as an untyped map, so omitting the field is strictly safer than sending `null`.
- Drop the unused `category` parameter from `signoz_list_dashboard_templates`. The bundled catalog is small and the tool description already directs the model to scan it in full and pick by intent, so the filter was redundant. Also removes the handler parsing, helper-function arg, README parameter docs, and the two category-filter tests.

## Test plan
- [x] `go build ./...`
- [x] `go test ./...` — all packages pass
- [x] `signoz_create_dashboard` without `tags` no longer emits `"tags": null` in the request body
- [x] `signoz_list_dashboard_templates` returns the full catalog and ignores any (now-unschemaed) `category` argument

🤖 Generated with [Claude Code](https://claude.com/claude-code)