### PR TITLE
fix: cache SigNoz clients by URL for connection reuse (#69)

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -99,11 +99,11 @@ subgraph GetClient["GetClient — Unified for Both Transports"]
     READ --> MISSING{"Both present?"}
 
     MISSING -->|No| ERR["Return error"]
-    MISSING -->|Yes| HASH["cacheKey = SHA256(apiKey + delimiter + signozURL)"]
+    MISSING -->|Yes| HASH["cacheKey = lowercase(signozURL)"]
 
     HASH --> LOOKUP{"clientCache LRU hit?"}
-    LOOKUP -->|Yes| HIT["Return cached client"]
-    LOOKUP -->|No| CREATE["Create new SigNoz client and cache it"]
+    LOOKUP -->|Yes| HIT["Return cached client (shared across API keys)"]
+    LOOKUP -->|No| CREATE["Create new credential-free SigNoz client and cache it"]
 
     CREATE --> HIT
 end
@@ -114,7 +114,7 @@ end
 
 subgraph APICall["SigNoz API Call"]
     CLIENT["SigNoz Client<br/>(otelhttp instrumented)"]
-    CLIENT --> APIREQ["HTTP Request with SIGNOZ-API-KEY header"]
+    CLIENT --> APIREQ["HTTP Request — auth header set<br/>per-request from ctx credentials"]
     APIREQ --> S1["SigNoz Instance 1"]
     APIREQ --> S2["SigNoz Instance 2"]
     APIREQ --> SN["SigNoz Instance N"]
@@ -147,6 +147,20 @@ One consequence: MCP client identity (name/version) is captured only on the
 `session_registered` analytics event, taken directly from the `initialize` request's
 `ClientInfo`. With no session to correlate against, it is not attached to later
 per-tool-call events.
+
+## Client Caching
+
+`GetClient` caches one `SigNoz` client per `signozURL` (case-insensitive), in a bounded
+expirable LRU. The client is **credential-free**: it does not store the API key or auth
+header. Instead, those are read from the request context and stamped onto each outbound
+request at send time. This lets multiple API keys targeting the same SigNoz URL share a
+single client — and therefore a single HTTP connection pool — maximizing connection reuse.
+This pairs naturally with the stateless transport above: every request is independent and
+self-authenticating, and the per-URL pool is what makes that efficient.
+
+A request with no API key in context fails closed (errors before any HTTP call) rather than
+sending an unauthenticated request. The analytics identity cache (`/me` lookups) lives on the
+shared client but is keyed per credential, so attribution stays correct across API keys.
 
 ## OAuth 2.1 — Stateless Token Design
 

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -145,39 +145,45 @@ func (s *SigNoz) ValidateCredentials(ctx context.Context) error {
 // orgId, v1 doesn't). API-key clients hit /api/v1/service_accounts/me.
 func (s *SigNoz) GetAnalyticsIdentity(ctx context.Context) (*AnalyticsIdentity, error) {
 	ctx = s.ensureTenantContext(ctx)
+
+	apiKey, authHeader, credErr := credentialsFromContext(ctx)
+	if credErr != nil {
+		return nil, credErr
+	}
+	cacheKey := util.HashCredential(apiKey, authHeader)
+
 	s.identityMu.Lock()
 	defer s.identityMu.Unlock()
 
-	if s.cachedIdentity != nil && time.Since(s.identityCachedAt) < analyticsIdentityCacheTTL {
+	if entry, ok := s.identityCache[cacheKey]; ok && time.Since(entry.cachedAt) < analyticsIdentityCacheTTL {
 		if s.meters != nil {
 			attrs := otelpkg.AppendTenantURL(ctx, nil)
 			s.meters.IdentityCacheHits.Add(ctx, 1, metric.WithAttributes(attrs...))
 		}
-		return s.cachedIdentity, nil
+		return entry.identity, nil
 	}
 	if s.meters != nil {
 		attrs := otelpkg.AppendTenantURL(ctx, nil)
 		s.meters.IdentityCacheMisses.Add(ctx, 1, metric.WithAttributes(attrs...))
 	}
 
-	identity, err := s.fetchAnalyticsIdentity(ctx)
+	identity, err := s.fetchAnalyticsIdentity(ctx, authHeader)
 	if err != nil {
 		return nil, err
 	}
 
-	s.cachedIdentity = identity
-	s.identityCachedAt = time.Now()
+	s.identityCache[cacheKey] = identityEntry{identity: identity, cachedAt: time.Now()}
 	return identity, nil
 }
 
-func (s *SigNoz) fetchAnalyticsIdentity(ctx context.Context) (*AnalyticsIdentity, error) {
+func (s *SigNoz) fetchAnalyticsIdentity(ctx context.Context, authHeader string) (*AnalyticsIdentity, error) {
 	ctx = s.ensureTenantContext(ctx)
 	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()
 
 	endpoint := "/api/v1/service_accounts/me"
 	principal := "service_account"
-	if strings.EqualFold(s.authHeaderName, "Authorization") {
+	if strings.EqualFold(authHeader, "Authorization") {
 		endpoint = "/api/v2/users/me"
 		principal = "user"
 	}

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -138,7 +138,7 @@ func (s *SigNoz) ValidateCredentials(ctx context.Context) error {
 }
 
 // GetAnalyticsIdentity returns the org + user identity for the current
-// credentials, cached per-client and mutex-serialized so a burst of events
+// credentials, cached per-credential and mutex-serialized so a burst of events
 // produces a single /me roundtrip.
 //
 // Auth-token clients hit /api/v2/users/me (v2 is required — it returns
@@ -152,6 +152,11 @@ func (s *SigNoz) GetAnalyticsIdentity(ctx context.Context) (*AnalyticsIdentity, 
 	}
 	cacheKey := util.HashCredential(apiKey, authHeader)
 
+	// identityMu is held across the fetch below, so distinct credentials do not
+	// fetch /me concurrently — this is intentional: the cache is per-credential,
+	// but identity lookups are rare and short, and global serialization keeps the
+	// burst dedup (one roundtrip per burst) simple. Revisit with singleflight only
+	// if concurrent multi-tenant identity fetches become a measured bottleneck.
 	s.identityMu.Lock()
 	defer s.identityMu.Unlock()
 

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -237,6 +237,22 @@ func parseAnalyticsIdentity(body []byte, principal string) (*AnalyticsIdentity, 
 	}, nil
 }
 
+// credentialsFromContext pulls the per-request API key and auth header from
+// ctx. The auth header defaults to SIGNOZ-API-KEY (matching the handler's
+// fallback). An empty apiKey is an error: we fail closed rather than send an
+// unauthenticated request, since the client no longer stores a credential.
+func credentialsFromContext(ctx context.Context) (apiKey, authHeader string, err error) {
+	apiKey, _ = util.GetAPIKey(ctx)
+	authHeader, _ = util.GetAuthHeader(ctx)
+	if authHeader == "" {
+		authHeader = SignozApiKey
+	}
+	if apiKey == "" {
+		return "", "", errors.New("missing API key in request context")
+	}
+	return apiKey, authHeader, nil
+}
+
 // doValidationRequest sends a GET request to the given URL with auth headers
 // and returns the HTTP status code, response body, and any transport error.
 func (s *SigNoz) doValidationRequest(ctx context.Context, reqURL string) (int, []byte, error) {
@@ -245,11 +261,16 @@ func (s *SigNoz) doValidationRequest(ctx context.Context, reqURL string) (int, [
 		return 0, nil, fmt.Errorf("failed to create validation request: %w", err)
 	}
 
+	apiKey, authHeader, credErr := credentialsFromContext(ctx)
+	if credErr != nil {
+		return 0, nil, credErr
+	}
+
 	req.Header.Set(ContentType, "application/json")
-	req.Header.Set(s.authHeaderName, s.apiKey)
+	req.Header.Set(authHeader, apiKey)
 
 	for k, v := range s.customHeaders {
-		if !strings.EqualFold(k, ContentType) && !strings.EqualFold(k, s.authHeaderName) {
+		if !strings.EqualFold(k, ContentType) && !strings.EqualFold(k, authHeader) {
 			req.Header.Set(k, v)
 		}
 	}
@@ -313,6 +334,11 @@ func (s *SigNoz) doRequest(ctx context.Context, method, reqURL string, body io.R
 		}
 	}
 
+	apiKey, authHeader, credErr := credentialsFromContext(ctx)
+	if credErr != nil {
+		return nil, credErr
+	}
+
 	var lastErr error
 	wait := retryBaseWait
 
@@ -328,11 +354,10 @@ func (s *SigNoz) doRequest(ctx context.Context, method, reqURL string, body io.R
 		}
 
 		req.Header.Set(ContentType, "application/json")
-
-		req.Header.Set(s.authHeaderName, s.apiKey)
+		req.Header.Set(authHeader, apiKey)
 
 		for k, v := range s.customHeaders {
-			if strings.EqualFold(k, ContentType) || strings.EqualFold(k, s.authHeaderName) {
+			if strings.EqualFold(k, ContentType) || strings.EqualFold(k, authHeader) {
 				s.logger.WarnContext(ctx, "Custom header overrides a reserved header",
 					slog.String("header", k), slog.String("value", v))
 				continue

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -53,26 +53,29 @@ type AnalyticsIdentity struct {
 }
 
 type SigNoz struct {
-	baseURL        string
-	apiKey         string
-	authHeaderName string
-	logger         *slog.Logger
-	httpClient     *http.Client
-	customHeaders  map[string]string
+	baseURL       string
+	logger        *slog.Logger
+	httpClient    *http.Client
+	customHeaders map[string]string
 
-	identityMu       sync.Mutex
-	cachedIdentity   *AnalyticsIdentity
-	identityCachedAt time.Time
-	meters           *otelpkg.Meters
+	identityMu    sync.Mutex
+	identityCache map[string]identityEntry // key: util.HashCredential(apiKey, authHeader)
+	meters        *otelpkg.Meters
 }
 
-func NewClient(log *slog.Logger, baseURL, apiKey, authHeaderName string, customHeaders map[string]string) *SigNoz {
+// identityEntry is one cached analytics identity with its fetch time, so the
+// per-credential cache can expire entries independently.
+type identityEntry struct {
+	identity *AnalyticsIdentity
+	cachedAt time.Time
+}
+
+func NewClient(log *slog.Logger, baseURL string, customHeaders map[string]string) *SigNoz {
 	return &SigNoz{
-		logger:         log,
-		baseURL:        baseURL,
-		apiKey:         apiKey,
-		authHeaderName: authHeaderName,
-		customHeaders:  customHeaders,
+		logger:        log,
+		baseURL:       baseURL,
+		customHeaders: customHeaders,
+		identityCache: make(map[string]identityEntry),
 		httpClient: &http.Client{
 			// Default client span name is just the HTTP method (per OTel HTTP
 			// semconv — the client doesn't know a templated route). We keep

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -1940,3 +1940,27 @@ func TestDoRequest_MissingCredentialFailsClosed(t *testing.T) {
 	assert.Contains(t, err.Error(), "missing API key")
 	assert.False(t, called, "no HTTP request should be sent without credentials")
 }
+
+func TestGetAnalyticsIdentity_PerCredentialCache(t *testing.T) {
+	var requests atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests.Add(1)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"status":"success","data":{"id":"sa-1","email":"a@x.io","orgId":"org-1"}}`))
+	}))
+	defer server.Close()
+
+	client := NewClient(logpkg.New("error"), server.URL, nil)
+
+	// Two distinct credentials -> two fetches.
+	_, err := client.GetAnalyticsIdentity(credCtxFor("key-a", "SIGNOZ-API-KEY"))
+	require.NoError(t, err)
+	_, err = client.GetAnalyticsIdentity(credCtxFor("key-b", "SIGNOZ-API-KEY"))
+	require.NoError(t, err)
+	assert.Equal(t, int32(2), requests.Load(), "different credentials must not share a cached identity")
+
+	// Repeating key-a hits the cache -> no new fetch.
+	_, err = client.GetAnalyticsIdentity(credCtxFor("key-a", "SIGNOZ-API-KEY"))
+	require.NoError(t, err)
+	assert.Equal(t, int32(2), requests.Load(), "same credential must reuse the cached identity")
+}

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -20,11 +20,26 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/SigNoz/signoz-mcp-server/pkg/types"
+	"github.com/SigNoz/signoz-mcp-server/pkg/util"
 )
 
 func newBufferedLogger(buf *bytes.Buffer, level slog.Level) *slog.Logger {
 	base := slog.NewJSONHandler(buf, &slog.HandlerOptions{Level: level})
 	return slog.New(logpkg.NewContextHandler(base))
+}
+
+// credCtx returns a context carrying the credentials the client now reads at
+// request time. Defaults match the old baked-in test values.
+func credCtx() context.Context {
+	ctx := util.SetAPIKey(context.Background(), "test-api-key")
+	return util.SetAuthHeader(ctx, "SIGNOZ-API-KEY")
+}
+
+// credCtxFor returns a credentialed context for a specific apiKey/authHeader,
+// used by tests that exercise the Authorization (user-token) path.
+func credCtxFor(apiKey, authHeader string) context.Context {
+	ctx := util.SetAPIKey(context.Background(), apiKey)
+	return util.SetAuthHeader(ctx, authHeader)
 }
 
 func TestGetAlertByRuleID(t *testing.T) {
@@ -99,9 +114,9 @@ func TestGetAlertByRuleID(t *testing.T) {
 			defer server.Close()
 
 			logger := logpkg.New("debug")
-			client := NewClient(logger, server.URL, "test-api-key", "SIGNOZ-API-KEY", nil)
+			client := NewClient(logger, server.URL, nil)
 
-			ctx := context.Background()
+			ctx := credCtx()
 			result, err := client.GetAlertByRuleID(ctx, tt.ruleID)
 
 			if tt.expectedError {
@@ -142,9 +157,9 @@ func TestListAlertRules(t *testing.T) {
 	defer server.Close()
 
 	logger := logpkg.New("debug")
-	client := NewClient(logger, server.URL, "test-api-key", "SIGNOZ-API-KEY", nil)
+	client := NewClient(logger, server.URL, nil)
 
-	result, err := client.ListAlertRules(context.Background())
+	result, err := client.ListAlertRules(credCtx())
 	require.NoError(t, err)
 	assert.Contains(t, string(result), `"id":"rule-1"`)
 }
@@ -233,9 +248,9 @@ func TestValidateCredentials(t *testing.T) {
 			defer server.Close()
 
 			logger := logpkg.New("debug")
-			client := NewClient(logger, server.URL, "test-api-key", "SIGNOZ-API-KEY", nil)
+			client := NewClient(logger, server.URL, nil)
 
-			err := client.ValidateCredentials(context.Background())
+			err := client.ValidateCredentials(credCtx())
 
 			if tt.expectedError {
 				assert.Error(t, err)
@@ -362,9 +377,9 @@ func TestGetAnalyticsIdentity(t *testing.T) {
 			if tt.authHeaderName == "Authorization" {
 				apiKey = "Bearer jwt-token"
 			}
-			client := NewClient(logger, server.URL, apiKey, tt.authHeaderName, nil)
+			client := NewClient(logger, server.URL, nil)
 
-			identity, err := client.GetAnalyticsIdentity(context.Background())
+			identity, err := client.GetAnalyticsIdentity(credCtxFor(apiKey, tt.authHeaderName))
 
 			if tt.checkErr != nil {
 				assert.Error(t, err)
@@ -389,10 +404,10 @@ func TestGetAnalyticsIdentity_CachesResult(t *testing.T) {
 	defer server.Close()
 
 	logger := logpkg.New("debug")
-	client := NewClient(logger, server.URL, "Bearer jwt", "Authorization", nil)
+	client := NewClient(logger, server.URL, nil)
 
 	for i := 0; i < 5; i++ {
-		identity, err := client.GetAnalyticsIdentity(context.Background())
+		identity, err := client.GetAnalyticsIdentity(credCtxFor("Bearer jwt", "Authorization"))
 		require.NoError(t, err)
 		assert.Equal(t, "user-1", identity.UserID)
 	}
@@ -411,7 +426,7 @@ func TestGetAnalyticsIdentity_ConcurrentCallsDedupe(t *testing.T) {
 	defer server.Close()
 
 	logger := logpkg.New("debug")
-	client := NewClient(logger, server.URL, "Bearer jwt", "Authorization", nil)
+	client := NewClient(logger, server.URL, nil)
 
 	const callers = 10
 	var wg sync.WaitGroup
@@ -419,7 +434,7 @@ func TestGetAnalyticsIdentity_ConcurrentCallsDedupe(t *testing.T) {
 	for i := 0; i < callers; i++ {
 		go func() {
 			defer wg.Done()
-			_, err := client.GetAnalyticsIdentity(context.Background())
+			_, err := client.GetAnalyticsIdentity(credCtxFor("Bearer jwt", "Authorization"))
 			assert.NoError(t, err)
 		}()
 	}
@@ -438,9 +453,9 @@ func TestDoRequest_RetryLogsDebugThenWarn(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := NewClient(newBufferedLogger(&logBuf, slog.LevelDebug), server.URL, "test-api-key", "SIGNOZ-API-KEY", nil)
+	client := NewClient(newBufferedLogger(&logBuf, slog.LevelDebug), server.URL, nil)
 
-	_, err := client.doRequest(context.Background(), http.MethodGet, server.URL, nil, time.Second)
+	_, err := client.doRequest(credCtx(), http.MethodGet, server.URL, nil, time.Second)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "unexpected status 503")
 
@@ -484,9 +499,9 @@ func TestDoRequest_SucceedsAfterRetryWithoutRetriesExhaustedLog(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := NewClient(newBufferedLogger(&logBuf, slog.LevelDebug), server.URL, "test-api-key", "SIGNOZ-API-KEY", nil)
+	client := NewClient(newBufferedLogger(&logBuf, slog.LevelDebug), server.URL, nil)
 
-	body, err := client.doRequest(context.Background(), http.MethodGet, server.URL, nil, time.Second)
+	body, err := client.doRequest(credCtx(), http.MethodGet, server.URL, nil, time.Second)
 	require.NoError(t, err)
 	assert.JSONEq(t, `{"status":"success"}`, string(body))
 
@@ -521,9 +536,9 @@ func TestDoRequest_NonRetryableStatusOmitsRetriesExhausted(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := NewClient(newBufferedLogger(&logBuf, slog.LevelDebug), server.URL, "test-api-key", "SIGNOZ-API-KEY", nil)
+	client := NewClient(newBufferedLogger(&logBuf, slog.LevelDebug), server.URL, nil)
 
-	_, err := client.doRequest(context.Background(), http.MethodGet, server.URL, nil, time.Second)
+	_, err := client.doRequest(credCtx(), http.MethodGet, server.URL, nil, time.Second)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "unexpected status 400")
 
@@ -616,9 +631,9 @@ func TestListMetricKeys(t *testing.T) {
 			defer server.Close()
 
 			logger := logpkg.New("debug")
-			client := NewClient(logger, server.URL, "test-api-key", "SIGNOZ-API-KEY", nil)
+			client := NewClient(logger, server.URL, nil)
 
-			ctx := context.Background()
+			ctx := credCtx()
 			result, err := client.ListMetricKeys(ctx)
 
 			if tt.expectedError {
@@ -736,9 +751,9 @@ func TestListDashboards(t *testing.T) {
 			defer server.Close()
 
 			logger := logpkg.New("debug")
-			client := NewClient(logger, server.URL, "test-api-key", "SIGNOZ-API-KEY", nil)
+			client := NewClient(logger, server.URL, nil)
 
-			ctx := context.Background()
+			ctx := credCtx()
 			result, err := client.ListDashboards(ctx)
 
 			if tt.expectedError {
@@ -865,9 +880,9 @@ func TestListServices(t *testing.T) {
 			defer server.Close()
 
 			logger := logpkg.New("debug")
-			client := NewClient(logger, server.URL, "test-api-key", "SIGNOZ-API-KEY", nil)
+			client := NewClient(logger, server.URL, nil)
 
-			ctx := context.Background()
+			ctx := credCtx()
 			result, err := client.ListServices(ctx, tt.start, tt.end)
 
 			if tt.expectedError {
@@ -1051,9 +1066,9 @@ func TestGetAlertHistory(t *testing.T) {
 			defer server.Close()
 
 			logger := logpkg.New("debug")
-			client := NewClient(logger, server.URL, "test-api-key", "SIGNOZ-API-KEY", nil)
+			client := NewClient(logger, server.URL, nil)
 
-			ctx := context.Background()
+			ctx := credCtx()
 			result, err := client.GetAlertHistory(ctx, tt.ruleID, tt.request)
 
 			if tt.expectedError {
@@ -1216,9 +1231,9 @@ func TestQueryBuilderV5(t *testing.T) {
 			defer server.Close()
 
 			logger := logpkg.New("debug")
-			client := NewClient(logger, server.URL, "test-api-key", "SIGNOZ-API-KEY", nil)
+			client := NewClient(logger, server.URL, nil)
 
-			ctx := context.Background()
+			ctx := credCtx()
 			result, err := client.QueryBuilderV5(ctx, tt.queryBody)
 
 			if tt.expectedError {
@@ -1272,7 +1287,7 @@ func TestCreateDashboard(t *testing.T) {
 	defer server.Close()
 
 	logger := logpkg.New("debug")
-	client := NewClient(logger, server.URL, "test-api-key", "SIGNOZ-API-KEY", nil)
+	client := NewClient(logger, server.URL, nil)
 
 	d := types.Dashboard{
 		Title:   "whatever",
@@ -1280,7 +1295,7 @@ func TestCreateDashboard(t *testing.T) {
 		Widgets: []types.Widget{},
 	}
 
-	ctx := context.Background()
+	ctx := credCtx()
 	resp, err := client.CreateDashboard(ctx, d)
 	require.NoError(t, err)
 
@@ -1310,7 +1325,7 @@ func TestUpdateDashboard(t *testing.T) {
 	defer srv.Close()
 
 	logger := logpkg.New("debug")
-	client := NewClient(logger, srv.URL, "test-api-key", "SIGNOZ-API-KEY", nil)
+	client := NewClient(logger, srv.URL, nil)
 
 	d := types.Dashboard{
 		Title:   "updated-title",
@@ -1318,7 +1333,7 @@ func TestUpdateDashboard(t *testing.T) {
 		Widgets: []types.Widget{},
 	}
 
-	err := client.UpdateDashboard(context.Background(), "id-123", d)
+	err := client.UpdateDashboard(credCtx(), "id-123", d)
 	require.NoError(t, err)
 }
 
@@ -1333,9 +1348,9 @@ func TestDeleteDashboard(t *testing.T) {
 	defer srv.Close()
 
 	logger := logpkg.New("debug")
-	client := NewClient(logger, srv.URL, "test-api-key", "SIGNOZ-API-KEY", nil)
+	client := NewClient(logger, srv.URL, nil)
 
-	err := client.DeleteDashboard(context.Background(), "dash-456")
+	err := client.DeleteDashboard(credCtx(), "dash-456")
 	require.NoError(t, err)
 }
 
@@ -1421,9 +1436,9 @@ func TestGetFieldKeys(t *testing.T) {
 			defer server.Close()
 
 			logger := logpkg.New("debug")
-			client := NewClient(logger, server.URL, "test-api-key", "SIGNOZ-API-KEY", nil)
+			client := NewClient(logger, server.URL, nil)
 
-			ctx := context.Background()
+			ctx := credCtx()
 			result, err := client.GetFieldKeys(ctx, tt.signal, tt.metricName, tt.searchText, tt.fieldContext, tt.fieldDataType, tt.source)
 
 			if tt.expectedError {
@@ -1522,9 +1537,9 @@ func TestGetFieldValues(t *testing.T) {
 			defer server.Close()
 
 			logger := logpkg.New("debug")
-			client := NewClient(logger, server.URL, "test-api-key", "SIGNOZ-API-KEY", nil)
+			client := NewClient(logger, server.URL, nil)
 
-			ctx := context.Background()
+			ctx := credCtx()
 			result, err := client.GetFieldValues(ctx, tt.signal, tt.fieldName, tt.metricName, tt.searchText, tt.source)
 
 			if tt.expectedError {
@@ -1558,9 +1573,9 @@ func TestDoRequest_RetryOn503ThenSuccess(t *testing.T) {
 	defer srv.Close()
 
 	logger := logpkg.New("debug")
-	c := NewClient(logger, srv.URL, "test-key", "SIGNOZ-API-KEY", nil)
+	c := NewClient(logger, srv.URL, nil)
 
-	result, err := c.doRequest(context.Background(), http.MethodGet, srv.URL+"/test", nil, DefaultQueryTimeout)
+	result, err := c.doRequest(credCtx(), http.MethodGet, srv.URL+"/test", nil, DefaultQueryTimeout)
 	require.NoError(t, err)
 	assert.Equal(t, 3, attempts)
 	assert.Contains(t, string(result), "success")
@@ -1576,9 +1591,9 @@ func TestDoRequest_RetriesExhausted(t *testing.T) {
 	defer srv.Close()
 
 	logger := logpkg.New("debug")
-	c := NewClient(logger, srv.URL, "test-key", "SIGNOZ-API-KEY", nil)
+	c := NewClient(logger, srv.URL, nil)
 
-	result, err := c.doRequest(context.Background(), http.MethodGet, srv.URL+"/test", nil, DefaultQueryTimeout)
+	result, err := c.doRequest(credCtx(), http.MethodGet, srv.URL+"/test", nil, DefaultQueryTimeout)
 	assert.Error(t, err)
 	assert.Nil(t, result)
 	assert.Equal(t, 3, attempts)
@@ -1593,9 +1608,9 @@ func TestDoRequest_ContextCancelled(t *testing.T) {
 	defer srv.Close()
 
 	logger := logpkg.New("debug")
-	c := NewClient(logger, srv.URL, "test-key", "SIGNOZ-API-KEY", nil)
+	c := NewClient(logger, srv.URL, nil)
 
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(credCtx())
 	cancel() // Cancel immediately
 
 	_, err := c.doRequest(ctx, http.MethodGet, srv.URL+"/test", nil, DefaultQueryTimeout)
@@ -1612,9 +1627,9 @@ func TestDoRequest_NoRetryOn4xx(t *testing.T) {
 	defer srv.Close()
 
 	logger := logpkg.New("debug")
-	c := NewClient(logger, srv.URL, "test-key", "SIGNOZ-API-KEY", nil)
+	c := NewClient(logger, srv.URL, nil)
 
-	_, err := c.doRequest(context.Background(), http.MethodGet, srv.URL+"/test", nil, DefaultQueryTimeout)
+	_, err := c.doRequest(credCtx(), http.MethodGet, srv.URL+"/test", nil, DefaultQueryTimeout)
 	assert.Error(t, err)
 	assert.Equal(t, 1, attempts)
 	assert.Contains(t, err.Error(), "400")
@@ -1635,9 +1650,9 @@ func TestDoRequest_RetryOn429(t *testing.T) {
 	defer srv.Close()
 
 	logger := logpkg.New("debug")
-	c := NewClient(logger, srv.URL, "test-key", "SIGNOZ-API-KEY", nil)
+	c := NewClient(logger, srv.URL, nil)
 
-	result, err := c.doRequest(context.Background(), http.MethodGet, srv.URL+"/test", nil, DefaultQueryTimeout)
+	result, err := c.doRequest(credCtx(), http.MethodGet, srv.URL+"/test", nil, DefaultQueryTimeout)
 	require.NoError(t, err)
 	assert.Equal(t, 2, attempts)
 	assert.Contains(t, string(result), "success")
@@ -1664,9 +1679,9 @@ func TestNewClient_SetsCustomHeaders(t *testing.T) {
 	defer server.Close()
 
 	logger := logpkg.New("debug")
-	client := NewClient(logger, server.URL, "test-api-key", "SIGNOZ-API-KEY", customHeaders)
+	client := NewClient(logger, server.URL, customHeaders)
 
-	_, err := client.ListAlerts(context.Background(), types.ListAlertsParams{})
+	_, err := client.ListAlerts(credCtx(), types.ListAlertsParams{})
 	assert.NoError(t, err)
 }
 
@@ -1682,9 +1697,9 @@ func TestNewClient_NilHeaders(t *testing.T) {
 	defer server.Close()
 
 	logger := logpkg.New("debug")
-	client := NewClient(logger, server.URL, "test-api-key", "SIGNOZ-API-KEY", nil)
+	client := NewClient(logger, server.URL, nil)
 
-	_, err := client.ListAlerts(context.Background(), types.ListAlertsParams{})
+	_, err := client.ListAlerts(credCtx(), types.ListAlertsParams{})
 	assert.NoError(t, err)
 }
 
@@ -1699,9 +1714,9 @@ func TestNewClient_EmptyHeaders(t *testing.T) {
 	defer server.Close()
 
 	logger := logpkg.New("debug")
-	client := NewClient(logger, server.URL, "test-api-key", "SIGNOZ-API-KEY", map[string]string{})
+	client := NewClient(logger, server.URL, map[string]string{})
 
-	_, err := client.ListAlerts(context.Background(), types.ListAlertsParams{})
+	_, err := client.ListAlerts(credCtx(), types.ListAlertsParams{})
 	assert.NoError(t, err)
 }
 
@@ -1726,9 +1741,9 @@ func TestNewClient_ReservedHeadersSkipped(t *testing.T) {
 	defer server.Close()
 
 	logger := logpkg.New("debug")
-	client := NewClient(logger, server.URL, "test-api-key", "SIGNOZ-API-KEY", customHeaders)
+	client := NewClient(logger, server.URL, customHeaders)
 
-	_, err := client.ListAlerts(context.Background(), types.ListAlertsParams{})
+	_, err := client.ListAlerts(credCtx(), types.ListAlertsParams{})
 	assert.NoError(t, err)
 }
 
@@ -1740,9 +1755,9 @@ func TestCreateAlertRule_v2Returns201(t *testing.T) {
 		_, _ = w.Write([]byte(`{"status":"success","data":{"id":"rule-123"}}`))
 	}))
 	defer srv.Close()
-	client := NewClient(logpkg.New("debug"), srv.URL, "k", "SIGNOZ-API-KEY", nil)
+	client := NewClient(logpkg.New("debug"), srv.URL, nil)
 
-	data, err := client.CreateAlertRule(context.Background(), []byte(`{"alert":"x"}`))
+	data, err := client.CreateAlertRule(credCtx(), []byte(`{"alert":"x"}`))
 	require.NoError(t, err)
 	assert.Equal(t, "/api/v2/rules", gotPath)
 	assert.Equal(t, http.MethodPost, gotMethod)
@@ -1756,9 +1771,9 @@ func TestUpdateAlertRule_v2Returns204(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	}))
 	defer srv.Close()
-	client := NewClient(logpkg.New("debug"), srv.URL, "k", "SIGNOZ-API-KEY", nil)
+	client := NewClient(logpkg.New("debug"), srv.URL, nil)
 
-	err := client.UpdateAlertRule(context.Background(), "abc-123", []byte(`{"alert":"x"}`))
+	err := client.UpdateAlertRule(credCtx(), "abc-123", []byte(`{"alert":"x"}`))
 	require.NoError(t, err)
 	assert.Equal(t, "/api/v2/rules/abc-123", gotPath)
 	assert.Equal(t, http.MethodPut, gotMethod)
@@ -1771,9 +1786,9 @@ func TestDeleteAlertRule_v2Returns204(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	}))
 	defer srv.Close()
-	client := NewClient(logpkg.New("debug"), srv.URL, "k", "SIGNOZ-API-KEY", nil)
+	client := NewClient(logpkg.New("debug"), srv.URL, nil)
 
-	err := client.DeleteAlertRule(context.Background(), "abc-123")
+	err := client.DeleteAlertRule(credCtx(), "abc-123")
 	require.NoError(t, err)
 	assert.Equal(t, "/api/v2/rules/abc-123", gotPath)
 	assert.Equal(t, http.MethodDelete, gotMethod)
@@ -1786,9 +1801,9 @@ func TestTestNotificationChannel_UsesNewPath(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	}))
 	defer srv.Close()
-	client := NewClient(logpkg.New("debug"), srv.URL, "k", "SIGNOZ-API-KEY", nil)
+	client := NewClient(logpkg.New("debug"), srv.URL, nil)
 
-	err := client.TestNotificationChannel(context.Background(), []byte(`{"name":"x"}`))
+	err := client.TestNotificationChannel(credCtx(), []byte(`{"name":"x"}`))
 	require.NoError(t, err)
 	assert.Equal(t, "/api/v1/channels/test", gotPath)
 }
@@ -1800,9 +1815,9 @@ func TestUpdateNotificationChannel_Returns204(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	}))
 	defer srv.Close()
-	client := NewClient(logpkg.New("debug"), srv.URL, "k", "SIGNOZ-API-KEY", nil)
+	client := NewClient(logpkg.New("debug"), srv.URL, nil)
 
-	err := client.UpdateNotificationChannel(context.Background(), "42", []byte(`{"name":"x"}`))
+	err := client.UpdateNotificationChannel(credCtx(), "42", []byte(`{"name":"x"}`))
 	require.NoError(t, err)
 	assert.Equal(t, "/api/v1/channels/42", gotPath)
 	assert.Equal(t, http.MethodPut, gotMethod)
@@ -1815,9 +1830,9 @@ func TestDeleteNotificationChannel(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	}))
 	defer srv.Close()
-	client := NewClient(logpkg.New("debug"), srv.URL, "k", "SIGNOZ-API-KEY", nil)
+	client := NewClient(logpkg.New("debug"), srv.URL, nil)
 
-	err := client.DeleteNotificationChannel(context.Background(), "42")
+	err := client.DeleteNotificationChannel(credCtx(), "42")
 	require.NoError(t, err)
 	assert.Equal(t, "/api/v1/channels/42", gotPath)
 	assert.Equal(t, http.MethodDelete, gotMethod)
@@ -1835,8 +1850,8 @@ func TestListViews(t *testing.T) {
 	}))
 	defer server.Close()
 
-	c := NewClient(logpkg.New("error"), server.URL, "k", "SIGNOZ-API-KEY", nil)
-	_, err := c.ListViews(context.Background(), "traces", "ak", "ops")
+	c := NewClient(logpkg.New("error"), server.URL, nil)
+	_, err := c.ListViews(credCtx(), "traces", "ak", "ops")
 	require.NoError(t, err)
 	assert.Equal(t, http.MethodGet, gotMethod)
 	assert.Equal(t, "/api/v1/explorer/views", gotPath)
@@ -1853,8 +1868,8 @@ func TestGetView(t *testing.T) {
 		_, _ = w.Write([]byte(`{"status":"success","data":{}}`))
 	}))
 	defer server.Close()
-	c := NewClient(logpkg.New("error"), server.URL, "k", "SIGNOZ-API-KEY", nil)
-	_, err := c.GetView(context.Background(), "view-uuid-1")
+	c := NewClient(logpkg.New("error"), server.URL, nil)
+	_, err := c.GetView(credCtx(), "view-uuid-1")
 	require.NoError(t, err)
 	assert.Equal(t, http.MethodGet, gotMethod)
 	assert.Equal(t, "/api/v1/explorer/views/view-uuid-1", gotPath)
@@ -1870,9 +1885,9 @@ func TestCreateView(t *testing.T) {
 		_, _ = w.Write([]byte(`{"status":"success","data":{"id":"new-id"}}`))
 	}))
 	defer server.Close()
-	c := NewClient(logpkg.New("error"), server.URL, "k", "SIGNOZ-API-KEY", nil)
+	c := NewClient(logpkg.New("error"), server.URL, nil)
 	body := []byte(`{"name":"x","sourcePage":"traces","compositeQuery":{}}`)
-	_, err := c.CreateView(context.Background(), body)
+	_, err := c.CreateView(credCtx(), body)
 	require.NoError(t, err)
 	assert.Equal(t, http.MethodPost, gotMethod)
 	assert.Equal(t, "/api/v1/explorer/views", gotPath)
@@ -1887,8 +1902,8 @@ func TestUpdateView(t *testing.T) {
 		_, _ = w.Write([]byte(`{"status":"success","data":{}}`))
 	}))
 	defer server.Close()
-	c := NewClient(logpkg.New("error"), server.URL, "k", "SIGNOZ-API-KEY", nil)
-	_, err := c.UpdateView(context.Background(), "view-1", []byte(`{}`))
+	c := NewClient(logpkg.New("error"), server.URL, nil)
+	_, err := c.UpdateView(credCtx(), "view-1", []byte(`{}`))
 	require.NoError(t, err)
 	assert.Equal(t, http.MethodPut, gotMethod)
 	assert.Equal(t, "/api/v1/explorer/views/view-1", gotPath)
@@ -1902,8 +1917,8 @@ func TestDeleteView(t *testing.T) {
 		_, _ = w.Write([]byte(`{"status":"success"}`))
 	}))
 	defer server.Close()
-	c := NewClient(logpkg.New("error"), server.URL, "k", "SIGNOZ-API-KEY", nil)
-	_, err := c.DeleteView(context.Background(), "view-1")
+	c := NewClient(logpkg.New("error"), server.URL, nil)
+	_, err := c.DeleteView(credCtx(), "view-1")
 	require.NoError(t, err)
 	assert.Equal(t, http.MethodDelete, gotMethod)
 	assert.Equal(t, "/api/v1/explorer/views/view-1", gotPath)

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -1923,3 +1923,20 @@ func TestDeleteView(t *testing.T) {
 	assert.Equal(t, http.MethodDelete, gotMethod)
 	assert.Equal(t, "/api/v1/explorer/views/view-1", gotPath)
 }
+
+func TestDoRequest_MissingCredentialFailsClosed(t *testing.T) {
+	called := false
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	client := NewClient(logpkg.New("error"), server.URL, nil)
+
+	// Background ctx has no API key -> must error before any HTTP call.
+	_, err := client.doRequest(context.Background(), http.MethodGet, server.URL, nil, time.Second)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "missing API key")
+	assert.False(t, called, "no HTTP request should be sent without credentials")
+}

--- a/internal/handler/tools/handler.go
+++ b/internal/handler/tools/handler.go
@@ -68,17 +68,12 @@ func (h *Handler) GetClient(ctx context.Context) (signozclient.Client, error) {
 
 	apiKey, _ := util.GetAPIKey(ctx)
 	signozURL, _ := util.GetSigNozURL(ctx)
-	authHeader, _ := util.GetAuthHeader(ctx)
 
 	if apiKey == "" || signozURL == "" {
 		return nil, fmt.Errorf("missing tenant credentials in context (apiKey or signozURL)")
 	}
 
-	if authHeader == "" {
-		authHeader = "SIGNOZ-API-KEY"
-	}
-
-	cacheKey := util.HashTenantKey(apiKey, signozURL)
+	cacheKey := strings.ToLower(signozURL)
 
 	if cachedClient, ok := h.clientCache.Get(cacheKey); ok {
 		return cachedClient, nil
@@ -93,7 +88,7 @@ func (h *Handler) GetClient(ctx context.Context) (signozclient.Client, error) {
 	}
 
 	h.logger.DebugContext(ctx, "Creating new SigNoz client for tenant")
-	newClient := signozclient.NewClient(h.logger, signozURL, apiKey, authHeader, headers)
+	newClient := signozclient.NewClient(h.logger, signozURL, headers)
 	newClient.SetMeters(h.meters)
 	h.clientCache.Add(cacheKey, newClient)
 	return newClient, nil

--- a/internal/handler/tools/handler_test.go
+++ b/internal/handler/tools/handler_test.go
@@ -1,0 +1,46 @@
+package tools
+
+import (
+	"context"
+	"testing"
+
+	expirable "github.com/hashicorp/golang-lru/v2/expirable"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	signozclient "github.com/SigNoz/signoz-mcp-server/internal/client"
+	logpkg "github.com/SigNoz/signoz-mcp-server/pkg/log"
+	"github.com/SigNoz/signoz-mcp-server/pkg/util"
+)
+
+func ctxWith(apiKey, url string) context.Context {
+	ctx := util.SetAPIKey(context.Background(), apiKey)
+	ctx = util.SetAuthHeader(ctx, "SIGNOZ-API-KEY")
+	return util.SetSigNozURL(ctx, url)
+}
+
+func TestGetClient_SharedAcrossAPIKeysPerURL(t *testing.T) {
+	h := &Handler{
+		logger:      logpkg.New("error"),
+		clientCache: expirable.NewLRU[string, *signozclient.SigNoz](16, nil, 0),
+	}
+
+	c1, err := h.GetClient(ctxWith("key-a", "https://tenant.example.com"))
+	require.NoError(t, err)
+	c2, err := h.GetClient(ctxWith("key-b", "https://tenant.example.com"))
+	require.NoError(t, err)
+	assert.True(t, c1 == c2, "same URL must reuse one cached client regardless of API key")
+
+	c3, err := h.GetClient(ctxWith("key-a", "https://other.example.com"))
+	require.NoError(t, err)
+	assert.False(t, c1 == c3, "different URLs must get different clients")
+}
+
+func TestGetClient_MissingCredentialsError(t *testing.T) {
+	h := &Handler{
+		logger:      logpkg.New("error"),
+		clientCache: expirable.NewLRU[string, *signozclient.SigNoz](16, nil, 0),
+	}
+	_, err := h.GetClient(util.SetSigNozURL(context.Background(), "https://x.io")) // no apiKey
+	assert.Error(t, err)
+}

--- a/internal/oauth/handlers.go
+++ b/internal/oauth/handlers.go
@@ -303,7 +303,13 @@ func (h *Handler) validateSigNozCredentials(ctx context.Context, signozURL, apiK
 	if strings.EqualFold(signozURL, configNormalized) {
 		headers = h.config.CustomHeaders
 	}
-	signozClient := client.NewClient(h.logger, signozURL, apiKey, "SIGNOZ-API-KEY", headers)
+
+	// The client reads credentials from context, so seed them here — the OAuth
+	// flow received them as form fields / decrypted grants, not on the context.
+	ctx = util.SetAPIKey(ctx, apiKey)
+	ctx = util.SetAuthHeader(ctx, "SIGNOZ-API-KEY")
+
+	signozClient := client.NewClient(h.logger, signozURL, headers)
 	return signozClient.ValidateCredentials(ctx)
 }
 

--- a/pkg/util/context.go
+++ b/pkg/util/context.go
@@ -147,11 +147,10 @@ func GetAssistantExecutionID(ctx context.Context) (string, bool) {
 	return id, ok
 }
 
-// HashTenantKey returns a SHA-256 hash of apiKey and signozURL, suitable for
-// use as a cache/map key without exposing the raw API key in memory.
-// A null-byte separator is used to prevent collisions between different
-// (apiKey, signozURL) pairs that contain colons.
-func HashTenantKey(apiKey, signozURL string) string {
-	h := sha256.Sum256([]byte(apiKey + "\x00" + signozURL))
+// HashCredential returns a SHA-256 hash of apiKey and authHeader, suitable for
+// use as a map key without exposing the raw API key in memory. A null-byte
+// separator prevents collisions between pairs that contain colons.
+func HashCredential(apiKey, authHeader string) string {
+	h := sha256.Sum256([]byte(apiKey + "\x00" + authHeader))
 	return hex.EncodeToString(h[:])
 }

--- a/plans/client-cache-by-url.context.md
+++ b/plans/client-cache-by-url.context.md
@@ -1,0 +1,47 @@
+# Feature: Cache SigNoz clients by URL (#69) — Context & Discussion
+
+## Original Prompt
+> Now let's implement caching(#69) on top of this PR
+
+(Where "this PR" = #192, the stateless-transport change on branch `feat/stateless-transport`.)
+
+## Reference Links
+- [Issue #69](https://github.com/SigNoz/signoz-mcp-server/issues/69) — "Why is the client storing the apikey? … incomplete attempt to cache the http client."
+- [PR #187 (closed)](https://github.com/SigNoz/signoz-mcp-server/pull/187) — akshaysw's original implementation, reused here.
+- Stacks on [PR #192](https://github.com/SigNoz/signoz-mcp-server/pull/192) (stateless transport).
+
+## Key Decisions & Discussion Log
+
+### 2026-06-07 — Decision: implement #69 stacked on the stateless PR, reusing #187
+- Earlier the plan was to do #69 after #192 merged; changed to stacking it on #192 now.
+- The client cache (#69) is INDEPENDENT of statelessness — but complementary: statelessness
+  makes every request independent, so a per-URL shared HTTP connection pool matters more, not
+  less. (See [[stateless-server.context]] / the closed-#187 discussion.)
+- #187 already implemented exactly this and was CI-green. Decision: REUSE it rather than
+  reimplement — cherry-pick its 11 code/test commits (preserving akshaysw's authorship), since
+  every file it touches (`client.go`, `client_test.go`, `handler.go`, `handler_test.go`,
+  `util/context.go`, `oauth/handlers.go`) is disjoint from the stateless changes. Cherry-pick
+  applied with zero conflicts.
+- PR structure: SEPARATE stacked PR (base `feat/stateless-transport`), to keep #192 focused.
+  Merges in order (#192 first; this PR then retargets to `main`).
+- `docs/architecture.md`: #187's doc commit was NOT cherry-picked (would clash with the
+  stateless section); replicated its cache-description edits by hand and added a "Client
+  Caching" section alongside the "Stateless Transport" section.
+
+## What changed (from #187, reused)
+- `SigNoz` client is credential-free: dropped `apiKey`/`authHeaderName`; credentials read from
+  request context and stamped per outbound request via `credentialsFromContext`. Missing API
+  key → fail closed (error before any HTTP call).
+- Client cache keyed by `lowercase(signozURL)` (was `HashTenantKey(apiKey, signozURL)`), so
+  different API keys on the same URL share one client + connection pool.
+- Analytics `/me` identity cache moved from a single per-client value to a map keyed by
+  `HashCredential(apiKey, authHeader)` (renamed from `HashTenantKey`).
+- OAuth validation path seeds credentials onto ctx before `ValidateCredentials`.
+- Tests migrated to context-supplied credentials; added: per-URL sharing, fail-closed,
+  per-credential identity isolation.
+
+## Open Questions
+- [x] Reuse #187 vs reimplement? → Reuse (cherry-pick), preserves authorship + tested code.
+- [x] Stack vs fold into #192? → Separate stacked PR (base `feat/stateless-transport`).
+- [ ] When #192 merges, retarget this PR to `main` and correct the #187 closing comment
+  (it inaccurately cited #190/#191 as superseding — the real successor is this PR).

--- a/plans/client-cache-by-url.plan.md
+++ b/plans/client-cache-by-url.plan.md
@@ -1,0 +1,41 @@
+# Plan: Cache SigNoz clients by URL (#69)
+
+## Status
+In Progress
+
+## Context
+`Handler.GetClient` cached `SigNoz` clients by `HashTenantKey(apiKey, signozURL)`, because the
+client baked the API key into itself and stamped it on every request. So two API keys on the
+same SigNoz URL got separate clients and separate HTTP connection pools — the "incomplete
+attempt to cache the http client" called out in #69. This is independent of, and complementary
+to, the stateless transport (#192): with stateless requests there is no session affinity, so a
+shared per-URL connection pool is what keeps per-request client resolution efficient.
+
+## Approach
+Reuse PR #187's implementation (cherry-picked, akshaysw authorship preserved), stacked on
+`feat/stateless-transport`:
+- **Credential-free client** — drop `apiKey`/`authHeaderName` from `SigNoz`/`NewClient`; read
+  credentials from request context and stamp per outbound request (`credentialsFromContext`).
+  Missing API key → fail closed before any HTTP call.
+- **Cache by URL** — `cacheKey = strings.ToLower(signozURL)`; one client + pool per backend URL.
+- **Per-credential identity cache** — `/me` cache becomes a map keyed by
+  `HashCredential(apiKey, authHeader)` (renamed from `HashTenantKey`), serialized by mutex.
+- **OAuth** — seed credentials onto ctx before `ValidateCredentials`.
+- **Docs** — `docs/architecture.md` cache labels + new "Client Caching" section (done by hand to
+  coexist with the stateless section, since #187's doc commit was not cherry-picked).
+
+## Files Modified
+- `internal/client/client.go`, `internal/client/client_test.go`
+- `internal/handler/tools/handler.go`, `internal/handler/tools/handler_test.go`
+- `internal/oauth/handlers.go`
+- `pkg/util/context.go` (`HashTenantKey` → `HashCredential`)
+- `docs/architecture.md` (cache description + Client Caching section)
+- `plans/client-cache-by-url.{context,plan}.md`
+
+## Verification
+- `go build ./...`, `go vet ./...`, `go test ./... -count=1`, `go test -race ./internal/client/... ./internal/handler/tools/...` — all green (done).
+- #187's own tests carried over: `TestGetClient_SharedAcrossAPIKeysPerURL` (different keys/same
+  URL reuse one client; different URLs differ), `TestGetClient_MissingCredentialsError` /
+  `TestDoRequest_MissingCredentialFailsClosed` (fail closed), `TestGetAnalyticsIdentity_PerCredentialCache`.
+- Stacked PR base = `feat/stateless-transport`; retarget to `main` after #192 merges.
+- Optional follow-up: a Codex review + live E2E pass mirroring the stateless PR, if desired.


### PR DESCRIPTION
## Summary

Closes #69. **Stacked on #192** (stateless transport) — base branch is `feat/stateless-transport`; will retarget to `main` once #192 merges.

Builds on @akshaysw's implementation from #187 (commits cherry-picked, authorship preserved).

`Handler.GetClient` cached `SigNoz` clients by `HashTenantKey(apiKey, signozURL)` because the client baked the API key into itself and stamped it on every request — so two API keys hitting the same SigNoz URL got separate clients and separate HTTP connection pools, defeating the point of caching the client (the concern raised in #69).

- **Credential-free client** — dropped `apiKey`/`authHeaderName` from `SigNoz`/`NewClient`; credentials are read from the request context and stamped onto each outbound request at send time. Missing API key → **fail closed** (error before any HTTP call).
- **Cache by URL** — `cacheKey = strings.ToLower(signozURL)`; one client + one connection pool per SigNoz URL, shared across API keys.
- **Per-credential identity cache** — the `/me` identity cache moved from a single per-client value to a map keyed by `HashCredential(apiKey, authHeader)` (renamed from `HashTenantKey`), so attribution stays correct on the shared client.
- **OAuth** validation path seeds credentials onto ctx before `ValidateCredentials`.

Complements the stateless transport in #192: with no session affinity, every request is independent, so a shared per-URL connection pool is what keeps per-request client resolution efficient.

No MCP tool schema / README / manifest changes. `docs/architecture.md` updated (cache labels + Client Caching section); `plans/` convention pair included.

## Test Plan
- [x] `go build ./...`, `go vet ./...`, `go test ./... -count=1` all pass
- [x] `go test -race ./internal/client/... ./internal/handler/tools/...` clean
- [x] `TestGetClient_SharedAcrossAPIKeysPerURL` — different API keys + same URL reuse one client; different URLs differ
- [x] `TestGetClient_MissingCredentialsError` / `TestDoRequest_MissingCredentialFailsClosed` — fail closed without credentials
- [x] `TestGetAnalyticsIdentity_PerCredentialCache` — distinct credentials don't share a cached identity
- [x] Existing client tests migrated to context-supplied credentials

Co-authored-by: Akshay Shrikantrao Walvekar <akshaywalvekar95@gmail.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)