### PR TITLE
perf(client): share one tuned HTTP transport for connection reuse

### DIFF
--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -66,6 +66,28 @@ type SigNoz struct {
 	meters           *otelpkg.Meters
 }
 
+// sharedTransport is a single process-wide *http.Transport — and therefore a
+// single connection pool — reused by every SigNoz client. Go pools idle
+// keep-alive connections per host on the Transport, so sharing one transport lets
+// all clients (and tenants) reuse connections to a given SigNoz host instead of
+// re-handshaking on each request.
+//
+// We clone http.DefaultTransport (preserving its dial/TLS timeouts, proxy, HTTP/2
+// settings, etc.) and raise the idle-connection limits. The stdlib defaults —
+// MaxIdleConnsPerHost=2, MaxIdleConns=100 — are tuned for a browser-like client
+// and throttle keep-alive reuse under the concurrency a multi-tenant MCP server
+// sees: once more than 2 requests to the same SigNoz host are in flight, the
+// surplus connections are closed rather than pooled, forcing fresh TCP+TLS
+// handshakes on the next request. These values are conservative starting points;
+// the per-host cap bounds reuse for a hot host while the global cap bounds total
+// idle FDs across many distinct tenant hosts.
+var sharedTransport = func() *http.Transport {
+	t := http.DefaultTransport.(*http.Transport).Clone()
+	t.MaxIdleConns = 200       // total idle conns across all SigNoz hosts (was 100)
+	t.MaxIdleConnsPerHost = 20 // idle conns kept per host for reuse (was 2)
+	return t
+}()
+
 func NewClient(log *slog.Logger, baseURL, apiKey, authHeaderName string, customHeaders map[string]string) *SigNoz {
 	return &SigNoz{
 		logger:         log,
@@ -81,7 +103,10 @@ func NewClient(log *slog.Logger, baseURL, apiKey, authHeaderName string, customH
 			// /channels/{id}, /explorer/views/{id}, /rules/{id}/history/...)
 			// which would blow up span-name cardinality in the backend. The
 			// full URL is still attached as a span attribute for drilling.
-			Transport: otelhttp.NewTransport(http.DefaultTransport),
+			//
+			// All clients share sharedTransport so connections to a SigNoz host
+			// are pooled/reused process-wide regardless of how many clients exist.
+			Transport: otelhttp.NewTransport(sharedTransport),
 		},
 	}
 }

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -1908,3 +1908,15 @@ func TestDeleteView(t *testing.T) {
 	assert.Equal(t, http.MethodDelete, gotMethod)
 	assert.Equal(t, "/api/v1/explorer/views/view-1", gotPath)
 }
+
+func TestSharedTransportPoolTuning(t *testing.T) {
+	// Idle-connection limits are raised above the stdlib defaults (per-host 2,
+	// total 100) so a multi-tenant server reuses keep-alive connections under
+	// concurrency instead of re-handshaking. Every other test in this file already
+	// drives requests through sharedTransport (NewClient wires it in), so this just
+	// guards the tuned values and that the transport is a proper DefaultTransport clone.
+	require.Equal(t, 20, sharedTransport.MaxIdleConnsPerHost, "MaxIdleConnsPerHost")
+	require.Equal(t, 200, sharedTransport.MaxIdleConns, "MaxIdleConns")
+	require.NotZero(t, sharedTransport.TLSHandshakeTimeout, "cloned DefaultTransport: TLSHandshakeTimeout preserved")
+	require.NotNil(t, sharedTransport.DialContext, "cloned DefaultTransport: DialContext preserved")
+}

--- a/plans/transport-pool-tuning.context.md
+++ b/plans/transport-pool-tuning.context.md
@@ -1,0 +1,34 @@
+# Feature: Tune the shared HTTP transport connection pool — Context & Discussion
+
+## Original Prompt
+> Also does existing cache not useful? Let's remove that if not
+> (resolved decision: "Tune transport instead")
+
+## Reference Links
+- Issue [#69](https://github.com/SigNoz/signoz-mcp-server/issues/69) (closed not-needed — connection reuse already global).
+- Related/closed: [#187](https://github.com/SigNoz/signoz-mcp-server/pull/187), [#193](https://github.com/SigNoz/signoz-mcp-server/pull/193) (cache-by-URL, dropped for unique-URL-per-tenant topology).
+
+## Key Decisions & Discussion Log
+
+### 2026-06-08 — Finding: the client cache never did connection pooling
+- Every `SigNoz` client was built with `otelhttp.NewTransport(http.DefaultTransport)`
+  (`client.go`), so all clients share Go's global `http.DefaultTransport` and its single
+  connection pool. Connection reuse to a SigNoz host already happens process-wide, independent
+  of the `handler.clientCache` (whose only warm state is the analytics `/me` identity, used
+  only when analytics is enabled). This also invalidated #69's premise and #193's perf rationale.
+- Decision (user): keep the client cache as-is; instead **tune the shared transport's idle-conn
+  limits**, which is the real lever for connection reuse under concurrency.
+
+### 2026-06-08 — Approach
+- Introduce a package-level `sharedTransport` (a clone of `http.DefaultTransport`) reused by
+  every client, so the single-shared-pool property is preserved while the limits are raised.
+  Must NOT give each client its own transport — that would fragment the pool.
+- Values: `MaxIdleConnsPerHost: 2 → 20`, `MaxIdleConns: 100 → 200`. Conservative starting
+  points: per-host cap aids a hot host; global cap bounds idle FDs across many tenant hosts.
+  Hardcoded for now (tunable later via env if metrics warrant).
+- Stacking: standalone PR off `main` (independent of #192 stateless; touches only `client.go`).
+
+## Open Questions
+- [x] Remove the client cache? → No; tune the transport instead (cache still dedups `/me`).
+- [ ] Make the limits env-configurable? → Deferred; revisit if prod metrics show connection
+  churn or idle-FD pressure at a specific tenant scale.

--- a/plans/transport-pool-tuning.plan.md
+++ b/plans/transport-pool-tuning.plan.md
@@ -1,0 +1,34 @@
+# Plan: Tune the shared HTTP transport connection pool
+
+## Status
+In Progress
+
+## Context
+All `SigNoz` clients share Go's global `http.DefaultTransport` (via
+`otelhttp.NewTransport(http.DefaultTransport)`), so connection reuse to a SigNoz host is
+already process-wide — the per-`(apiKey,URL)` client cache does not affect it. But the stdlib
+defaults (`MaxIdleConnsPerHost=2`, `MaxIdleConns=100`) throttle keep-alive reuse under the
+concurrency a multi-tenant MCP server sees: beyond 2 in-flight requests to the same host, idle
+connections are closed rather than pooled, forcing fresh TCP+TLS handshakes. Raising these is
+the actual lever for connection efficiency (vs the client cache, which is really a `/me`
+identity cache).
+
+## Approach
+- Add a package-level `sharedTransport` in `internal/client/client.go`: clone
+  `http.DefaultTransport` (preserves dial/TLS timeouts, proxy, HTTP/2), then set
+  `MaxIdleConns=200`, `MaxIdleConnsPerHost=20`. Wire `NewClient` to
+  `otelhttp.NewTransport(sharedTransport)` so every client shares the one tuned pool
+  (single-pool property preserved — do not create per-client transports).
+
+## Files Modified
+- `internal/client/client.go` — `sharedTransport` var + use it in `NewClient`.
+- `internal/client/client_test.go` — `TestSharedTransportPoolTuning` (guards the tuned values +
+  that it's a proper `DefaultTransport` clone; the rest of the suite already drives requests
+  through it).
+- `plans/transport-pool-tuning.{context,plan}.md`.
+
+## Verification
+- `go build ./...`, `go vet ./...`, `go test ./... -count=1`, `go test -race ./internal/client/...` — green.
+- Standalone PR off `main`.
+- Future (optional): make limits env-configurable; observe connection-reuse / idle-FD metrics
+  in prod to confirm the chosen values.


### PR DESCRIPTION
## Summary

Raises the HTTP client's idle-connection limits so the multi-tenant server actually reuses keep-alive connections to SigNoz under concurrency.

**Why (the non-obvious part):** every `SigNoz` client is built with `otelhttp.NewTransport(http.DefaultTransport)`, so they all already share Go's global `http.DefaultTransport` and its single connection pool — connection reuse to a host is process-wide *regardless of the client cache*. (This is also why #69's premise — that per-`(apiKey,URL)` caching fragments connection pools — doesn't actually hold; #69 closed as not-needed.) The real bottleneck is the stdlib defaults: `MaxIdleConnsPerHost=2`, `MaxIdleConns=100`. Beyond 2 in-flight requests to the same SigNoz host, surplus connections are closed instead of pooled, forcing fresh TCP+TLS handshakes.

**Change:** introduce a package-level `sharedTransport` — a `Clone()` of `http.DefaultTransport` (preserving dial/TLS timeouts, proxy, HTTP/2) — with:
- `MaxIdleConnsPerHost: 2 → 20`
- `MaxIdleConns: 100 → 200`

`NewClient` wires every client to `otelhttp.NewTransport(sharedTransport)`, preserving the single-shared-pool property (no per-client transports → no pool fragmentation) while letting connections be reused under load. The per-host cap aids a hot host; the global cap bounds idle FDs across many distinct tenant hosts.

The client cache is unchanged (its real role is deduping the analytics `/me` identity lookup, not connection pooling).

## Test Plan
- [x] `go build ./...`, `go vet ./...`, `go test ./... -count=1` (17 pkgs) pass
- [x] `go test -race ./internal/client/...` clean
- [x] New `TestSharedTransportPoolTuning` guards the tuned values + that the transport is a proper `DefaultTransport` clone (the rest of the client suite already drives requests through `sharedTransport`)

Values are conservative starting points; can be made env-configurable later if prod metrics show connection churn or idle-FD pressure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)