### PR TITLE
docs: track plan files for assistant-correlation-headers + correct CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 ## Feature Planning Convention
 
-For every non-trivial feature, maintain a file pair in `plans/` (git-ignored, own git repo):
+For every non-trivial feature, maintain a file pair in `plans/` and commit it alongside the feature PR:
 
 ```
 plans/

--- a/plans/assistant-correlation-headers.context.md
+++ b/plans/assistant-correlation-headers.context.md
@@ -1,0 +1,63 @@
+# Feature: Assistant Correlation Headers — Context & Discussion
+
+## Original Prompt
+> SigNoz AI assistant calls SigNoz cloud MCP server and even MCP server produces it's own events. Now how to differentiate if MCP server is being used by SigNoz AI Assistant or user's client?
+> We added Custom HTTP headers set by the AI Assistant backend on every MCP call. This is the cleanest mechanism and the one to build around. When the assistant backend (or the Claude Agent SDK on its behalf) calls the MCP server, inject:
+>
+> X-SigNoz-Client-Source: ai-assistant
+> X-SigNoz-Assistant-Thread-Id: <thread_id>
+> X-SigNoz-Assistant-Execution-Id: <execution_id>
+>
+> In this PR: https://github.com/SigNoz/signoz-ai-assistant/pull/136, consume them in your events or logs
+
+## Reference Links
+- AI Assistant PR (sender side, merged): https://github.com/SigNoz/signoz-ai-assistant/pull/136
+- Existing analytics design: `plans/analytics.md`
+- Existing observability refactor: `plans/observability-refactor.plan.md`
+
+## Key Decisions & Discussion Log
+
+### 2026-05-06 — Mechanism choice
+- Three correlation headers carried on every MCP HTTP request from the AI Assistant backend:
+  - `X-SigNoz-Client-Source` — categorical, low-cardinality (`ai-assistant` today; default `user-client` when absent).
+  - `X-SigNoz-Assistant-Thread-Id` — UUID, high cardinality.
+  - `X-SigNoz-Assistant-Execution-Id` — UUID, high cardinality.
+- Followed the existing `searchContext` pipeline as the template: `authMiddleware` reads → ctx via `pkg/util/context.go` setters → log handler / span / metrics / analytics auto-enrich.
+
+### 2026-05-06 — Default for missing `X-SigNoz-Client-Source`
+- Default to literal string `"user-client"` (not empty) when header is absent or blank, so the dimension is always populated and downstream group-bys never have to handle null.
+- Kept as a raw string with no enum validation. The assistant PR explicitly leaves taxonomy headroom (`ai-assistant-agent`, `ai-assistant-undo`, etc.) — strict validation here would force a coordinated deploy on every taxonomy change.
+
+### 2026-05-06 — Analytics emission policy
+- Decision: keep emit-with-tag, do **not** suppress `MCP Tool: Called` (and similar) when `client_source = ai-assistant`.
+- Reason: suppression at the source loses data we cannot reconstruct. Filtering downstream (`client_source != 'ai-assistant'`) is cheap; un-emitting is irreversible. The assistant team can still split user-facing counts in dashboards.
+
+### 2026-05-06 — Cardinality split between metrics and other sinks
+- `client_source` is added as an attribute to the OTel counters (`ToolCalls`, `MethodCalls`, `SessionRegistered`, etc.). Bounded set, useful for split-by.
+- `assistant.thread_id` and `assistant.execution_id` are **not** added to metrics. Per-execution UUIDs would explode Prometheus / metrics backend cardinality. They go on logs, spans, and analytics events only.
+
+### 2026-05-06 — Drop `searchContext` from analytics events
+- Decision: stop including `searchContext` as an analytics attribute. Keep it on logs and spans where it is still useful for trace-level debugging.
+- Reason: `searchContext` is free-form LLM-authored prose and unbounded as an analytics dimension; it inflates Segment payload size with no aggregation value. Logs/spans retain it for individual-request investigation, which is where it actually pays off.
+- Touchpoint: remove the `props[analytics.AttrSearchContext] = sc` block in `internal/mcp-server/server.go` (around the tool-called event); the `AttrSearchContext` constant in `pkg/analytics/events.go` is removed if it has no remaining users.
+
+### 2026-05-07 — Multi-AI review pass (Codex gpt-5.4/xhigh + Gemini gemini-3-flash-preview)
+- Both reviewers concurred on two real risks; Codex flagged three additional issues. Findings and resolution:
+  - **Header length bloat (Codex M / Gemini M)** — all three correlation headers were forwarded raw into ctx and from there into every log/span/Segment payload. A single oversized header would multiply downstream. **Resolved**: introduced `util.CallerCorrelationHeaderMaxLen = 256` and `util.TruncateCallerCorrelationValue` in `pkg/util/context.go`; `authMiddleware` truncates each of the three header values before stashing on ctx. Truncation is silent — preserves the "advisory, never gates" rule.
+  - **Cardinality on `client_source` (Codex H / Gemini L)** — Codex argued the deliberate "no allowlist" design lets a hostile client spray unique values into `mcp.tool.calls` / `mcp.method.calls` / `mcp.session.registered` counters. **Decision**: stay with length-cap-only (option 2 in the synthesis). The 256-char truncation bounds per-value size; we accept residual unique-value spam risk in exchange for taxonomy headroom on the assistant side. Revisit if the metric backend ever shows actual cardinality pressure here.
+  - **stdio path missing default (Codex L)** — `runStdio.SetContextFunc` seeded API key and URL but never `client_source`, so stdio sessions emitted the dimension absent. **Resolved**: stdio context func now sets `util.SetClientSource(ctx, util.ClientSourceUserClient)`, matching `authMiddleware`'s default.
+  - **Test gap on metric invariant (Codex L)** — no test asserted the central cardinality claim (`client_source` present on counters, `assistant_*` absent). **Resolved**: added `TestLoggingMiddleware_MetricCardinalityInvariants` that runs the middleware against a real `sdkmetric.ManualReader` and asserts the attribute presence/absence on both `mcp.tool.calls` and `mcp.tool.call.duration`.
+  - **`AttrSearchContext` removal as Go API break (Codex L)** — `pkg/analytics` is not `internal/`, so external Go importers could in theory exist. **Decision**: accept the break. There are no known external consumers; a deprecated-but-kept constant is a maintenance smell that would silently rot. Mentioned in plan/context for future readers.
+  - Gemini also flagged "manual ctx-copy in `detachedAnalyticsContext` is brittle as fields grow" (Nit) and "redundant root-span attrs vs child spans" (Nit, acceptable). Both deferred.
+- HTTP-path propagation, `r.WithContext` correctness, and `detachedAnalyticsContext` copy were validated by both reviewers as correct.
+
+### 2026-05-06 — Implementation: OAuth counters out of scope
+- During implementation, confirmed the assistant only injects the three correlation headers on `/mcp` calls. The OAuth handler endpoints (`/oauth/authorize`, `/oauth/token`, etc.) are browser-driven and never carry these headers, so `OAuthEvents` / `OAuthFailures` counters cannot meaningfully be tagged with `client_source`.
+- Removed OAuth counters from the metrics-tagging scope. The `/mcp` POST that *uses* an OAuth bearer token still flows through `authMiddleware` and is correctly tagged because header reading happens there, before any auth-method branching.
+
+## Open Questions
+- [x] Default value for missing `X-SigNoz-Client-Source`? Answer: `"user-client"`.
+- [x] Suppress analytics events when `client_source = ai-assistant`? Answer: no — emit with tag, filter downstream.
+- [x] Add `thread_id` / `execution_id` to metrics? Answer: no, cardinality risk; logs + spans + analytics only.
+- [x] Keep `searchContext` on analytics events? Answer: no — drop from analytics, retain on logs and spans.
+- [ ] Future: when `X-SigNoz-Client-Source` taxonomy expands beyond `ai-assistant`, do we want a server-side allowlist or stay permissive? Out of scope for this change.

--- a/plans/assistant-correlation-headers.plan.md
+++ b/plans/assistant-correlation-headers.plan.md
@@ -1,0 +1,61 @@
+# Plan: Assistant Correlation Headers
+
+## Status
+In Progress
+
+## Context
+The SigNoz AI Assistant backend now sends three correlation headers on every outbound MCP call (see PR https://github.com/SigNoz/signoz-ai-assistant/pull/136):
+
+- `X-SigNoz-Client-Source` — categorical (`ai-assistant`); default `user-client` when absent.
+- `X-SigNoz-Assistant-Thread-Id` — UUID per assistant thread.
+- `X-SigNoz-Assistant-Execution-Id` — UUID per assistant execution.
+
+The MCP server emits its own logs, spans, metrics, and Segment analytics events (`MCP Tool: Called`, `MCP Session: Registered`, etc.). Without these correlation tags, assistant-driven traffic is indistinguishable from direct user-client traffic, which makes it impossible to (a) split usage analytics, (b) join MCP-side traces back to a specific assistant execution during incident triage, or (c) avoid double-counting when the assistant team builds user-facing usage dashboards.
+
+This change consumes the headers and propagates them through the same observability pipeline that already handles `searchContext` and `sessionID`.
+
+## Approach
+Mirror the existing `searchContext` flow exactly. No new machinery — just three more context-borne fields plumbed through the same five surfaces. Also drop `searchContext` from analytics events as a side-quest cleanup (it stays on logs and spans).
+
+1. **Context keys.** Add `clientSourceContextKey`, `assistantThreadIDContextKey`, `assistantExecutionIDContextKey` in `pkg/util/context.go` next to the existing keys. Each gets a `Get*` / `Set*` helper pair following the file's established pattern.
+
+2. **Header read in `authMiddleware`.** In `internal/mcp-server/server.go` (around the existing `X-SigNoz-URL` / auth-header extraction in `authMiddleware`), pull the three headers off the request, normalize `X-SigNoz-Client-Source` to `"user-client"` when blank, and stash all three on the request context via the new setters before calling `r.WithContext(ctx)`.
+
+3. **Auto-enrich slog records.** Extend the context-aware handler in `pkg/log/handler.go` so every emitted log line picks up `mcp.client_source`, `mcp.assistant.thread_id`, and `mcp.assistant.execution_id` when they are present in context. Free coverage for every existing slog call site — no per-call-site edits needed.
+
+4. **Span attributes.** Define new attribute keys in `pkg/otel/attr.go` (dotted semconv form: `mcp.client_source`, `mcp.assistant.thread_id`, `mcp.assistant.execution_id`). Apply them at the existing `span.SetAttributes(...)` sites in `internal/mcp-server/server.go` — the tool-call span in `loggingMiddleware`, the hooks span, and the auth-middleware span.
+
+5. **Metrics — `client_source` only.** Add `client_source` as an attribute to the OTel counters whose call sites can see the headers: `ToolCalls`, `ToolCallDuration`, `MethodCalls`, `MethodDuration`, `SessionRegistered`. A small helper in `pkg/otel/attr.go` (`AppendClientSource(ctx, attrs)`) keeps call sites tidy. Do **not** add the two UUID fields to any metric — per-execution cardinality is unbounded. **OAuth counters are excluded** — `/oauth/*` endpoints are browser-driven and never carry the assistant headers.
+
+6. **Analytics properties.** Add `AttrClientSource`, `AttrAssistantThreadID`, `AttrAssistantExecutionID` constants in `pkg/analytics/events.go` (camelCase per the file's stated convention). Merge the three values into the property maps at the `trackEventAsync` sites for `EventToolCalled`, `EventSessionRegistered`, `EventPromptFetched`, `EventResourceFetched`. Skip the OAuth analytics events — same reason as the metrics exclusion. Same code shape as how `sessionID` is already merged.
+
+7. **Drop `searchContext` from analytics.** Remove the `props[analytics.AttrSearchContext] = sc` injection in the tool-called analytics path in `internal/mcp-server/server.go`. Remove the `AttrSearchContext` constant in `pkg/analytics/events.go` if grep confirms it has no remaining consumers. `searchContext` continues to flow into logs (via the slog handler) and spans (via `MCPSearchContextKey`) as before.
+
+8. **Async context preservation.** `detachedAnalyticsContext()` in `internal/mcp-server/server.go` already copies `searchContext` and `sessionID` forward into background goroutines. Add the three new keys to that copy so async analytics emissions keep the tags.
+
+## Files to Modify
+- `pkg/util/context.go` — three new context keys + `Get*`/`Set*` pairs.
+- `internal/mcp-server/server.go`:
+  - `authMiddleware` — read the three headers, default `client_source`, attach to ctx.
+  - `loggingMiddleware` and hooks span sites — add the new span attributes.
+  - Tool-called / session-registered / prompt / resource analytics property maps — merge the three new attrs.
+  - Tool-called analytics property map — remove `props[analytics.AttrSearchContext] = sc`.
+  - `detachedAnalyticsContext()` — extend ctx copy with the three new keys.
+  - Metric attribute lists for `ToolCalls`, `ToolCallDuration`, `MethodCalls`, `MethodDuration`, `SessionRegistered` — add `client_source`.
+- `pkg/log/handler.go` — emit the three new fields on every record when present in ctx.
+- `pkg/otel/attr.go` — three new attribute key constants and an `AppendClientSource` helper for metrics.
+- `pkg/analytics/events.go` — three new attribute constants; remove `AttrSearchContext` if unused after step 7.
+- `internal/mcp-server/server_test.go` (or whichever existing test file covers `authMiddleware` and analytics emission) — header propagation, default-when-absent, metric attribute presence, analytics map shape (including absence of `searchContext`).
+- `pkg/log/handler_test.go` — log enrichment when ctx carries the three keys.
+- `README.md` — document the three honored request headers (under whatever section already covers `X-SigNoz-URL`).
+- `manifest.json` / `docs/` — review per CLAUDE.md doc-sync checklist; likely no change since these are transport-level headers, not tool inputs.
+
+## Verification
+- `go test ./pkg/util ./pkg/log ./pkg/otel ./pkg/analytics ./internal/mcp-server`
+- `go test ./...`
+- Local end-to-end: run the MCP server, hit a tool with all three headers via `curl` (and with none), confirm:
+  - JSON log lines for the request carry `mcp.client_source`, `mcp.assistant.thread_id`, `mcp.assistant.execution_id` when supplied; carry `mcp.client_source=user-client` when not.
+  - The OTel span for the tool call carries the three attributes.
+  - The `mcp_server_tool_calls_total` counter increments with a `client_source` label.
+  - The Segment debug sink (or capture) shows `clientSource`, `assistantThreadId`, `assistantExecutionId` on `MCP Tool: Called`, and shows that `searchContext` is **no longer** an attribute.
+- Coordinate one E2E sweep against the AI Assistant local instance (the sender PR documented all 3 paths — agent-driven, approval-snapshot, undo/replay) to confirm headers are received and tagged.


### PR DESCRIPTION
## Summary

Adds the plan file pair for #167 and corrects the stale CLAUDE.md text that mis-described `plans/` as git-ignored.

- `plans/assistant-correlation-headers.context.md` — original prompt, dated discussion log including the multi-AI review pass (Codex + Gemini), the cardinality-vs-allowlist decision, OAuth-counters-out-of-scope decision, and the searchContext-drop decision.
- `plans/assistant-correlation-headers.plan.md` — implementation plan (Status: In Progress).
- `CLAUDE.md` — drop the inaccurate "(git-ignored, own git repo)" clause; the directory has never been gitignored and every feature PR since #87 has committed its plan-file pair.

## Why a follow-up

This pair was supposed to ship in #167. The plan files were left out of #167 on a misreading of the CLAUDE.md text — backfilling here so the design log lives in the repo alongside the other 22 plan-file pairs (#137, #140, #142, #144, #145, #149, #165, …).

## Test plan

- [x] `git ls-files plans/` shows the new pair alongside existing ones.
- [x] No code changes; nothing to test.