### PR TITLE
chore: improve MCP auth failure telemetry

### DIFF
--- a/internal/mcp-server/e2e_docs_test.go
+++ b/internal/mcp-server/e2e_docs_test.go
@@ -1,18 +1,31 @@
 package mcp_server
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
+	"log/slog"
+	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/SigNoz/signoz-mcp-server/internal/config"
 	docsindex "github.com/SigNoz/signoz-mcp-server/internal/docs"
+	"github.com/SigNoz/signoz-mcp-server/internal/handler/tools"
+	otelpkg "github.com/SigNoz/signoz-mcp-server/pkg/otel"
+	"github.com/SigNoz/signoz-mcp-server/pkg/util"
+	"github.com/SigNoz/signoz-mcp-server/pkg/version"
 	"github.com/mark3labs/mcp-go/client"
 	"github.com/mark3labs/mcp-go/client/transport"
 	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 )
 
 // TestE2EDocsAgentFlow drives the SigNoz MCP docs feature with a real
@@ -125,6 +138,64 @@ func TestE2EDocsAgentFlow(t *testing.T) {
 	require.Contains(t, textContent.Text, "Send logs to SigNoz")
 }
 
+func TestE2EAuthFailureTelemetry(t *testing.T) {
+	traceExporter := tracetest.NewInMemoryExporter()
+	traceProvider := sdktrace.NewTracerProvider(sdktrace.WithSyncer(traceExporter))
+	prevTracerProvider := otel.GetTracerProvider()
+	otel.SetTracerProvider(traceProvider)
+	t.Cleanup(func() {
+		otel.SetTracerProvider(prevTracerProvider)
+		require.NoError(t, traceProvider.Shutdown(context.Background()))
+	})
+
+	var logBuf lockedBuffer
+	handler := newDocsHTTPHandlerWithLogger(t, newBufferedLogger(&logBuf, slog.LevelDebug))
+	testSrv := httptest.NewServer(handler)
+	t.Cleanup(testSrv.Close)
+
+	req, err := http.NewRequest(http.MethodPost, testSrv.URL+"/mcp", bytes.NewBufferString(`{"jsonrpc":"2.0","id":1,"method":"tools/list"}`))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("User-Agent", "claude-code/2.1.133 (cli)")
+	req.Header.Set("X-Forwarded-For", "198.51.100.9, 10.0.0.2")
+	req.Header.Set(util.HeaderMCPSessionID, "mcp-session-e2e")
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+	require.Equal(t, http.StatusUnauthorized, resp.StatusCode)
+
+	records := parseJSONLogLines(t, &logBuf)
+	require.NotEmpty(t, records)
+	rec := records[len(records)-1]
+	require.Equal(t, "No API key found in headers or environment", rec["msg"])
+	require.Equal(t, authFailureMissingCredential, rec["mcp.auth.failure_reason"])
+	require.Equal(t, authModeNone, rec["mcp.auth.mode"])
+	require.Equal(t, "198.51.100.9", rec["client.address"])
+	require.Equal(t, "claude-code/2.1.133 (cli)", rec["user_agent.original"])
+	require.Equal(t, "mcp-session-e2e", rec["mcp.session.id"])
+
+	var httpAttrs []attribute.KeyValue
+	for _, span := range traceExporter.GetSpans() {
+		if span.Name == "HTTP POST /mcp" {
+			httpAttrs = span.Attributes
+			break
+		}
+	}
+	require.NotNil(t, httpAttrs, "expected otelhttp root span")
+	for key, want := range map[attribute.Key]string{
+		"mcp.auth.failure_reason": authFailureMissingCredential,
+		"mcp.auth.mode":           authModeNone,
+		"client.address":          "198.51.100.9",
+		"user_agent.original":     "claude-code/2.1.133 (cli)",
+		otelpkg.MCPSessionIDKey:   "mcp-session-e2e",
+	} {
+		got, ok := spanAttrValue(httpAttrs, key)
+		require.True(t, ok, "missing span attr %s", key)
+		require.Equal(t, want, got.AsString(), "span attr %s", key)
+	}
+}
+
 func firstTextContent(t *testing.T, content []mcp.Content) string {
 	t.Helper()
 	for _, c := range content {
@@ -134,4 +205,29 @@ func firstTextContent(t *testing.T, content []mcp.Content) string {
 	}
 	t.Fatalf("no TextContent in tool result")
 	return ""
+}
+
+func newDocsHTTPHandlerWithLogger(t *testing.T, logger *slog.Logger) http.Handler {
+	t.Helper()
+	cfg := &config.Config{
+		TransportMode:   "http",
+		Port:            "0",
+		OAuthEnabled:    true,
+		OAuthIssuerURL:  "https://mcp.example.com",
+		ClientCacheSize: 8,
+		ClientCacheTTL:  time.Minute,
+	}
+	h := tools.NewHandler(logger, cfg)
+	ctx, cancel := context.WithCancel(context.Background())
+	reg, err := docsindex.NewIndexRegistry(ctx, docsSnapshot())
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		cancel()
+		reg.Close(context.Background())
+	})
+	h.SetDocsIndex(reg)
+	m := NewMCPServer(logger, h, cfg, nil, nil)
+	s := server.NewMCPServer("SigNozMCP", version.Version, server.WithToolCapabilities(false), server.WithRecovery())
+	h.RegisterDocsHandlers(s)
+	return m.buildHTTP(s).Handler
 }

--- a/internal/mcp-server/server.go
+++ b/internal/mcp-server/server.go
@@ -1142,6 +1142,78 @@ func isJWTToken(token string) bool {
 	return strings.Count(token, ".") == 2 && strings.HasPrefix(token, "eyJ")
 }
 
+const (
+	authModeNone                = "none"
+	authModeSignozAPIKeyHeader  = "signoz-api-key-header"
+	authModeAuthorizationAPIKey = "authorization-api-key"
+	authModeAuthorizationBearer = "authorization-bearer"
+	authModeAuthorizationJWT    = "authorization-jwt"
+	authModeOAuthAccessToken    = "oauth-access-token"
+	authModeConfigAPIKey        = "config-api-key"
+
+	authFailureExpiredOAuthToken = "expired_oauth_token"
+	authFailureInvalidOAuthToken = "invalid_oauth_token"
+	authFailureInvalidSignozURL  = "invalid_signoz_url"
+	authFailureMissingCredential = "missing_credentials"
+	authFailureMissingSignozURL  = "missing_signoz_url"
+)
+
+func httpRequestSpanAttrs(r *http.Request) []attribute.KeyValue {
+	if r == nil {
+		return nil
+	}
+
+	attrs := []attribute.KeyValue{
+		attribute.String("http.request.method", r.Method),
+	}
+	if r.URL != nil && r.URL.Path != "" {
+		attrs = append(attrs, attribute.String("url.path", r.URL.Path))
+	}
+	if serverAddress := util.HTTPServerAddress(r); serverAddress != "" {
+		attrs = append(attrs, attribute.String("server.address", serverAddress))
+	}
+	if clientAddress := util.HTTPClientAddress(r); clientAddress != "" {
+		attrs = append(attrs, attribute.String("client.address", clientAddress))
+	}
+	if userAgent := util.HTTPUserAgent(r); userAgent != "" {
+		attrs = append(attrs, attribute.String("user_agent.original", userAgent))
+	}
+	if sessionID := util.HTTPSessionID(r); sessionID != "" {
+		attrs = append(attrs, otelpkg.MCPSessionIDKey.String(sessionID))
+	}
+	return attrs
+}
+
+func decorateAuthSpan(ctx context.Context, r *http.Request, authMode string, attrs ...attribute.KeyValue) {
+	span := trace.SpanFromContext(ctx)
+	if !span.IsRecording() {
+		return
+	}
+
+	spanAttrs := httpRequestSpanAttrs(r)
+	if authMode != "" {
+		spanAttrs = append(spanAttrs, attribute.String("mcp.auth.mode", authMode))
+	}
+	spanAttrs = append(spanAttrs, attrs...)
+	span.SetAttributes(spanAttrs...)
+}
+
+func (m *MCPServer) logAuthFailure(ctx context.Context, r *http.Request, status int, reason, authMode, msg string, attrs ...slog.Attr) {
+	decorateAuthSpan(ctx, r, authMode,
+		attribute.Int("http.response.status_code", status),
+		attribute.String("mcp.auth.failure_reason", reason),
+	)
+
+	logAttrs := []slog.Attr{
+		slog.Int("http.response.status_code", status),
+		slog.String("mcp.auth.failure_reason", reason),
+		slog.String("mcp.auth.mode", authMode),
+	}
+	logAttrs = append(logAttrs, logpkg.MCPHTTPRequestAttrs(r)...)
+	logAttrs = append(logAttrs, attrs...)
+	m.logger.LogAttrs(ctx, slog.LevelWarn, msg, logAttrs...)
+}
+
 func (m *MCPServer) authMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		ctx := r.Context()
@@ -1182,10 +1254,12 @@ func (m *MCPServer) authMiddleware(next http.Handler) http.Handler {
 		var apiKey string
 		var signozURL string
 		var usedOAuthToken bool
+		authMode := authModeNone
 
 		if signozAPIKey != "" {
 			// Explicit PAT via SIGNOZ-API-KEY header — forward as-is.
 			apiKey = strings.TrimPrefix(signozAPIKey, "Bearer ")
+			authMode = authModeSignozAPIKeyHeader
 
 			ctx = util.SetAPIKey(ctx, apiKey)
 			ctx = util.SetAuthHeader(ctx, "SIGNOZ-API-KEY")
@@ -1196,12 +1270,14 @@ func (m *MCPServer) authMiddleware(next http.Handler) http.Handler {
 				if isJWTToken(token) {
 					// JWT token — forward via Authorization: Bearer <token>
 					apiKey = "Bearer " + token
+					authMode = authModeAuthorizationJWT
 					ctx = util.SetAPIKey(ctx, apiKey)
 					ctx = util.SetAuthHeader(ctx, "Authorization")
 					m.logger.DebugContext(ctx, "Using JWT token authentication via Authorization header", slog.String("mcp.tenant_url", customURL))
 				} else {
 					// PAT token — forward via SIGNOZ-API-KEY
 					apiKey = token
+					authMode = authModeAuthorizationAPIKey
 					ctx = util.SetAPIKey(ctx, apiKey)
 					ctx = util.SetAuthHeader(ctx, "SIGNOZ-API-KEY")
 					m.logger.DebugContext(ctx, "Using API KEY token authentication via SIGNOZ-API-KEY header", slog.String("mcp.tenant_url", customURL))
@@ -1213,10 +1289,12 @@ func (m *MCPServer) authMiddleware(next http.Handler) http.Handler {
 					apiKey = decryptedAPIKey
 					signozURL = decryptedURL
 					usedOAuthToken = true
+					authMode = authModeOAuthAccessToken
 					ctx = util.SetAPIKey(ctx, apiKey)
 					ctx = util.SetAuthHeader(ctx, "SIGNOZ-API-KEY")
 					m.logger.DebugContext(ctx, "OAuth access token extracted from Authorization header", slog.String("mcp.tenant_url", signozURL))
 				case errors.Is(err, oauth.ErrExpiredToken):
+					authMode = authModeOAuthAccessToken
 					// The token is expired but was once server-issued, so the
 					// embedded URL is a trusted tenant value. Decorate the
 					// otelhttp root span so the 401 trace carries mcp.tenant_url.
@@ -1226,6 +1304,7 @@ func (m *MCPServer) authMiddleware(next http.Handler) http.Handler {
 							trace.SpanFromContext(ctx).SetAttributes(attr)
 						}
 					}
+					m.logAuthFailure(ctx, r, http.StatusUnauthorized, authFailureExpiredOAuthToken, authMode, "OAuth access token expired")
 					m.setOAuthChallenge(w, `error="invalid_token", error_description="access token expired"`)
 					http.Error(w, "OAuth access token expired", http.StatusUnauthorized)
 					return
@@ -1234,18 +1313,20 @@ func (m *MCPServer) authMiddleware(next http.Handler) http.Handler {
 					// carries an explicit SigNoz URL (header or config). Otherwise a
 					// stale bearer token can mask the OAuth challenge flow.
 					if customURL == "" && m.config.URL == "" {
-						m.logger.WarnContext(ctx, "Bearer token did not match OAuth token format and no SigNoz URL is available for legacy fallback")
+						m.logAuthFailure(ctx, r, http.StatusUnauthorized, authFailureInvalidOAuthToken, authModeAuthorizationBearer, "Bearer token did not match OAuth token format and no SigNoz URL is available for legacy fallback")
 						m.setOAuthChallenge(w, `error="invalid_token", error_description="access token is invalid"`)
 						http.Error(w, "OAuth access token is invalid", http.StatusUnauthorized)
 						return
 					}
 					apiKey = token
+					authMode = authModeAuthorizationAPIKey
 					ctx = util.SetAPIKey(ctx, apiKey)
 					ctx = util.SetAuthHeader(ctx, "SIGNOZ-API-KEY")
 					m.logger.DebugContext(ctx, "Bearer token did not match OAuth token format, falling back to raw API key")
 				}
 			} else {
 				apiKey = token
+				authMode = authModeAuthorizationAPIKey
 				ctx = util.SetAPIKey(ctx, apiKey)
 				ctx = util.SetAuthHeader(ctx, "SIGNOZ-API-KEY")
 				m.logger.DebugContext(ctx, "Using API KEY token authentication via SIGNOZ-API-KEY header")
@@ -1254,11 +1335,12 @@ func (m *MCPServer) authMiddleware(next http.Handler) http.Handler {
 		} else if m.config.APIKey != "" {
 			// Fallback to config API key
 			apiKey = m.config.APIKey
+			authMode = authModeConfigAPIKey
 			ctx = util.SetAPIKey(ctx, apiKey)
 			ctx = util.SetAuthHeader(ctx, "SIGNOZ-API-KEY")
 			m.logger.DebugContext(ctx, "Using API key from environment config")
 		} else {
-			m.logger.WarnContext(ctx, "No API key found in headers or environment")
+			m.logAuthFailure(ctx, r, http.StatusUnauthorized, authFailureMissingCredential, authMode, "No API key found in headers or environment")
 			if m.config.OAuthEnabled {
 				m.setOAuthChallenge(w, "")
 			}
@@ -1271,6 +1353,7 @@ func (m *MCPServer) authMiddleware(next http.Handler) http.Handler {
 			if attr, ok := otelpkg.TenantURLAttr(ctx); ok {
 				trace.SpanFromContext(ctx).SetAttributes(attr)
 			}
+			decorateAuthSpan(ctx, r, authMode)
 			r = r.WithContext(ctx)
 			next.ServeHTTP(w, r)
 			return
@@ -1281,7 +1364,7 @@ func (m *MCPServer) authMiddleware(next http.Handler) http.Handler {
 			trimmed := strings.TrimSuffix(customURL, "/")
 			normalized, err := util.NormalizeSigNozURL(trimmed)
 			if err != nil {
-				m.logger.WarnContext(ctx, "Invalid X-SigNoz-URL header",
+				m.logAuthFailure(ctx, r, http.StatusBadRequest, authFailureInvalidSignozURL, authMode, "Invalid X-SigNoz-URL header",
 					slog.String("url", customURL), logpkg.ErrAttr(err))
 				http.Error(w, fmt.Sprintf("Invalid X-SigNoz-URL: %v", err), http.StatusBadRequest)
 				return
@@ -1292,7 +1375,7 @@ func (m *MCPServer) authMiddleware(next http.Handler) http.Handler {
 			signozURL = m.config.URL
 			m.logger.DebugContext(ctx, "Using URL from environment config", slog.String("mcp.tenant_url", signozURL))
 		} else {
-			m.logger.WarnContext(ctx, "No SigNoz URL found in X-SigNoz-URL header or environment")
+			m.logAuthFailure(ctx, r, http.StatusBadRequest, authFailureMissingSignozURL, authMode, "No SigNoz URL found in X-SigNoz-URL header or environment")
 			http.Error(w, "SigNoz instance URL is required", http.StatusBadRequest)
 			return
 		}
@@ -1304,6 +1387,7 @@ func (m *MCPServer) authMiddleware(next http.Handler) http.Handler {
 		if attr, ok := otelpkg.TenantURLAttr(ctx); ok {
 			trace.SpanFromContext(ctx).SetAttributes(attr)
 		}
+		decorateAuthSpan(ctx, r, authMode)
 
 		r = r.WithContext(ctx)
 		next.ServeHTTP(w, r)

--- a/internal/mcp-server/server_test.go
+++ b/internal/mcp-server/server_test.go
@@ -518,6 +518,234 @@ func TestAuthMiddlewareReturnsOAuthChallengeWhenMissingAuth(t *testing.T) {
 	}
 }
 
+func TestAuthMiddlewareLogsAndSpansAuthFailureTelemetry(t *testing.T) {
+	var buf lockedBuffer
+	logger := newBufferedLogger(&buf, slog.LevelDebug)
+	cfg := &config.Config{
+		OAuthEnabled:   true,
+		OAuthIssuerURL: "https://mcp.example.com",
+	}
+	server := &MCPServer{logger: logger, config: cfg, analytics: noopanalytics.New()}
+
+	spanRecorder := tracetest.NewSpanRecorder()
+	tracerProvider := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(spanRecorder))
+	ctx, span := tracerProvider.Tracer("test").Start(context.Background(), "HTTP POST /mcp")
+
+	req := httptest.NewRequest(http.MethodPost, "https://mcp.us.signoz.cloud/mcp", nil).WithContext(ctx)
+	req.RemoteAddr = "203.0.113.10:54321"
+	req.Header.Set("X-Forwarded-For", "198.51.100.7, 10.0.0.2")
+	req.Header.Set("User-Agent", "claude-code/2.1.133 (cli)")
+	req.Header.Set(util.HeaderMCPSessionID, "mcp-session-test")
+	rr := httptest.NewRecorder()
+
+	server.authMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Fatal("next handler should not be called")
+	})).ServeHTTP(rr, req)
+	span.End()
+
+	if rr.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want %d", rr.Code, http.StatusUnauthorized)
+	}
+
+	records := parseJSONLogLines(t, &buf)
+	if len(records) == 0 {
+		t.Fatal("expected auth failure log line")
+	}
+	rec := records[len(records)-1]
+	if rec["msg"] != "No API key found in headers or environment" {
+		t.Fatalf("msg = %v, want missing API key log", rec["msg"])
+	}
+	if rec["mcp.auth.failure_reason"] != authFailureMissingCredential {
+		t.Fatalf("mcp.auth.failure_reason = %v, want %s", rec["mcp.auth.failure_reason"], authFailureMissingCredential)
+	}
+	if rec["mcp.auth.mode"] != authModeNone {
+		t.Fatalf("mcp.auth.mode = %v, want %s", rec["mcp.auth.mode"], authModeNone)
+	}
+	if rec["http.response.status_code"] != float64(http.StatusUnauthorized) {
+		t.Fatalf("http.response.status_code = %v, want %d", rec["http.response.status_code"], http.StatusUnauthorized)
+	}
+	if rec["http.request.method"] != http.MethodPost {
+		t.Fatalf("http.request.method = %v, want POST", rec["http.request.method"])
+	}
+	if rec["url.path"] != "/mcp" {
+		t.Fatalf("url.path = %v, want /mcp", rec["url.path"])
+	}
+	if rec["server.address"] != "mcp.us.signoz.cloud" {
+		t.Fatalf("server.address = %v, want mcp.us.signoz.cloud", rec["server.address"])
+	}
+	if rec["client.address"] != "198.51.100.7" {
+		t.Fatalf("client.address = %v, want 198.51.100.7", rec["client.address"])
+	}
+	if rec["user_agent.original"] != "claude-code/2.1.133 (cli)" {
+		t.Fatalf("user_agent.original = %v, want claude-code user agent", rec["user_agent.original"])
+	}
+	if rec["mcp.session.id"] != "mcp-session-test" {
+		t.Fatalf("mcp.session.id = %v, want mcp-session-test", rec["mcp.session.id"])
+	}
+	if rec["mcp.client_source"] != util.ClientSourceUserClient {
+		t.Fatalf("mcp.client_source = %v, want %s", rec["mcp.client_source"], util.ClientSourceUserClient)
+	}
+
+	spans := spanRecorder.Ended()
+	if len(spans) != 1 {
+		t.Fatalf("ended spans = %d, want 1", len(spans))
+	}
+	attrs := spans[0].Attributes()
+	for key, want := range map[attribute.Key]string{
+		"mcp.auth.failure_reason": authFailureMissingCredential,
+		"mcp.auth.mode":           authModeNone,
+		"http.request.method":     http.MethodPost,
+		"url.path":                "/mcp",
+		"server.address":          "mcp.us.signoz.cloud",
+		"client.address":          "198.51.100.7",
+		"user_agent.original":     "claude-code/2.1.133 (cli)",
+		otelpkg.MCPSessionIDKey:   "mcp-session-test",
+	} {
+		got, ok := spanAttrValue(attrs, key)
+		if !ok {
+			t.Fatalf("span attr %s missing", key)
+		}
+		if got.AsString() != want {
+			t.Fatalf("span attr %s = %q, want %q", key, got.AsString(), want)
+		}
+	}
+	gotStatus, ok := spanAttrValue(attrs, "http.response.status_code")
+	if !ok {
+		t.Fatal("span attr http.response.status_code missing")
+	}
+	if gotStatus.AsInt64() != int64(http.StatusUnauthorized) {
+		t.Fatalf("span attr http.response.status_code = %d, want %d", gotStatus.AsInt64(), http.StatusUnauthorized)
+	}
+}
+
+func TestAuthMiddlewareAuthFailureTelemetryBranches(t *testing.T) {
+	const tokenSecret = "0123456789abcdef0123456789abcdef"
+	expiredToken, err := oauth.EncryptToken(
+		"oauth-api-key",
+		"https://oauth.example.com",
+		"client-1",
+		time.Now().UTC().Add(-time.Hour),
+		[]byte(tokenSecret),
+	)
+	if err != nil {
+		t.Fatalf("EncryptToken() error = %v", err)
+	}
+
+	tests := []struct {
+		name       string
+		cfg        config.Config
+		setup      func(*http.Request)
+		wantStatus int
+		wantReason string
+		wantMode   string
+	}{
+		{
+			name: "invalid OAuth bearer without fallback URL",
+			cfg: config.Config{
+				OAuthEnabled:     true,
+				OAuthTokenSecret: tokenSecret,
+				OAuthIssuerURL:   "https://mcp.example.com",
+			},
+			setup: func(req *http.Request) {
+				req.Header.Set("Authorization", "Bearer stale-token")
+			},
+			wantStatus: http.StatusUnauthorized,
+			wantReason: authFailureInvalidOAuthToken,
+			wantMode:   authModeAuthorizationBearer,
+		},
+		{
+			name: "expired OAuth bearer",
+			cfg: config.Config{
+				OAuthEnabled:     true,
+				OAuthTokenSecret: tokenSecret,
+				OAuthIssuerURL:   "https://mcp.example.com",
+			},
+			setup: func(req *http.Request) {
+				req.Header.Set("Authorization", "Bearer "+expiredToken)
+			},
+			wantStatus: http.StatusUnauthorized,
+			wantReason: authFailureExpiredOAuthToken,
+			wantMode:   authModeOAuthAccessToken,
+		},
+		{
+			name: "invalid SigNoz URL",
+			setup: func(req *http.Request) {
+				req.Header.Set("Authorization", "Bearer raw-api-key")
+				req.Header.Set("X-SigNoz-URL", "https://tenant.example.com/path")
+			},
+			wantStatus: http.StatusBadRequest,
+			wantReason: authFailureInvalidSignozURL,
+			wantMode:   authModeAuthorizationAPIKey,
+		},
+		{
+			name: "missing SigNoz URL",
+			setup: func(req *http.Request) {
+				req.Header.Set("SIGNOZ-API-KEY", "api-key")
+			},
+			wantStatus: http.StatusBadRequest,
+			wantReason: authFailureMissingSignozURL,
+			wantMode:   authModeSignozAPIKeyHeader,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var buf lockedBuffer
+			cfg := tt.cfg
+			server := &MCPServer{logger: newBufferedLogger(&buf, slog.LevelDebug), config: &cfg, analytics: noopanalytics.New()}
+
+			spanRecorder := tracetest.NewSpanRecorder()
+			tracerProvider := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(spanRecorder))
+			ctx, span := tracerProvider.Tracer("test").Start(context.Background(), "HTTP POST /mcp")
+
+			req := httptest.NewRequest(http.MethodPost, "https://mcp.example.com/mcp", nil).WithContext(ctx)
+			tt.setup(req)
+			rr := httptest.NewRecorder()
+
+			server.authMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				t.Fatal("next handler should not be called")
+			})).ServeHTTP(rr, req)
+			span.End()
+
+			if rr.Code != tt.wantStatus {
+				t.Fatalf("status = %d, want %d", rr.Code, tt.wantStatus)
+			}
+
+			records := parseJSONLogLines(t, &buf)
+			if len(records) == 0 {
+				t.Fatal("expected auth failure log line")
+			}
+			rec := records[len(records)-1]
+			if rec["mcp.auth.failure_reason"] != tt.wantReason {
+				t.Fatalf("log mcp.auth.failure_reason = %v, want %s", rec["mcp.auth.failure_reason"], tt.wantReason)
+			}
+			if rec["mcp.auth.mode"] != tt.wantMode {
+				t.Fatalf("log mcp.auth.mode = %v, want %s", rec["mcp.auth.mode"], tt.wantMode)
+			}
+
+			spans := spanRecorder.Ended()
+			if len(spans) != 1 {
+				t.Fatalf("ended spans = %d, want 1", len(spans))
+			}
+			attrs := spans[0].Attributes()
+			gotReason, ok := spanAttrValue(attrs, "mcp.auth.failure_reason")
+			if !ok {
+				t.Fatal("span attr mcp.auth.failure_reason missing")
+			}
+			if gotReason.AsString() != tt.wantReason {
+				t.Fatalf("span mcp.auth.failure_reason = %q, want %q", gotReason.AsString(), tt.wantReason)
+			}
+			gotMode, ok := spanAttrValue(attrs, "mcp.auth.mode")
+			if !ok {
+				t.Fatal("span attr mcp.auth.mode missing")
+			}
+			if gotMode.AsString() != tt.wantMode {
+				t.Fatalf("span mcp.auth.mode = %q, want %q", gotMode.AsString(), tt.wantMode)
+			}
+		})
+	}
+}
+
 func TestBuildHooks_APIKeyAnalyticsUseServiceAccountIdentity(t *testing.T) {
 	var requests atomic.Int32
 	sigNoz := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/oauth/handlers.go
+++ b/internal/oauth/handlers.go
@@ -502,12 +502,7 @@ func (h *Handler) recordOAuthFailure(ctx context.Context, r *http.Request, statu
 		slog.String("oauth.error_code", code),
 		slog.String("oauth.error_description", description),
 	}
-	if r != nil {
-		attrs = append(attrs,
-			slog.String("http.request.method", r.Method),
-			slog.String("url.path", r.URL.Path),
-		)
-	}
+	attrs = append(attrs, logpkg.HTTPRequestAttrs(r)...)
 
 	if h.meters != nil {
 		metricAttrs := []attribute.KeyValue{

--- a/internal/oauth/handlers_test.go
+++ b/internal/oauth/handlers_test.go
@@ -943,6 +943,9 @@ func TestWriteOAuthErrorLogsRequestMetadata(t *testing.T) {
 	handler := NewHandler(newBufferedLogger(&buf, slog.LevelDebug), cfg, nil, nil)
 	req := httptest.NewRequest(http.MethodPost, "/oauth/token", bytes.NewBufferString("grant_type=bogus"))
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("User-Agent", "claude-code/2.1.133 (cli)")
+	req.Header.Set("X-Forwarded-For", "198.51.100.8, 10.0.0.2")
+	req.Header.Set("Mcp-Session-Id", "mcp-session-oauth")
 	rr := httptest.NewRecorder()
 
 	handler.HandleToken(rr, req)
@@ -967,5 +970,14 @@ func TestWriteOAuthErrorLogsRequestMetadata(t *testing.T) {
 	}
 	if rec["url.path"] != "/oauth/token" {
 		t.Fatalf("url.path = %v, want /oauth/token", rec["url.path"])
+	}
+	if rec["client.address"] != "198.51.100.8" {
+		t.Fatalf("client.address = %v, want 198.51.100.8", rec["client.address"])
+	}
+	if rec["user_agent.original"] != "claude-code/2.1.133 (cli)" {
+		t.Fatalf("user_agent.original = %v, want claude-code user agent", rec["user_agent.original"])
+	}
+	if _, ok := rec["mcp.session.id"]; ok {
+		t.Fatalf("mcp.session.id = %v, want field omitted for OAuth request logs", rec["mcp.session.id"])
 	}
 }

--- a/pkg/log/http.go
+++ b/pkg/log/http.go
@@ -1,0 +1,46 @@
+package log
+
+import (
+	"log/slog"
+	"net/http"
+
+	"github.com/SigNoz/signoz-mcp-server/pkg/util"
+)
+
+// HTTPRequestAttrs returns stable request metadata for logs. It intentionally
+// excludes query strings and auth material.
+func HTTPRequestAttrs(r *http.Request) []slog.Attr {
+	return httpRequestAttrs(r, false)
+}
+
+// MCPHTTPRequestAttrs returns stable request metadata plus the MCP session
+// header. Use it only on /mcp-scoped request logs.
+func MCPHTTPRequestAttrs(r *http.Request) []slog.Attr {
+	return httpRequestAttrs(r, true)
+}
+
+func httpRequestAttrs(r *http.Request, includeMCPSession bool) []slog.Attr {
+	if r == nil {
+		return nil
+	}
+
+	attrs := []slog.Attr{
+		slog.String("http.request.method", r.Method),
+	}
+	if r.URL != nil && r.URL.Path != "" {
+		attrs = append(attrs, slog.String("url.path", r.URL.Path))
+	}
+	if serverAddress := util.HTTPServerAddress(r); serverAddress != "" {
+		attrs = append(attrs, slog.String("server.address", serverAddress))
+	}
+	if clientAddress := util.HTTPClientAddress(r); clientAddress != "" {
+		attrs = append(attrs, slog.String("client.address", clientAddress))
+	}
+	if userAgent := util.HTTPUserAgent(r); userAgent != "" {
+		attrs = append(attrs, slog.String("user_agent.original", userAgent))
+	}
+	if sessionID := util.HTTPSessionID(r); includeMCPSession && sessionID != "" {
+		attrs = append(attrs, slog.String("mcp.session.id", sessionID))
+	}
+	return attrs
+}

--- a/pkg/util/http.go
+++ b/pkg/util/http.go
@@ -1,0 +1,102 @@
+package util
+
+import (
+	"net"
+	"net/http"
+	"net/netip"
+	"strings"
+)
+
+const HeaderMCPSessionID = "Mcp-Session-Id"
+
+// HTTPClientAddress returns the best available client address for request
+// telemetry. It prefers forwarded headers because production traffic reaches
+// the server through ingress/proxy layers.
+func HTTPClientAddress(r *http.Request) string {
+	if r == nil {
+		return ""
+	}
+	if forwardedFor := r.Header.Get("X-Forwarded-For"); forwardedFor != "" {
+		if client := normalizeClientAddress(strings.Split(forwardedFor, ",")[0]); client != "" {
+			return client
+		}
+	}
+	if realIP := normalizeClientAddress(r.Header.Get("X-Real-IP")); realIP != "" {
+		return realIP
+	}
+	if host, _, err := net.SplitHostPort(r.RemoteAddr); err == nil {
+		if client := normalizeClientAddress(host); client != "" {
+			return client
+		}
+	}
+	return NormalizeCallerCorrelationValue(r.RemoteAddr)
+}
+
+// HTTPServerAddress returns the host handling the request without a port.
+func HTTPServerAddress(r *http.Request) string {
+	if r == nil {
+		return ""
+	}
+	host := forwardedHost(r.Header.Get("Forwarded"))
+	if host == "" {
+		host = firstHeaderValue(r.Header.Get("X-Forwarded-Host"))
+	}
+	if host == "" {
+		host = r.Host
+	}
+	if host == "" && r.URL != nil {
+		host = r.URL.Host
+	}
+	return normalizeServerAddress(host)
+}
+
+func normalizeServerAddress(host string) string {
+	host = strings.TrimSpace(host)
+	host = strings.Trim(host, "\"")
+	if splitHost, _, err := net.SplitHostPort(host); err == nil {
+		host = splitHost
+	}
+	return NormalizeCallerCorrelationValue(strings.Trim(host, " []\""))
+}
+
+// HTTPUserAgent returns a bounded user-agent value for request telemetry.
+func HTTPUserAgent(r *http.Request) string {
+	if r == nil {
+		return ""
+	}
+	return NormalizeCallerCorrelationValue(r.UserAgent())
+}
+
+// HTTPSessionID returns the MCP session ID header after basic normalization.
+func HTTPSessionID(r *http.Request) string {
+	if r == nil {
+		return ""
+	}
+	return NormalizeCallerCorrelationValue(r.Header.Get(HeaderMCPSessionID))
+}
+
+func normalizeClientAddress(s string) string {
+	s = strings.Trim(strings.TrimSpace(s), "\"[]")
+	if host, _, err := net.SplitHostPort(s); err == nil {
+		s = strings.Trim(host, "[]")
+	}
+	if _, err := netip.ParseAddr(s); err != nil {
+		return ""
+	}
+	return s
+}
+
+func firstHeaderValue(s string) string {
+	return strings.TrimSpace(strings.Split(s, ",")[0])
+}
+
+func forwardedHost(header string) string {
+	for _, field := range strings.Split(firstHeaderValue(header), ";") {
+		key, value, ok := strings.Cut(strings.TrimSpace(field), "=")
+		if !ok || !strings.EqualFold(key, "host") {
+			continue
+		}
+		return strings.TrimSpace(value)
+	}
+	return ""
+}

--- a/pkg/util/http_test.go
+++ b/pkg/util/http_test.go
@@ -1,0 +1,78 @@
+package util
+
+import (
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestHTTPClientAddressValidatesForwardedHeaders(t *testing.T) {
+	req := httptest.NewRequest("POST", "https://internal.example/mcp", nil)
+	req.RemoteAddr = "203.0.113.10:54321"
+	req.Header.Set("X-Forwarded-For", "not-an-ip, 198.51.100.1")
+	req.Header.Set("X-Real-IP", "198.51.100.7")
+
+	if got := HTTPClientAddress(req); got != "198.51.100.7" {
+		t.Fatalf("HTTPClientAddress() = %q, want X-Real-IP fallback", got)
+	}
+
+	req.Header.Set("X-Forwarded-For", "198.51.100.9, 198.51.100.1")
+	if got := HTTPClientAddress(req); got != "198.51.100.9" {
+		t.Fatalf("HTTPClientAddress() = %q, want first valid X-Forwarded-For value", got)
+	}
+}
+
+func TestHTTPServerAddressPrefersForwardedHost(t *testing.T) {
+	req := httptest.NewRequest("POST", "https://internal.example/mcp", nil)
+	req.Host = "internal.service.local:8080"
+	req.Header.Set("X-Forwarded-Host", "mcp.us.signoz.cloud, proxy.local")
+
+	if got := HTTPServerAddress(req); got != "mcp.us.signoz.cloud" {
+		t.Fatalf("HTTPServerAddress() = %q, want forwarded host", got)
+	}
+
+	req.Header.Del("X-Forwarded-Host")
+	req.Header.Set("Forwarded", `for=198.51.100.9;proto=https;host="mcp.eu.signoz.cloud"`)
+	if got := HTTPServerAddress(req); got != "mcp.eu.signoz.cloud" {
+		t.Fatalf("HTTPServerAddress() = %q, want RFC Forwarded host", got)
+	}
+}
+
+func TestHTTPServerAddressNormalizesQuotedForwardedHostPort(t *testing.T) {
+	tests := []struct {
+		name      string
+		forwarded string
+		want      string
+	}{
+		{
+			name:      "hostname with port",
+			forwarded: `for=198.51.100.9;proto=https;host="mcp.us.signoz.cloud:443"`,
+			want:      "mcp.us.signoz.cloud",
+		},
+		{
+			name:      "bracketed IPv6 with port",
+			forwarded: `for=198.51.100.9;proto=https;host="[2001:db8::1]:443"`,
+			want:      "2001:db8::1",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest("POST", "https://internal.example/mcp", nil)
+			req.Header.Set("Forwarded", tt.forwarded)
+
+			if got := HTTPServerAddress(req); got != tt.want {
+				t.Fatalf("HTTPServerAddress() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestHTTPUserAgentIsBounded(t *testing.T) {
+	req := httptest.NewRequest("POST", "https://mcp.example.com/mcp", nil)
+	req.Header.Set("User-Agent", strings.Repeat("a", CallerCorrelationHeaderMaxLen+10))
+
+	if got := HTTPUserAgent(req); len(got) != CallerCorrelationHeaderMaxLen {
+		t.Fatalf("HTTPUserAgent() length = %d, want %d", len(got), CallerCorrelationHeaderMaxLen)
+	}
+}

--- a/plans/auth-failure-telemetry.context.md
+++ b/plans/auth-failure-telemetry.context.md
@@ -1,0 +1,35 @@
+# Feature: MCP Auth Failure Telemetry - Context & Discussion
+
+## Original Prompt
+> An user reported
+>
+> lichu@frontec.ai https://massive-leech.us.signoz.cloud
+> May 8, 9:54:29 PM> when i connect the signoz MCP to claude code, it connects correctly but IMMEDIATELY disconnects. I don't understand what's happening and it's very annoying
+>
+> Investigate this, all telemetry data is available on nightswatch
+>
+> Ok let's improve telemetry
+
+## Reference Links
+- None
+
+## Key Decisions & Discussion Log
+### 2026-05-11 - Initial investigation
+- Live telemetry showed healthy long-lived MCP streams for the tenant and repeated unauthenticated `/mcp` requests from the same client shape.
+- The code should make unauthenticated `/mcp` rejects easier to diagnose by logging auth mode, failure reason, request path, server host, client address, user agent, and MCP session ID when present.
+
+### 2026-05-11 - Multi-agent review follow-up
+- Review flagged that unauthenticated request metadata must be bounded and sanitized because it is sourced from request headers.
+- Review also flagged that OAuth request logs should not copy MCP session headers because OAuth endpoints are not MCP session scoped.
+- Review asked for E2E coverage through the real HTTP handler and `otelhttp` root span, not only direct middleware unit tests.
+
+### 2026-05-11 - Verification
+- Added unit and E2E-style coverage for `/mcp` auth failure logs and spans, request metadata normalization, and OAuth request metadata boundaries.
+- Verified with targeted E2E, touched-package tests, and the full `go test ./...` suite.
+
+### 2026-05-12 - PR review: quoted forwarded host normalization
+- Codex review flagged that quoted RFC `Forwarded` host parameters with ports were split before quote removal.
+- Fixed `server.address` normalization to remove surrounding quotes before stripping ports, and added coverage for quoted hostname and bracketed IPv6 host values with ports.
+
+## Open Questions
+- [x] Should OAuth failure logs include `mcp.session.id` if a caller sends that header? Answer: no; only `/mcp` request logs should include MCP session IDs.

--- a/plans/auth-failure-telemetry.plan.md
+++ b/plans/auth-failure-telemetry.plan.md
@@ -1,0 +1,30 @@
+# Plan: MCP Auth Failure Telemetry
+
+## Status
+Done
+
+## Context
+Some Claude Code connection failures currently appear to users as immediate disconnects, while the server only reports a generic missing credential response. We need enough structured log and span metadata on `/mcp` auth failures to identify whether a client is missing credentials, presenting a stale OAuth token, sending an invalid SigNoz URL, or falling into another auth branch.
+
+## Approach
+- Add bounded HTTP request metadata helpers for `server.address`, `client.address`, `user_agent.original`, and MCP session ID.
+- Decorate `/mcp` auth failure logs and the `otelhttp` root span with `mcp.auth.mode`, `mcp.auth.failure_reason`, status, and request metadata.
+- Keep OAuth failure logs on generic request metadata only, without MCP session IDs.
+- Validate forwarded client addresses before recording them and bound user-agent/header-derived values.
+- Add unit coverage for the helpers and auth failure log/span metadata.
+- Add an E2E-style test that exercises the real HTTP mux and `otelhttp` stack for an unauthenticated `/mcp` request.
+
+## Files to Modify
+- `internal/mcp-server/server.go` - decorate auth failures with structured log and span attributes.
+- `internal/mcp-server/server_test.go` - cover middleware auth-failure telemetry.
+- `internal/mcp-server/e2e_docs_test.go` - cover the real HTTP stack and root span.
+- `internal/oauth/handlers.go` - reuse generic request metadata in OAuth failure logs.
+- `internal/oauth/handlers_test.go` - cover OAuth request metadata without MCP session leakage.
+- `pkg/util/http.go` - centralize bounded HTTP metadata extraction.
+- `pkg/util/http_test.go` - cover forwarded address, server host, and user-agent normalization.
+- `pkg/log/http.go` - centralize structured request log attributes.
+
+## Verification
+- `go test ./internal/mcp-server -run 'TestE2E(AuthFailureTelemetry|DocsAgentFlow)' -count=1`
+- `go test ./internal/mcp-server ./internal/oauth ./pkg/util ./pkg/log`
+- `go test ./...`


### PR DESCRIPTION
## Summary
- add structured auth-mode and failure-reason telemetry for `/mcp` auth rejects
- centralize bounded request metadata helpers for server address, client address, user agent, and MCP session ID
- keep OAuth failure logs on generic request metadata so fake MCP session IDs do not leak into OAuth logs
- add the required plan/context files for the telemetry change

## Why
A user reported Claude Code connecting to hosted MCP and immediately disconnecting. Live telemetry pointed at repeated unauthenticated `/mcp` requests, but the server logs were too generic to quickly tell which auth branch failed.

## Validation
- `go test ./internal/mcp-server -run 'TestE2E(AuthFailureTelemetry|DocsAgentFlow)|TestAuthMiddlewareAuthFailureTelemetryBranches' -count=1`\n- `go test ./internal/mcp-server ./internal/oauth ./pkg/util ./pkg/log`\n- `go test ./...`\n- `git diff --check`