### PR TITLE
perf(server): auto-set GOMEMLIMIT from the container memory limit

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -22,6 +22,7 @@ import (
 	"github.com/SigNoz/signoz-mcp-server/pkg/analytics/segmentanalytics"
 	"github.com/SigNoz/signoz-mcp-server/pkg/dashboard"
 	logpkg "github.com/SigNoz/signoz-mcp-server/pkg/log"
+	"github.com/SigNoz/signoz-mcp-server/pkg/memlimit"
 	otelpkg "github.com/SigNoz/signoz-mcp-server/pkg/otel"
 	"github.com/SigNoz/signoz-mcp-server/pkg/version"
 )
@@ -45,6 +46,12 @@ func main() {
 	logger.InfoContext(ctx, "Starting SigNoz MCP Server",
 		slog.String("log_level", cfg.LogLevel),
 		slog.String("transport_mode", cfg.TransportMode))
+
+	// Derive GOMEMLIMIT from the container memory limit before the heavy
+	// docs-index build, so the GC reclaims under pressure instead of the cgroup
+	// OOM-killing the pod. No-op when GOMEMLIMIT is already set or no cgroup
+	// limit is detected (e.g. local/stdio runs).
+	memlimit.Configure(ctx, logger)
 
 	// resource.New returns a best-effort Resource even when individual
 	// detectors fail (e.g. malformed OTEL_RESOURCE_ATTRIBUTES), so log the

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -127,6 +127,26 @@ HIT --> CLIENT
 LOOKUP -.->|read/write| LRU_C
 ```
 
+## Memory Limit (GOMEMLIMIT)
+
+At startup the server derives a soft memory limit from the container's cgroup memory limit and
+applies it via `debug.SetMemoryLimit` (see `pkg/memlimit`). This makes the garbage collector
+reclaim more aggressively as the heap approaches the limit, so the pod is far less likely to be
+cgroup OOM-killed under steady-state or gradual-growth pressure.
+
+- Reads the cgroup limit (v2 `memory.max`, falling back to v1 `memory.limit_in_bytes`) and sets
+  `GOMEMLIMIT` to `ratio × limit`. Ratio defaults to **0.9** and is overridable via
+  `SIGNOZ_GOMEMLIMIT_RATIO` — headroom covers non-heap memory (goroutine stacks, the docs index,
+  runtime overhead).
+- **Fails open:** if `GOMEMLIMIT` is already set explicitly, no cgroup limit is detected (e.g.
+  local/stdio runs, non-containerized), or the limit is implausibly small, the runtime default is
+  left untouched. The decision is logged at startup.
+- `GOMAXPROCS` is intentionally not touched — the Go runtime (≥1.25) already derives it from the
+  cgroup CPU quota.
+
+Note: a soft limit is a backstop, not a hard cap — it cannot prevent a single transient
+allocation larger than the limit (e.g. a docs-index rebuild spike); that is addressed separately.
+
 ## OAuth 2.1 — Stateless Token Design
 
 The OAuth implementation is fully stateless — no database or in-memory store is needed. All state is encrypted into the tokens themselves using AES-GCM with a shared `OAUTH_TOKEN_SECRET`.

--- a/pkg/memlimit/memlimit.go
+++ b/pkg/memlimit/memlimit.go
@@ -1,0 +1,121 @@
+// Package memlimit sets Go's soft memory limit (GOMEMLIMIT) from the container's
+// cgroup memory limit at startup, so the garbage collector reclaims aggressively
+// as the process approaches the limit instead of the cgroup OOM-killing the pod.
+//
+// It fails open: if no finite container limit can be determined (not Linux, no
+// cgroup limit, unreadable) or GOMEMLIMIT was already set explicitly, it leaves
+// the runtime default untouched and never errors. GOMEMLIMIT is a backstop for
+// steady-state and gradual-growth pressure — it does not prevent a single
+// transient allocation larger than the limit.
+package memlimit
+
+import (
+	"context"
+	"log/slog"
+	"math"
+	"os"
+	"runtime/debug"
+	"strconv"
+	"strings"
+)
+
+const (
+	// defaultRatio is the fraction of the container memory limit used as the soft
+	// GOMEMLIMIT, leaving headroom for non-heap memory (goroutine stacks, the
+	// mmap'd docs index, runtime overhead) so the GC target stays below the hard
+	// cgroup limit.
+	defaultRatio = 0.9
+
+	// minLimitBytes guards against pathologically small or misread limits that
+	// would cause GC thrashing; below this we leave GOMEMLIMIT unset.
+	minLimitBytes = 64 << 20 // 64 MiB
+
+	// v1UnlimitedThreshold: cgroup v1 reports "unlimited" as a near-max value
+	// (e.g. 0x7FFFFFFFFFFFF000). Treat anything this large as no limit.
+	v1UnlimitedThreshold = uint64(1) << 62
+
+	cgroupV2Path = "/sys/fs/cgroup/memory.max"
+	cgroupV1Path = "/sys/fs/cgroup/memory/memory.limit_in_bytes"
+
+	ratioEnv = "SIGNOZ_GOMEMLIMIT_RATIO"
+)
+
+// Configure sets GOMEMLIMIT from the cgroup memory limit unless it was already
+// set explicitly. It logs what it did (or why it skipped) and never errors.
+func Configure(ctx context.Context, logger *slog.Logger) {
+	// The Go runtime applies the GOMEMLIMIT env var before main runs, so a
+	// non-default current value means the operator set it — respect it.
+	if cur := debug.SetMemoryLimit(-1); cur != math.MaxInt64 {
+		logger.InfoContext(ctx, "GOMEMLIMIT already set; leaving as-is",
+			slog.Int64("gomemlimit_bytes", cur))
+		return
+	}
+
+	limit, ok := readMemoryLimitFrom(cgroupV2Path, cgroupV1Path)
+	if !ok {
+		logger.InfoContext(ctx, "No cgroup memory limit detected; GOMEMLIMIT left unset (GC default)")
+		return
+	}
+	if limit < minLimitBytes {
+		logger.WarnContext(ctx, "cgroup memory limit too small; GOMEMLIMIT left unset",
+			slog.Uint64("cgroup_limit_bytes", limit))
+		return
+	}
+
+	ratio := ratioFromEnv(os.Getenv(ratioEnv))
+	soft := int64(float64(limit) * ratio)
+	debug.SetMemoryLimit(soft)
+	logger.InfoContext(ctx, "GOMEMLIMIT set from cgroup memory limit",
+		slog.Uint64("cgroup_limit_bytes", limit),
+		slog.Float64("ratio", ratio),
+		slog.Int64("gomemlimit_bytes", soft))
+}
+
+func ratioFromEnv(s string) float64 {
+	if s == "" {
+		return defaultRatio
+	}
+	r, err := strconv.ParseFloat(strings.TrimSpace(s), 64)
+	if err != nil || r <= 0 || r > 1 {
+		return defaultRatio
+	}
+	return r
+}
+
+// readMemoryLimitFrom returns the container memory limit in bytes from cgroup v2,
+// then v1, or ok=false if neither yields a finite limit. It reads the standard
+// root cgroup paths, which are correct for the common containerized case (private
+// cgroup namespace); anything else fails open.
+func readMemoryLimitFrom(v2Path, v1Path string) (uint64, bool) {
+	// cgroup v2 takes precedence; if its file exists, don't consult v1.
+	if b, err := os.ReadFile(v2Path); err == nil {
+		return parseMemMax(string(b))
+	}
+	if b, err := os.ReadFile(v1Path); err == nil {
+		return parseMemLimitV1(string(b))
+	}
+	return 0, false
+}
+
+// parseMemMax parses a cgroup v2 memory.max value; "max" means unlimited.
+func parseMemMax(s string) (uint64, bool) {
+	s = strings.TrimSpace(s)
+	if s == "" || s == "max" {
+		return 0, false
+	}
+	v, err := strconv.ParseUint(s, 10, 64)
+	if err != nil || v == 0 {
+		return 0, false
+	}
+	return v, true
+}
+
+// parseMemLimitV1 parses cgroup v1 memory.limit_in_bytes; near-max values are the
+// "unlimited" sentinel.
+func parseMemLimitV1(s string) (uint64, bool) {
+	v, err := strconv.ParseUint(strings.TrimSpace(s), 10, 64)
+	if err != nil || v == 0 || v >= v1UnlimitedThreshold {
+		return 0, false
+	}
+	return v, true
+}

--- a/pkg/memlimit/memlimit_test.go
+++ b/pkg/memlimit/memlimit_test.go
@@ -1,0 +1,119 @@
+package memlimit
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestParseMemMax(t *testing.T) {
+	cases := []struct {
+		in       string
+		want     uint64
+		wantOK   bool
+		describe string
+	}{
+		{"max\n", 0, false, "v2 unlimited"},
+		{"  max  ", 0, false, "v2 unlimited padded"},
+		{"", 0, false, "empty"},
+		{"0", 0, false, "zero"},
+		{"536870912\n", 536870912, true, "512 MiB"},
+		{"notanumber", 0, false, "garbage"},
+	}
+	for _, c := range cases {
+		got, ok := parseMemMax(c.in)
+		if got != c.want || ok != c.wantOK {
+			t.Errorf("%s: parseMemMax(%q) = (%d,%v), want (%d,%v)", c.describe, c.in, got, ok, c.want, c.wantOK)
+		}
+	}
+}
+
+func TestParseMemLimitV1(t *testing.T) {
+	cases := []struct {
+		in     string
+		want   uint64
+		wantOK bool
+	}{
+		{"9223372036854771712\n", 0, false}, // near-max unlimited sentinel
+		{"0", 0, false},
+		{"268435456\n", 268435456, true}, // 256 MiB
+		{"  1073741824 ", 1073741824, true},
+		{"garbage", 0, false},
+	}
+	for _, c := range cases {
+		got, ok := parseMemLimitV1(c.in)
+		if got != c.want || ok != c.wantOK {
+			t.Errorf("parseMemLimitV1(%q) = (%d,%v), want (%d,%v)", c.in, got, ok, c.want, c.wantOK)
+		}
+	}
+}
+
+func TestRatioFromEnv(t *testing.T) {
+	cases := []struct {
+		in   string
+		want float64
+	}{
+		{"", defaultRatio},
+		{"0.75", 0.75},
+		{"  0.5 ", 0.5},
+		{"1", 1},
+		{"0", defaultRatio},    // out of range → default
+		{"1.5", defaultRatio},  // > 1 → default
+		{"-0.2", defaultRatio}, // negative → default
+		{"abc", defaultRatio},  // unparseable → default
+	}
+	for _, c := range cases {
+		if got := ratioFromEnv(c.in); got != c.want {
+			t.Errorf("ratioFromEnv(%q) = %v, want %v", c.in, got, c.want)
+		}
+	}
+}
+
+func TestReadMemoryLimitFrom(t *testing.T) {
+	dir := t.TempDir()
+	write := func(name, content string) string {
+		p := filepath.Join(dir, name)
+		if err := os.WriteFile(p, []byte(content), 0o644); err != nil {
+			t.Fatalf("write %s: %v", name, err)
+		}
+		return p
+	}
+	missing := filepath.Join(dir, "does-not-exist")
+
+	t.Run("v2 finite limit wins", func(t *testing.T) {
+		v2 := write("v2-finite", "536870912\n")
+		got, ok := readMemoryLimitFrom(v2, missing)
+		if !ok || got != 536870912 {
+			t.Fatalf("got (%d,%v), want (536870912,true)", got, ok)
+		}
+	})
+
+	t.Run("v2 max → unlimited, does not fall through to v1", func(t *testing.T) {
+		v2 := write("v2-max", "max\n")
+		v1 := write("v1-finite", "268435456\n")
+		if got, ok := readMemoryLimitFrom(v2, v1); ok {
+			t.Fatalf("got (%d,%v), want (_,false) — v2 present means v1 is ignored", got, ok)
+		}
+	})
+
+	t.Run("v2 absent → v1 used", func(t *testing.T) {
+		v1 := write("v1-only", "268435456\n")
+		got, ok := readMemoryLimitFrom(missing, v1)
+		if !ok || got != 268435456 {
+			t.Fatalf("got (%d,%v), want (268435456,true)", got, ok)
+		}
+	})
+
+	t.Run("v1 unlimited sentinel → false", func(t *testing.T) {
+		v1 := write("v1-unlimited", "9223372036854771712\n")
+		if _, ok := readMemoryLimitFrom(missing, v1); ok {
+			t.Fatalf("v1 near-max should read as unlimited (ok=false)")
+		}
+	})
+
+	t.Run("both absent → false", func(t *testing.T) {
+		if _, ok := readMemoryLimitFrom(missing, missing); ok {
+			t.Fatalf("both paths missing should fail open (ok=false)")
+		}
+	})
+}

--- a/plans/auto-gomemlimit.context.md
+++ b/plans/auto-gomemlimit.context.md
@@ -1,0 +1,39 @@
+# Feature: Auto-set GOMEMLIMIT from the container memory limit — Context & Discussion
+
+## Original Prompt
+> Ok what other improvement can we make? → (chose) "GOMEMLIMIT auto-set"
+
+## Reference Links
+- Memory model / OOM: `memory/project_mcp_oom.md` — bleve docs index ~323 MiB resident +
+  ~1.5 GiB rebuild churn; **no GOMEMLIMIT**; a 2026-06-06 production OOM (sub-60s burst).
+- Go 1.25 release notes: GOMAXPROCS is now cgroup-CPU-aware by default (so no automaxprocs needed).
+
+## Key Decisions & Discussion Log
+
+### 2026-06-08 — Why GOMEMLIMIT, and scope
+- `grep`: no `GOMEMLIMIT`/`SetMemoryLimit` anywhere; the runtime leaves the soft limit off
+  (math.MaxInt64) unless the `GOMEMLIMIT` env is set. Setting it makes the GC reclaim more
+  aggressively as the heap approaches the limit, reducing cgroup OOM-kill risk.
+- GOMAXPROCS: already cgroup-aware on Go ≥1.25 (`go.mod` says `go 1.25.5`) → no action.
+- Honest scope: GOMEMLIMIT backstops steady-state / gradual-growth OOM and earlier reclaim. It
+  does NOT prevent a genuine transient allocation spike larger than the limit — the docs-index
+  rebuild churn (~1.5 GiB) still warrants its own fix (the deferred "shrink rebuild peak" item).
+
+### 2026-06-08 — Implementation choices
+- Dependency: `automemlimit` is the standard lib but NOT vendored, and adding it needs network.
+  Decision: hand-roll a small, **fail-open** cgroup reader (v2 `memory.max`, v1
+  `memory.limit_in_bytes`) — if no finite limit is found, or GOMEMLIMIT was already set
+  explicitly, leave the runtime default untouched. Never errors.
+- Respect explicit override: the Go runtime applies the `GOMEMLIMIT` env before `main`; detect
+  via `debug.SetMemoryLimit(-1) != math.MaxInt64` and skip auto-setting.
+- Ratio: default 0.9 (headroom for non-heap memory), override via `SIGNOZ_GOMEMLIMIT_RATIO`.
+- Floor: ignore limits < 64 MiB (misread/pathological) to avoid GC thrash.
+- Placement: `pkg/memlimit`, called from `cmd/server/main.go` right after the logger is created
+  (before the heavy docs-index build / server start).
+- Caveat (cgroup namespace): reads the standard root cgroup paths, correct for the common
+  containerized case (private cgroupns); fails open otherwise. Documented in code.
+
+## Open Questions
+- [x] automemlimit vs hand-roll? → hand-roll, fail-open (no new dep).
+- [x] GOMAXPROCS too? → no, runtime handles it on Go ≥1.25.
+- [ ] Pair with the docs-index rebuild-peak fix later (the transient-spike OOM root cause).

--- a/plans/auto-gomemlimit.plan.md
+++ b/plans/auto-gomemlimit.plan.md
@@ -1,0 +1,34 @@
+# Plan: Auto-set GOMEMLIMIT from the container memory limit
+
+## Status
+In Progress
+
+## Context
+The server runs no soft memory limit (GOMEMLIMIT unset), so the GC only reclaims on its normal
+schedule — under memory pressure the cgroup OOM-kills the pod before Go gives memory back. A
+documented production OOM (2026-06-06) and the bleve-index-dominated memory model make a soft
+limit a cheap, high-value backstop. (GOMAXPROCS is already cgroup-aware on Go ≥1.25.)
+
+## Approach
+New `pkg/memlimit` with `Configure(ctx, logger)`, called early in `cmd/server/main.go`:
+1. If GOMEMLIMIT is already set (`debug.SetMemoryLimit(-1) != math.MaxInt64`) → log + skip.
+2. Read the container memory limit: cgroup v2 `/sys/fs/cgroup/memory.max` (`"max"` = unlimited),
+   else cgroup v1 `/sys/fs/cgroup/memory/memory.limit_in_bytes` (huge value = unlimited).
+3. If no finite limit, or < 64 MiB → log + skip (fail open; preserves current behavior).
+4. Else `debug.SetMemoryLimit(ratio * limit)`, ratio default 0.9 (env `SIGNOZ_GOMEMLIMIT_RATIO`),
+   and log the decision.
+Pure helpers (`parseMemMax`, `parseMemLimitV1`, `ratioFromEnv`, `readMemoryLimitFrom`) are split
+out for unit testing without a real cgroup.
+
+## Files to Modify
+- `pkg/memlimit/memlimit.go` (new), `pkg/memlimit/memlimit_test.go` (new)
+- `cmd/server/main.go` — call `memlimit.Configure(ctx, logger)` after the logger is created
+- `docs/architecture.md` — env list + a short "Memory limit (GOMEMLIMIT)" note
+
+## Verification
+- `go build ./...`, `go vet ./...`, `go test ./pkg/memlimit/... ./... -count=1` — green.
+- Unit tests cover parse + read (temp files) + ratio + the skip/set decision.
+- Manual: run with `GOMEMLIMIT=512MiB` → logs "already set; leaving as-is"; run with a fake
+  cgroup v2 file → logs the derived limit; run on macOS/no-cgroup → logs "left unset".
+- Codex review. (E2E not meaningfully applicable — would need a memory-limited container to
+  observe GC behavior; covered by unit tests + startup-log verification instead.)


### PR DESCRIPTION
## Summary

Adds an automatic soft memory limit (`GOMEMLIMIT`) derived from the container's cgroup memory limit, as a backstop against cgroup OOM-kills.

**Why:** the server ran with no `GOMEMLIMIT`, so Go's GC only reclaimed on its normal schedule — under memory pressure the cgroup OOM-kills the pod before the runtime gives memory back. Memory here is dominated by the in-memory bleve docs index, and there was a production OOM.

**What:** new `pkg/memlimit`, called once at startup from `cmd/server/main.go`:
- Reads the cgroup memory limit — v2 `/sys/fs/cgroup/memory.max` (`"max"` = unlimited), falling back to v1 `/sys/fs/cgroup/memory/memory.limit_in_bytes` (near-max = unlimited).
- Sets `GOMEMLIMIT = ratio × limit` via `debug.SetMemoryLimit`. Ratio defaults to **0.9** (headroom for non-heap memory), overridable via `SIGNOZ_GOMEMLIMIT_RATIO`.
- **Fails open:** leaves the runtime default untouched if `GOMEMLIMIT` is already set explicitly, no cgroup limit is detected (local/stdio, non-containerized), or the limit is < 64 MiB. Logs the decision either way; never errors.
- `GOMAXPROCS` is intentionally untouched — the Go runtime derives it from the cgroup CPU quota since Go 1.25.

No new dependencies (hand-rolled cgroup read rather than pulling in `automemlimit`).

**Scope (honest):** a soft limit is a backstop for steady-state / gradual-growth pressure and earlier reclaim; it cannot prevent a single *transient* allocation larger than the limit (e.g. a docs-index rebuild spike) — that root cause is tracked separately.

## Test Plan
- [x] `go build ./...`, `go vet ./...`, `go test ./... -count=1` (18 pkgs) pass
- [x] Unit tests: cgroup v2/v1 parsing, unlimited sentinels, v2 precedence, ratio clamping, read-from temp files
- [x] Runtime check on the built binary: no-cgroup (macOS) → logs "GOMEMLIMIT left unset"; `GOMEMLIMIT=512MiB` → logs "already set; leaving as-is"
- [ ] Cgroup-derive path is covered by unit tests; not observable on macOS (needs a memory-limited Linux container)

🤖 Generated with [Claude Code](https://claude.com/claude-code)