### PR TITLE
perf(docs,tools): in-memory scorch index + cap raw-search limit to bound memory

### DIFF
--- a/README.md
+++ b/README.md
@@ -640,6 +640,21 @@ Get possible values for a specific field key for a given signal.
   - `source` (optional) - Filter by source
 
 
+#### `signoz_search_traces`
+
+Search traces/spans with flexible filtering.
+
+- **Parameters**:
+  - `query` (optional) - Filter expression using SigNoz search syntax (e.g., "service.name = 'payment-svc' AND hasError = true")
+  - `service` (optional) - Service name to filter by
+  - `operation` (optional) - Operation/span name to filter by
+  - `error` (optional) - Filter by error status ('true' or 'false')
+  - `minDuration` / `maxDuration` (optional) - Min/max span duration in nanoseconds (e.g., '500000000' for 500ms)
+  - `timeRange` (optional) - Time range like '30m', '1h', '6h', '24h' (default: '1h'; ignored when both `start` and `end` are provided)
+  - `start` / `end` (optional) - Start/end time in milliseconds. When both are provided, they override `timeRange`
+  - `limit` (optional) - Maximum number of traces to return (default: 100, max: 10000; higher values are clamped — paginate with `offset`)
+  - `offset` (optional) - Offset for pagination (default: 0)
+
 #### `signoz_aggregate_traces`
 
 Aggregate trace statistics like count, average, sum, min, max, or percentiles over spans, optionally grouped by fields.

--- a/README.md
+++ b/README.md
@@ -598,7 +598,7 @@ Aggregate logs with count, average, sum, min, max, or percentiles, optionally gr
   - `service` (optional) - Shortcut filter for service name
   - `severity` (optional) - Shortcut filter for severity (DEBUG, INFO, WARN, ERROR, FATAL)
   - `orderBy` (optional) - Order expression and direction (e.g., 'count() desc')
-  - `limit` (optional) - Maximum number of groups to return (default: 10)
+  - `limit` (optional) - Maximum number of groups to return (default: 10, max: 10000; higher values are clamped to bound server memory)
   - `timeRange` (optional) - Time range like '30m', '1h', '6h', '24h' (default: '1h'; ignored when both `start` and `end` are provided)
   - `start` / `end` (optional) - Start/end time in milliseconds. When both are provided, they override `timeRange`
 
@@ -668,7 +668,7 @@ Aggregate trace statistics like count, average, sum, min, max, or percentiles ov
   - `operation` (optional) - Shortcut filter for span/operation name
   - `error` (optional) - Shortcut filter for error spans ('true' or 'false')
   - `orderBy` (optional) - Order expression and direction (e.g., 'avg(durationNano) desc')
-  - `limit` (optional) - Maximum number of groups to return (default: 10)
+  - `limit` (optional) - Maximum number of groups to return (default: 10, max: 10000; higher values are clamped to bound server memory)
   - `timeRange` (optional) - Time range like '30m', '1h', '6h', '24h' (default: '1h'; ignored when both `start` and `end` are provided)
   - `start` / `end` (optional) - Start/end time in milliseconds. When both are provided, they override `timeRange`
 
@@ -780,6 +780,7 @@ Executes a SigNoz Query Builder v5 query.
 | `LOG_LEVEL`       | Logging level: `info`(default), `debug`, `warn`, `error`                       | No                                  |
 | `TRANSPORT_MODE`  | MCP transport mode: `stdio`(default) or `http`                                 | No                                  |
 | `MCP_SERVER_PORT` | Port for HTTP transport mode                                                   | Yes only when `TRANSPORT_MODE=http` |
+| `MCP_MAX_REQUEST_BYTES` | Max inbound MCP HTTP request body size in bytes (default: `4194304` / 4 MiB). Bounds memory from a single oversized request. | No |
 | `SIGNOZ_DOCS_REFRESH_INTERVAL` | Runtime docs sitemap refresh interval (Go duration, default: `6h`) | No |
 | `SIGNOZ_DOCS_FULL_REFRESH_INTERVAL` | Runtime full docs refresh interval (Go duration, default: `24h`) | No |
 | `OAUTH_ENABLED`   | Enable OAuth 2.1 authentication flow (`true`/`false`)                          | No (default: `false`)               |

--- a/README.md
+++ b/README.md
@@ -613,7 +613,7 @@ Search logs with flexible filtering across all services.
   - `searchText` (optional) - Text to search for in log body (uses CONTAINS matching)
   - `timeRange` (optional) - Time range like '30m', '1h', '6h', '24h' (default: '1h'; ignored when both `start` and `end` are provided)
   - `start` / `end` (optional) - Start/end time in milliseconds. When both are provided, they override `timeRange`
-  - `limit` (optional) - Maximum number of logs to return (default: 100)
+  - `limit` (optional) - Maximum number of logs to return (default: 100, max: 10000; higher values are clamped — paginate with `offset`)
   - `offset` (optional) - Offset for pagination (default: 0)
 
 #### `signoz_get_field_keys`

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -292,6 +292,12 @@ const (
 	retryMultiply = 4
 )
 
+// maxResponseBytes caps how many bytes doRequest buffers from one backend
+// response, so an unbounded response (e.g. a builder query for millions of
+// rows) can't OOM the shared pod. We error rather than truncate, so callers
+// never get invalid JSON.
+const maxResponseBytes int64 = 64 << 20 // 64 MiB
+
 // doRequest performs an HTTP request with standard headers, timeout, status
 // checking, body reading, and retry with exponential backoff for transient
 // failures (429, 502, 503, 504, network errors).
@@ -364,11 +370,16 @@ func (s *SigNoz) doRequest(ctx context.Context, method, reqURL string, body io.R
 			break
 		}
 
-		respBody, readErr := io.ReadAll(resp.Body)
+		// Read one byte past the cap to detect (and reject, not truncate) an
+		// over-limit response. Oversize is terminal, not retried.
+		respBody, readErr := io.ReadAll(io.LimitReader(resp.Body, maxResponseBytes+1))
 		_ = resp.Body.Close()
 
 		if readErr != nil {
 			return nil, fmt.Errorf("failed to read response body: %w", readErr)
+		}
+		if int64(len(respBody)) > maxResponseBytes {
+			return nil, fmt.Errorf("response body (status %d) exceeds maximum allowed size of %d bytes; if this was a data query, narrow it (reduce limit, time range, or cardinality)", resp.StatusCode, maxResponseBytes)
 		}
 
 		if resp.StatusCode >= 200 && resp.StatusCode < 300 {

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -696,7 +696,7 @@ func (s *SigNoz) GetTraceDetails(ctx context.Context, traceID string, includeSpa
 	filterExpression := fmt.Sprintf("traceID = '%s'", traceID)
 	limit := 1000
 
-	queryPayload := types.BuildTracesQueryPayload(startTime, endTime, filterExpression, limit, 0)
+	queryPayload := types.BuildTracesQueryPayload(startTime, endTime, filterExpression, limit)
 	queryJSON, err := json.Marshal(queryPayload)
 	if err != nil {
 		return nil, fmt.Errorf("failed to marshal query payload: %w", err)

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -696,7 +696,7 @@ func (s *SigNoz) GetTraceDetails(ctx context.Context, traceID string, includeSpa
 	filterExpression := fmt.Sprintf("traceID = '%s'", traceID)
 	limit := 1000
 
-	queryPayload := types.BuildTracesQueryPayload(startTime, endTime, filterExpression, limit)
+	queryPayload := types.BuildTracesQueryPayload(startTime, endTime, filterExpression, limit, 0)
 	queryJSON, err := json.Marshal(queryPayload)
 	if err != nil {
 		return nil, fmt.Errorf("failed to marshal query payload: %w", err)

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -1908,3 +1908,50 @@ func TestDeleteView(t *testing.T) {
 	assert.Equal(t, http.MethodDelete, gotMethod)
 	assert.Equal(t, "/api/v1/explorer/views/view-1", gotPath)
 }
+
+// TestDoRequest_RejectsOversizeResponse verifies the response-size guard: a
+// backend response larger than maxResponseBytes is rejected with a clear error
+// (never silently truncated into invalid JSON), bounding single-request memory
+// on the shared multi-tenant pod.
+func TestDoRequest_RejectsOversizeResponse(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		// Stream just past the cap without buffering it all server-side.
+		chunk := bytes.Repeat([]byte("a"), 1<<20) // 1 MiB
+		var written int64
+		for written <= maxResponseBytes {
+			n, err := w.Write(chunk)
+			if err != nil {
+				return
+			}
+			written += int64(n)
+		}
+	}))
+	defer server.Close()
+
+	var logBuf bytes.Buffer
+	client := NewClient(newBufferedLogger(&logBuf, slog.LevelDebug), server.URL, "test-api-key", "SIGNOZ-API-KEY", nil)
+
+	_, err := client.doRequest(context.Background(), http.MethodGet, server.URL, nil, 30*time.Second)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "exceeds maximum allowed size")
+}
+
+// TestDoRequest_AllowsLargeUnderCapResponse verifies a large-but-under-cap
+// response is returned intact, so the guard does not regress legitimate large
+// (e.g. ~10k-row) results.
+func TestDoRequest_AllowsLargeUnderCapResponse(t *testing.T) {
+	body := bytes.Repeat([]byte("b"), 4<<20) // 4 MiB, well under cap
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(body)
+	}))
+	defer server.Close()
+
+	var logBuf bytes.Buffer
+	client := NewClient(newBufferedLogger(&logBuf, slog.LevelDebug), server.URL, "test-api-key", "SIGNOZ-API-KEY", nil)
+
+	got, err := client.doRequest(context.Background(), http.MethodGet, server.URL, nil, 30*time.Second)
+	require.NoError(t, err)
+	assert.Equal(t, len(body), len(got))
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -34,6 +34,9 @@ type Config struct {
 
 	DocsRefreshInterval     time.Duration
 	DocsFullRefreshInterval time.Duration
+
+	// MaxRequestBytes caps the size of an inbound MCP HTTP request body.
+	MaxRequestBytes int
 }
 
 const (
@@ -60,6 +63,8 @@ const (
 	DocsRefreshIntervalEnv     = "SIGNOZ_DOCS_REFRESH_INTERVAL"
 	DocsFullRefreshIntervalEnv = "SIGNOZ_DOCS_FULL_REFRESH_INTERVAL"
 
+	MaxRequestBytesEnv = "MCP_MAX_REQUEST_BYTES"
+
 	defaultClientCacheSize       = 256
 	defaultClientCacheTTLMinutes = 30
 	defaultAccessTTLMinutes      = 60    // 1 hour
@@ -67,6 +72,9 @@ const (
 	defaultAuthCodeTTLSeconds    = 600
 	defaultDocsRefreshInterval   = 6 * time.Hour
 	defaultDocsFullRefreshPeriod = 24 * time.Hour
+	// defaultMaxRequestBytes bounds inbound MCP request bodies; 4 MiB is far
+	// above any legitimate tool-call payload (incl. dashboard imports).
+	defaultMaxRequestBytes = 4 << 20 // 4 MiB
 )
 
 func LoadConfig() (*Config, error) {
@@ -121,6 +129,7 @@ func LoadConfig() (*Config, error) {
 		SegmentKey:              getEnv(SegmentKeyEnv, ""),
 		DocsRefreshInterval:     docsRefreshInterval,
 		DocsFullRefreshInterval: docsFullRefreshInterval,
+		MaxRequestBytes:         getEnvInt(MaxRequestBytesEnv, defaultMaxRequestBytes),
 	}, nil
 }
 

--- a/internal/docs/index.go
+++ b/internal/docs/index.go
@@ -21,6 +21,7 @@ import (
 	"unicode/utf8"
 
 	"github.com/blevesearch/bleve/v2"
+	"github.com/blevesearch/bleve/v2/index/scorch"
 	"github.com/blevesearch/bleve/v2/mapping"
 	bleveQuery "github.com/blevesearch/bleve/v2/search/query"
 )
@@ -317,7 +318,14 @@ func BuildIndex(snapshot CorpusSnapshot) (bleve.Index, error) {
 	if snapshot.SchemaVersion != CorpusSchemaVersion {
 		return nil, fmt.Errorf("unsupported corpus schema version %d", snapshot.SchemaVersion)
 	}
-	idx, err := bleve.NewMemOnly(newIndexMapping())
+	// In-memory scorch index. scorch (bleve's default on-disk backend) supports
+	// a path-less in-memory mode and is dramatically more memory-efficient than
+	// the legacy upsidedown+gtreap store that bleve.NewMemOnly uses: profiling
+	// the 777-page corpus showed ~323 MiB resident + ~1.5 GiB allocation churn
+	// per rebuild on upsidedown/gtreap, which dominated the server's footprint
+	// and made the periodic docs refresh a latent OOM trigger on the
+	// memory-limited multi-tenant pod.
+	idx, err := bleve.NewUsing("", newIndexMapping(), scorch.Name, scorch.Name, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/handler/tools/aggregate_helper.go
+++ b/internal/handler/tools/aggregate_helper.go
@@ -200,7 +200,7 @@ func clampLimit(n int) (int, bool) {
 func rawSearchResult(payload []byte, limitClamped bool) *mcp.CallToolResult {
 	res := mcp.NewToolResultText(string(payload))
 	if limitClamped {
-		note := fmt.Sprintf("note: result limited to %d rows to bound server memory; narrow the time range or filters to see more.", MaxRawResultLimit)
+		note := fmt.Sprintf("note: result limited to %d rows to bound server memory; paginate with \"offset\" (or narrow the time range/filters) for more.", MaxRawResultLimit)
 		res.Content = append(res.Content, mcp.NewTextContent(note))
 	}
 	return res

--- a/internal/handler/tools/aggregate_helper.go
+++ b/internal/handler/tools/aggregate_helper.go
@@ -42,6 +42,7 @@ type AggregateRequest struct {
 	OrderExpr        string
 	OrderDir         string
 	Limit            int
+	LimitClamped     bool
 	StartTime        int64
 	EndTime          int64
 	RequestType      string // "scalar" (default) or "time_series"
@@ -110,6 +111,9 @@ func parseAggregateArgs(args map[string]any, signal string, filterExpr string) (
 	if err != nil {
 		return nil, err
 	}
+	// Bound the group limit (high-cardinality groupBy). Surfaced via
+	// aggregateResult's note since aggregations have no offset pagination.
+	limit, limitClamped := clampLimit(limit)
 
 	startTime, endTime, err := resolveTimestamps(args, "1h")
 	if err != nil {
@@ -135,6 +139,7 @@ func parseAggregateArgs(args map[string]any, signal string, filterExpr string) (
 		OrderExpr:        orderExpr,
 		OrderDir:         orderDir,
 		Limit:            limit,
+		LimitClamped:     limitClamped,
 		StartTime:        startTime,
 		EndTime:          endTime,
 		RequestType:      requestType,
@@ -192,16 +197,29 @@ func clampLimit(n int) (int, bool) {
 	return n, false
 }
 
-// rawSearchResult wraps a raw backend JSON payload as a tool result. The JSON
-// payload is always the first content block so clients can parse it intact;
-// when the requested row limit was clamped, a pagination note is appended as a
-// separate second content block (rather than prepended into the JSON) so the
-// caller is told the response is truncated without breaking JSON parsing.
-func rawSearchResult(payload []byte, limitClamped bool) *mcp.CallToolResult {
+// clampedResult wraps a raw JSON payload as a tool result. The JSON is always
+// the first (parseable) content block; when clamped, `note` is appended as a
+// separate block rather than prepended into the JSON.
+func clampedResult(payload []byte, limitClamped bool, note string) *mcp.CallToolResult {
 	res := mcp.NewToolResultText(string(payload))
 	if limitClamped {
-		note := fmt.Sprintf("note: result limited to %d rows to bound server memory; paginate with \"offset\" (or narrow the time range/filters) for more.", MaxRawResultLimit)
 		res.Content = append(res.Content, mcp.NewTextContent(note))
 	}
 	return res
+}
+
+// rawSearchResult is the result wrapper for raw row tools (search_logs /
+// search_traces), which support offset pagination.
+func rawSearchResult(payload []byte, limitClamped bool) *mcp.CallToolResult {
+	return clampedResult(payload, limitClamped, fmt.Sprintf(
+		"note: result limited to %d rows to bound server memory; paginate with \"offset\" (or narrow the time range/filters) for more.",
+		MaxRawResultLimit))
+}
+
+// aggregateResult is the result wrapper for aggregation tools. Aggregations
+// have no offset pagination, so the note advises narrowing the query instead.
+func aggregateResult(payload []byte, limitClamped bool) *mcp.CallToolResult {
+	return clampedResult(payload, limitClamped, fmt.Sprintf(
+		"note: result limited to %d groups to bound server memory; narrow the time range, filters, or groupBy cardinality for fewer, more-specific groups.",
+		MaxRawResultLimit))
 }

--- a/internal/handler/tools/aggregate_helper.go
+++ b/internal/handler/tools/aggregate_helper.go
@@ -200,7 +200,7 @@ func clampLimit(n int) (int, bool) {
 func rawSearchResult(payload []byte, limitClamped bool) *mcp.CallToolResult {
 	res := mcp.NewToolResultText(string(payload))
 	if limitClamped {
-		note := fmt.Sprintf("note: result limited to %d rows to bound server memory; paginate with \"offset\" for more.", MaxRawResultLimit)
+		note := fmt.Sprintf("note: result limited to %d rows to bound server memory; narrow the time range or filters to see more.", MaxRawResultLimit)
 		res.Content = append(res.Content, mcp.NewTextContent(note))
 	}
 	return res

--- a/internal/handler/tools/aggregate_helper.go
+++ b/internal/handler/tools/aggregate_helper.go
@@ -6,6 +6,8 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/mark3labs/mcp-go/mcp"
+
 	"github.com/SigNoz/signoz-mcp-server/pkg/timeutil"
 	"github.com/SigNoz/signoz-mcp-server/pkg/types"
 )
@@ -171,4 +173,35 @@ func intArg(args map[string]any, key string, defaultVal int) (int, error) {
 		return defaultVal, nil
 	}
 	return num, nil
+}
+
+// MaxRawResultLimit caps how many raw rows search_logs / search_traces will
+// request from the backend. Each row is read fully into memory, decoded, and
+// re-marshaled into the tool response (~1.6 MiB per 1000 log rows measured
+// against a real backend), so an uncapped limit is an unbounded single-request
+// memory vector on the shared, memory-limited multi-tenant pod. Callers that
+// need more rows should paginate via offset.
+const MaxRawResultLimit = 10000
+
+// clampLimit bounds a parsed limit to MaxRawResultLimit. It returns the
+// effective limit and whether clamping occurred so handlers can surface it.
+func clampLimit(n int) (int, bool) {
+	if n > MaxRawResultLimit {
+		return MaxRawResultLimit, true
+	}
+	return n, false
+}
+
+// rawSearchResult wraps a raw backend JSON payload as a tool result. The JSON
+// payload is always the first content block so clients can parse it intact;
+// when the requested row limit was clamped, a pagination note is appended as a
+// separate second content block (rather than prepended into the JSON) so the
+// caller is told the response is truncated without breaking JSON parsing.
+func rawSearchResult(payload []byte, limitClamped bool) *mcp.CallToolResult {
+	res := mcp.NewToolResultText(string(payload))
+	if limitClamped {
+		note := fmt.Sprintf("note: result limited to %d rows to bound server memory; paginate with \"offset\" for more.", MaxRawResultLimit)
+		res.Content = append(res.Content, mcp.NewTextContent(note))
+	}
+	return res
 }

--- a/internal/handler/tools/aggregate_helper_test.go
+++ b/internal/handler/tools/aggregate_helper_test.go
@@ -20,3 +20,29 @@ func TestResolveTimestampsEndOnlyUsesDefaultRange(t *testing.T) {
 		t.Fatalf("delta = %dms, want about 1h", delta)
 	}
 }
+
+func TestParseAggregateArgs_LimitClamped(t *testing.T) {
+	over, err := parseAggregateArgs(map[string]any{
+		"aggregation": "count",
+		"limit":       "50000",
+		"timeRange":   "1h",
+	}, "logs", "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if over.Limit != MaxRawResultLimit || !over.LimitClamped {
+		t.Fatalf("over-cap aggregate: Limit=%d Clamped=%v, want %d true", over.Limit, over.LimitClamped, MaxRawResultLimit)
+	}
+
+	under, err := parseAggregateArgs(map[string]any{
+		"aggregation": "count",
+		"limit":       "25",
+		"timeRange":   "1h",
+	}, "logs", "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if under.Limit != 25 || under.LimitClamped {
+		t.Fatalf("under-cap aggregate: Limit=%d Clamped=%v, want 25 false", under.Limit, under.LimitClamped)
+	}
+}

--- a/internal/handler/tools/limit_clamp_test.go
+++ b/internal/handler/tools/limit_clamp_test.go
@@ -1,0 +1,75 @@
+package tools
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/mark3labs/mcp-go/mcp"
+)
+
+func TestParseSearchLogsArgs_LimitClamped(t *testing.T) {
+	over, err := parseSearchLogsArgs(map[string]any{"limit": "50000", "timeRange": "1h"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if over.Limit != MaxRawResultLimit || !over.LimitClamped {
+		t.Fatalf("over-cap: Limit=%d Clamped=%v, want %d true", over.Limit, over.LimitClamped, MaxRawResultLimit)
+	}
+
+	under, err := parseSearchLogsArgs(map[string]any{"limit": "500", "timeRange": "1h"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if under.Limit != 500 || under.LimitClamped {
+		t.Fatalf("under-cap: Limit=%d Clamped=%v, want 500 false", under.Limit, under.LimitClamped)
+	}
+}
+
+func TestParseSearchTracesArgs_LimitClamped(t *testing.T) {
+	over, err := parseSearchTracesArgs(map[string]any{"limit": "50000", "timeRange": "1h"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if over.Limit != MaxRawResultLimit || !over.LimitClamped {
+		t.Fatalf("over-cap: Limit=%d Clamped=%v, want %d true", over.Limit, over.LimitClamped, MaxRawResultLimit)
+	}
+
+	under, err := parseSearchTracesArgs(map[string]any{"limit": "500", "timeRange": "1h"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if under.Limit != 500 || under.LimitClamped {
+		t.Fatalf("under-cap: Limit=%d Clamped=%v, want 500 false", under.Limit, under.LimitClamped)
+	}
+}
+
+// TestRawSearchResult_NoteIsSeparateBlock guards the contract that the raw JSON
+// payload is always the first, independently-parseable content block, and the
+// clamp note (when present) is a separate trailing block — never prepended into
+// the JSON.
+func TestRawSearchResult_NoteIsSeparateBlock(t *testing.T) {
+	payload := []byte(`{"status":"success","data":[]}`)
+
+	notClamped := rawSearchResult(payload, false)
+	if len(notClamped.Content) != 1 {
+		t.Fatalf("not-clamped: want 1 content block, got %d", len(notClamped.Content))
+	}
+
+	clamped := rawSearchResult(payload, true)
+	if len(clamped.Content) != 2 {
+		t.Fatalf("clamped: want 2 content blocks, got %d", len(clamped.Content))
+	}
+	block0, ok := clamped.Content[0].(mcp.TextContent)
+	if !ok {
+		t.Fatalf("clamped: block 0 is %T, want mcp.TextContent", clamped.Content[0])
+	}
+	var parsed map[string]any
+	if err := json.Unmarshal([]byte(block0.Text), &parsed); err != nil {
+		t.Fatalf("clamped: block 0 must be valid JSON, got %q (err: %v)", block0.Text, err)
+	}
+	block1, ok := clamped.Content[1].(mcp.TextContent)
+	if !ok || !strings.Contains(block1.Text, "result limited to") {
+		t.Fatalf("clamped: block 1 should be the pagination note, got %#v", clamped.Content[1])
+	}
+}

--- a/internal/handler/tools/limit_clamp_test.go
+++ b/internal/handler/tools/limit_clamp_test.go
@@ -73,3 +73,31 @@ func TestRawSearchResult_NoteIsSeparateBlock(t *testing.T) {
 		t.Fatalf("clamped: block 1 should be the pagination note, got %#v", clamped.Content[1])
 	}
 }
+
+// TestAggregateResult_SurfaceSeparateNote guards that aggregateResult follows
+// the same contract as rawSearchResult — parseable JSON as block 0, a note as a
+// separate block 1 only when clamped.
+func TestAggregateResult_SurfaceSeparateNote(t *testing.T) {
+	payload := []byte(`{"status":"success","data":[]}`)
+
+	clamped := aggregateResult(payload, true)
+	if len(clamped.Content) != 2 {
+		t.Fatalf("clamped: want 2 content blocks, got %d", len(clamped.Content))
+	}
+	block0, ok := clamped.Content[0].(mcp.TextContent)
+	if !ok {
+		t.Fatalf("clamped: block 0 is %T, want mcp.TextContent", clamped.Content[0])
+	}
+	var parsed map[string]any
+	if err := json.Unmarshal([]byte(block0.Text), &parsed); err != nil {
+		t.Fatalf("clamped: block 0 must be valid JSON, got %q (err: %v)", block0.Text, err)
+	}
+	block1, ok := clamped.Content[1].(mcp.TextContent)
+	if !ok || !strings.Contains(block1.Text, "groups") {
+		t.Fatalf("clamped: block 1 should be the groups note, got %#v", clamped.Content[1])
+	}
+
+	if n := len(aggregateResult(payload, false).Content); n != 1 {
+		t.Fatalf("not-clamped aggregate: want 1 content block, got %d", n)
+	}
+}

--- a/internal/handler/tools/logs.go
+++ b/internal/handler/tools/logs.go
@@ -56,7 +56,7 @@ func (h *Handler) RegisterLogsHandlers(s *server.MCPServer) {
 		mcp.WithString("timeRange", mcp.Description("Time range string. Format: <number><unit> where unit is 'm' (minutes), 'h' (hours), or 'd' (days). Examples: '30m', '1h', '6h', '24h', '7d'. Defaults to '1h'.")),
 		mcp.WithString("start", mcp.Description("Start time in milliseconds (optional). When both start and end are provided, they override timeRange.")),
 		mcp.WithString("end", mcp.Description("End time in milliseconds (optional). When both start and end are provided, they override timeRange.")),
-		mcp.WithString("limit", mcp.Description("Maximum number of logs to return (default: 100)")),
+		mcp.WithString("limit", mcp.Description("Maximum number of logs to return (default: 100, max: 10000; higher values are clamped — paginate with offset)")),
 		mcp.WithString("offset", mcp.Description("Offset for pagination (default: 0)")),
 	)
 
@@ -139,5 +139,5 @@ func (h *Handler) handleSearchLogs(ctx context.Context, req mcp.CallToolRequest)
 		return mcp.NewToolResultError(err.Error()), nil
 	}
 
-	return mcp.NewToolResultText(string(result)), nil
+	return rawSearchResult(result, reqData.LimitClamped), nil
 }

--- a/internal/handler/tools/logs.go
+++ b/internal/handler/tools/logs.go
@@ -30,7 +30,7 @@ func (h *Handler) RegisterLogsHandlers(s *server.MCPServer) {
 		mcp.WithString("service", mcp.Description("Shortcut filter for service name. Equivalent to adding service.name = '<value>' to filter.")),
 		mcp.WithString("severity", mcp.Description("Shortcut filter for log severity (DEBUG, INFO, WARN, ERROR, FATAL). Equivalent to adding severity_text = '<value>' to filter.")),
 		mcp.WithString("orderBy", mcp.Description("How to order results. Format: '<expression> <direction>', e.g. 'count() desc' or 'avg(duration) asc'. Defaults to the aggregation expression descending.")),
-		mcp.WithString("limit", mcp.Description("Maximum number of groups to return (default: 10)")),
+		mcp.WithString("limit", mcp.Description("Maximum number of groups to return (default: 10, max: 10000; higher values are clamped)")),
 		mcp.WithString("timeRange", mcp.Description("Time range string. Format: <number><unit> where unit is 'm' (minutes), 'h' (hours), or 'd' (days). Examples: '30m', '1h', '6h', '24h', '7d'. Defaults to '1h'.")),
 		mcp.WithString("start", mcp.Description("Start time in milliseconds (optional). When both start and end are provided, they override timeRange.")),
 		mcp.WithString("end", mcp.Description("End time in milliseconds (optional). When both start and end are provided, they override timeRange.")),
@@ -101,7 +101,7 @@ func (h *Handler) handleAggregateLogs(ctx context.Context, req mcp.CallToolReque
 		return mcp.NewToolResultError(err.Error()), nil
 	}
 
-	return mcp.NewToolResultText(string(result)), nil
+	return aggregateResult(result, reqData.LimitClamped), nil
 }
 
 func (h *Handler) handleSearchLogs(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {

--- a/internal/handler/tools/logs_helper.go
+++ b/internal/handler/tools/logs_helper.go
@@ -19,6 +19,7 @@ func parseAggregateLogsArgs(args map[string]any) (*AggregateRequest, error) {
 type SearchLogsRequest struct {
 	FilterExpression string
 	Limit            int
+	LimitClamped     bool
 	Offset           int
 	StartTime        int64
 	EndTime          int64
@@ -35,6 +36,7 @@ func parseSearchLogsArgs(args map[string]any) (*SearchLogsRequest, error) {
 	if err != nil {
 		return nil, err
 	}
+	limit, clamped := clampLimit(limit)
 
 	offset, err := intArg(args, "offset", 0)
 	if err != nil {
@@ -49,6 +51,7 @@ func parseSearchLogsArgs(args map[string]any) (*SearchLogsRequest, error) {
 	return &SearchLogsRequest{
 		FilterExpression: filterExpr,
 		Limit:            limit,
+		LimitClamped:     clamped,
 		Offset:           offset,
 		StartTime:        startTime,
 		EndTime:          endTime,

--- a/internal/handler/tools/traces.go
+++ b/internal/handler/tools/traces.go
@@ -36,7 +36,7 @@ func (h *Handler) RegisterTracesHandlers(s *server.MCPServer) {
 		mcp.WithString("minDuration", mcp.Description("Minimum span duration in nanoseconds. Example: '500000000' for 500ms.")),
 		mcp.WithString("maxDuration", mcp.Description("Maximum span duration in nanoseconds. Example: '2000000000' for 2s.")),
 		mcp.WithString("orderBy", mcp.Description("How to order results. Format: '<expression> <direction>', e.g. 'count() desc' or 'avg(durationNano) asc'. Defaults to the aggregation expression descending.")),
-		mcp.WithString("limit", mcp.Description("Maximum number of groups to return (default: 10)")),
+		mcp.WithString("limit", mcp.Description("Maximum number of groups to return (default: 10, max: 10000; higher values are clamped)")),
 		mcp.WithString("timeRange", mcp.Description("Time range string. Format: <number><unit> where unit is 'm' (minutes), 'h' (hours), or 'd' (days). Examples: '30m', '1h', '6h', '24h', '7d'. Defaults to '1h'.")),
 		mcp.WithString("start", mcp.Description("Start time in milliseconds (optional). When both start and end are provided, they override timeRange.")),
 		mcp.WithString("end", mcp.Description("End time in milliseconds (optional). When both start and end are provided, they override timeRange.")),
@@ -121,7 +121,7 @@ func (h *Handler) handleAggregateTraces(ctx context.Context, req mcp.CallToolReq
 		return mcp.NewToolResultError(err.Error()), nil
 	}
 
-	return mcp.NewToolResultText(string(result)), nil
+	return aggregateResult(result, reqData.LimitClamped), nil
 }
 
 func (h *Handler) handleSearchTraces(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {

--- a/internal/handler/tools/traces.go
+++ b/internal/handler/tools/traces.go
@@ -62,7 +62,7 @@ func (h *Handler) RegisterTracesHandlers(s *server.MCPServer) {
 		mcp.WithString("timeRange", mcp.Description("Time range string. Format: <number><unit> where unit is 'm' (minutes), 'h' (hours), or 'd' (days). Examples: '30m', '1h', '6h', '24h', '7d'. Defaults to '1h'.")),
 		mcp.WithString("start", mcp.Description("Start time in milliseconds (optional). When both start and end are provided, they override timeRange.")),
 		mcp.WithString("end", mcp.Description("End time in milliseconds (optional). When both start and end are provided, they override timeRange.")),
-		mcp.WithString("limit", mcp.Description("Maximum number of traces to return (default: 100, max: 10000; higher values are clamped)")),
+		mcp.WithString("limit", mcp.Description("Maximum number of traces to return (default: 100, max: 10000; higher values are clamped — paginate with offset)")),
 		mcp.WithString("offset", mcp.Description("Offset for pagination (default: 0)")),
 	)
 
@@ -135,7 +135,7 @@ func (h *Handler) handleSearchTraces(ctx context.Context, req mcp.CallToolReques
 		return mcp.NewToolResultError(err.Error()), nil
 	}
 
-	queryPayload := types.BuildTracesQueryPayload(reqData.StartTime, reqData.EndTime, reqData.FilterExpression, reqData.Limit)
+	queryPayload := types.BuildTracesQueryPayload(reqData.StartTime, reqData.EndTime, reqData.FilterExpression, reqData.Limit, reqData.Offset)
 
 	queryJSON, err := json.Marshal(queryPayload)
 	if err != nil {

--- a/internal/handler/tools/traces.go
+++ b/internal/handler/tools/traces.go
@@ -62,7 +62,7 @@ func (h *Handler) RegisterTracesHandlers(s *server.MCPServer) {
 		mcp.WithString("timeRange", mcp.Description("Time range string. Format: <number><unit> where unit is 'm' (minutes), 'h' (hours), or 'd' (days). Examples: '30m', '1h', '6h', '24h', '7d'. Defaults to '1h'.")),
 		mcp.WithString("start", mcp.Description("Start time in milliseconds (optional). When both start and end are provided, they override timeRange.")),
 		mcp.WithString("end", mcp.Description("End time in milliseconds (optional). When both start and end are provided, they override timeRange.")),
-		mcp.WithString("limit", mcp.Description("Maximum number of traces to return (default: 100)")),
+		mcp.WithString("limit", mcp.Description("Maximum number of traces to return (default: 100, max: 10000; higher values are clamped — paginate with offset)")),
 		mcp.WithString("offset", mcp.Description("Offset for pagination (default: 0)")),
 	)
 
@@ -135,7 +135,7 @@ func (h *Handler) handleSearchTraces(ctx context.Context, req mcp.CallToolReques
 		return mcp.NewToolResultError(err.Error()), nil
 	}
 
-	queryPayload := types.BuildTracesQueryPayload(reqData.StartTime, reqData.EndTime, reqData.FilterExpression, reqData.Limit)
+	queryPayload := types.BuildTracesQueryPayload(reqData.StartTime, reqData.EndTime, reqData.FilterExpression, reqData.Limit, reqData.Offset)
 
 	queryJSON, err := json.Marshal(queryPayload)
 	if err != nil {
@@ -156,7 +156,7 @@ func (h *Handler) handleSearchTraces(ctx context.Context, req mcp.CallToolReques
 		return mcp.NewToolResultError(err.Error()), nil
 	}
 
-	return mcp.NewToolResultText(string(result)), nil
+	return rawSearchResult(result, reqData.LimitClamped), nil
 }
 
 func (h *Handler) handleGetTraceDetails(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {

--- a/internal/handler/tools/traces.go
+++ b/internal/handler/tools/traces.go
@@ -62,7 +62,7 @@ func (h *Handler) RegisterTracesHandlers(s *server.MCPServer) {
 		mcp.WithString("timeRange", mcp.Description("Time range string. Format: <number><unit> where unit is 'm' (minutes), 'h' (hours), or 'd' (days). Examples: '30m', '1h', '6h', '24h', '7d'. Defaults to '1h'.")),
 		mcp.WithString("start", mcp.Description("Start time in milliseconds (optional). When both start and end are provided, they override timeRange.")),
 		mcp.WithString("end", mcp.Description("End time in milliseconds (optional). When both start and end are provided, they override timeRange.")),
-		mcp.WithString("limit", mcp.Description("Maximum number of traces to return (default: 100, max: 10000; higher values are clamped — paginate with offset)")),
+		mcp.WithString("limit", mcp.Description("Maximum number of traces to return (default: 100, max: 10000; higher values are clamped)")),
 		mcp.WithString("offset", mcp.Description("Offset for pagination (default: 0)")),
 	)
 
@@ -135,7 +135,7 @@ func (h *Handler) handleSearchTraces(ctx context.Context, req mcp.CallToolReques
 		return mcp.NewToolResultError(err.Error()), nil
 	}
 
-	queryPayload := types.BuildTracesQueryPayload(reqData.StartTime, reqData.EndTime, reqData.FilterExpression, reqData.Limit, reqData.Offset)
+	queryPayload := types.BuildTracesQueryPayload(reqData.StartTime, reqData.EndTime, reqData.FilterExpression, reqData.Limit)
 
 	queryJSON, err := json.Marshal(queryPayload)
 	if err != nil {

--- a/internal/handler/tools/traces_helper.go
+++ b/internal/handler/tools/traces_helper.go
@@ -9,6 +9,7 @@ import (
 type SearchTracesRequest struct {
 	FilterExpression string
 	Limit            int
+	LimitClamped     bool
 	Offset           int
 	StartTime        int64
 	EndTime          int64
@@ -27,6 +28,7 @@ func parseSearchTracesArgs(args map[string]any) (*SearchTracesRequest, error) {
 	if err != nil {
 		return nil, err
 	}
+	limit, clamped := clampLimit(limit)
 
 	offset, err := intArg(args, "offset", 0)
 	if err != nil {
@@ -41,6 +43,7 @@ func parseSearchTracesArgs(args map[string]any) (*SearchTracesRequest, error) {
 	return &SearchTracesRequest{
 		FilterExpression: filterExpr,
 		Limit:            limit,
+		LimitClamped:     clamped,
 		Offset:           offset,
 		StartTime:        startTime,
 		EndTime:          endTime,

--- a/internal/mcp-server/server.go
+++ b/internal/mcp-server/server.go
@@ -798,6 +798,29 @@ func (m *MCPServer) methodSpanMiddleware(next http.Handler) http.Handler {
 	})
 }
 
+// maxBytesMiddleware bounds an inbound /mcp request body (config.MaxRequestBytes,
+// default 4 MiB; env MCP_MAX_REQUEST_BYTES) so one oversized POST can't OOM the
+// shared pod: a declared over-cap Content-Length is rejected early with 413,
+// otherwise MaxBytesReader bounds the (possibly chunked) stream and an over-cap
+// read surfaces downstream as mcp-go's JSON-RPC parse error. Outermost /mcp
+// middleware, so the cap also covers the methodSpanMiddleware peek. The limit<=0
+// guard is defensive for directly-constructed configs (e.g. tests).
+func (m *MCPServer) maxBytesMiddleware(next http.Handler) http.Handler {
+	limit := int64(m.config.MaxRequestBytes)
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if limit > 0 {
+			if r.ContentLength > limit {
+				http.Error(w, "request body too large", http.StatusRequestEntityTooLarge)
+				return
+			}
+			if r.Body != nil {
+				r.Body = http.MaxBytesReader(w, r.Body, limit)
+			}
+		}
+		next.ServeHTTP(w, r)
+	})
+}
+
 // buildHooks returns lifecycle hooks for observability.
 func (m *MCPServer) buildHooks() *server.Hooks {
 	hooks := &server.Hooks{}
@@ -1439,7 +1462,7 @@ func (m *MCPServer) buildHTTP(s *server.MCPServer) *http.Server {
 	mcpHandler := server.NewStreamableHTTPServer(s,
 		server.WithHeartbeatInterval(streamableHTTPHeartbeatInterval),
 	)
-	mux.Handle("/mcp", m.authMiddleware(m.methodSpanMiddleware(mcpHandler)))
+	mux.Handle("/mcp", m.maxBytesMiddleware(m.authMiddleware(m.methodSpanMiddleware(mcpHandler))))
 
 	m.logger.Info("Listening for MCP clients",
 		slog.String("addr", addr),

--- a/internal/mcp-server/server_test.go
+++ b/internal/mcp-server/server_test.go
@@ -3067,3 +3067,73 @@ func TestRun_HTTPShutdownRaceDuringStartup(t *testing.T) {
 		t.Fatal("Run did not exit within 5s of Shutdown")
 	}
 }
+
+// TestMaxBytesMiddlewareRejectsOversizeBody verifies the inbound request-body
+// cap: an over-cap body declared via Content-Length is rejected early with 413
+// (inner not reached); an over-cap body of unknown length is bounded by
+// MaxBytesReader so the downstream read fails; an under-cap body is readable in
+// full.
+func TestMaxBytesMiddlewareRejectsOversizeBody(t *testing.T) {
+	server := &MCPServer{logger: logpkg.New("error"), config: &config.Config{MaxRequestBytes: 16}, analytics: noopanalytics.New()}
+
+	var innerCalled bool
+	var readErr error
+	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		innerCalled = true
+		_, readErr = io.ReadAll(r.Body)
+		w.WriteHeader(http.StatusOK)
+	})
+
+	t.Run("declared length over cap -> 413", func(t *testing.T) {
+		innerCalled, readErr = false, nil
+		req := httptest.NewRequest(http.MethodPost, "/mcp", strings.NewReader(strings.Repeat("x", 100)))
+		rr := httptest.NewRecorder()
+		server.maxBytesMiddleware(inner).ServeHTTP(rr, req)
+		if rr.Code != http.StatusRequestEntityTooLarge {
+			t.Fatalf("status = %d, want %d", rr.Code, http.StatusRequestEntityTooLarge)
+		}
+		if innerCalled {
+			t.Fatal("inner handler must not be called for a declared over-cap body")
+		}
+	})
+
+	t.Run("unknown length over cap -> read error", func(t *testing.T) {
+		innerCalled, readErr = false, nil
+		req := httptest.NewRequest(http.MethodPost, "/mcp", strings.NewReader(strings.Repeat("x", 100)))
+		req.ContentLength = -1 // simulate chunked / unknown length
+		server.maxBytesMiddleware(inner).ServeHTTP(httptest.NewRecorder(), req)
+		if !innerCalled {
+			t.Fatal("inner handler should run for an unknown-length body")
+		}
+		if readErr == nil {
+			t.Fatal("expected read error for over-cap streamed body, got nil")
+		}
+	})
+
+	t.Run("under cap -> ok", func(t *testing.T) {
+		innerCalled, readErr = false, nil
+		req := httptest.NewRequest(http.MethodPost, "/mcp", strings.NewReader("hello"))
+		server.maxBytesMiddleware(inner).ServeHTTP(httptest.NewRecorder(), req)
+		if !innerCalled || readErr != nil {
+			t.Fatalf("under-cap body: innerCalled=%v readErr=%v, want true/nil", innerCalled, readErr)
+		}
+	})
+}
+
+// TestMaxBytesMiddlewareDisabledWhenZero verifies a zero/unset cap is a no-op
+// (so tests / configs that don't set MaxRequestBytes are not silently capped).
+func TestMaxBytesMiddlewareDisabledWhenZero(t *testing.T) {
+	server := &MCPServer{logger: logpkg.New("error"), config: &config.Config{MaxRequestBytes: 0}, analytics: noopanalytics.New()}
+
+	var readErr error
+	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, readErr = io.ReadAll(r.Body)
+		w.WriteHeader(http.StatusOK)
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/mcp", strings.NewReader(strings.Repeat("x", 1000)))
+	server.maxBytesMiddleware(inner).ServeHTTP(httptest.NewRecorder(), req)
+	if readErr != nil {
+		t.Fatalf("zero cap should not limit body, got err: %v", readErr)
+	}
+}

--- a/pkg/types/querybuilder.go
+++ b/pkg/types/querybuilder.go
@@ -535,7 +535,7 @@ func BuildMetricsQueryPayloadJSON(startTime, endTime, stepInterval int64, querie
 	return json.Marshal(payload)
 }
 
-func BuildTracesQueryPayload(startTime, endTime int64, filterExpression string, limit int) *QueryPayload {
+func BuildTracesQueryPayload(startTime, endTime int64, filterExpression string, limit int, offset int) *QueryPayload {
 	return &QueryPayload{
 		SchemaVersion: "v1",
 		Start:         startTime,
@@ -551,7 +551,7 @@ func BuildTracesQueryPayload(startTime, endTime int64, filterExpression string, 
 						Disabled: false,
 						Filter:   &Filter{Expression: filterExpression},
 						Limit:    limit,
-						Offset:   0,
+						Offset:   offset,
 						Order: []Order{
 							{Key: Key{Name: "timestamp"}, Direction: "desc"},
 						},

--- a/pkg/types/querybuilder.go
+++ b/pkg/types/querybuilder.go
@@ -535,7 +535,7 @@ func BuildMetricsQueryPayloadJSON(startTime, endTime, stepInterval int64, querie
 	return json.Marshal(payload)
 }
 
-func BuildTracesQueryPayload(startTime, endTime int64, filterExpression string, limit int, offset int) *QueryPayload {
+func BuildTracesQueryPayload(startTime, endTime int64, filterExpression string, limit int) *QueryPayload {
 	return &QueryPayload{
 		SchemaVersion: "v1",
 		Start:         startTime,
@@ -551,7 +551,7 @@ func BuildTracesQueryPayload(startTime, endTime int64, filterExpression string, 
 						Disabled: false,
 						Filter:   &Filter{Expression: filterExpression},
 						Limit:    limit,
-						Offset:   offset,
+						Offset:   0,
 						Order: []Order{
 							{Key: Key{Name: "timestamp"}, Direction: "desc"},
 						},

--- a/pkg/types/querybuilder_test.go
+++ b/pkg/types/querybuilder_test.go
@@ -403,3 +403,14 @@ func TestQueryPayloadValidate_LogsTimeSeriesRequiresAggregations(t *testing.T) {
 
 	require.Error(t, q.Validate())
 }
+
+// TestBuildTracesQueryPayload_PropagatesOffset guards against a regression where
+// the traces payload hardcoded Offset:0 and ignored the caller's offset, making
+// signoz_search_traces pagination a silent no-op.
+func TestBuildTracesQueryPayload_PropagatesOffset(t *testing.T) {
+	payload := BuildTracesQueryPayload(1000, 2000, "service.name = 'x'", 50, 25)
+	spec, ok := payload.CompositeQuery.Queries[0].Spec.(QuerySpec)
+	require.True(t, ok, "expected QuerySpec, got %T", payload.CompositeQuery.Queries[0].Spec)
+	require.Equal(t, 50, spec.Limit)
+	require.Equal(t, 25, spec.Offset, "offset must propagate into the traces query")
+}

--- a/plans/mcp-oom-hardening.context.md
+++ b/plans/mcp-oom-hardening.context.md
@@ -39,6 +39,12 @@
 - Coupled fix: since offset is a no-op for traces again, the clamp note no longer promises offset pagination — reworded `rawSearchResult` note to "narrow the time range or filters to see more" (accurate for both logs and traces), and dropped "paginate with offset" from the `search_traces` `limit` description. Logs keep the offset mention (logs pagination via offset genuinely works).
 - Possible follow-up: either remove the dead `offset` param from `search_traces` or wire it intentionally — left out of this PR.
 
+### 2026-06-07 — Trace offset re-wired (owner decision, reversed)
+- Owner: "if offset is supported then let's use it, update relevant docs too." Since `offset` is a registered param, parsed, and the backend honors it (E2E-verified: offset=0 vs offset=5 returned distinct pages), re-applied the wiring: `BuildTracesQueryPayload` takes `offset` again / `Offset: offset`; `handleSearchTraces` passes `reqData.Offset`; `GetTraceDetails` passes 0 (single trace).
+- Restored the offset wording: clamp note → "paginate with \"offset\" (or narrow the time range/filters)"; `search_traces` `limit` description → "paginate with offset".
+- Docs: added a full `#### signoz_search_traces` parameter section to README (it previously had only a table row), documenting query/service/operation/error/min-maxDuration/timeRange/start/end/limit(max 10000)/offset. manifest.json carries no per-param schema for these tools (nothing to sync there).
+- Regression guard: `TestBuildTracesQueryPayload_PropagatesOffset` in pkg/types asserts offset reaches the query spec (the field that was the silent no-op).
+
 ## Open Questions
 - [x] Do scorch in-memory search results match the golden tests? — **Yes.** Full `internal/docs` suite (golden/verification/index/sitemap) passes with no golden changes.
 - [x] Final cap value for `limit`? — **10000** (≈16 MiB result, validated). Constant `MaxRawResultLimit`; can be promoted to env config later if needed.

--- a/plans/mcp-oom-hardening.context.md
+++ b/plans/mcp-oom-hardening.context.md
@@ -33,6 +33,12 @@
 - **Fixed (Codex real bug):** trace `offset` was a no-op — `BuildTracesQueryPayload` hardcoded `Offset:0` and didn't take the param, so `parseSearchTracesArgs` discarded offset and the clamp note's "paginate with offset" was false for traces. Wired offset through `BuildTracesQueryPayload` (+ `client.GetTraceDetails` passes 0). Logs already honored offset.
 - **Scope:** user chose "targeted now + follow-up" — ship search_logs/search_traces clamp; follow-ups recorded in `.plan.md`.
 
+### 2026-06-07 — Trace offset wiring reverted (owner decision)
+- Owner: the trace `offset` change isn't needed; keep this PR scoped to the memory/OOM fix (not a trace-pagination behavior change). Reverted the offset wiring: `BuildTracesQueryPayload` back to 4 args / `Offset: 0`; `traces.go` + `client.go` callers back to 4 args.
+- Factual note for the record: `offset` *is* a registered tool param for `signoz_search_traces` (traces.go:66) and is parsed (traces_helper.go:33), so it was a parsed-but-discarded value pre-PR (silent no-op). The revert restores that pre-existing state — it does NOT remove the dead param (out of scope).
+- Coupled fix: since offset is a no-op for traces again, the clamp note no longer promises offset pagination — reworded `rawSearchResult` note to "narrow the time range or filters to see more" (accurate for both logs and traces), and dropped "paginate with offset" from the `search_traces` `limit` description. Logs keep the offset mention (logs pagination via offset genuinely works).
+- Possible follow-up: either remove the dead `offset` param from `search_traces` or wire it intentionally — left out of this PR.
+
 ## Open Questions
 - [x] Do scorch in-memory search results match the golden tests? — **Yes.** Full `internal/docs` suite (golden/verification/index/sitemap) passes with no golden changes.
 - [x] Final cap value for `limit`? — **10000** (≈16 MiB result, validated). Constant `MaxRawResultLimit`; can be promoted to env config later if needed.

--- a/plans/mcp-oom-hardening.context.md
+++ b/plans/mcp-oom-hardening.context.md
@@ -1,0 +1,39 @@
+# Feature: MCP Server OOM Hardening — Context & Discussion
+
+## Original Prompt
+> Investigate a prod OOMKill of signoz-mcp-server (pod ...wljg5, 2026-06-06 ~03:42 UTC), debug it,
+> check the memory profile locally, and check whether current production servers are enough.
+> Then: "Let's go" — implement the fixes.
+
+## Reference Links
+- Alert investigated: `[platform][k8s] pod has been oomkilled` (ruleId 019dd9d2-5eee-7220-96f7-554bae501e6a) on nightswatch.signoz.cloud
+- Memory: `~/.claude/.../memory/project_mcp_oom.md` (measured model)
+
+## Key Decisions & Discussion Log
+### 2026-06-07 — Root-cause findings (measured)
+- Prod OOM (wljg5): `go.memory.used`/`gc.goal`/`go.goroutine.count` all FLAT through the spike → sub-60s burst invisible to the 60s OTel export. NOT a leak, NOT goroutine pileup. Docs refresh ruled out (generation flat at 4, 0 fetches). No tool call logged in the spike window. Specific trigger unidentified.
+- Root condition: hot replicaset (`84454bd5dd`: v946p 1496 MiB, cnmws 1461 MiB at ~1.5 GiB limit) + **no GOMEMLIMIT** → any transient → SIGKILL.
+- Offline profile (`internal/docs/memprofile_test.go`): one in-memory bleve index = **323 MiB resident** for 777 pages, **~1.5 GiB alloc churn/rebuild**, ~520 MiB double-resident during Swap, no leak. Heap profile: 93% in `BuildIndex` → bleve **upsidedown + gtreap** backend (legacy, memory-hungry). `bleve.NewMemOnly` = upsidedown/gtreap.
+- Real-backend load profile (`internal/handler/tools/loadprofile_test.go`, vs app.us.staging): request path bounded — 1.68 MiB result / 5.9 MiB churn per 1000-log query; 8.2 MiB / 29 MiB for 5000 logs; 40 concurrent peaked only +16 MiB (staging latency serializes). BUT `limit` is uncapped (`intArg`, no max; no clamp) → a single huge-limit query is an unbounded OOM vector.
+
+### 2026-06-07 — Fix decisions
+- Biggest lever = docs index backend. Swap `bleve.NewMemOnly` (upsidedown/gtreap) → in-memory **scorch** (`bleve.NewUsing("", mapping, scorch.Name, scorch.Name, nil)`). Transparent to our code (generic `bleve.Index`). bleve v2.5.4 already defaults on-disk index type to scorch; scorch supports path=="" in-memory.
+- Cap `limit` in raw-data tools (search_logs, search_traces) to close the unbounded single-request vector. Make the cap a constant (with room to make env-configurable).
+- GOMEMLIMIT + container limit bump = deploy/infra-repo change (NOT this repo) → leave as a recommendation in the PR description.
+- Mapping trim (dedup body / term-vectors) deferred: both `body` (highlight) and `body_markdown` (snippet retrieval) are used; backend swap is the dominant win — measure first.
+
+### 2026-06-07 — Implemented + measured results
+- **Scorch swap landed** (`internal/docs/index.go`: `bleve.NewMemOnly` → `bleve.NewUsing("", mapping, scorch.Name, scorch.Name, nil)`). Re-profiled via `memprofile_test.go`: resident/index **323→32.4 MiB (−90%)**, churn/rebuild **1510→414 MiB (−73%)**, Swap double-resident peak **520→62 MiB (−88%)**, no leak. All `internal/docs` tests pass unchanged (no golden updates needed).
+- **Limit clamp landed** (`MaxRawResultLimit=10000` + `clampLimit`/`rawSearchResult` in `aggregate_helper.go`; applied in `logs_helper.go`/`traces_helper.go`; surfaced via a pagination note; param descriptions + README updated). Validated against real staging: `limit=50000` now returns 16.5 MiB (~10k rows) instead of ~82 MiB. Unit test in `limit_clamp_test.go`. Full `go test ./...` green.
+- Deploy-side fixes (GOMEMLIMIT≈1280MiB, container limit 1.5→2 GiB) remain for the infra repo — call out in PR description, not in this repo.
+
+### 2026-06-07 — Codex (gpt-5.5 / xhigh) review + responses
+- Codex verified the scorch swap against bleve v2.5.4 source: `NewUsing("", mapping, scorch.Name, scorch.Name, nil)` ⇒ in-memory mode (no MkdirAll/Bolt/persister/merger); non-empty kvstore string required (`index_impl.go:87`), scorch ignores it; introducer goroutine ⇒ `Close()` required (our `closeWhenDrained` already does it). Highlight/stored-fields safe. No change needed — high-risk change validated.
+- **Fixed (Codex blocker):** clamp note was prepended into the JSON payload, breaking JSON parsing. Now the JSON is `Content[0]` (parseable) and the note is a separate `Content[1]` block. User chose "note as separate content block." Locked with `TestRawSearchResult_NoteIsSeparateBlock`.
+- **Fixed (Codex real bug):** trace `offset` was a no-op — `BuildTracesQueryPayload` hardcoded `Offset:0` and didn't take the param, so `parseSearchTracesArgs` discarded offset and the clamp note's "paginate with offset" was false for traces. Wired offset through `BuildTracesQueryPayload` (+ `client.GetTraceDetails` passes 0). Logs already honored offset.
+- **Scope:** user chose "targeted now + follow-up" — ship search_logs/search_traces clamp; follow-ups recorded in `.plan.md`.
+
+## Open Questions
+- [x] Do scorch in-memory search results match the golden tests? — **Yes.** Full `internal/docs` suite (golden/verification/index/sitemap) passes with no golden changes.
+- [x] Final cap value for `limit`? — **10000** (≈16 MiB result, validated). Constant `MaxRawResultLimit`; can be promoted to env config later if needed.
+- [x] How to surface clamping without breaking JSON? — **Separate MCP content block** (JSON stays parseable as `Content[0]`).

--- a/plans/mcp-oom-hardening.plan.md
+++ b/plans/mcp-oom-hardening.plan.md
@@ -1,0 +1,30 @@
+# Plan: MCP Server OOM Hardening
+
+## Status
+In Progress — code complete & validated locally (scorch −90% resident, limit clamp verified vs staging); pending review/commit + deploy-side GOMEMLIMIT/limit changes in infra repo.
+
+## Context
+Prod `signoz-mcp-server` OOMKills on a ~1.5 GiB-limited, multi-tenant shared pod. Measured root condition: the in-memory docs **bleve index** (legacy upsidedown/gtreap backend) costs ~323 MiB resident + ~1.5 GiB allocation churn per 6h/24h rebuild — ~42% of steady state and a latent per-replica rebuild spike — and there is no `GOMEMLIMIT` soft ceiling, so any transient burst goes straight to SIGKILL. Separately, raw-data tools accept an uncapped `limit`, making a single large query an unbounded memory vector.
+
+## Approach
+1. **Docs index backend → scorch (in-memory).** In `internal/docs/index.go` `BuildIndex`, replace `bleve.NewMemOnly(newIndexMapping())` with `bleve.NewUsing("", newIndexMapping(), scorch.Name, scorch.Name, nil)`. scorch is far more memory-efficient than upsidedown/gtreap and is already bleve's on-disk default. No other code changes — everything uses the generic `bleve.Index` interface. Validate search still works via the existing docs test suite; re-run `memprofile_test.go` to quantify the resident + churn reduction.
+2. **Cap `limit` in raw-data tools.** In `internal/handler/tools` clamp `search_logs` / `search_traces` `limit` to a max (start 10000) so a single tenant query cannot buffer an unbounded response. Log/annotate when clamped.
+3. **Deploy recommendations (separate infra repo, not this PR):** set `GOMEMLIMIT≈1280MiB` (+`GOGC=50`) and raise the container memory limit 1.5→2 GiB. Documented in the PR description.
+
+## Files to Modify
+- `internal/docs/index.go` — import `index/scorch`; swap `NewMemOnly` → in-memory scorch in `BuildIndex`.
+- `internal/handler/tools/logs_helper.go` + `traces_helper.go` (or shared `intArg` call sites) — clamp `limit` to a max constant.
+- `plans/mcp-oom-hardening.*` — this pair (committed alongside).
+
+## Follow-ups (out of scope for this PR — Codex review, 2026-06-07)
+- Bound `signoz_execute_builder_query`: tenant controls `limit` inside the raw query-builder JSON, so it bypasses the clamp — an equivalent large-response vector. Needs query-level inspection/clamp.
+- Clamp `aggregate_logs` / `aggregate_traces` `limit` (groups; smaller payloads, lower priority — reuse `clampLimit`).
+- Consider a client-layer response guard. NOTE: a hard `io.LimitReader` byte cap at `client.go` would truncate valid JSON mid-stream → parse errors; prefer per-query limits over a blunt byte cap.
+- README: add a detailed `signoz_search_traces` parameter section (currently only a table row); note the trace `limit` cap + the newly-honored `offset`.
+- Deploy/infra repo: `GOMEMLIMIT≈1280MiB` (+`GOGC=50`) and raise container limit 1.5→2 GiB.
+
+## Verification
+- `go build ./...` and `go test ./internal/docs ./internal/handler/tools` pass (update snippet/score goldens only if scorch legitimately changes them).
+- Re-run `go test ./internal/docs -run TestMemProfileDocsIndex -v` → resident heap and churn/build should drop materially vs the upsidedown baseline (323 MiB / 1.5 GiB).
+- Re-run the real-backend load harness with a huge `limit` → confirm the clamp caps the response.
+- Throwaway harnesses (`memprofile_test.go`, `loadprofile_test.go`) are NOT committed unless converted to proper benchmarks.

--- a/plans/mcp-oom-hardening.plan.md
+++ b/plans/mcp-oom-hardening.plan.md
@@ -17,7 +17,6 @@ Prod `signoz-mcp-server` OOMKills on a ~1.5 GiB-limited, multi-tenant shared pod
 - `plans/mcp-oom-hardening.*` — this pair (committed alongside).
 
 ## Follow-ups (out of scope for this PR — Codex review, 2026-06-07)
-- `signoz_search_traces` exposes an `offset` param that is parsed but ignored (pre-existing no-op; `BuildTracesQueryPayload` hardcodes `Offset: 0`). Either wire it intentionally or remove the dead param. (Offset wiring was added then reverted per owner decision to keep this PR scoped.)
 - Bound `signoz_execute_builder_query`: tenant controls `limit` inside the raw query-builder JSON, so it bypasses the clamp — an equivalent large-response vector. Needs query-level inspection/clamp.
 - Clamp `aggregate_logs` / `aggregate_traces` `limit` (groups; smaller payloads, lower priority — reuse `clampLimit`).
 - Consider a client-layer response guard. NOTE: a hard `io.LimitReader` byte cap at `client.go` would truncate valid JSON mid-stream → parse errors; prefer per-query limits over a blunt byte cap.

--- a/plans/mcp-oom-hardening.plan.md
+++ b/plans/mcp-oom-hardening.plan.md
@@ -17,6 +17,7 @@ Prod `signoz-mcp-server` OOMKills on a ~1.5 GiB-limited, multi-tenant shared pod
 - `plans/mcp-oom-hardening.*` — this pair (committed alongside).
 
 ## Follow-ups (out of scope for this PR — Codex review, 2026-06-07)
+- `signoz_search_traces` exposes an `offset` param that is parsed but ignored (pre-existing no-op; `BuildTracesQueryPayload` hardcodes `Offset: 0`). Either wire it intentionally or remove the dead param. (Offset wiring was added then reverted per owner decision to keep this PR scoped.)
 - Bound `signoz_execute_builder_query`: tenant controls `limit` inside the raw query-builder JSON, so it bypasses the clamp — an equivalent large-response vector. Needs query-level inspection/clamp.
 - Clamp `aggregate_logs` / `aggregate_traces` `limit` (groups; smaller payloads, lower priority — reuse `clampLimit`).
 - Consider a client-layer response guard. NOTE: a hard `io.LimitReader` byte cap at `client.go` would truncate valid JSON mid-stream → parse errors; prefer per-query limits over a blunt byte cap.

--- a/plans/response-request-body-limits.context.md
+++ b/plans/response-request-body-limits.context.md
@@ -1,0 +1,56 @@
+# Feature: Response & Request Body Limits — Context & Discussion
+
+## Original Prompt
+> (Follow-up to PR #189 / mcp-oom-hardening.) "Do we need to apply any more limits in responses?
+> ... Let's work on next steps in new PR." Then: "Should we also implement these?
+> https://github.com/SigNoz/signoz-mcp-server/issues/70"
+
+## Reference Links
+- Predecessor PR #189 (`fix/docs-index-scorch-oom-hardening`): scorch index + search_logs/search_traces raw limit clamp.
+- Predecessor plan: `plans/mcp-oom-hardening.*` (its "Follow-ups" section is the seed for this PR).
+- Issue #70: "timeout and body size limit is not defined" — read/write timeout, stateful/stateless, request/response body size limit.
+
+## Key Decisions & Discussion Log
+### 2026-06-07 — Audit of remaining unbounded-response vectors (post-#189)
+- `execute_builder_query`: caller embeds `limit` inside opaque QB-v5 JSON → bypasses the #189 search clamp. **Highest remaining row-vector.**
+- `aggregate_logs` / `aggregate_traces`: group `limit` (default 10) unclamped. Low payload risk (groups ≪ raw rows) but trivial to bound.
+- `client.go doRequest` (shared executor for EVERY backend call): `io.ReadAll(resp.Body)` with no size guard → every tool buffers the full upstream response into memory.
+- Already bounded (no action): `get_alert_history` (validated 1–1000), `list_*` (org-scale), `get_trace_details` (hardcoded 1000 spans), `query_metrics` (backend bounds points).
+
+### 2026-06-07 — Scope decision (owner)
+- Owner chose **"All three"**: execute_builder_query clamp + client-layer response guard + aggregate clamp.
+- Stacked on #189's branch (reuses `clampLimit` / `MaxRawResultLimit` / `rawSearchResult`); base = `fix/docs-index-scorch-oom-hardening` until #189 merges, then rebase to `main`.
+
+### 2026-06-07 — Issue #70 assessment + scope (owner)
+- **#70 item 1 (read/write timeouts): already handled** — `ReadHeaderTimeout: 10s`, `ReadTimeout: 30s`, `MaxHeaderBytes: 1MB`; `WriteTimeout`/`IdleTimeout` deliberately 0 (documented: SSE streaming). Will comment on #70 confirming. Optional future: finite `IdleTimeout` to reap dead keep-alive conns.
+- **#70 item 2 (stateful/stateless): separate PR** — server uses `NewStreamableHTTPServer` without `WithStateLess(true)` (stateful). Stateless is worth evaluating for the memory-limited multi-tenant pod but is a behavior change needing its own investigation.
+- **#70 item 3 (request/response body size): closed by this PR.** Response half = the doRequest guard; owner approved folding in the **request half** (inbound `MaxBytesReader` on `/mcp`), default 4 MiB, configurable via `MCP_MAX_REQUEST_BYTES`.
+
+### 2026-06-07 — Design notes
+- **Response guard** lives in `doRequest` (one chokepoint for all tools). Reads `maxResponseBytes+1` (64 MiB) and **errors rather than truncates** — never hands back invalid JSON. Oversize is terminal (not retried).
+- **execute_builder_query clamp** only fires when resolved `requestType == "raw"` (scalar/time_series `limit` bounds aggregation groups, not rows). Zero/unset limit left for backend default. Reuses `clampLimit`; surfaces the existing pagination note via `rawSearchResult` (offset IS valid for raw builder queries).
+- **aggregate clamp** is silent (no note): aggregations have no offset pagination, and >10000 groups is far outside normal usage — clamping is a pure memory bound.
+- **Request body cap** middleware is the outermost `/mcp` middleware so the limit also governs the body that `methodSpanMiddleware` peeks (1 MiB peek < 4 MiB cap → composes) and reconstructs downstream. `limit <= 0` disables (no-op) so tests/configs without the field set are unaffected.
+
+### 2026-06-07 — Codex (gpt-5.5 / xhigh) review + responses
+- Codex: no blockers. Confirmed value-type `QuerySpec` mutation persists (reassigned to `Queries[i].Spec`), type assertion safely skips promql/clickhouse_sql/builder_formula/raw-JSON specs, `MaxBytesReader` caps end-to-end through the method-span peek (no double-count), and SSE GET is unharmed.
+- **Fixed (should-fix):** builder clamp only covered `requestType=="raw"`, but traces also have `requestType=="trace"` (raw-like, querybuilder.go:246) and scalar/time_series group limits bypassed it. **Removed the requestType gate — now clamps every `builder_query` `QuerySpec.Limit > 10000`** (rows for raw/trace, groups for scalar/time_series; matches the aggregate tools' group cap). Note reworded to type-agnostic via `builderQueryResult`.
+- **Fixed (should-fix):** silent aggregate clamp was a correctness surprise. **Now surfaced** — `AggregateRequest.LimitClamped` + `aggregateResult` appends a non-pagination note ("narrow time/filters/groupBy"). Refactored result wrappers to a shared `clampedResult(payload, clamped, note)` core (rawSearchResult / aggregateResult / builderQueryResult).
+- **Fixed (should-fix):** the "respond 413" claim was false — mcp-go maps a body read error to a JSON-RPC parse error (HTTP 400), not 413. **Added an early `ContentLength > limit` → 413 path** (clean rejection when length is declared) and kept `MaxBytesReader` for chunked/unknown-length; corrected the comment.
+- **Noted (should-fix, comment-only):** `MCP_MAX_REQUEST_BYTES=0` can't disable via env because `getEnvInt` rejects ≤0 → falls back to 4 MiB. Chosen resolution: **keep env positive-only (no disable foot-gun for a memory-safety feature)**; the middleware `limit<=0` guard is documented as defensive for programmatically-constructed configs (tests). README does not advertise 0-disable.
+- **Fixed (nit):** oversize response error now includes `resp.StatusCode` and less query-specific wording (it fires on any backend call).
+- **Decided (nit):** manifest.json change NOT needed — its `user_config`/`env` only exposes a curated UI subset (url/api_key/log_level); all other operational env vars (CLIENT_CACHE_SIZE, SIGNOZ_DOCS_*, etc.) are README-only, so `MCP_MAX_REQUEST_BYTES` is consistent there. Tool descriptions are behavior-agnostic.
+
+### 2026-06-07 — clampBuilderQueryLimits removed (owner decision)
+- Owner questioned whether the builder clamp was needed/correct/maintainable. Assessment: the 64 MiB `doRequest` response guard already bounds `execute_builder_query`, so the clamp was NOT needed for the OOM ceiling — it only tightened this tool from ~64 MiB to ~16 MiB (consistency with search tools + concurrent-load, churn ~3.5×) and gave graceful degradation. Correct (Codex-verified) and low-maintenance, but it rewrote the caller's *authored* query.
+- Owner chose **remove**. Dropped `clampBuilderQueryLimits`, `builderQueryResult`, the builder-clamp tests, and the tool-description/README cap notes. `execute_builder_query` reverts to `NewToolResultText`; the 64 MiB response guard is its sole bound. Comments across the PR also trimmed for concision.
+
+## Open Questions
+- [x] Which limits in this PR? — response guard + aggregate clamp + request body cap (builder clamp removed below).
+- [x] Aggregate clamp: silent or surfaced? — **Surfaced** (reversed the earlier silent decision per Codex).
+- [x] Request cap env-disable? — **No** (positive-only; guard is defensive for tests).
+- [x] Keep the builder clamp? — **No** (removed; response guard suffices — see 2026-06-07 entry).
+- [x] Response guard: hard byte cap vs error? — **Error** (read cap+1, reject) so JSON is never truncated.
+- [x] Aggregate clamp: surface a note? — **No** (silent); offset note is inaccurate for aggregations.
+- [x] Request body cap value / configurability? — **4 MiB default, `MCP_MAX_REQUEST_BYTES`**.
+- [ ] #70 item 2 (stateful/stateless) — defer to its own investigation/PR.

--- a/plans/response-request-body-limits.plan.md
+++ b/plans/response-request-body-limits.plan.md
@@ -1,0 +1,39 @@
+# Plan: Response & Request Body Limits
+
+## Status
+In Progress — code complete & tested (build/vet/full suite green); Codex (gpt-5.5/xhigh) reviewed; builder-query clamp removed per owner (response guard suffices). Stacked on PR #189.
+
+## Context
+Follow-up to PR #189 (scorch index + search_logs/search_traces raw clamp). Three unbounded-response vectors remained on the shared, memory-limited multi-tenant pod, and issue #70 flagged that request/response body size is undefined. This PR closes the remaining response vectors and the inbound request-body gap (fully closing #70 item 3).
+
+## Approach
+1. **Client-layer response guard** (`internal/client/client.go`): in `doRequest` (shared executor for every backend call), read `io.LimitReader(resp.Body, maxResponseBytes+1)` where `maxResponseBytes = 64 MiB`; if the body exceeds the cap, return a clear error (terminal, not retried) rather than truncating. One chokepoint bounds every tool, including future ones.
+2. **Aggregate group clamp** (`internal/handler/tools/aggregate_helper.go`): `parseAggregateArgs` clamps `limit` via `clampLimit` and records `AggregateRequest.LimitClamped`; handlers return via `aggregateResult`, which **surfaces** a non-pagination note ("narrow time/filters/groupBy") when clamped.
+3. **Inbound request body cap** (`internal/config/config.go` + `internal/mcp-server/server.go`): `MaxRequestBytes` config (env `MCP_MAX_REQUEST_BYTES`, default 4 MiB, positive-only). `maxBytesMiddleware` (outermost `/mcp` middleware, so it also bounds the method-span peek/reconstruct): rejects a declared over-cap `Content-Length` early with **413**; otherwise `http.MaxBytesReader` bounds the chunked/unknown-length stream (an over-cap read surfaces as mcp-go's JSON-RPC parse error). `limit <= 0` is a defensive no-op for programmatic configs.
+
+Result wrappers share a `clampedResult(payload, clamped, note)` core: `rawSearchResult` (offset pagination) and `aggregateResult` (narrow).
+
+**Not done — `execute_builder_query` clamp (removed per owner):** considered clamping the `limit` embedded in the caller's QB JSON, but the 64 MiB response guard already bounds it; clamping rewrote the caller's authored query for a ~64→16 MiB gain that wasn't worth the surface area. The response guard is its sole bound.
+
+## Files to Modify
+- `internal/client/client.go` — `maxResponseBytes` const + bounded read/error in `doRequest`.
+- `internal/client/client_test.go` — oversize-rejected + large-under-cap-allowed tests.
+- `internal/handler/tools/aggregate_helper.go` — `clampedResult`/`aggregateResult` helpers; clamp `limit` + `LimitClamped` in `parseAggregateArgs`.
+- `internal/handler/tools/logs.go` / `traces.go` — aggregate handlers return via `aggregateResult`; `limit` param description (max 10000).
+- `internal/handler/tools/aggregate_helper_test.go` — `TestParseAggregateArgs_LimitClamped`.
+- `internal/handler/tools/limit_clamp_test.go` — `aggregateResult` note-as-separate-block test.
+- `internal/config/config.go` — `MaxRequestBytes` field, env const, default 4 MiB.
+- `internal/mcp-server/server.go` — `maxBytesMiddleware`, applied to `/mcp`.
+- `internal/mcp-server/server_test.go` — middleware over/under cap + disabled-when-zero tests.
+- `README.md` — `MCP_MAX_REQUEST_BYTES` env row; aggregate `limit` max.
+- `plans/response-request-body-limits.*` — this pair.
+
+## Out of Scope (separate)
+- #70 item 1 (timeouts): already handled — comment on the issue.
+- #70 item 2 (stateful/stateless streamable-HTTP): own investigation/PR.
+- Deploy/infra: `GOMEMLIMIT≈1280MiB`, container limit 1.5→2 GiB (tracked in `mcp-oom-hardening.plan.md`).
+
+## Verification
+- `go build ./...`, `go vet ./...`, `go test ./...` all green.
+- New tests execute and pass: `TestDoRequest_RejectsOversizeResponse` / `_AllowsLargeUnderCapResponse`; `TestClampBuilderQueryLimits_*`; `TestParseAggregateArgs_LimitClamped`; `TestMaxBytesMiddleware*`.
+- Codex (gpt-5.5/xhigh) review of the diff.


### PR DESCRIPTION
## Why

A prod `signoz-mcp-server` pod was OOMKilled (multi-tenant, ~1.5 GiB cgroup limit). Investigation + local and real-backend profiling traced the memory pressure to two issues this PR fixes. (The specific OOM trigger was a sub-60s burst invisible to the 60s in-process metric export; the root *condition* was a hot replica with no `GOMEMLIMIT` — addressed deploy-side, see below.)

## Changes

### 1. Docs index → in-memory scorch (the big lever)
`BuildIndex` used `bleve.NewMemOnly` — the legacy **upsidedown + gtreap** backend. Offline profiling of the embedded 777-page corpus:

| Metric | upsidedown/gtreap | scorch | Δ |
|---|---|---|---|
| Resident / index | 323 MiB | **32 MiB** | **−90%** |
| Alloc churn / rebuild | 1510 MiB | **414 MiB** | **−73%** |
| Double-resident peak (Swap) | 520 MiB | **62 MiB** | **−88%** |

The index was ~42% of steady-state heap, and the 6h/24h refresh rebuild was a latent per-replica OOM spike. Switched to in-memory scorch via `bleve.NewUsing("", mapping, scorch.Name, scorch.Name, nil)` (path-less ⇒ no disk/Bolt/persister loops; the introducer goroutine is still stopped by the existing `Close()` path). Search relevance, highlighting, and stored-field retrieval verified unchanged against bleve v2.5.4 internals + the full `internal/docs` suite.

### 2. Cap unbounded raw-search `limit`
`signoz_search_logs` / `signoz_search_traces` accepted any `limit` and buffered the whole result (~1.6 MiB/1000 log rows measured against a real backend) — an unbounded single-request memory vector on the shared pod. Added `MaxRawResultLimit = 10000` + `clampLimit`. When clamped, the raw JSON stays the **first** MCP content block (so clients can still parse it) and a pagination note is appended as a **separate** block. Validated against staging: `limit=50000` returns ~10k rows (~16 MiB) instead of ~82 MiB.

### 3. Wire trace `offset` (functional pagination)
`signoz_search_traces` exposes an `offset` param that was parsed but discarded (`BuildTracesQueryPayload` hardcoded `Offset: 0`), so trace pagination was a silent no-op. Now threaded through (logs already honored offset). `get_trace_details` keeps offset 0 (single-trace fetch).

### 4. Docs
Added a `signoz_search_traces` parameter section to the README (previously only a table row) documenting filters, time range, `limit` (max 10000), and `offset`; updated the `search_logs` `limit` description for the cap.

## Testing
- `go build ./...` + full `go test ./...` green.
- New tests: `limit_clamp_test.go` (clamp behavior + asserts a clamped result's `Content[0]` is valid JSON and the note is a separate block) and `TestBuildTracesQueryPayload_PropagatesOffset` (guards the offset no-op regression).
- **End-to-end verified against a real staging backend**: `limit` boundary (10000 = no clamp, 10001 = clamped), clamp enforced (50000 → exactly 10k rows), JSON-safe content blocks, trace `offset` returns distinct pages, docs search/highlight unchanged vs the old backend, `get_trace_details` intact.

## Reviewed by Codex (gpt-5.5, xhigh)
Validated the scorch swap against bleve source; flagged the JSON-purity issue (fixed via separate content block) and the trace-offset no-op (fixed). See `plans/mcp-oom-hardening.context.md` for the full log.