### PR TITLE
fix: cache SigNoz clients by URL for connection reuse (#69)

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -99,11 +99,11 @@ subgraph GetClient["GetClient — Unified for Both Transports"]
     READ --> MISSING{"Both present?"}
 
     MISSING -->|No| ERR["Return error"]
-    MISSING -->|Yes| HASH["cacheKey = SHA256(apiKey + delimiter + signozURL)"]
+    MISSING -->|Yes| HASH["cacheKey = lowercase(signozURL)"]
 
     HASH --> LOOKUP{"clientCache LRU hit?"}
-    LOOKUP -->|Yes| HIT["Return cached client"]
-    LOOKUP -->|No| CREATE["Create new SigNoz client and cache it"]
+    LOOKUP -->|Yes| HIT["Return cached client (shared across API keys)"]
+    LOOKUP -->|No| CREATE["Create new credential-free SigNoz client and cache it"]
 
     CREATE --> HIT
 end
@@ -114,7 +114,7 @@ end
 
 subgraph APICall["SigNoz API Call"]
     CLIENT["SigNoz Client<br/>(otelhttp instrumented)"]
-    CLIENT --> APIREQ["HTTP Request with SIGNOZ-API-KEY header"]
+    CLIENT --> APIREQ["HTTP Request — auth header set<br/>per-request from ctx credentials"]
     APIREQ --> S1["SigNoz Instance 1"]
     APIREQ --> S2["SigNoz Instance 2"]
     APIREQ --> SN["SigNoz Instance N"]
@@ -126,6 +126,18 @@ HIT --> CLIENT
 
 LOOKUP -.->|read/write| LRU_C
 ```
+
+## Client Caching
+
+`GetClient` caches one `SigNoz` client per `signozURL` (case-insensitive), in a bounded
+expirable LRU. The client is **credential-free**: it does not store the API key or auth
+header. Instead, those are read from the request context and stamped onto each outbound
+request at send time. This lets multiple API keys targeting the same SigNoz URL share a
+single client — and therefore a single HTTP connection pool — maximizing connection reuse.
+
+A request with no API key in context fails closed (errors before any HTTP call) rather than
+sending an unauthenticated request. The analytics identity cache (`/me` lookups) lives on the
+shared client but is keyed per credential, so attribution stays correct across API keys.
 
 ## OAuth 2.1 — Stateless Token Design
 

--- a/docs/superpowers/plans/2026-06-04-client-cache-by-url.md
+++ b/docs/superpowers/plans/2026-06-04-client-cache-by-url.md
@@ -1,0 +1,700 @@
+# Cache SigNoz Clients by URL Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Cache one `SigNoz` client (and its connection pool) per `signozURL`, shared across API keys, by reading per-request credentials from context instead of baking them into the client.
+
+**Architecture:** Remove `apiKey`/`authHeaderName` from the `SigNoz` struct; `doRequest` and `doValidationRequest` read them from the request context (fail closed if absent). The handler cache keys on the URL alone. The per-client analytics identity cache becomes a per-credential map so attribution stays correct.
+
+**Tech Stack:** Go 1.25, `net/http`, `hashicorp/golang-lru/v2/expirable`, `slog`, `testify`.
+
+Spec: `docs/superpowers/specs/2026-06-04-client-cache-by-url-design.md`. Issue: [#69](https://github.com/SigNoz/signoz-mcp-server/issues/69).
+
+---
+
+## File Structure
+
+- `pkg/util/context.go` — rename `HashTenantKey(apiKey, signozURL)` → `HashCredential(apiKey, authHeader)` (same SHA-256 body).
+- `internal/client/client.go` — drop `apiKey`/`authHeaderName` from struct + `NewClient`; read creds from ctx in `doRequest`/`doValidationRequest`; per-credential identity cache.
+- `internal/handler/tools/handler.go` — cache key = `strings.ToLower(signozURL)`; updated `NewClient` call.
+- `internal/oauth/handlers.go` — `validateSigNozCredentials` seeds ctx with creds before calling `ValidateCredentials`.
+- `internal/client/client_test.go` — migrate ~40 `NewClient` call sites to 3-arg form + credentialed ctx; add per-credential identity-cache test.
+- `docs/architecture.md` — update caching description.
+
+> **Note on TDD ordering:** because the `NewClient` signature changes, the package will not compile until Task 2 + Task 6 are both done. Tasks 1–6 form one compile unit; run the full `go build ./...` / `go test ./internal/client/...` only at the checkpoints noted. Commit per task regardless (a red build mid-sequence is expected and called out).
+
+---
+
+### Task 1: Rename `HashTenantKey` → `HashCredential`
+
+**Files:**
+- Modify: `pkg/util/context.go:138-146`
+- Test: `pkg/util/` (add if a context_test.go exists; otherwise skip — pure rename)
+
+- [ ] **Step 1: Rename the function and update its doc comment**
+
+In `pkg/util/context.go`, replace the existing `HashTenantKey`:
+
+```go
+// HashCredential returns a SHA-256 hash of apiKey and authHeader, suitable for
+// use as a map key without exposing the raw API key in memory. A null-byte
+// separator prevents collisions between pairs that contain colons.
+func HashCredential(apiKey, authHeader string) string {
+	h := sha256.Sum256([]byte(apiKey + "\x00" + authHeader))
+	return hex.EncodeToString(h[:])
+}
+```
+
+- [ ] **Step 2: Verify no other references remain**
+
+Run: `grep -rn "HashTenantKey" --include="*.go" .`
+Expected: no output (the only caller, `handler.go`, is rewritten in Task 5).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add pkg/util/context.go
+git commit -m "refactor(util): rename HashTenantKey to HashCredential"
+```
+
+---
+
+### Task 2: Drop baked-in credentials from the `SigNoz` struct and `NewClient`
+
+**Files:**
+- Modify: `internal/client/client.go:55-87`
+
+> This task intentionally leaves the package non-compiling (the `s.apiKey` / `s.authHeaderName` references in `doRequest`/`doValidationRequest`/`fetchAnalyticsIdentity` and the identity-cache fields are fixed in Tasks 3–4). Commit anyway.
+
+- [ ] **Step 1: Edit the struct — remove `apiKey`, `authHeaderName`, `cachedIdentity`, `identityCachedAt`; add the identity map**
+
+Replace the `SigNoz` struct (lines 55-67) with:
+
+```go
+type SigNoz struct {
+	baseURL       string
+	logger        *slog.Logger
+	httpClient    *http.Client
+	customHeaders map[string]string
+
+	identityMu    sync.Mutex
+	identityCache map[string]identityEntry // key: util.HashCredential(apiKey, authHeader)
+	meters        *otelpkg.Meters
+}
+
+// identityEntry is one cached analytics identity with its fetch time, so the
+// per-credential cache can expire entries independently.
+type identityEntry struct {
+	identity *AnalyticsIdentity
+	cachedAt time.Time
+}
+```
+
+- [ ] **Step 2: Edit `NewClient` — drop `apiKey`/`authHeaderName` params, init the map**
+
+Replace the `NewClient` signature and body (lines 69-87):
+
+```go
+func NewClient(log *slog.Logger, baseURL string, customHeaders map[string]string) *SigNoz {
+	return &SigNoz{
+		logger:        log,
+		baseURL:       baseURL,
+		customHeaders: customHeaders,
+		identityCache: make(map[string]identityEntry),
+		httpClient: &http.Client{
+			// Default client span name is just the HTTP method (per OTel HTTP
+			// semconv — the client doesn't know a templated route). We keep
+			// the default rather than stamping the raw path because several
+			// SigNoz API paths embed IDs (/dashboards/{uuid}, /rules/{id},
+			// /channels/{id}, /explorer/views/{id}, /rules/{id}/history/...)
+			// which would blow up span-name cardinality in the backend. The
+			// full URL is still attached as a span attribute for drilling.
+			Transport: otelhttp.NewTransport(http.DefaultTransport),
+		},
+	}
+}
+```
+
+- [ ] **Step 3: Add the util import if not present**
+
+Check the import block already has `"github.com/SigNoz/signoz-mcp-server/pkg/util"` (it does — used by `ensureTenantContext`). No change needed.
+
+- [ ] **Step 4: Commit (build still red — expected)**
+
+```bash
+git add internal/client/client.go
+git commit -m "refactor(client): remove baked-in credentials from SigNoz struct"
+```
+
+---
+
+### Task 3: Read credentials from context in the two request senders
+
+**Files:**
+- Modify: `internal/client/client.go` — `doValidationRequest` (~239-270) and `doRequest` (~298-338)
+
+- [ ] **Step 1: Add a small credential resolver near the senders**
+
+Add this helper above `doValidationRequest`:
+
+```go
+// credentialsFromContext pulls the per-request API key and auth header from
+// ctx. The auth header defaults to SIGNOZ-API-KEY (matching the handler's
+// fallback). An empty apiKey is an error: we fail closed rather than send an
+// unauthenticated request, since the client no longer stores a credential.
+func credentialsFromContext(ctx context.Context) (apiKey, authHeader string, err error) {
+	apiKey, _ = util.GetAPIKey(ctx)
+	authHeader, _ = util.GetAuthHeader(ctx)
+	if authHeader == "" {
+		authHeader = SignozApiKey
+	}
+	if apiKey == "" {
+		return "", "", errors.New("missing API key in request context")
+	}
+	return apiKey, authHeader, nil
+}
+```
+
+(`SignozApiKey` is the existing const `"SIGNOZ-API-KEY"` at client.go:26. `errors` is already imported.)
+
+- [ ] **Step 2: Update `doValidationRequest` to use ctx creds**
+
+Replace the header-stamping block (currently lines 245-252):
+
+```go
+	apiKey, authHeader, err := credentialsFromContext(ctx)
+	if err != nil {
+		return 0, nil, err
+	}
+
+	req.Header.Set(ContentType, "application/json")
+	req.Header.Set(authHeader, apiKey)
+
+	for k, v := range s.customHeaders {
+		if !strings.EqualFold(k, ContentType) && !strings.EqualFold(k, authHeader) {
+			req.Header.Set(k, v)
+		}
+	}
+```
+
+(The `err` from `credentialsFromContext` shadows nothing — `req, err :=` is above it; reuse `err =` if Go complains about redeclaration, i.e. write `apiKey, authHeader, err := ...` only if `err` is not already in scope at that point. It is in scope from `http.NewRequestWithContext`, so use `var apiKey, authHeader string; apiKey, authHeader, err = credentialsFromContext(ctx)` OR simply `apiKey, authHeader, credErr := credentialsFromContext(ctx); if credErr != nil { return 0, nil, credErr }`. Use the `credErr` form to avoid the shadowing question.)
+
+Final form for clarity:
+
+```go
+	apiKey, authHeader, credErr := credentialsFromContext(ctx)
+	if credErr != nil {
+		return 0, nil, credErr
+	}
+
+	req.Header.Set(ContentType, "application/json")
+	req.Header.Set(authHeader, apiKey)
+
+	for k, v := range s.customHeaders {
+		if !strings.EqualFold(k, ContentType) && !strings.EqualFold(k, authHeader) {
+			req.Header.Set(k, v)
+		}
+	}
+```
+
+- [ ] **Step 3: Update `doRequest` to use ctx creds**
+
+In `doRequest`, resolve credentials once before the retry loop (after the body-buffering block, before `for attempt := range maxRetries`):
+
+```go
+	apiKey, authHeader, credErr := credentialsFromContext(ctx)
+	if credErr != nil {
+		return nil, credErr
+	}
+```
+
+Then replace the in-loop header block (currently lines 327-338):
+
+```go
+		req.Header.Set(ContentType, "application/json")
+		req.Header.Set(authHeader, apiKey)
+
+		for k, v := range s.customHeaders {
+			if strings.EqualFold(k, ContentType) || strings.EqualFold(k, authHeader) {
+				s.logger.WarnContext(ctx, "Custom header overrides a reserved header",
+					slog.String("header", k), slog.String("value", v))
+				continue
+			}
+			req.Header.Set(k, v)
+		}
+```
+
+- [ ] **Step 4: Commit (build still red until Task 4 — expected)**
+
+```bash
+git add internal/client/client.go
+git commit -m "refactor(client): stamp auth header from request context"
+```
+
+---
+
+### Task 4: Make the analytics identity cache per-credential
+
+**Files:**
+- Modify: `internal/client/client.go` — `GetAnalyticsIdentity` (~143-168), `fetchAnalyticsIdentity` (~170-200)
+
+- [ ] **Step 1: Rewrite `GetAnalyticsIdentity` to key the cache by credential**
+
+Replace the body of `GetAnalyticsIdentity` (from `ctx = s.ensureTenantContext(ctx)` through the final `return`):
+
+```go
+func (s *SigNoz) GetAnalyticsIdentity(ctx context.Context) (*AnalyticsIdentity, error) {
+	ctx = s.ensureTenantContext(ctx)
+
+	apiKey, authHeader, credErr := credentialsFromContext(ctx)
+	if credErr != nil {
+		return nil, credErr
+	}
+	cacheKey := util.HashCredential(apiKey, authHeader)
+
+	s.identityMu.Lock()
+	defer s.identityMu.Unlock()
+
+	if entry, ok := s.identityCache[cacheKey]; ok && time.Since(entry.cachedAt) < analyticsIdentityCacheTTL {
+		if s.meters != nil {
+			attrs := otelpkg.AppendTenantURL(ctx, nil)
+			s.meters.IdentityCacheHits.Add(ctx, 1, metric.WithAttributes(attrs...))
+		}
+		return entry.identity, nil
+	}
+	if s.meters != nil {
+		attrs := otelpkg.AppendTenantURL(ctx, nil)
+		s.meters.IdentityCacheMisses.Add(ctx, 1, metric.WithAttributes(attrs...))
+	}
+
+	identity, err := s.fetchAnalyticsIdentity(ctx, authHeader)
+	if err != nil {
+		return nil, err
+	}
+
+	s.identityCache[cacheKey] = identityEntry{identity: identity, cachedAt: time.Now()}
+	return identity, nil
+}
+```
+
+- [ ] **Step 2: Update `fetchAnalyticsIdentity` to take the auth header explicitly**
+
+Change the signature and endpoint selection (replace `func (s *SigNoz) fetchAnalyticsIdentity(ctx context.Context)` and the `strings.EqualFold(s.authHeaderName, ...)` block):
+
+```go
+func (s *SigNoz) fetchAnalyticsIdentity(ctx context.Context, authHeader string) (*AnalyticsIdentity, error) {
+	ctx = s.ensureTenantContext(ctx)
+	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+
+	endpoint := "/api/v1/service_accounts/me"
+	principal := "service_account"
+	if strings.EqualFold(authHeader, "Authorization") {
+		endpoint = "/api/v2/users/me"
+		principal = "user"
+	}
+	// ... rest unchanged (reqURL, doValidationRequest, parse) ...
+```
+
+Passing `authHeader` explicitly (rather than re-reading ctx) guarantees the endpoint matches the credential used for the cache key — same value, no second default applied.
+
+- [ ] **Step 3: Build the client package**
+
+Run: `go build ./internal/client/...`
+Expected: success (package compiles again).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add internal/client/client.go
+git commit -m "refactor(client): key analytics identity cache by credential"
+```
+
+---
+
+### Task 5: Cache clients by URL in the handler
+
+**Files:**
+- Modify: `internal/handler/tools/handler.go:81,96`
+
+- [ ] **Step 1: Replace the cache key and `NewClient` call**
+
+In `GetClient`, replace line 81:
+
+```go
+	cacheKey := strings.ToLower(signozURL)
+```
+
+And the `NewClient` call (line 96):
+
+```go
+	newClient := signozclient.NewClient(h.logger, signozURL, headers)
+```
+
+Leave the `apiKey == "" || signozURL == ""` guard, the `authHeader` default, and the custom-header URL gate untouched. (`authHeader` is now unused locally after this change — remove the `authHeader, _ := util.GetAuthHeader(ctx)` line and the `if authHeader == "" {...}` block, since the client reads it from ctx itself. Keep `apiKey` for the guard.)
+
+- [ ] **Step 2: Build**
+
+Run: `go build ./...`
+Expected: success.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add internal/handler/tools/handler.go
+git commit -m "feat(handler): cache SigNoz clients by URL for connection reuse"
+```
+
+---
+
+### Task 6: Seed context in the OAuth validation path
+
+**Files:**
+- Modify: `internal/oauth/handlers.go:297-308`
+
+- [ ] **Step 1: Seed apiKey + auth header into ctx before validation**
+
+Replace the body of `validateSigNozCredentials`:
+
+```go
+func (h *Handler) validateSigNozCredentials(ctx context.Context, signozURL, apiKey string) error {
+	// Only forward custom headers when the user-supplied URL matches the
+	// configured SIGNOZ_URL to prevent leaking proxy-auth credentials to
+	// attacker-controlled hosts.
+	var headers map[string]string
+	configNormalized, _ := util.NormalizeSigNozURL(h.config.URL)
+	if strings.EqualFold(signozURL, configNormalized) {
+		headers = h.config.CustomHeaders
+	}
+
+	// The client reads credentials from context, so seed them here — the OAuth
+	// flow received them as form fields / decrypted grants, not on the context.
+	ctx = util.SetAPIKey(ctx, apiKey)
+	ctx = util.SetAuthHeader(ctx, "SIGNOZ-API-KEY")
+
+	signozClient := client.NewClient(h.logger, signozURL, headers)
+	return signozClient.ValidateCredentials(ctx)
+}
+```
+
+- [ ] **Step 2: Confirm `util` is imported in handlers.go**
+
+Run: `grep -n '"github.com/SigNoz/signoz-mcp-server/pkg/util"' internal/oauth/handlers.go`
+Expected: a match (it is already imported — used by `NormalizeSigNozURL`).
+
+- [ ] **Step 3: Build**
+
+Run: `go build ./...`
+Expected: success.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add internal/oauth/handlers.go
+git commit -m "fix(oauth): seed request context credentials for validation"
+```
+
+---
+
+### Task 7: Add a credentialed-context test helper and migrate client tests
+
+**Files:**
+- Modify: `internal/client/client_test.go` (all ~40 `NewClient` call sites + ctx usage)
+
+- [ ] **Step 1: Add a test helper for a credentialed context**
+
+Add near the top of `client_test.go` (after imports):
+
+```go
+// credCtx returns a context carrying the credentials the client now reads at
+// request time. Defaults match the old baked-in test values.
+func credCtx() context.Context {
+	ctx := util.SetAPIKey(context.Background(), "test-api-key")
+	return util.SetAuthHeader(ctx, "SIGNOZ-API-KEY")
+}
+
+// credCtxFor returns a credentialed context for a specific apiKey/authHeader,
+// used by tests that exercise the Authorization (user-token) path.
+func credCtxFor(apiKey, authHeader string) context.Context {
+	ctx := util.SetAPIKey(context.Background(), apiKey)
+	return util.SetAuthHeader(ctx, authHeader)
+}
+```
+
+Add `"github.com/SigNoz/signoz-mcp-server/pkg/util"` to the test imports.
+
+- [ ] **Step 2: Migrate all `NewClient` calls to the 3-arg form**
+
+Run a mechanical replacement, then fix the credential-bearing call sites:
+
+```bash
+# Drop the apiKey + authHeader args from every NewClient(...) in the test file.
+# Do this by hand or with gofmt-safe sed; verify with the build afterward.
+grep -n "NewClient(" internal/client/client_test.go
+```
+
+For each call `NewClient(logger, server.URL, "test-api-key", "SIGNOZ-API-KEY", nil)` →
+`NewClient(logger, server.URL, nil)`: drop the 3rd (apiKey) and 4th (authHeader) args, keep
+the final headers arg as-is. The three call sites that pass a non-nil headers value — lines
+**1667** and **1729** (`customHeaders`) and **1702** (`map[string]string{}`) — must keep that
+final arg: e.g. `NewClient(logger, server.URL, customHeaders)`.
+
+- [ ] **Step 3: Replace `context.Background()` with credentialed ctx at request call sites**
+
+Every `client.<Method>(context.Background(), ...)` and `c.doRequest(context.Background(), ...)` becomes `...(credCtx(), ...)`. For the `ctx := context.Background()` locals (lines 104, 621, 741, 870, 1056, 1221, 1283, 1426, 1527), change to `ctx := credCtx()`.
+
+For the cancellation test (line 1598, `ctx, cancel := context.WithCancel(context.Background())`), wrap the credentialed base: `ctx, cancel := context.WithCancel(credCtx())`.
+
+- [ ] **Step 4: Fix the auth-header-varying identity tests to set creds on ctx**
+
+In `TestGetAnalyticsIdentity` (lines ~355-377), the `NewClient(logger, server.URL, apiKey, tt.authHeaderName, nil)` becomes `NewClient(logger, server.URL, nil)`, and the call becomes:
+
+```go
+			client := NewClient(logger, server.URL, nil)
+			apiKey := "test-api-key"
+			if tt.authHeaderName == "Authorization" {
+				apiKey = "Bearer jwt-token"
+			}
+			identity, err := client.GetAnalyticsIdentity(credCtxFor(apiKey, tt.authHeaderName))
+```
+
+In `TestGetAnalyticsIdentity_CachesResult` and `..._ConcurrentCallsDedupe`, replace `NewClient(logger, server.URL, "Bearer jwt", "Authorization", nil)` with `NewClient(logger, server.URL, nil)` and pass `credCtxFor("Bearer jwt", "Authorization")` to each `GetAnalyticsIdentity` call.
+
+- [ ] **Step 5: Run the client tests**
+
+Run: `go test ./internal/client/... -count=1`
+Expected: PASS. (If a request test asserts `r.Header.Get("SIGNOZ-API-KEY") == "test-api-key"`, it still passes because `credCtx()` carries that value.)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/client/client_test.go
+git commit -m "test(client): migrate tests to context-supplied credentials"
+```
+
+---
+
+### Task 8: New test — missing-credential request fails closed
+
+**Files:**
+- Modify: `internal/client/client_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+func TestDoRequest_MissingCredentialFailsClosed(t *testing.T) {
+	called := false
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	client := NewClient(logpkg.New("error"), server.URL, nil)
+
+	// Background ctx has no API key -> must error before any HTTP call.
+	_, err := client.doRequest(context.Background(), http.MethodGet, server.URL, nil, time.Second)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "missing API key")
+	assert.False(t, called, "no HTTP request should be sent without credentials")
+}
+```
+
+- [ ] **Step 2: Run it**
+
+Run: `go test ./internal/client/ -run TestDoRequest_MissingCredentialFailsClosed -v -count=1`
+Expected: PASS (implementation from Task 3 already enforces this).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add internal/client/client_test.go
+git commit -m "test(client): assert requests fail closed without credentials"
+```
+
+---
+
+### Task 9: New test — identity cache is per-credential
+
+**Files:**
+- Modify: `internal/client/client_test.go`
+
+- [ ] **Step 1: Write the test**
+
+```go
+func TestGetAnalyticsIdentity_PerCredentialCache(t *testing.T) {
+	var requests atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests.Add(1)
+		w.WriteHeader(http.StatusOK)
+		// service_accounts/me shape — id echoed from the API key isn't needed;
+		// we only assert request counts differ per credential.
+		_, _ = w.Write([]byte(`{"status":"success","data":{"id":"sa-1","email":"a@x.io","orgId":"org-1"}}`))
+	}))
+	defer server.Close()
+
+	client := NewClient(logpkg.New("error"), server.URL, nil)
+
+	// Two distinct credentials -> two fetches.
+	_, err := client.GetAnalyticsIdentity(credCtxFor("key-a", "SIGNOZ-API-KEY"))
+	require.NoError(t, err)
+	_, err = client.GetAnalyticsIdentity(credCtxFor("key-b", "SIGNOZ-API-KEY"))
+	require.NoError(t, err)
+	assert.Equal(t, int32(2), requests.Load(), "different credentials must not share a cached identity")
+
+	// Repeating key-a hits the cache -> no new fetch.
+	_, err = client.GetAnalyticsIdentity(credCtxFor("key-a", "SIGNOZ-API-KEY"))
+	require.NoError(t, err)
+	assert.Equal(t, int32(2), requests.Load(), "same credential must reuse the cached identity")
+}
+```
+
+- [ ] **Step 2: Run it**
+
+Run: `go test ./internal/client/ -run TestGetAnalyticsIdentity_PerCredentialCache -v -count=1`
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add internal/client/client_test.go
+git commit -m "test(client): verify per-credential identity cache isolation"
+```
+
+---
+
+### Task 10: New test — handler shares one client across API keys per URL
+
+**Files:**
+- Create or Modify: `internal/handler/tools/handler_test.go` (no handler-level cache test exists today; create the file if absent)
+
+- [ ] **Step 1: Write the test**
+
+```go
+package tools
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	expirable "github.com/hashicorp/golang-lru/v2/expirable"
+	signozclient "github.com/SigNoz/signoz-mcp-server/internal/client"
+	logpkg "github.com/SigNoz/signoz-mcp-server/pkg/log"
+	"github.com/SigNoz/signoz-mcp-server/pkg/util"
+)
+
+func ctxWith(apiKey, url string) context.Context {
+	ctx := util.SetAPIKey(context.Background(), apiKey)
+	ctx = util.SetAuthHeader(ctx, "SIGNOZ-API-KEY")
+	return util.SetSigNozURL(ctx, url)
+}
+
+func TestGetClient_SharedAcrossAPIKeysPerURL(t *testing.T) {
+	h := &Handler{
+		logger:      logpkg.New("error"),
+		clientCache: expirable.NewLRU[string, *signozclient.SigNoz](16, nil, 0),
+	}
+
+	c1, err := h.GetClient(ctxWith("key-a", "https://tenant.example.com"))
+	require.NoError(t, err)
+	c2, err := h.GetClient(ctxWith("key-b", "https://tenant.example.com"))
+	require.NoError(t, err)
+	assert.Same(t, c1, c2, "same URL must reuse one cached client regardless of API key")
+
+	c3, err := h.GetClient(ctxWith("key-a", "https://other.example.com"))
+	require.NoError(t, err)
+	assert.NotSame(t, c1, c3, "different URLs must get different clients")
+}
+
+func TestGetClient_MissingCredentialsError(t *testing.T) {
+	h := &Handler{
+		logger:      logpkg.New("error"),
+		clientCache: expirable.NewLRU[string, *signozclient.SigNoz](16, nil, 0),
+	}
+	_, err := h.GetClient(util.SetSigNozURL(context.Background(), "https://x.io")) // no apiKey
+	assert.Error(t, err)
+}
+```
+
+(`GetClient` returns the `signozclient.Client` interface; `assert.Same` compares the underlying pointers, which works because both are the same `*SigNoz`. If `assert.Same` rejects interface values, compare `c1 == c2` directly instead.)
+
+- [ ] **Step 2: Run it**
+
+Run: `go test ./internal/handler/tools/ -run TestGetClient -v -count=1`
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add internal/handler/tools/handler_test.go
+git commit -m "test(handler): verify per-URL client cache sharing"
+```
+
+---
+
+### Task 11: Update architecture docs
+
+**Files:**
+- Modify: `docs/architecture.md` (caching section / the `HANDLER` node + auth flow text)
+
+- [ ] **Step 1: Update the caching description**
+
+Find the text describing the cache key (currently per-tenant apiKey+URL). Replace the description with: the handler caches one `SigNoz` client per `signozURL` (case-insensitive), shared across API keys to maximize HTTP connection reuse; per-request credentials (`apiKey`, auth header) are read from the request context at send time, and the analytics identity cache is keyed per credential. Adjust the `Handler with LRU clientCache` node label/notes if they mention the key composition.
+
+- [ ] **Step 2: Verify no other doc references the old key**
+
+Run: `grep -rn -i "apiKey.*signozURL\|HashTenantKey\|per-tenant" docs/`
+Expected: no stale references to apiKey-based client caching remain.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/architecture.md
+git commit -m "docs: describe per-URL client caching"
+```
+
+---
+
+### Task 12: Update the plans/ convention pair and full verification
+
+**Files:**
+- Create: `plans/handle-client-cache.context.md`, `plans/handle-client-cache.plan.md`
+
+- [ ] **Step 1: Write the repo-convention plan pair**
+
+Create `plans/handle-client-cache.context.md` (original prompt = issue #69 + the PR #63 review thread quoted in the task; reference links to #69 and #63; a dated decision-log entry summarizing the chosen approach) and `plans/handle-client-cache.plan.md` with `## Status\nDone` once shipped, pointing at the design spec and this plan.
+
+- [ ] **Step 2: Run the full verification suite**
+
+Run:
+```bash
+go build ./...
+go vet ./...
+go test ./... -count=1
+```
+Expected: all pass.
+
+- [ ] **Step 3: Run the linter per repo CI**
+
+Run: `golangci-lint run` (or the command in this repo's `CLAUDE.md`/Makefile).
+Expected: no new findings.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add plans/handle-client-cache.context.md plans/handle-client-cache.plan.md
+git commit -m "docs(plans): record client-cache-by-url feature plan"
+```
+
+---
+
+## Verification (end-to-end)
+
+- `go build ./... && go vet ./... && go test ./... -count=1` all green.
+- `grep -rn "HashTenantKey" --include="*.go" .` → empty (rename complete, no dead code).
+- `grep -rn "s.apiKey\|s.authHeaderName" internal/client/client.go` → empty (no baked-in creds).
+- Manual: two MCP requests with different API keys against the same `SIGNOZ_URL` reuse one client (observe a single client-creation debug log per URL, and connection reuse in OTel HTTP metrics).
+- Manual: request with no API key in context returns the "missing API key"/"missing tenant credentials" error, never an anonymous upstream call.

--- a/docs/superpowers/specs/2026-06-04-client-cache-by-url-design.md
+++ b/docs/superpowers/specs/2026-06-04-client-cache-by-url-design.md
@@ -42,15 +42,24 @@ fields. No new method-signature churn.
   the credential. (`customHeaders` is already config-derived and URL-gated by the caller.)
 - `NewClient` signature drops `apiKey` and `authHeaderName`:
   `NewClient(log, baseURL, customHeaders)`.
-- In `doRequest` / `doValidationRequest`, resolve credentials from `ctx`:
+- In **both** `doRequest` *and* `doValidationRequest` (the two functions that actually stamp
+  the auth header — lines 246 and 329), resolve credentials from `ctx`:
   - `apiKey, _ := util.GetAPIKey(ctx)`
   - `authHeader, _ := util.GetAuthHeader(ctx)`; default to `SIGNOZ-API-KEY` if empty
     (preserving the current fallback that lives in `GetClient`).
   - If `apiKey == ""`, return an error before sending — fail closed rather than send an
-    unauthenticated request. This guards the implicit-context risk.
+    unauthenticated request. This guards the implicit-context risk. Applies to both functions.
   - `req.Header.Set(authHeader, apiKey)` and use `authHeader` in the reserved-header skip
-    checks for `customHeaders` (replacing the `s.authHeaderName` references at lines 249,
+    checks for `customHeaders` (replacing the `s.authHeaderName` references at lines 249–250,
     329, 332).
+  - Note: `doValidationRequest` is the shared sender for `ValidateCredentials` *and*
+    `fetchAnalyticsIdentity`, so fixing it covers all three public entry points. The URL
+    strings those callers build still come from `s.baseURL` (unchanged — `baseURL` stays on
+    the struct); only the auth header now comes from ctx.
+- `fetchAnalyticsIdentity` (line ~177) currently selects its endpoint via
+  `strings.EqualFold(s.authHeaderName, "Authorization")`. Change this to read the auth header
+  from ctx (`authHeader, _ := util.GetAuthHeader(ctx)`) so endpoint selection follows the
+  per-request credential, not a struct field.
 
 ### Identity cache (resolves the deferred open question)
 
@@ -64,9 +73,18 @@ Fix: replace the single-value cache with a per-credential map guarded by the exi
 `identityMu`:
 
 ```go
+// remove: cachedIdentity *AnalyticsIdentity / identityCachedAt time.Time
 identityMu    sync.Mutex
-identityCache map[string]identityEntry // key: hash of (apiKey, authHeader)
+identityCache map[string]identityEntry // key: HashCredential(apiKey, authHeader)
+
+type identityEntry struct {
+    identity *AnalyticsIdentity
+    cachedAt time.Time
+}
 ```
+
+(The map is lazily initialized — `if s.identityCache == nil { s.identityCache = map[...]{} }`
+under the mutex, or initialized in `NewClient`.)
 
 - Key by a hash of `(apiKey, authHeader)` — the auth header is part of the key because it
   changes which endpoint is queried and thus which identity shape comes back. `HashTenantKey`
@@ -74,6 +92,12 @@ identityCache map[string]identityEntry // key: hash of (apiKey, authHeader)
   no callers. Repurpose it into `util.HashCredential(apiKey, authHeader)` (same SHA-256
   approach) and use it as the identity-cache map key, so raw keys are never held in the map and
   no dead code is left behind.
+- **Defaulting consistency (avoid a subtle cache-mismatch bug):** apply the
+  `authHeader == "" → "SIGNOZ-API-KEY"` default *once*, before both the key computation and
+  the endpoint selection in `fetchAnalyticsIdentity`. If the map key used the raw (empty)
+  header while the endpoint logic used the defaulted header, two equivalent requests could
+  map to different keys or pick mismatched endpoints. Resolve+default the header at the top of
+  `GetAnalyticsIdentity`, pass the normalized header down (or re-default identically).
 - `GetAnalyticsIdentity` reads `apiKey` / `authHeader` from `ctx`, computes the key, and
   does per-entry TTL expiry (same `analyticsIdentityCacheTTL`). Cache-hit / cache-miss meter
   emission is unchanged.
@@ -82,9 +106,18 @@ identityCache map[string]identityEntry // key: hash of (apiKey, authHeader)
 
 ### Cache-key change (`internal/handler/tools/handler.go`)
 
-- `GetClient`: `cacheKey := util.NormalizeSigNozURL(signozURL)` (already normalized
-  upstream; use the normalized URL string as the key) instead of
-  `util.HashTenantKey(apiKey, signozURL)`.
+- `GetClient`: replace `cacheKey := util.HashTenantKey(apiKey, signozURL)` with a key derived
+  from the URL alone: `cacheKey := strings.ToLower(signozURL)`.
+  - **Do not** call `util.NormalizeSigNozURL` here: it returns `(string, error)` (can't be
+    assigned inline) and is not applied to the ctx URL anywhere today, so introducing it would
+    be a behavior change beyond this issue's scope. The ctx `signozURL` is used raw today (the
+    old key hashed it raw); we keep that semantics and only drop the apiKey from the key.
+  - `ToLower` is used (rather than the raw string) only to match the case-insensitive
+    `strings.EqualFold(signozURL, h.configURL)` semantics already used for the custom-header
+    gate — so a single tenant URL maps to one cache entry regardless of case. This is a
+    deliberate, conservative choice; if exact-match keying is preferred we can use `signozURL`
+    verbatim, which is also correct (just slightly less sharing). Either way it is not a
+    correctness/security issue because credentials are no longer part of the key.
 - Still read `apiKey` from ctx and keep the "missing tenant credentials" guard — a request
   with no API key is still an error; we just don't key the cache on it.
 - `NewClient` call updated to the new signature (drop `apiKey`, `authHeader`).
@@ -136,6 +169,14 @@ client.Method(ctx) → doRequest(ctx):
 
 ## Testing / verification
 
+- **Existing-test migration (large, mechanical, mandatory):** `internal/client/client_test.go`
+  has ~40 call sites using the old 5-arg `NewClient(logger, url, apiKey, authHeader, headers)`.
+  All must move to the 3-arg signature, and every test that then calls a request method must
+  seed the credential into the test's ctx (`ctx = util.SetAPIKey(ctx, "test-api-key"); ctx =
+  util.SetAuthHeader(ctx, "SIGNOZ-API-KEY")`). Tests that today vary `authHeaderName` per case
+  (e.g. lines 365, 392, 414 — the `Authorization` cases) must set the header on ctx instead of
+  passing it to the constructor. Without this, the new fail-closed guard makes every request
+  test error. A shared test helper that returns a credentialed ctx is the cleanest path.
 - Unit: `internal/client/client_test.go` — request methods stamp the ctx credential;
   missing-credential ctx errors; identity cache is keyed per credential (two ctxs with
   different keys against one client get distinct identities; same key hits cache).

--- a/docs/superpowers/specs/2026-06-04-client-cache-by-url-design.md
+++ b/docs/superpowers/specs/2026-06-04-client-cache-by-url-design.md
@@ -1,0 +1,162 @@
+# Design: Cache SigNoz clients by URL (decouple credentials from the client)
+
+Tracking issue: [#69](https://github.com/SigNoz/signoz-mcp-server/issues/69)
+(follow-up to review comment on [#63](https://github.com/SigNoz/signoz-mcp-server/pull/63))
+
+## Problem
+
+`internal/handler/tools/handler.go` caches `*signozclient.SigNoz` instances keyed by
+`util.HashTenantKey(apiKey, signozURL)`. The cache key includes the API key because the
+client bakes the credential into itself: `SigNoz` stores `apiKey` / `authHeaderName` as
+struct fields and stamps them onto every outbound request
+(`req.Header.Set(s.authHeaderName, s.apiKey)` in `doRequest` and `doValidationRequest`).
+
+Consequence: two users with **different API keys** but the **same `signozURL`** get two
+separate `SigNoz` objects, each with its own `http.Client` and therefore its own TCP/TLS
+connection pool. The whole point of caching the HTTP client — connection reuse — is
+defeated for the multi-tenant-same-URL case.
+
+The reviewer's framing (#69): the client should not store the API key at all. The cacheable
+unit is the connection pool, which is a property of the **destination URL**, not of the
+caller's credential. Credentials are inherently per-request and should travel per-request.
+
+## Goal
+
+Cache one `SigNoz` client (and thus one connection pool) **per `signozURL`**, shared across
+all API keys hitting that URL, while keeping every request authenticated with the correct
+caller-specific credential.
+
+## Approach (chosen)
+
+**Context-sourced credentials.** Credentials already enter the system through the request
+`context` — both transports set `apiKey` / `authHeader` / `signozURL` on the context before
+any tool handler runs, and that is exactly how `GetClient` reads them today. Every request
+method on `SigNoz` already threads `ctx` through to `doRequest` / `doValidationRequest`. So
+the request methods can read the credential from `ctx` at send time instead of from struct
+fields. No new method-signature churn.
+
+### Client changes (`internal/client/client.go`)
+
+- Remove `apiKey` and `authHeaderName` from the `SigNoz` struct.
+- Keep `baseURL` and `customHeaders` on the struct — both are properties of the *URL*, not
+  the credential. (`customHeaders` is already config-derived and URL-gated by the caller.)
+- `NewClient` signature drops `apiKey` and `authHeaderName`:
+  `NewClient(log, baseURL, customHeaders)`.
+- In `doRequest` / `doValidationRequest`, resolve credentials from `ctx`:
+  - `apiKey, _ := util.GetAPIKey(ctx)`
+  - `authHeader, _ := util.GetAuthHeader(ctx)`; default to `SIGNOZ-API-KEY` if empty
+    (preserving the current fallback that lives in `GetClient`).
+  - If `apiKey == ""`, return an error before sending — fail closed rather than send an
+    unauthenticated request. This guards the implicit-context risk.
+  - `req.Header.Set(authHeader, apiKey)` and use `authHeader` in the reserved-header skip
+    checks for `customHeaders` (replacing the `s.authHeaderName` references at lines 249,
+    329, 332).
+
+### Identity cache (resolves the deferred open question)
+
+`GetAnalyticsIdentity` caches an `AnalyticsIdentity` per client and selects the `/me`
+endpoint from the auth header (`Authorization` → user endpoint, else service-account). Both
+the cached value and the endpoint choice are **credential-specific**. With the client now
+shared per-URL, a single `cachedIdentity` field would mix identities across API keys and
+corrupt analytics attribution.
+
+Fix: replace the single-value cache with a per-credential map guarded by the existing
+`identityMu`:
+
+```go
+identityMu    sync.Mutex
+identityCache map[string]identityEntry // key: hash of (apiKey, authHeader)
+```
+
+- Key by a hash of `(apiKey, authHeader)` — the auth header is part of the key because it
+  changes which endpoint is queried and thus which identity shape comes back. `HashTenantKey`
+  is currently used *only* at the cache-key site we're replacing, so after this change it has
+  no callers. Repurpose it into `util.HashCredential(apiKey, authHeader)` (same SHA-256
+  approach) and use it as the identity-cache map key, so raw keys are never held in the map and
+  no dead code is left behind.
+- `GetAnalyticsIdentity` reads `apiKey` / `authHeader` from `ctx`, computes the key, and
+  does per-entry TTL expiry (same `analyticsIdentityCacheTTL`). Cache-hit / cache-miss meter
+  emission is unchanged.
+- `fetchAnalyticsIdentity` picks the endpoint from the ctx auth header instead of
+  `s.authHeaderName`.
+
+### Cache-key change (`internal/handler/tools/handler.go`)
+
+- `GetClient`: `cacheKey := util.NormalizeSigNozURL(signozURL)` (already normalized
+  upstream; use the normalized URL string as the key) instead of
+  `util.HashTenantKey(apiKey, signozURL)`.
+- Still read `apiKey` from ctx and keep the "missing tenant credentials" guard — a request
+  with no API key is still an error; we just don't key the cache on it.
+- `NewClient` call updated to the new signature (drop `apiKey`, `authHeader`).
+- The custom-headers URL gate (`strings.EqualFold(signozURL, h.configURL)`) is unchanged.
+
+### OAuth validation path (`internal/oauth/handlers.go`)
+
+`validateSigNozCredentials` builds a client directly (not via the cache) and calls
+`ValidateCredentials(ctx)`. It has `apiKey` / `signozURL` as function args but does **not**
+put them on the context today — it relied on the struct fields. After the refactor it must
+seed the context:
+
+```go
+ctx = util.SetAPIKey(ctx, apiKey)
+ctx = util.SetAuthHeader(ctx, "SIGNOZ-API-KEY")
+signozClient := client.NewClient(h.logger, signozURL, headers)
+return signozClient.ValidateCredentials(ctx)
+```
+
+### Interface / mocks
+
+- `internal/client/interface.go` — `GetAnalyticsIdentity` / `ValidateCredentials`
+  signatures are unchanged (still ctx-only), so the interface is unaffected.
+- `internal/client/mock.go` — unaffected (no creds in the mock surface).
+
+## Data flow (after)
+
+```
+transport middleware ──sets ctx{apiKey, authHeader, signozURL}──► tool handler
+        │
+        ▼
+GetClient(ctx): cacheKey = normalize(signozURL)         ◄── shared across API keys
+        │  cache hit/miss → one *SigNoz per URL
+        ▼
+client.Method(ctx) → doRequest(ctx):
+        apiKey/authHeader read from ctx → Header.Set     ◄── correct per-caller credential
+        one http.Client / connection pool per URL        ◄── reused across callers
+```
+
+## Security considerations
+
+- **No credential mixing.** The connection pool is shared, but each request stamps its own
+  caller credential from its own context. HTTP keep-alive connections are not credential-
+  bound at the TCP layer (auth is per-request header), so sharing the pool is safe.
+- **Fail closed.** Missing `apiKey` in ctx → error before send, never an anonymous request.
+- **Custom-header gate unchanged.** Proxy-auth headers are still only attached when the
+  tenant URL equals the configured URL.
+- **Identity attribution stays per-credential** via the keyed identity cache.
+
+## Testing / verification
+
+- Unit: `internal/client/client_test.go` — request methods stamp the ctx credential;
+  missing-credential ctx errors; identity cache is keyed per credential (two ctxs with
+  different keys against one client get distinct identities; same key hits cache).
+- Unit: `internal/handler/tools/handler_test.go` (if present) / `GetClient` — two different
+  API keys + same URL return the **same** cached client instance; different URLs return
+  different instances.
+- Unit: OAuth `validateSigNozCredentials` still authenticates after seeding ctx.
+- `go test ./...`, `go vet ./...`, lint per repo CI.
+
+## Docs / metadata sync
+
+- `docs/architecture.md` — update the caching section (currently describes per-tenant
+  apiKey+URL caching) to per-URL client caching with per-request credentials.
+- No MCP tool schema, `README.md` tool table, or `manifest.json` changes — this is internal
+  plumbing with no user-facing tool/config surface change.
+- `plans/handle-client-cache.context.md` + `.plan.md` per repo convention.
+
+## Out of scope / YAGNI
+
+- No change to how transports populate the context (already correct).
+- No new config knobs.
+- `HashTenantKey` is repurposed (renamed to `HashCredential`), not deleted — same hashing,
+  new call site.
+```

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -145,39 +145,45 @@ func (s *SigNoz) ValidateCredentials(ctx context.Context) error {
 // orgId, v1 doesn't). API-key clients hit /api/v1/service_accounts/me.
 func (s *SigNoz) GetAnalyticsIdentity(ctx context.Context) (*AnalyticsIdentity, error) {
 	ctx = s.ensureTenantContext(ctx)
+
+	apiKey, authHeader, credErr := credentialsFromContext(ctx)
+	if credErr != nil {
+		return nil, credErr
+	}
+	cacheKey := util.HashCredential(apiKey, authHeader)
+
 	s.identityMu.Lock()
 	defer s.identityMu.Unlock()
 
-	if s.cachedIdentity != nil && time.Since(s.identityCachedAt) < analyticsIdentityCacheTTL {
+	if entry, ok := s.identityCache[cacheKey]; ok && time.Since(entry.cachedAt) < analyticsIdentityCacheTTL {
 		if s.meters != nil {
 			attrs := otelpkg.AppendTenantURL(ctx, nil)
 			s.meters.IdentityCacheHits.Add(ctx, 1, metric.WithAttributes(attrs...))
 		}
-		return s.cachedIdentity, nil
+		return entry.identity, nil
 	}
 	if s.meters != nil {
 		attrs := otelpkg.AppendTenantURL(ctx, nil)
 		s.meters.IdentityCacheMisses.Add(ctx, 1, metric.WithAttributes(attrs...))
 	}
 
-	identity, err := s.fetchAnalyticsIdentity(ctx)
+	identity, err := s.fetchAnalyticsIdentity(ctx, authHeader)
 	if err != nil {
 		return nil, err
 	}
 
-	s.cachedIdentity = identity
-	s.identityCachedAt = time.Now()
+	s.identityCache[cacheKey] = identityEntry{identity: identity, cachedAt: time.Now()}
 	return identity, nil
 }
 
-func (s *SigNoz) fetchAnalyticsIdentity(ctx context.Context) (*AnalyticsIdentity, error) {
+func (s *SigNoz) fetchAnalyticsIdentity(ctx context.Context, authHeader string) (*AnalyticsIdentity, error) {
 	ctx = s.ensureTenantContext(ctx)
 	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()
 
 	endpoint := "/api/v1/service_accounts/me"
 	principal := "service_account"
-	if strings.EqualFold(s.authHeaderName, "Authorization") {
+	if strings.EqualFold(authHeader, "Authorization") {
 		endpoint = "/api/v2/users/me"
 		principal = "user"
 	}

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -138,7 +138,7 @@ func (s *SigNoz) ValidateCredentials(ctx context.Context) error {
 }
 
 // GetAnalyticsIdentity returns the org + user identity for the current
-// credentials, cached per-client and mutex-serialized so a burst of events
+// credentials, cached per-credential and mutex-serialized so a burst of events
 // produces a single /me roundtrip.
 //
 // Auth-token clients hit /api/v2/users/me (v2 is required — it returns
@@ -152,6 +152,11 @@ func (s *SigNoz) GetAnalyticsIdentity(ctx context.Context) (*AnalyticsIdentity, 
 	}
 	cacheKey := util.HashCredential(apiKey, authHeader)
 
+	// identityMu is held across the fetch below, so distinct credentials do not
+	// fetch /me concurrently — this is intentional: the cache is per-credential,
+	// but identity lookups are rare and short, and global serialization keeps the
+	// burst dedup (one roundtrip per burst) simple. Revisit with singleflight only
+	// if concurrent multi-tenant identity fetches become a measured bottleneck.
 	s.identityMu.Lock()
 	defer s.identityMu.Unlock()
 

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -237,6 +237,22 @@ func parseAnalyticsIdentity(body []byte, principal string) (*AnalyticsIdentity, 
 	}, nil
 }
 
+// credentialsFromContext pulls the per-request API key and auth header from
+// ctx. The auth header defaults to SIGNOZ-API-KEY (matching the handler's
+// fallback). An empty apiKey is an error: we fail closed rather than send an
+// unauthenticated request, since the client no longer stores a credential.
+func credentialsFromContext(ctx context.Context) (apiKey, authHeader string, err error) {
+	apiKey, _ = util.GetAPIKey(ctx)
+	authHeader, _ = util.GetAuthHeader(ctx)
+	if authHeader == "" {
+		authHeader = SignozApiKey
+	}
+	if apiKey == "" {
+		return "", "", errors.New("missing API key in request context")
+	}
+	return apiKey, authHeader, nil
+}
+
 // doValidationRequest sends a GET request to the given URL with auth headers
 // and returns the HTTP status code, response body, and any transport error.
 func (s *SigNoz) doValidationRequest(ctx context.Context, reqURL string) (int, []byte, error) {
@@ -245,11 +261,16 @@ func (s *SigNoz) doValidationRequest(ctx context.Context, reqURL string) (int, [
 		return 0, nil, fmt.Errorf("failed to create validation request: %w", err)
 	}
 
+	apiKey, authHeader, credErr := credentialsFromContext(ctx)
+	if credErr != nil {
+		return 0, nil, credErr
+	}
+
 	req.Header.Set(ContentType, "application/json")
-	req.Header.Set(s.authHeaderName, s.apiKey)
+	req.Header.Set(authHeader, apiKey)
 
 	for k, v := range s.customHeaders {
-		if !strings.EqualFold(k, ContentType) && !strings.EqualFold(k, s.authHeaderName) {
+		if !strings.EqualFold(k, ContentType) && !strings.EqualFold(k, authHeader) {
 			req.Header.Set(k, v)
 		}
 	}
@@ -313,6 +334,11 @@ func (s *SigNoz) doRequest(ctx context.Context, method, reqURL string, body io.R
 		}
 	}
 
+	apiKey, authHeader, credErr := credentialsFromContext(ctx)
+	if credErr != nil {
+		return nil, credErr
+	}
+
 	var lastErr error
 	wait := retryBaseWait
 
@@ -328,11 +354,10 @@ func (s *SigNoz) doRequest(ctx context.Context, method, reqURL string, body io.R
 		}
 
 		req.Header.Set(ContentType, "application/json")
-
-		req.Header.Set(s.authHeaderName, s.apiKey)
+		req.Header.Set(authHeader, apiKey)
 
 		for k, v := range s.customHeaders {
-			if strings.EqualFold(k, ContentType) || strings.EqualFold(k, s.authHeaderName) {
+			if strings.EqualFold(k, ContentType) || strings.EqualFold(k, authHeader) {
 				s.logger.WarnContext(ctx, "Custom header overrides a reserved header",
 					slog.String("header", k), slog.String("value", v))
 				continue

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -53,26 +53,29 @@ type AnalyticsIdentity struct {
 }
 
 type SigNoz struct {
-	baseURL        string
-	apiKey         string
-	authHeaderName string
-	logger         *slog.Logger
-	httpClient     *http.Client
-	customHeaders  map[string]string
+	baseURL       string
+	logger        *slog.Logger
+	httpClient    *http.Client
+	customHeaders map[string]string
 
-	identityMu       sync.Mutex
-	cachedIdentity   *AnalyticsIdentity
-	identityCachedAt time.Time
-	meters           *otelpkg.Meters
+	identityMu    sync.Mutex
+	identityCache map[string]identityEntry // key: util.HashCredential(apiKey, authHeader)
+	meters        *otelpkg.Meters
 }
 
-func NewClient(log *slog.Logger, baseURL, apiKey, authHeaderName string, customHeaders map[string]string) *SigNoz {
+// identityEntry is one cached analytics identity with its fetch time, so the
+// per-credential cache can expire entries independently.
+type identityEntry struct {
+	identity *AnalyticsIdentity
+	cachedAt time.Time
+}
+
+func NewClient(log *slog.Logger, baseURL string, customHeaders map[string]string) *SigNoz {
 	return &SigNoz{
-		logger:         log,
-		baseURL:        baseURL,
-		apiKey:         apiKey,
-		authHeaderName: authHeaderName,
-		customHeaders:  customHeaders,
+		logger:        log,
+		baseURL:       baseURL,
+		customHeaders: customHeaders,
+		identityCache: make(map[string]identityEntry),
 		httpClient: &http.Client{
 			// Default client span name is just the HTTP method (per OTel HTTP
 			// semconv — the client doesn't know a templated route). We keep

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -1940,3 +1940,27 @@ func TestDoRequest_MissingCredentialFailsClosed(t *testing.T) {
 	assert.Contains(t, err.Error(), "missing API key")
 	assert.False(t, called, "no HTTP request should be sent without credentials")
 }
+
+func TestGetAnalyticsIdentity_PerCredentialCache(t *testing.T) {
+	var requests atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests.Add(1)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"status":"success","data":{"id":"sa-1","email":"a@x.io","orgId":"org-1"}}`))
+	}))
+	defer server.Close()
+
+	client := NewClient(logpkg.New("error"), server.URL, nil)
+
+	// Two distinct credentials -> two fetches.
+	_, err := client.GetAnalyticsIdentity(credCtxFor("key-a", "SIGNOZ-API-KEY"))
+	require.NoError(t, err)
+	_, err = client.GetAnalyticsIdentity(credCtxFor("key-b", "SIGNOZ-API-KEY"))
+	require.NoError(t, err)
+	assert.Equal(t, int32(2), requests.Load(), "different credentials must not share a cached identity")
+
+	// Repeating key-a hits the cache -> no new fetch.
+	_, err = client.GetAnalyticsIdentity(credCtxFor("key-a", "SIGNOZ-API-KEY"))
+	require.NoError(t, err)
+	assert.Equal(t, int32(2), requests.Load(), "same credential must reuse the cached identity")
+}

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -20,11 +20,26 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/SigNoz/signoz-mcp-server/pkg/types"
+	"github.com/SigNoz/signoz-mcp-server/pkg/util"
 )
 
 func newBufferedLogger(buf *bytes.Buffer, level slog.Level) *slog.Logger {
 	base := slog.NewJSONHandler(buf, &slog.HandlerOptions{Level: level})
 	return slog.New(logpkg.NewContextHandler(base))
+}
+
+// credCtx returns a context carrying the credentials the client now reads at
+// request time. Defaults match the old baked-in test values.
+func credCtx() context.Context {
+	ctx := util.SetAPIKey(context.Background(), "test-api-key")
+	return util.SetAuthHeader(ctx, "SIGNOZ-API-KEY")
+}
+
+// credCtxFor returns a credentialed context for a specific apiKey/authHeader,
+// used by tests that exercise the Authorization (user-token) path.
+func credCtxFor(apiKey, authHeader string) context.Context {
+	ctx := util.SetAPIKey(context.Background(), apiKey)
+	return util.SetAuthHeader(ctx, authHeader)
 }
 
 func TestGetAlertByRuleID(t *testing.T) {
@@ -99,9 +114,9 @@ func TestGetAlertByRuleID(t *testing.T) {
 			defer server.Close()
 
 			logger := logpkg.New("debug")
-			client := NewClient(logger, server.URL, "test-api-key", "SIGNOZ-API-KEY", nil)
+			client := NewClient(logger, server.URL, nil)
 
-			ctx := context.Background()
+			ctx := credCtx()
 			result, err := client.GetAlertByRuleID(ctx, tt.ruleID)
 
 			if tt.expectedError {
@@ -142,9 +157,9 @@ func TestListAlertRules(t *testing.T) {
 	defer server.Close()
 
 	logger := logpkg.New("debug")
-	client := NewClient(logger, server.URL, "test-api-key", "SIGNOZ-API-KEY", nil)
+	client := NewClient(logger, server.URL, nil)
 
-	result, err := client.ListAlertRules(context.Background())
+	result, err := client.ListAlertRules(credCtx())
 	require.NoError(t, err)
 	assert.Contains(t, string(result), `"id":"rule-1"`)
 }
@@ -233,9 +248,9 @@ func TestValidateCredentials(t *testing.T) {
 			defer server.Close()
 
 			logger := logpkg.New("debug")
-			client := NewClient(logger, server.URL, "test-api-key", "SIGNOZ-API-KEY", nil)
+			client := NewClient(logger, server.URL, nil)
 
-			err := client.ValidateCredentials(context.Background())
+			err := client.ValidateCredentials(credCtx())
 
 			if tt.expectedError {
 				assert.Error(t, err)
@@ -362,9 +377,9 @@ func TestGetAnalyticsIdentity(t *testing.T) {
 			if tt.authHeaderName == "Authorization" {
 				apiKey = "Bearer jwt-token"
 			}
-			client := NewClient(logger, server.URL, apiKey, tt.authHeaderName, nil)
+			client := NewClient(logger, server.URL, nil)
 
-			identity, err := client.GetAnalyticsIdentity(context.Background())
+			identity, err := client.GetAnalyticsIdentity(credCtxFor(apiKey, tt.authHeaderName))
 
 			if tt.checkErr != nil {
 				assert.Error(t, err)
@@ -389,10 +404,10 @@ func TestGetAnalyticsIdentity_CachesResult(t *testing.T) {
 	defer server.Close()
 
 	logger := logpkg.New("debug")
-	client := NewClient(logger, server.URL, "Bearer jwt", "Authorization", nil)
+	client := NewClient(logger, server.URL, nil)
 
 	for i := 0; i < 5; i++ {
-		identity, err := client.GetAnalyticsIdentity(context.Background())
+		identity, err := client.GetAnalyticsIdentity(credCtxFor("Bearer jwt", "Authorization"))
 		require.NoError(t, err)
 		assert.Equal(t, "user-1", identity.UserID)
 	}
@@ -411,7 +426,7 @@ func TestGetAnalyticsIdentity_ConcurrentCallsDedupe(t *testing.T) {
 	defer server.Close()
 
 	logger := logpkg.New("debug")
-	client := NewClient(logger, server.URL, "Bearer jwt", "Authorization", nil)
+	client := NewClient(logger, server.URL, nil)
 
 	const callers = 10
 	var wg sync.WaitGroup
@@ -419,7 +434,7 @@ func TestGetAnalyticsIdentity_ConcurrentCallsDedupe(t *testing.T) {
 	for i := 0; i < callers; i++ {
 		go func() {
 			defer wg.Done()
-			_, err := client.GetAnalyticsIdentity(context.Background())
+			_, err := client.GetAnalyticsIdentity(credCtxFor("Bearer jwt", "Authorization"))
 			assert.NoError(t, err)
 		}()
 	}
@@ -438,9 +453,9 @@ func TestDoRequest_RetryLogsDebugThenWarn(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := NewClient(newBufferedLogger(&logBuf, slog.LevelDebug), server.URL, "test-api-key", "SIGNOZ-API-KEY", nil)
+	client := NewClient(newBufferedLogger(&logBuf, slog.LevelDebug), server.URL, nil)
 
-	_, err := client.doRequest(context.Background(), http.MethodGet, server.URL, nil, time.Second)
+	_, err := client.doRequest(credCtx(), http.MethodGet, server.URL, nil, time.Second)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "unexpected status 503")
 
@@ -484,9 +499,9 @@ func TestDoRequest_SucceedsAfterRetryWithoutRetriesExhaustedLog(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := NewClient(newBufferedLogger(&logBuf, slog.LevelDebug), server.URL, "test-api-key", "SIGNOZ-API-KEY", nil)
+	client := NewClient(newBufferedLogger(&logBuf, slog.LevelDebug), server.URL, nil)
 
-	body, err := client.doRequest(context.Background(), http.MethodGet, server.URL, nil, time.Second)
+	body, err := client.doRequest(credCtx(), http.MethodGet, server.URL, nil, time.Second)
 	require.NoError(t, err)
 	assert.JSONEq(t, `{"status":"success"}`, string(body))
 
@@ -521,9 +536,9 @@ func TestDoRequest_NonRetryableStatusOmitsRetriesExhausted(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := NewClient(newBufferedLogger(&logBuf, slog.LevelDebug), server.URL, "test-api-key", "SIGNOZ-API-KEY", nil)
+	client := NewClient(newBufferedLogger(&logBuf, slog.LevelDebug), server.URL, nil)
 
-	_, err := client.doRequest(context.Background(), http.MethodGet, server.URL, nil, time.Second)
+	_, err := client.doRequest(credCtx(), http.MethodGet, server.URL, nil, time.Second)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "unexpected status 400")
 
@@ -616,9 +631,9 @@ func TestListMetricKeys(t *testing.T) {
 			defer server.Close()
 
 			logger := logpkg.New("debug")
-			client := NewClient(logger, server.URL, "test-api-key", "SIGNOZ-API-KEY", nil)
+			client := NewClient(logger, server.URL, nil)
 
-			ctx := context.Background()
+			ctx := credCtx()
 			result, err := client.ListMetricKeys(ctx)
 
 			if tt.expectedError {
@@ -736,9 +751,9 @@ func TestListDashboards(t *testing.T) {
 			defer server.Close()
 
 			logger := logpkg.New("debug")
-			client := NewClient(logger, server.URL, "test-api-key", "SIGNOZ-API-KEY", nil)
+			client := NewClient(logger, server.URL, nil)
 
-			ctx := context.Background()
+			ctx := credCtx()
 			result, err := client.ListDashboards(ctx)
 
 			if tt.expectedError {
@@ -865,9 +880,9 @@ func TestListServices(t *testing.T) {
 			defer server.Close()
 
 			logger := logpkg.New("debug")
-			client := NewClient(logger, server.URL, "test-api-key", "SIGNOZ-API-KEY", nil)
+			client := NewClient(logger, server.URL, nil)
 
-			ctx := context.Background()
+			ctx := credCtx()
 			result, err := client.ListServices(ctx, tt.start, tt.end)
 
 			if tt.expectedError {
@@ -1051,9 +1066,9 @@ func TestGetAlertHistory(t *testing.T) {
 			defer server.Close()
 
 			logger := logpkg.New("debug")
-			client := NewClient(logger, server.URL, "test-api-key", "SIGNOZ-API-KEY", nil)
+			client := NewClient(logger, server.URL, nil)
 
-			ctx := context.Background()
+			ctx := credCtx()
 			result, err := client.GetAlertHistory(ctx, tt.ruleID, tt.request)
 
 			if tt.expectedError {
@@ -1216,9 +1231,9 @@ func TestQueryBuilderV5(t *testing.T) {
 			defer server.Close()
 
 			logger := logpkg.New("debug")
-			client := NewClient(logger, server.URL, "test-api-key", "SIGNOZ-API-KEY", nil)
+			client := NewClient(logger, server.URL, nil)
 
-			ctx := context.Background()
+			ctx := credCtx()
 			result, err := client.QueryBuilderV5(ctx, tt.queryBody)
 
 			if tt.expectedError {
@@ -1272,7 +1287,7 @@ func TestCreateDashboard(t *testing.T) {
 	defer server.Close()
 
 	logger := logpkg.New("debug")
-	client := NewClient(logger, server.URL, "test-api-key", "SIGNOZ-API-KEY", nil)
+	client := NewClient(logger, server.URL, nil)
 
 	d := types.Dashboard{
 		Title:   "whatever",
@@ -1280,7 +1295,7 @@ func TestCreateDashboard(t *testing.T) {
 		Widgets: []types.Widget{},
 	}
 
-	ctx := context.Background()
+	ctx := credCtx()
 	resp, err := client.CreateDashboard(ctx, d)
 	require.NoError(t, err)
 
@@ -1310,7 +1325,7 @@ func TestUpdateDashboard(t *testing.T) {
 	defer srv.Close()
 
 	logger := logpkg.New("debug")
-	client := NewClient(logger, srv.URL, "test-api-key", "SIGNOZ-API-KEY", nil)
+	client := NewClient(logger, srv.URL, nil)
 
 	d := types.Dashboard{
 		Title:   "updated-title",
@@ -1318,7 +1333,7 @@ func TestUpdateDashboard(t *testing.T) {
 		Widgets: []types.Widget{},
 	}
 
-	err := client.UpdateDashboard(context.Background(), "id-123", d)
+	err := client.UpdateDashboard(credCtx(), "id-123", d)
 	require.NoError(t, err)
 }
 
@@ -1333,9 +1348,9 @@ func TestDeleteDashboard(t *testing.T) {
 	defer srv.Close()
 
 	logger := logpkg.New("debug")
-	client := NewClient(logger, srv.URL, "test-api-key", "SIGNOZ-API-KEY", nil)
+	client := NewClient(logger, srv.URL, nil)
 
-	err := client.DeleteDashboard(context.Background(), "dash-456")
+	err := client.DeleteDashboard(credCtx(), "dash-456")
 	require.NoError(t, err)
 }
 
@@ -1421,9 +1436,9 @@ func TestGetFieldKeys(t *testing.T) {
 			defer server.Close()
 
 			logger := logpkg.New("debug")
-			client := NewClient(logger, server.URL, "test-api-key", "SIGNOZ-API-KEY", nil)
+			client := NewClient(logger, server.URL, nil)
 
-			ctx := context.Background()
+			ctx := credCtx()
 			result, err := client.GetFieldKeys(ctx, tt.signal, tt.metricName, tt.searchText, tt.fieldContext, tt.fieldDataType, tt.source)
 
 			if tt.expectedError {
@@ -1522,9 +1537,9 @@ func TestGetFieldValues(t *testing.T) {
 			defer server.Close()
 
 			logger := logpkg.New("debug")
-			client := NewClient(logger, server.URL, "test-api-key", "SIGNOZ-API-KEY", nil)
+			client := NewClient(logger, server.URL, nil)
 
-			ctx := context.Background()
+			ctx := credCtx()
 			result, err := client.GetFieldValues(ctx, tt.signal, tt.fieldName, tt.metricName, tt.searchText, tt.source)
 
 			if tt.expectedError {
@@ -1558,9 +1573,9 @@ func TestDoRequest_RetryOn503ThenSuccess(t *testing.T) {
 	defer srv.Close()
 
 	logger := logpkg.New("debug")
-	c := NewClient(logger, srv.URL, "test-key", "SIGNOZ-API-KEY", nil)
+	c := NewClient(logger, srv.URL, nil)
 
-	result, err := c.doRequest(context.Background(), http.MethodGet, srv.URL+"/test", nil, DefaultQueryTimeout)
+	result, err := c.doRequest(credCtx(), http.MethodGet, srv.URL+"/test", nil, DefaultQueryTimeout)
 	require.NoError(t, err)
 	assert.Equal(t, 3, attempts)
 	assert.Contains(t, string(result), "success")
@@ -1576,9 +1591,9 @@ func TestDoRequest_RetriesExhausted(t *testing.T) {
 	defer srv.Close()
 
 	logger := logpkg.New("debug")
-	c := NewClient(logger, srv.URL, "test-key", "SIGNOZ-API-KEY", nil)
+	c := NewClient(logger, srv.URL, nil)
 
-	result, err := c.doRequest(context.Background(), http.MethodGet, srv.URL+"/test", nil, DefaultQueryTimeout)
+	result, err := c.doRequest(credCtx(), http.MethodGet, srv.URL+"/test", nil, DefaultQueryTimeout)
 	assert.Error(t, err)
 	assert.Nil(t, result)
 	assert.Equal(t, 3, attempts)
@@ -1593,9 +1608,9 @@ func TestDoRequest_ContextCancelled(t *testing.T) {
 	defer srv.Close()
 
 	logger := logpkg.New("debug")
-	c := NewClient(logger, srv.URL, "test-key", "SIGNOZ-API-KEY", nil)
+	c := NewClient(logger, srv.URL, nil)
 
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(credCtx())
 	cancel() // Cancel immediately
 
 	_, err := c.doRequest(ctx, http.MethodGet, srv.URL+"/test", nil, DefaultQueryTimeout)
@@ -1612,9 +1627,9 @@ func TestDoRequest_NoRetryOn4xx(t *testing.T) {
 	defer srv.Close()
 
 	logger := logpkg.New("debug")
-	c := NewClient(logger, srv.URL, "test-key", "SIGNOZ-API-KEY", nil)
+	c := NewClient(logger, srv.URL, nil)
 
-	_, err := c.doRequest(context.Background(), http.MethodGet, srv.URL+"/test", nil, DefaultQueryTimeout)
+	_, err := c.doRequest(credCtx(), http.MethodGet, srv.URL+"/test", nil, DefaultQueryTimeout)
 	assert.Error(t, err)
 	assert.Equal(t, 1, attempts)
 	assert.Contains(t, err.Error(), "400")
@@ -1635,9 +1650,9 @@ func TestDoRequest_RetryOn429(t *testing.T) {
 	defer srv.Close()
 
 	logger := logpkg.New("debug")
-	c := NewClient(logger, srv.URL, "test-key", "SIGNOZ-API-KEY", nil)
+	c := NewClient(logger, srv.URL, nil)
 
-	result, err := c.doRequest(context.Background(), http.MethodGet, srv.URL+"/test", nil, DefaultQueryTimeout)
+	result, err := c.doRequest(credCtx(), http.MethodGet, srv.URL+"/test", nil, DefaultQueryTimeout)
 	require.NoError(t, err)
 	assert.Equal(t, 2, attempts)
 	assert.Contains(t, string(result), "success")
@@ -1664,9 +1679,9 @@ func TestNewClient_SetsCustomHeaders(t *testing.T) {
 	defer server.Close()
 
 	logger := logpkg.New("debug")
-	client := NewClient(logger, server.URL, "test-api-key", "SIGNOZ-API-KEY", customHeaders)
+	client := NewClient(logger, server.URL, customHeaders)
 
-	_, err := client.ListAlerts(context.Background(), types.ListAlertsParams{})
+	_, err := client.ListAlerts(credCtx(), types.ListAlertsParams{})
 	assert.NoError(t, err)
 }
 
@@ -1682,9 +1697,9 @@ func TestNewClient_NilHeaders(t *testing.T) {
 	defer server.Close()
 
 	logger := logpkg.New("debug")
-	client := NewClient(logger, server.URL, "test-api-key", "SIGNOZ-API-KEY", nil)
+	client := NewClient(logger, server.URL, nil)
 
-	_, err := client.ListAlerts(context.Background(), types.ListAlertsParams{})
+	_, err := client.ListAlerts(credCtx(), types.ListAlertsParams{})
 	assert.NoError(t, err)
 }
 
@@ -1699,9 +1714,9 @@ func TestNewClient_EmptyHeaders(t *testing.T) {
 	defer server.Close()
 
 	logger := logpkg.New("debug")
-	client := NewClient(logger, server.URL, "test-api-key", "SIGNOZ-API-KEY", map[string]string{})
+	client := NewClient(logger, server.URL, map[string]string{})
 
-	_, err := client.ListAlerts(context.Background(), types.ListAlertsParams{})
+	_, err := client.ListAlerts(credCtx(), types.ListAlertsParams{})
 	assert.NoError(t, err)
 }
 
@@ -1726,9 +1741,9 @@ func TestNewClient_ReservedHeadersSkipped(t *testing.T) {
 	defer server.Close()
 
 	logger := logpkg.New("debug")
-	client := NewClient(logger, server.URL, "test-api-key", "SIGNOZ-API-KEY", customHeaders)
+	client := NewClient(logger, server.URL, customHeaders)
 
-	_, err := client.ListAlerts(context.Background(), types.ListAlertsParams{})
+	_, err := client.ListAlerts(credCtx(), types.ListAlertsParams{})
 	assert.NoError(t, err)
 }
 
@@ -1740,9 +1755,9 @@ func TestCreateAlertRule_v2Returns201(t *testing.T) {
 		_, _ = w.Write([]byte(`{"status":"success","data":{"id":"rule-123"}}`))
 	}))
 	defer srv.Close()
-	client := NewClient(logpkg.New("debug"), srv.URL, "k", "SIGNOZ-API-KEY", nil)
+	client := NewClient(logpkg.New("debug"), srv.URL, nil)
 
-	data, err := client.CreateAlertRule(context.Background(), []byte(`{"alert":"x"}`))
+	data, err := client.CreateAlertRule(credCtx(), []byte(`{"alert":"x"}`))
 	require.NoError(t, err)
 	assert.Equal(t, "/api/v2/rules", gotPath)
 	assert.Equal(t, http.MethodPost, gotMethod)
@@ -1756,9 +1771,9 @@ func TestUpdateAlertRule_v2Returns204(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	}))
 	defer srv.Close()
-	client := NewClient(logpkg.New("debug"), srv.URL, "k", "SIGNOZ-API-KEY", nil)
+	client := NewClient(logpkg.New("debug"), srv.URL, nil)
 
-	err := client.UpdateAlertRule(context.Background(), "abc-123", []byte(`{"alert":"x"}`))
+	err := client.UpdateAlertRule(credCtx(), "abc-123", []byte(`{"alert":"x"}`))
 	require.NoError(t, err)
 	assert.Equal(t, "/api/v2/rules/abc-123", gotPath)
 	assert.Equal(t, http.MethodPut, gotMethod)
@@ -1771,9 +1786,9 @@ func TestDeleteAlertRule_v2Returns204(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	}))
 	defer srv.Close()
-	client := NewClient(logpkg.New("debug"), srv.URL, "k", "SIGNOZ-API-KEY", nil)
+	client := NewClient(logpkg.New("debug"), srv.URL, nil)
 
-	err := client.DeleteAlertRule(context.Background(), "abc-123")
+	err := client.DeleteAlertRule(credCtx(), "abc-123")
 	require.NoError(t, err)
 	assert.Equal(t, "/api/v2/rules/abc-123", gotPath)
 	assert.Equal(t, http.MethodDelete, gotMethod)
@@ -1786,9 +1801,9 @@ func TestTestNotificationChannel_UsesNewPath(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	}))
 	defer srv.Close()
-	client := NewClient(logpkg.New("debug"), srv.URL, "k", "SIGNOZ-API-KEY", nil)
+	client := NewClient(logpkg.New("debug"), srv.URL, nil)
 
-	err := client.TestNotificationChannel(context.Background(), []byte(`{"name":"x"}`))
+	err := client.TestNotificationChannel(credCtx(), []byte(`{"name":"x"}`))
 	require.NoError(t, err)
 	assert.Equal(t, "/api/v1/channels/test", gotPath)
 }
@@ -1800,9 +1815,9 @@ func TestUpdateNotificationChannel_Returns204(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	}))
 	defer srv.Close()
-	client := NewClient(logpkg.New("debug"), srv.URL, "k", "SIGNOZ-API-KEY", nil)
+	client := NewClient(logpkg.New("debug"), srv.URL, nil)
 
-	err := client.UpdateNotificationChannel(context.Background(), "42", []byte(`{"name":"x"}`))
+	err := client.UpdateNotificationChannel(credCtx(), "42", []byte(`{"name":"x"}`))
 	require.NoError(t, err)
 	assert.Equal(t, "/api/v1/channels/42", gotPath)
 	assert.Equal(t, http.MethodPut, gotMethod)
@@ -1815,9 +1830,9 @@ func TestDeleteNotificationChannel(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	}))
 	defer srv.Close()
-	client := NewClient(logpkg.New("debug"), srv.URL, "k", "SIGNOZ-API-KEY", nil)
+	client := NewClient(logpkg.New("debug"), srv.URL, nil)
 
-	err := client.DeleteNotificationChannel(context.Background(), "42")
+	err := client.DeleteNotificationChannel(credCtx(), "42")
 	require.NoError(t, err)
 	assert.Equal(t, "/api/v1/channels/42", gotPath)
 	assert.Equal(t, http.MethodDelete, gotMethod)
@@ -1835,8 +1850,8 @@ func TestListViews(t *testing.T) {
 	}))
 	defer server.Close()
 
-	c := NewClient(logpkg.New("error"), server.URL, "k", "SIGNOZ-API-KEY", nil)
-	_, err := c.ListViews(context.Background(), "traces", "ak", "ops")
+	c := NewClient(logpkg.New("error"), server.URL, nil)
+	_, err := c.ListViews(credCtx(), "traces", "ak", "ops")
 	require.NoError(t, err)
 	assert.Equal(t, http.MethodGet, gotMethod)
 	assert.Equal(t, "/api/v1/explorer/views", gotPath)
@@ -1853,8 +1868,8 @@ func TestGetView(t *testing.T) {
 		_, _ = w.Write([]byte(`{"status":"success","data":{}}`))
 	}))
 	defer server.Close()
-	c := NewClient(logpkg.New("error"), server.URL, "k", "SIGNOZ-API-KEY", nil)
-	_, err := c.GetView(context.Background(), "view-uuid-1")
+	c := NewClient(logpkg.New("error"), server.URL, nil)
+	_, err := c.GetView(credCtx(), "view-uuid-1")
 	require.NoError(t, err)
 	assert.Equal(t, http.MethodGet, gotMethod)
 	assert.Equal(t, "/api/v1/explorer/views/view-uuid-1", gotPath)
@@ -1870,9 +1885,9 @@ func TestCreateView(t *testing.T) {
 		_, _ = w.Write([]byte(`{"status":"success","data":{"id":"new-id"}}`))
 	}))
 	defer server.Close()
-	c := NewClient(logpkg.New("error"), server.URL, "k", "SIGNOZ-API-KEY", nil)
+	c := NewClient(logpkg.New("error"), server.URL, nil)
 	body := []byte(`{"name":"x","sourcePage":"traces","compositeQuery":{}}`)
-	_, err := c.CreateView(context.Background(), body)
+	_, err := c.CreateView(credCtx(), body)
 	require.NoError(t, err)
 	assert.Equal(t, http.MethodPost, gotMethod)
 	assert.Equal(t, "/api/v1/explorer/views", gotPath)
@@ -1887,8 +1902,8 @@ func TestUpdateView(t *testing.T) {
 		_, _ = w.Write([]byte(`{"status":"success","data":{}}`))
 	}))
 	defer server.Close()
-	c := NewClient(logpkg.New("error"), server.URL, "k", "SIGNOZ-API-KEY", nil)
-	_, err := c.UpdateView(context.Background(), "view-1", []byte(`{}`))
+	c := NewClient(logpkg.New("error"), server.URL, nil)
+	_, err := c.UpdateView(credCtx(), "view-1", []byte(`{}`))
 	require.NoError(t, err)
 	assert.Equal(t, http.MethodPut, gotMethod)
 	assert.Equal(t, "/api/v1/explorer/views/view-1", gotPath)
@@ -1902,8 +1917,8 @@ func TestDeleteView(t *testing.T) {
 		_, _ = w.Write([]byte(`{"status":"success"}`))
 	}))
 	defer server.Close()
-	c := NewClient(logpkg.New("error"), server.URL, "k", "SIGNOZ-API-KEY", nil)
-	_, err := c.DeleteView(context.Background(), "view-1")
+	c := NewClient(logpkg.New("error"), server.URL, nil)
+	_, err := c.DeleteView(credCtx(), "view-1")
 	require.NoError(t, err)
 	assert.Equal(t, http.MethodDelete, gotMethod)
 	assert.Equal(t, "/api/v1/explorer/views/view-1", gotPath)

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -1923,3 +1923,20 @@ func TestDeleteView(t *testing.T) {
 	assert.Equal(t, http.MethodDelete, gotMethod)
 	assert.Equal(t, "/api/v1/explorer/views/view-1", gotPath)
 }
+
+func TestDoRequest_MissingCredentialFailsClosed(t *testing.T) {
+	called := false
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	client := NewClient(logpkg.New("error"), server.URL, nil)
+
+	// Background ctx has no API key -> must error before any HTTP call.
+	_, err := client.doRequest(context.Background(), http.MethodGet, server.URL, nil, time.Second)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "missing API key")
+	assert.False(t, called, "no HTTP request should be sent without credentials")
+}

--- a/internal/handler/tools/handler.go
+++ b/internal/handler/tools/handler.go
@@ -68,17 +68,12 @@ func (h *Handler) GetClient(ctx context.Context) (signozclient.Client, error) {
 
 	apiKey, _ := util.GetAPIKey(ctx)
 	signozURL, _ := util.GetSigNozURL(ctx)
-	authHeader, _ := util.GetAuthHeader(ctx)
 
 	if apiKey == "" || signozURL == "" {
 		return nil, fmt.Errorf("missing tenant credentials in context (apiKey or signozURL)")
 	}
 
-	if authHeader == "" {
-		authHeader = "SIGNOZ-API-KEY"
-	}
-
-	cacheKey := util.HashTenantKey(apiKey, signozURL)
+	cacheKey := strings.ToLower(signozURL)
 
 	if cachedClient, ok := h.clientCache.Get(cacheKey); ok {
 		return cachedClient, nil
@@ -93,7 +88,7 @@ func (h *Handler) GetClient(ctx context.Context) (signozclient.Client, error) {
 	}
 
 	h.logger.DebugContext(ctx, "Creating new SigNoz client for tenant")
-	newClient := signozclient.NewClient(h.logger, signozURL, apiKey, authHeader, headers)
+	newClient := signozclient.NewClient(h.logger, signozURL, headers)
 	newClient.SetMeters(h.meters)
 	h.clientCache.Add(cacheKey, newClient)
 	return newClient, nil

--- a/internal/handler/tools/handler_test.go
+++ b/internal/handler/tools/handler_test.go
@@ -1,0 +1,46 @@
+package tools
+
+import (
+	"context"
+	"testing"
+
+	expirable "github.com/hashicorp/golang-lru/v2/expirable"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	signozclient "github.com/SigNoz/signoz-mcp-server/internal/client"
+	logpkg "github.com/SigNoz/signoz-mcp-server/pkg/log"
+	"github.com/SigNoz/signoz-mcp-server/pkg/util"
+)
+
+func ctxWith(apiKey, url string) context.Context {
+	ctx := util.SetAPIKey(context.Background(), apiKey)
+	ctx = util.SetAuthHeader(ctx, "SIGNOZ-API-KEY")
+	return util.SetSigNozURL(ctx, url)
+}
+
+func TestGetClient_SharedAcrossAPIKeysPerURL(t *testing.T) {
+	h := &Handler{
+		logger:      logpkg.New("error"),
+		clientCache: expirable.NewLRU[string, *signozclient.SigNoz](16, nil, 0),
+	}
+
+	c1, err := h.GetClient(ctxWith("key-a", "https://tenant.example.com"))
+	require.NoError(t, err)
+	c2, err := h.GetClient(ctxWith("key-b", "https://tenant.example.com"))
+	require.NoError(t, err)
+	assert.True(t, c1 == c2, "same URL must reuse one cached client regardless of API key")
+
+	c3, err := h.GetClient(ctxWith("key-a", "https://other.example.com"))
+	require.NoError(t, err)
+	assert.False(t, c1 == c3, "different URLs must get different clients")
+}
+
+func TestGetClient_MissingCredentialsError(t *testing.T) {
+	h := &Handler{
+		logger:      logpkg.New("error"),
+		clientCache: expirable.NewLRU[string, *signozclient.SigNoz](16, nil, 0),
+	}
+	_, err := h.GetClient(util.SetSigNozURL(context.Background(), "https://x.io")) // no apiKey
+	assert.Error(t, err)
+}

--- a/internal/oauth/handlers.go
+++ b/internal/oauth/handlers.go
@@ -303,7 +303,13 @@ func (h *Handler) validateSigNozCredentials(ctx context.Context, signozURL, apiK
 	if strings.EqualFold(signozURL, configNormalized) {
 		headers = h.config.CustomHeaders
 	}
-	signozClient := client.NewClient(h.logger, signozURL, apiKey, "SIGNOZ-API-KEY", headers)
+
+	// The client reads credentials from context, so seed them here — the OAuth
+	// flow received them as form fields / decrypted grants, not on the context.
+	ctx = util.SetAPIKey(ctx, apiKey)
+	ctx = util.SetAuthHeader(ctx, "SIGNOZ-API-KEY")
+
+	signozClient := client.NewClient(h.logger, signozURL, headers)
 	return signozClient.ValidateCredentials(ctx)
 }
 

--- a/pkg/util/context.go
+++ b/pkg/util/context.go
@@ -135,11 +135,10 @@ func GetAssistantExecutionID(ctx context.Context) (string, bool) {
 	return id, ok
 }
 
-// HashTenantKey returns a SHA-256 hash of apiKey and signozURL, suitable for
-// use as a cache/map key without exposing the raw API key in memory.
-// A null-byte separator is used to prevent collisions between different
-// (apiKey, signozURL) pairs that contain colons.
-func HashTenantKey(apiKey, signozURL string) string {
-	h := sha256.Sum256([]byte(apiKey + "\x00" + signozURL))
+// HashCredential returns a SHA-256 hash of apiKey and authHeader, suitable for
+// use as a map key without exposing the raw API key in memory. A null-byte
+// separator prevents collisions between pairs that contain colons.
+func HashCredential(apiKey, authHeader string) string {
+	h := sha256.Sum256([]byte(apiKey + "\x00" + authHeader))
 	return hex.EncodeToString(h[:])
 }

--- a/plans/handle-client-cache.context.md
+++ b/plans/handle-client-cache.context.md
@@ -1,0 +1,71 @@
+# Feature: Cache SigNoz Clients by URL — Context & Discussion
+
+## Original Prompt
+> work on https://github.com/SigNoz/signoz-mcp-server/issues/69
+>
+> Issue #69 (follow-up to a review comment on PR #63):
+>
+> internal/handler/tools/handler.go
+> ```
+> return nil, fmt.Errorf("missing tenant credentials in context (apiKey or signozURL)")
+> }
+> cacheKey := util.HashTenantKey(apiKey, signozURL)
+> ```
+>
+> @therealpandey: In order to make the best use of the client cache, it is better to cache
+> clients based on just signozURL instead of using a combination of apiKey + signozURL.
+> Multiple apiKeys can reuse the same signozURL cache which is ideal for reusing connections
+> to the same signozURL.
+>
+> @akshaysw: The client stores the apiKey and uses it to set the SIGNOZ-API-KEY header on
+> every request. If we cache by just signozURL, different user with different API keys would
+> share the same client — and requests would go out with the wrong API key.
+>
+> @therealpandey: Understood. Why is the client storing the apikey? If we are caching the
+> http client, we should reuse as much as possible to reuse connections. Otherwise it's an
+> incomplete attempt to cache the http client. If the answer to this is "legacy" code, please
+> take it up as an enhancement to be done later.
+
+## Reference Links
+- [Issue #69](https://github.com/SigNoz/signoz-mcp-server/issues/69)
+- [PR #63 review thread](https://github.com/SigNoz/signoz-mcp-server/pull/63#discussion_r2955296138)
+- Design spec: `docs/superpowers/specs/2026-06-04-client-cache-by-url-design.md`
+- Implementation plan: `docs/superpowers/plans/2026-06-04-client-cache-by-url.md`
+
+## Key Decisions & Discussion Log
+
+### 2026-06-04 — Chosen approach: context-sourced credentials
+- The reviewer's question ("why is the client storing the apiKey?") is answered by removing
+  the credential from the client entirely. Credentials already enter the system via the
+  request context (both transports set apiKey/authHeader/signozURL on ctx before any handler
+  runs). The client reads them from ctx at send time instead of from struct fields.
+- Cache the full `SigNoz` client keyed by `signozURL` alone → connection pools are reused
+  across API keys hitting the same URL. Considered (and rejected) a "share transport only"
+  variant that keeps apiKey in the client — that's the incomplete fix the reviewer called out.
+
+### 2026-06-04 — Open question resolved: analytics identity cache
+- The per-client `cachedIdentity` is credential-specific (used for analytics attribution and
+  picks the /me endpoint by auth header). With the client now shared per-URL, a single cached
+  value would mix identities across API keys.
+- **Resolved:** make it a per-credential map keyed by `HashCredential(apiKey, authHeader)`,
+  guarded by the existing mutex. The auth-header default (`SIGNOZ-API-KEY`) is applied once so
+  the cache key and the endpoint selection always agree.
+
+### 2026-06-04 — Spec adversarial re-review caught 6 issues before implementation
+- Non-compiling `NormalizeSigNozURL` in the cache-key pseudocode → use `strings.ToLower`.
+- Fail-closed guard must cover `doValidationRequest` (shared by ValidateCredentials &
+  fetchAnalyticsIdentity), not just `doRequest`.
+- `fetchAnalyticsIdentity` endpoint selection must read auth header from ctx, not a struct field.
+- Identity-cache key/endpoint default must be applied consistently to avoid a split-cache bug.
+- ~40 `client_test.go` call sites need migration to ctx-supplied credentials.
+- `HashTenantKey` had exactly one caller; repurposed → `HashCredential` (no dead code).
+
+### 2026-06-04 — Cache-key keying choice
+- `strings.ToLower(signozURL)` rather than the raw URL, to match the existing case-insensitive
+  `EqualFold` custom-header gate. Deliberately NOT applying `NormalizeSigNozURL` (out of scope;
+  not applied to the ctx URL today). Credentials are no longer part of the key, so the exact
+  keying is a sharing-efficiency choice, not a correctness/security one.
+
+## Open Questions
+- [x] How should the analytics identity cache behave on a shared client? → per-credential map
+  keyed by `HashCredential(apiKey, authHeader)`. (Resolved 2026-06-04.)

--- a/plans/handle-client-cache.plan.md
+++ b/plans/handle-client-cache.plan.md
@@ -1,0 +1,40 @@
+# Plan: Cache SigNoz Clients by URL
+
+## Status
+Done
+
+## Context
+`Handler.GetClient` cached clients by `HashTenantKey(apiKey, signozURL)` because the `SigNoz`
+client baked the API key into itself and stamped it on every request. That defeated HTTP
+connection reuse for the common multi-tenant-same-URL case (different API keys → different
+clients → different connection pools). Issue #69 asks to cache by `signozURL` alone, which
+requires removing the credential from the client.
+
+## Approach
+- Make the `SigNoz` client credential-free: drop `apiKey` / `authHeaderName` from the struct
+  and `NewClient`. Read `apiKey` / `authHeader` from the request context inside `doRequest`
+  and `doValidationRequest` (via `credentialsFromContext`), defaulting the header to
+  `SIGNOZ-API-KEY`. Fail closed when no API key is present.
+- Cache the client per URL: `cacheKey = strings.ToLower(signozURL)`.
+- Make the analytics identity cache per-credential: a map keyed by
+  `util.HashCredential(apiKey, authHeader)` (renamed from `HashTenantKey`), guarded by the
+  existing mutex; `fetchAnalyticsIdentity` takes the resolved auth header as a parameter.
+- Seed credentials onto ctx in the OAuth `validateSigNozCredentials` path (it builds a client
+  directly and previously relied on the struct fields).
+
+## Files to Modify
+- `pkg/util/context.go` — `HashTenantKey` → `HashCredential(apiKey, authHeader)`.
+- `internal/client/client.go` — credential-free struct/`NewClient`; ctx-sourced creds in both
+  senders; per-credential identity cache.
+- `internal/handler/tools/handler.go` — URL-only cache key; 3-arg `NewClient`.
+- `internal/oauth/handlers.go` — seed ctx creds before `ValidateCredentials`.
+- `internal/client/client_test.go` — migrate to ctx-supplied creds; add fail-closed and
+  per-credential-cache tests.
+- `internal/handler/tools/handler_test.go` (new) — per-URL cache sharing tests.
+- `docs/architecture.md` — per-URL caching description.
+
+## Verification
+- `go build ./... && go vet ./... && go test ./... -count=1` all green.
+- Two different API keys + same URL return the same cached client; different URLs differ.
+- A request with no API key in context fails closed (no HTTP sent).
+- See the full TDD breakdown in `docs/superpowers/plans/2026-06-04-client-cache-by-url.md`.


### PR DESCRIPTION
## Summary

Closes #69.

Previously `Handler.GetClient` cached `SigNoz` clients by `HashTenantKey(apiKey, signozURL)`. Because the client **baked the API key into itself** and stamped it on every request, the cache key had to include the API key — so two users with different API keys hitting the same SigNoz URL got separate clients and separate HTTP connection pools, defeating the point of caching the client.

This answers the reviewer's question from #63 ("why is the client storing the apiKey?") by removing the credential from the client entirely:

- **Credential-free client.** Dropped `apiKey`/`authHeaderName` from the `SigNoz` struct and `NewClient`. Credentials are now read from the request `context` (where both transports already place them) and stamped onto each outbound request at send time via a new `credentialsFromContext` helper. Missing API key → **fail closed** (error before any HTTP call), never an anonymous upstream request.
- **Cache by URL.** `cacheKey = strings.ToLower(signozURL)` — one client (and one connection pool) per SigNoz URL, shared across API keys.
- **Per-credential identity cache.** The analytics `/me` identity cache moved from a single per-client value to a map keyed by `HashCredential(apiKey, authHeader)` (renamed from `HashTenantKey`), so attribution stays correct on the now-shared client. The auth-header default is applied once so the cache key and the `/me` endpoint selection always agree.
- **OAuth validation path** seeds credentials onto ctx before calling `ValidateCredentials`.
- The custom-header URL gate (only forward proxy-auth headers when the tenant URL matches the configured URL) is unchanged.

No MCP tool schema, `README.md`, or `manifest.json` changes — this is internal plumbing with no user-facing surface change. `docs/architecture.md` and the `plans/` convention pair are updated; design spec + implementation plan are under `docs/superpowers/`.

## Test Plan

- [x] `go build ./...`, `go vet ./...`, `go test ./... -count=1` all pass
- [x] `golangci-lint run` clean on changed packages; `go test -race` clean on affected packages
- [x] New: `TestGetClient_SharedAcrossAPIKeysPerURL` — different API keys + same URL reuse one client; different URLs differ
- [x] New: `TestGetClient_MissingCredentialsError` / `TestDoRequest_MissingCredentialFailsClosed` — fail closed without credentials (no HTTP sent)
- [x] New: `TestGetAnalyticsIdentity_PerCredentialCache` — distinct credentials don't share a cached identity; same credential hits cache
- [x] Existing client tests migrated to context-supplied credentials with all assertions preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)