### PR TITLE
feat: add webUrl resource deep links to tool outputs (#245)

### DIFF
--- a/README.md
+++ b/README.md
@@ -378,6 +378,8 @@ HTTP mode exposes unauthenticated probe endpoints. New Kubernetes deployments sh
 
 For detailed usage and examples, see the [full documentation](https://signoz.io/docs/ai/signoz-mcp-server/).
 
+> **Resource deep links:** the resource read tools (`signoz_list_dashboards`, `signoz_get_dashboard`, `signoz_list_alerts`, `signoz_list_alert_rules`, `signoz_get_alert`, `signoz_list_services`) include a `webUrl` field — an absolute deep link to the resource in the SigNoz web UI — when the request carries a SigNoz instance URL.
+
 ### Agent Routing Guidance
 
 Use `signoz_search_docs` for any SigNoz product question: how-to, feature usage, setup, configuration, API behavior, deployment, instrumentation, OpenTelemetry integration with SigNoz, and troubleshooting. Use live data tools for actual telemetry, alert state, dashboard contents, saved views, and tenant-specific resources. When a docs search result needs exact commands or a specific section, call `signoz_fetch_doc`.

--- a/README.md
+++ b/README.md
@@ -378,7 +378,7 @@ HTTP mode exposes unauthenticated probe endpoints. New Kubernetes deployments sh
 
 For detailed usage and examples, see the [full documentation](https://signoz.io/docs/ai/signoz-mcp-server/).
 
-> **Resource deep links:** the resource read tools (`signoz_list_dashboards`, `signoz_get_dashboard`, `signoz_list_alerts`, `signoz_list_alert_rules`, `signoz_get_alert`, `signoz_list_services`) include a `webUrl` field — an absolute deep link to the resource in the SigNoz web UI — when the request carries a SigNoz instance URL.
+> **Resource deep links:** the resource read tools (`signoz_list_dashboards`, `signoz_get_dashboard`, `signoz_list_alerts`, `signoz_list_alert_rules`, `signoz_get_alert`, `signoz_list_services`, `signoz_get_trace_details`) include a `webUrl` field — an absolute deep link to the resource in the SigNoz web UI — when the request carries a SigNoz instance URL.
 
 ### Agent Routing Guidance
 

--- a/internal/handler/tools/alerts.go
+++ b/internal/handler/tools/alerts.go
@@ -297,31 +297,11 @@ func (h *Handler) handleGetAlert(ctx context.Context, req mcp.CallToolRequest) (
 }
 
 // enrichAlertWebURL injects a webUrl deep link into a single-alert passthrough
-// body. On any parse failure it returns the original bytes unchanged so
-// enrichment can never break a working response.
+// body. Delegates to util.InjectWebURL, which preserves large int64 fields and
+// fails open on unparseable input.
 func enrichAlertWebURL(ctx context.Context, data []byte, ruleID string) []byte {
-	base, hasURL := util.GetSigNozURL(ctx)
-	if !hasURL {
-		return data
-	}
-	webURL, ok := util.ResourceWebURL(base, "alert", ruleID)
-	if !ok {
-		return data
-	}
-	var obj map[string]any
-	if err := json.Unmarshal(data, &obj); err != nil {
-		return data
-	}
-	if inner, ok := obj["data"].(map[string]any); ok {
-		inner["webUrl"] = webURL
-	} else {
-		obj["webUrl"] = webURL
-	}
-	out, err := json.Marshal(obj)
-	if err != nil {
-		return data
-	}
-	return out
+	base, _ := util.GetSigNozURL(ctx)
+	return util.InjectWebURL(data, base, "alert", ruleID)
 }
 
 func (h *Handler) handleGetAlertHistory(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {

--- a/internal/handler/tools/alerts.go
+++ b/internal/handler/tools/alerts.go
@@ -174,8 +174,10 @@ func (h *Handler) handleListAlerts(ctx context.Context, req mcp.CallToolRequest)
 	}
 
 	// takes only meaningful data
+	base, _ := util.GetSigNozURL(ctx)
 	alertsList := make([]types.Alert, 0, len(apiResponse.Data))
 	for _, apiAlert := range apiResponse.Data {
+		webURL, _ := util.ResourceWebURL(base, "alert", apiAlert.Labels.RuleID)
 		alertsList = append(alertsList, types.Alert{
 			Alertname: apiAlert.Labels.Alertname,
 			RuleID:    apiAlert.Labels.RuleID,
@@ -183,6 +185,7 @@ func (h *Handler) handleListAlerts(ctx context.Context, req mcp.CallToolRequest)
 			StartsAt:  apiAlert.StartsAt,
 			EndsAt:    apiAlert.EndsAt,
 			State:     apiAlert.Status.State,
+			WebURL:    webURL,
 		})
 	}
 
@@ -222,6 +225,7 @@ func (h *Handler) handleListAlertRules(ctx context.Context, req mcp.CallToolRequ
 		return mcp.NewToolResultError("failed to parse alert rules response: " + err.Error()), nil
 	}
 
+	base, _ := util.GetSigNozURL(ctx)
 	ruleSummaries := make([]types.AlertRuleSummary, 0, len(apiResponse.Data))
 	for _, apiRule := range apiResponse.Data {
 		createdAt := apiRule.CreatedAt
@@ -233,6 +237,7 @@ func (h *Handler) handleListAlertRules(ctx context.Context, req mcp.CallToolRequ
 			updatedAt = apiRule.UpdateAt
 		}
 
+		webURL, _ := util.ResourceWebURL(base, "alert", apiRule.ID)
 		ruleSummaries = append(ruleSummaries, types.AlertRuleSummary{
 			RuleID:      apiRule.ID,
 			Alert:       apiRule.Alert,
@@ -245,6 +250,7 @@ func (h *Handler) handleListAlertRules(ctx context.Context, req mcp.CallToolRequ
 			Labels:      apiRule.Labels,
 			CreatedAt:   createdAt,
 			UpdatedAt:   updatedAt,
+			WebURL:      webURL,
 		})
 	}
 
@@ -286,7 +292,36 @@ func (h *Handler) handleGetAlert(ctx context.Context, req mcp.CallToolRequest) (
 		return mcp.NewToolResultError(err.Error()), nil
 	}
 
+	respJSON = enrichAlertWebURL(ctx, respJSON, ruleID)
 	return mcp.NewToolResultText(string(respJSON)), nil
+}
+
+// enrichAlertWebURL injects a webUrl deep link into a single-alert passthrough
+// body. On any parse failure it returns the original bytes unchanged so
+// enrichment can never break a working response.
+func enrichAlertWebURL(ctx context.Context, data []byte, ruleID string) []byte {
+	base, hasURL := util.GetSigNozURL(ctx)
+	if !hasURL {
+		return data
+	}
+	webURL, ok := util.ResourceWebURL(base, "alert", ruleID)
+	if !ok {
+		return data
+	}
+	var obj map[string]any
+	if err := json.Unmarshal(data, &obj); err != nil {
+		return data
+	}
+	if inner, ok := obj["data"].(map[string]any); ok {
+		inner["webUrl"] = webURL
+	} else {
+		obj["webUrl"] = webURL
+	}
+	out, err := json.Marshal(obj)
+	if err != nil {
+		return data
+	}
+	return out
 }
 
 func (h *Handler) handleGetAlertHistory(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {

--- a/internal/handler/tools/alerts_test.go
+++ b/internal/handler/tools/alerts_test.go
@@ -1192,6 +1192,27 @@ func TestHandleDeleteAlert_ClientError(t *testing.T) {
 	}
 }
 
+func TestHandleListAlerts_AddsWebURL(t *testing.T) {
+	mock := &client.MockClient{
+		ListAlertsFn: func(ctx context.Context, params types.ListAlertsParams) (json.RawMessage, error) {
+			return json.RawMessage(`{"status":"success","data":[{"labels":{"alertname":"High CPU","ruleId":"rule-123","severity":"critical"},"status":{"state":"firing"},"startsAt":"2026-06-10T00:00:00Z","endsAt":"0001-01-01T00:00:00Z"}]}`), nil
+		},
+	}
+	h := newTestHandler(mock)
+	req := makeToolRequest("signoz_list_alerts", map[string]any{})
+	result, err := h.handleListAlerts(ctxWithURL(), req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("handler returned error result: %v", result.Content)
+	}
+	body := textContent(t, result)
+	if !strings.Contains(body, "/alerts/overview?ruleId=rule-123") || !strings.Contains(body, "tab=AlertRules") {
+		t.Fatalf("expected alert webUrl in list_alerts output, got: %s", body)
+	}
+}
+
 func TestHandleListAlertRules_AddsWebURL(t *testing.T) {
 	mock := &client.MockClient{
 		ListAlertRulesFn: func(ctx context.Context) (json.RawMessage, error) {

--- a/internal/handler/tools/alerts_test.go
+++ b/internal/handler/tools/alerts_test.go
@@ -1208,7 +1208,7 @@ func TestHandleListAlerts_AddsWebURL(t *testing.T) {
 		t.Fatalf("handler returned error result: %v", result.Content)
 	}
 	body := textContent(t, result)
-	if !strings.Contains(body, "/alerts/overview?ruleId=rule-123") || !strings.Contains(body, "tab=AlertRules") {
+	if !strings.Contains(body, "/alerts/overview?ruleId=rule-123") {
 		t.Fatalf("expected alert webUrl in list_alerts output, got: %s", body)
 	}
 }
@@ -1229,8 +1229,7 @@ func TestHandleListAlertRules_AddsWebURL(t *testing.T) {
 		t.Fatalf("handler returned error result")
 	}
 	body := textContent(t, result)
-	// Go's json.Marshal HTML-escapes & as & by default
-	if !strings.Contains(body, "rule-123") || !strings.Contains(body, "/alerts/overview?ruleId=rule-123") || !strings.Contains(body, "tab=AlertRules") {
+	if !strings.Contains(body, "rule-123") || !strings.Contains(body, "/alerts/overview?ruleId=rule-123") {
 		t.Fatalf("expected alert webUrl, got: %s", body)
 	}
 }
@@ -1274,7 +1273,7 @@ func TestHandleGetAlert_WrappedBodyGetsWebURL(t *testing.T) {
 	if !ok {
 		t.Fatalf("expected wrapped data object, got: %s", body)
 	}
-	if inner["webUrl"] != "https://signoz.example.com/alerts/overview?ruleId=rule-123&tab=AlertRules" {
+	if inner["webUrl"] != "https://signoz.example.com/alerts/overview?ruleId=rule-123" {
 		t.Fatalf("expected webUrl on inner object, got: %v", inner["webUrl"])
 	}
 }

--- a/internal/handler/tools/alerts_test.go
+++ b/internal/handler/tools/alerts_test.go
@@ -1191,3 +1191,87 @@ func TestHandleDeleteAlert_ClientError(t *testing.T) {
 		t.Fatal("expected error result from client error")
 	}
 }
+
+func TestHandleListAlertRules_AddsWebURL(t *testing.T) {
+	mock := &client.MockClient{
+		ListAlertRulesFn: func(ctx context.Context) (json.RawMessage, error) {
+			return json.RawMessage(`{"data":[{"id":"rule-123","alert":"High CPU","state":"inactive","alertType":"METRIC_BASED_ALERT","ruleType":"threshold_rule","disabled":false}]}`), nil
+		},
+	}
+	h := newTestHandler(mock)
+	req := makeToolRequest("signoz_list_alert_rules", map[string]any{})
+	result, err := h.handleListAlertRules(ctxWithURL(), req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("handler returned error result")
+	}
+	body := textContent(t, result)
+	// Go's json.Marshal HTML-escapes & as & by default
+	if !strings.Contains(body, "rule-123") || !strings.Contains(body, "/alerts/overview?ruleId=rule-123") || !strings.Contains(body, "tab=AlertRules") {
+		t.Fatalf("expected alert webUrl, got: %s", body)
+	}
+}
+
+func TestHandleListAlertRules_OmitsWebURLWhenNoBaseURL(t *testing.T) {
+	mock := &client.MockClient{
+		ListAlertRulesFn: func(ctx context.Context) (json.RawMessage, error) {
+			return json.RawMessage(`{"data":[{"id":"rule-123","alert":"High CPU","state":"inactive","alertType":"METRIC_BASED_ALERT","ruleType":"threshold_rule","disabled":false}]}`), nil
+		},
+	}
+	h := newTestHandler(mock)
+	req := makeToolRequest("signoz_list_alert_rules", map[string]any{})
+	result, err := h.handleListAlertRules(testCtx(), req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	body := textContent(t, result)
+	if strings.Contains(body, "webUrl") {
+		t.Fatalf("expected NO webUrl without base URL, got: %s", body)
+	}
+}
+
+func TestHandleGetAlert_WrappedBodyGetsWebURL(t *testing.T) {
+	mock := &client.MockClient{
+		GetAlertByRuleIDFn: func(ctx context.Context, ruleID string) (json.RawMessage, error) {
+			return json.RawMessage(`{"data":{"id":"rule-123","alert":"High CPU"}}`), nil
+		},
+	}
+	h := newTestHandler(mock)
+	req := makeToolRequest("signoz_get_alert", map[string]any{"ruleId": "rule-123"})
+	result, err := h.handleGetAlert(ctxWithURL(), req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	body := textContent(t, result)
+	var obj map[string]any
+	if err := json.Unmarshal([]byte(body), &obj); err != nil {
+		t.Fatalf("body not json: %v", err)
+	}
+	inner, ok := obj["data"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected wrapped data object, got: %s", body)
+	}
+	if inner["webUrl"] != "https://signoz.example.com/alerts/overview?ruleId=rule-123&tab=AlertRules" {
+		t.Fatalf("expected webUrl on inner object, got: %v", inner["webUrl"])
+	}
+}
+
+func TestHandleGetAlert_OmitsWebURLWhenNoBaseURL(t *testing.T) {
+	mock := &client.MockClient{
+		GetAlertByRuleIDFn: func(ctx context.Context, ruleID string) (json.RawMessage, error) {
+			return json.RawMessage(`{"data":{"id":"rule-123"}}`), nil
+		},
+	}
+	h := newTestHandler(mock)
+	req := makeToolRequest("signoz_get_alert", map[string]any{"ruleId": "rule-123"})
+	result, err := h.handleGetAlert(testCtx(), req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	body := textContent(t, result)
+	if strings.Contains(body, "webUrl") {
+		t.Fatalf("expected NO webUrl without base URL, got: %s", body)
+	}
+}

--- a/internal/handler/tools/dashboards.go
+++ b/internal/handler/tools/dashboards.go
@@ -231,31 +231,11 @@ func (h *Handler) handleGetDashboard(ctx context.Context, req mcp.CallToolReques
 }
 
 // enrichDashboardWebURL injects a webUrl deep link into a single-dashboard
-// passthrough body. On any parse failure it returns the original bytes
-// unchanged so enrichment can never break a working response.
+// passthrough body. Delegates to util.InjectWebURL, which preserves large
+// int64 fields and fails open on unparseable input.
 func enrichDashboardWebURL(ctx context.Context, data []byte, uuid string) []byte {
-	base, hasURL := util.GetSigNozURL(ctx)
-	if !hasURL {
-		return data
-	}
-	webURL, ok := util.ResourceWebURL(base, "dashboard", uuid)
-	if !ok {
-		return data
-	}
-	var obj map[string]any
-	if err := json.Unmarshal(data, &obj); err != nil {
-		return data
-	}
-	if inner, ok := obj["data"].(map[string]any); ok {
-		inner["webUrl"] = webURL
-	} else {
-		obj["webUrl"] = webURL
-	}
-	out, err := json.Marshal(obj)
-	if err != nil {
-		return data
-	}
-	return out
+	base, _ := util.GetSigNozURL(ctx)
+	return util.InjectWebURL(data, base, "dashboard", uuid)
 }
 
 func (h *Handler) handleCreateDashboard(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {

--- a/internal/handler/tools/dashboards.go
+++ b/internal/handler/tools/dashboards.go
@@ -19,6 +19,7 @@ import (
 	"github.com/SigNoz/signoz-mcp-server/pkg/paginate"
 	"github.com/SigNoz/signoz-mcp-server/pkg/promql"
 	"github.com/SigNoz/signoz-mcp-server/pkg/types"
+	"github.com/SigNoz/signoz-mcp-server/pkg/util"
 )
 
 // Template fetch configuration for signoz_import_dashboard.
@@ -179,6 +180,19 @@ func (h *Handler) handleListDashboards(ctx context.Context, req mcp.CallToolRequ
 		return mcp.NewToolResultError("invalid response format: expected data array"), nil
 	}
 
+	if base, hasURL := util.GetSigNozURL(ctx); hasURL {
+		for _, item := range data {
+			m, ok := item.(map[string]any)
+			if !ok {
+				continue
+			}
+			uuid, _ := m["uuid"].(string)
+			if webURL, ok := util.ResourceWebURL(base, "dashboard", uuid); ok {
+				m["webUrl"] = webURL
+			}
+		}
+	}
+
 	total := len(data)
 	pagedData := paginate.Array(data, offset, limit)
 
@@ -212,7 +226,36 @@ func (h *Handler) handleGetDashboard(ctx context.Context, req mcp.CallToolReques
 		h.logger.ErrorContext(ctx, "Failed to get dashboard", slog.String("uuid", uuid), logpkg.ErrAttr(err))
 		return mcp.NewToolResultError(err.Error()), nil
 	}
+	data = enrichDashboardWebURL(ctx, data, uuid)
 	return mcp.NewToolResultText(string(data)), nil
+}
+
+// enrichDashboardWebURL injects a webUrl deep link into a single-dashboard
+// passthrough body. On any parse failure it returns the original bytes
+// unchanged so enrichment can never break a working response.
+func enrichDashboardWebURL(ctx context.Context, data []byte, uuid string) []byte {
+	base, hasURL := util.GetSigNozURL(ctx)
+	if !hasURL {
+		return data
+	}
+	webURL, ok := util.ResourceWebURL(base, "dashboard", uuid)
+	if !ok {
+		return data
+	}
+	var obj map[string]any
+	if err := json.Unmarshal(data, &obj); err != nil {
+		return data
+	}
+	if inner, ok := obj["data"].(map[string]any); ok {
+		inner["webUrl"] = webURL
+	} else {
+		obj["webUrl"] = webURL
+	}
+	out, err := json.Marshal(obj)
+	if err != nil {
+		return data
+	}
+	return out
 }
 
 func (h *Handler) handleCreateDashboard(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {

--- a/internal/handler/tools/dashboards_test.go
+++ b/internal/handler/tools/dashboards_test.go
@@ -304,3 +304,44 @@ func TestHandleImportDashboard_NotFound(t *testing.T) {
 		t.Error("expected error result on 404")
 	}
 }
+
+func TestHandleListDashboards_AddsWebURL(t *testing.T) {
+	mock := &client.MockClient{
+		ListDashboardsFn: func(ctx context.Context) (json.RawMessage, error) {
+			return json.RawMessage(`{"data":[{"uuid":"abc-123","name":"Hosts"}]}`), nil
+		},
+	}
+	h := newTestHandler(mock)
+	req := makeToolRequest("signoz_list_dashboards", map[string]any{})
+
+	result, err := h.handleListDashboards(ctxWithURL(), req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("handler returned error result")
+	}
+	body := textContent(t, result)
+	if !strings.Contains(body, `"webUrl":"https://signoz.example.com/dashboard/abc-123"`) {
+		t.Fatalf("expected webUrl in output, got: %s", body)
+	}
+}
+
+func TestHandleListDashboards_OmitsWebURLWhenNoBaseURL(t *testing.T) {
+	mock := &client.MockClient{
+		ListDashboardsFn: func(ctx context.Context) (json.RawMessage, error) {
+			return json.RawMessage(`{"data":[{"uuid":"abc-123","name":"Hosts"}]}`), nil
+		},
+	}
+	h := newTestHandler(mock)
+	req := makeToolRequest("signoz_list_dashboards", map[string]any{})
+
+	result, err := h.handleListDashboards(testCtx(), req) // no URL in ctx
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	body := textContent(t, result)
+	if strings.Contains(body, "webUrl") {
+		t.Fatalf("expected NO webUrl without base URL, got: %s", body)
+	}
+}

--- a/internal/handler/tools/dashboards_test.go
+++ b/internal/handler/tools/dashboards_test.go
@@ -345,3 +345,86 @@ func TestHandleListDashboards_OmitsWebURLWhenNoBaseURL(t *testing.T) {
 		t.Fatalf("expected NO webUrl without base URL, got: %s", body)
 	}
 }
+
+func TestHandleGetDashboard_WrappedBodyGetsWebURL(t *testing.T) {
+	mock := &client.MockClient{
+		GetDashboardFn: func(ctx context.Context, uuid string) (json.RawMessage, error) {
+			return json.RawMessage(`{"data":{"uuid":"x","name":"Hosts"}}`), nil
+		},
+	}
+	h := newTestHandler(mock)
+	req := makeToolRequest("signoz_get_dashboard", map[string]any{"uuid": "x"})
+	result, err := h.handleGetDashboard(ctxWithURL(), req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("handler returned error result")
+	}
+	body := textContent(t, result)
+	var obj map[string]any
+	if err := json.Unmarshal([]byte(body), &obj); err != nil {
+		t.Fatalf("body not json: %v", err)
+	}
+	inner, ok := obj["data"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected wrapped data object, got: %s", body)
+	}
+	if inner["webUrl"] != "https://signoz.example.com/dashboard/x" {
+		t.Fatalf("expected webUrl on inner object, got: %s", body)
+	}
+}
+
+func TestHandleGetDashboard_BareBodyGetsWebURL(t *testing.T) {
+	mock := &client.MockClient{
+		GetDashboardFn: func(ctx context.Context, uuid string) (json.RawMessage, error) {
+			return json.RawMessage(`{"uuid":"x","name":"Hosts"}`), nil
+		},
+	}
+	h := newTestHandler(mock)
+	req := makeToolRequest("signoz_get_dashboard", map[string]any{"uuid": "x"})
+	result, err := h.handleGetDashboard(ctxWithURL(), req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	body := textContent(t, result)
+	if !strings.Contains(body, `"webUrl":"https://signoz.example.com/dashboard/x"`) {
+		t.Fatalf("expected top-level webUrl, got: %s", body)
+	}
+}
+
+func TestHandleGetDashboard_OmitsWebURLWhenNoBaseURL(t *testing.T) {
+	mock := &client.MockClient{
+		GetDashboardFn: func(ctx context.Context, uuid string) (json.RawMessage, error) {
+			return json.RawMessage(`{"data":{"uuid":"x"}}`), nil
+		},
+	}
+	h := newTestHandler(mock)
+	req := makeToolRequest("signoz_get_dashboard", map[string]any{"uuid": "x"})
+	result, err := h.handleGetDashboard(testCtx(), req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	body := textContent(t, result)
+	if strings.Contains(body, "webUrl") {
+		t.Fatalf("expected NO webUrl without base URL, got: %s", body)
+	}
+}
+
+func TestHandleGetDashboard_MalformedBodyReturnedVerbatim(t *testing.T) {
+	mock := &client.MockClient{
+		GetDashboardFn: func(ctx context.Context, uuid string) (json.RawMessage, error) {
+			return json.RawMessage(`not json`), nil
+		},
+	}
+	h := newTestHandler(mock)
+	req := makeToolRequest("signoz_get_dashboard", map[string]any{"uuid": "x"})
+	result, err := h.handleGetDashboard(ctxWithURL(), req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	body := textContent(t, result)
+	if body != "not json" {
+		t.Fatalf("expected malformed body returned verbatim, got: %s", body)
+	}
+}

--- a/internal/handler/tools/services.go
+++ b/internal/handler/tools/services.go
@@ -11,6 +11,7 @@ import (
 	logpkg "github.com/SigNoz/signoz-mcp-server/pkg/log"
 	"github.com/SigNoz/signoz-mcp-server/pkg/paginate"
 	"github.com/SigNoz/signoz-mcp-server/pkg/timeutil"
+	"github.com/SigNoz/signoz-mcp-server/pkg/util"
 )
 
 func (h *Handler) RegisterServiceHandlers(s *server.MCPServer) {
@@ -66,6 +67,19 @@ func (h *Handler) handleListServices(ctx context.Context, req mcp.CallToolReques
 	if err := json.Unmarshal(result, &services); err != nil {
 		h.logger.ErrorContext(ctx, "Failed to parse services response", logpkg.ErrAttr(err))
 		return mcp.NewToolResultError("failed to parse response: " + err.Error()), nil
+	}
+
+	if base, hasURL := util.GetSigNozURL(ctx); hasURL {
+		for _, item := range services {
+			m, ok := item.(map[string]any)
+			if !ok {
+				continue
+			}
+			name, _ := m["serviceName"].(string)
+			if webURL, ok := util.ResourceWebURL(base, "service", name); ok {
+				m["webUrl"] = webURL
+			}
+		}
 	}
 
 	total := len(services)

--- a/internal/handler/tools/services_test.go
+++ b/internal/handler/tools/services_test.go
@@ -3,10 +3,52 @@ package tools
 import (
 	"context"
 	"encoding/json"
+	"strings"
 	"testing"
 
 	"github.com/SigNoz/signoz-mcp-server/internal/client"
 )
+
+func TestHandleListServices_AddsWebURL(t *testing.T) {
+	mock := &client.MockClient{
+		ListServicesFn: func(ctx context.Context, start, end string) (json.RawMessage, error) {
+			return json.RawMessage(`[{"serviceName":"cart service"}]`), nil
+		},
+	}
+	h := newTestHandler(mock)
+	req := makeToolRequest("signoz_list_services", map[string]any{"timeRange": "1h"})
+
+	result, err := h.handleListServices(ctxWithURL(), req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("handler returned error result")
+	}
+	body := textContent(t, result)
+	if !strings.Contains(body, `"webUrl":"https://signoz.example.com/services/cart%20service"`) {
+		t.Fatalf("expected encoded service webUrl, got: %s", body)
+	}
+}
+
+func TestHandleListServices_OmitsWebURLWhenNoBaseURL(t *testing.T) {
+	mock := &client.MockClient{
+		ListServicesFn: func(ctx context.Context, start, end string) (json.RawMessage, error) {
+			return json.RawMessage(`[{"serviceName":"cart service"}]`), nil
+		},
+	}
+	h := newTestHandler(mock)
+	req := makeToolRequest("signoz_list_services", map[string]any{"timeRange": "1h"})
+
+	result, err := h.handleListServices(testCtx(), req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	body := textContent(t, result)
+	if strings.Contains(body, "webUrl") {
+		t.Fatalf("expected NO webUrl without base URL, got: %s", body)
+	}
+}
 
 func TestHandleListServices_ExplicitStartEndOverrideTimeRange(t *testing.T) {
 	var capturedStart string

--- a/internal/handler/tools/testutil_test.go
+++ b/internal/handler/tools/testutil_test.go
@@ -2,8 +2,10 @@ package tools
 
 import (
 	"context"
+	"testing"
 
 	logpkg "github.com/SigNoz/signoz-mcp-server/pkg/log"
+	"github.com/SigNoz/signoz-mcp-server/pkg/util"
 	"github.com/mark3labs/mcp-go/mcp"
 
 	signozclient "github.com/SigNoz/signoz-mcp-server/internal/client"
@@ -33,4 +35,22 @@ func makeToolRequest(toolName string, args map[string]any) mcp.CallToolRequest {
 // Because we use clientOverride, no API key or URL is needed in the context.
 func testCtx() context.Context {
 	return context.Background()
+}
+
+// ctxWithURL returns a test context carrying a fixed SigNoz instance origin.
+func ctxWithURL() context.Context {
+	return util.SetSigNozURL(context.Background(), "https://signoz.example.com")
+}
+
+// textContent extracts the first text content block from a tool result.
+func textContent(t *testing.T, r *mcp.CallToolResult) string {
+	t.Helper()
+	if len(r.Content) == 0 {
+		t.Fatalf("result has no content")
+	}
+	tc, ok := mcp.AsTextContent(r.Content[0])
+	if !ok {
+		t.Fatalf("first content block is not text")
+	}
+	return tc.Text
 }

--- a/internal/handler/tools/traces.go
+++ b/internal/handler/tools/traces.go
@@ -12,6 +12,7 @@ import (
 	logpkg "github.com/SigNoz/signoz-mcp-server/pkg/log"
 	"github.com/SigNoz/signoz-mcp-server/pkg/timeutil"
 	"github.com/SigNoz/signoz-mcp-server/pkg/types"
+	"github.com/SigNoz/signoz-mcp-server/pkg/util"
 )
 
 func (h *Handler) RegisterTracesHandlers(s *server.MCPServer) {
@@ -192,5 +193,34 @@ func (h *Handler) handleGetTraceDetails(ctx context.Context, req mcp.CallToolReq
 		h.logger.ErrorContext(ctx, "Failed to get trace details", slog.String("traceId", traceID), logpkg.ErrAttr(err))
 		return mcp.NewToolResultError(err.Error()), nil
 	}
+	result = enrichTraceWebURL(ctx, result, traceID)
 	return mcp.NewToolResultText(string(result)), nil
+}
+
+// enrichTraceWebURL injects a webUrl deep link into a single-trace passthrough
+// body. On any parse failure it returns the original bytes unchanged so
+// enrichment can never break a working response.
+func enrichTraceWebURL(ctx context.Context, data []byte, traceID string) []byte {
+	base, hasURL := util.GetSigNozURL(ctx)
+	if !hasURL {
+		return data
+	}
+	webURL, ok := util.ResourceWebURL(base, "trace", traceID)
+	if !ok {
+		return data
+	}
+	var obj map[string]any
+	if err := json.Unmarshal(data, &obj); err != nil {
+		return data
+	}
+	if inner, ok := obj["data"].(map[string]any); ok {
+		inner["webUrl"] = webURL
+	} else {
+		obj["webUrl"] = webURL
+	}
+	out, err := json.Marshal(obj)
+	if err != nil {
+		return data
+	}
+	return out
 }

--- a/internal/handler/tools/traces.go
+++ b/internal/handler/tools/traces.go
@@ -198,29 +198,9 @@ func (h *Handler) handleGetTraceDetails(ctx context.Context, req mcp.CallToolReq
 }
 
 // enrichTraceWebURL injects a webUrl deep link into a single-trace passthrough
-// body. On any parse failure it returns the original bytes unchanged so
-// enrichment can never break a working response.
+// body. Delegates to util.InjectWebURL, which preserves large int64 fields
+// (e.g. durationNano) and fails open on unparseable input.
 func enrichTraceWebURL(ctx context.Context, data []byte, traceID string) []byte {
-	base, hasURL := util.GetSigNozURL(ctx)
-	if !hasURL {
-		return data
-	}
-	webURL, ok := util.ResourceWebURL(base, "trace", traceID)
-	if !ok {
-		return data
-	}
-	var obj map[string]any
-	if err := json.Unmarshal(data, &obj); err != nil {
-		return data
-	}
-	if inner, ok := obj["data"].(map[string]any); ok {
-		inner["webUrl"] = webURL
-	} else {
-		obj["webUrl"] = webURL
-	}
-	out, err := json.Marshal(obj)
-	if err != nil {
-		return data
-	}
-	return out
+	base, _ := util.GetSigNozURL(ctx)
+	return util.InjectWebURL(data, base, "trace", traceID)
 }

--- a/internal/handler/tools/traces_test.go
+++ b/internal/handler/tools/traces_test.go
@@ -291,3 +291,73 @@ func TestHandleGetTraceDetails_EmptyTraceId(t *testing.T) {
 		t.Error("expected error result for empty traceId")
 	}
 }
+
+func TestHandleGetTraceDetails_WrappedBodyGetsWebURL(t *testing.T) {
+	mock := &client.MockClient{
+		GetTraceDetailsFn: func(ctx context.Context, traceID string, includeSpans bool, startTime, endTime int64) (json.RawMessage, error) {
+			return json.RawMessage(`{"data":{"spans":[]}}`), nil
+		},
+	}
+	h := newTestHandler(mock)
+	req := makeToolRequest("signoz_get_trace_details", map[string]any{
+		"traceId": "e4dfc429fd5655656d46a0e9db386296",
+	})
+
+	result, err := h.handleGetTraceDetails(ctxWithURL(), req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("handler returned error result")
+	}
+	body := textContent(t, result)
+	var obj map[string]any
+	if err := json.Unmarshal([]byte(body), &obj); err != nil {
+		t.Fatalf("body not json: %v", err)
+	}
+	inner, ok := obj["data"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected wrapped data object, got: %s", body)
+	}
+	if inner["webUrl"] != "https://signoz.example.com/trace/e4dfc429fd5655656d46a0e9db386296" {
+		t.Fatalf("expected webUrl on inner object, got: %v", inner["webUrl"])
+	}
+}
+
+func TestHandleGetTraceDetails_BareBodyGetsWebURL(t *testing.T) {
+	mock := &client.MockClient{
+		GetTraceDetailsFn: func(ctx context.Context, traceID string, includeSpans bool, startTime, endTime int64) (json.RawMessage, error) {
+			return json.RawMessage(`{"spans":[]}`), nil
+		},
+	}
+	h := newTestHandler(mock)
+	req := makeToolRequest("signoz_get_trace_details", map[string]any{"traceId": "abc-123"})
+
+	result, err := h.handleGetTraceDetails(ctxWithURL(), req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	body := textContent(t, result)
+	if !strings.Contains(body, `"webUrl":"https://signoz.example.com/trace/abc-123"`) {
+		t.Fatalf("expected top-level webUrl, got: %s", body)
+	}
+}
+
+func TestHandleGetTraceDetails_OmitsWebURLWhenNoBaseURL(t *testing.T) {
+	mock := &client.MockClient{
+		GetTraceDetailsFn: func(ctx context.Context, traceID string, includeSpans bool, startTime, endTime int64) (json.RawMessage, error) {
+			return json.RawMessage(`{"data":{"spans":[]}}`), nil
+		},
+	}
+	h := newTestHandler(mock)
+	req := makeToolRequest("signoz_get_trace_details", map[string]any{"traceId": "abc-123"})
+
+	result, err := h.handleGetTraceDetails(testCtx(), req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	body := textContent(t, result)
+	if strings.Contains(body, "webUrl") {
+		t.Fatalf("expected NO webUrl without base URL, got: %s", body)
+	}
+}

--- a/pkg/instructions/instructions.go
+++ b/pkg/instructions/instructions.go
@@ -43,5 +43,5 @@ const ServerInstructions = `# SigNoz MCP Server — Instructions
 
 5. **Never convert Unix timestamps manually.** All SigNoz timestamps (start, end, and time series values) are Unix milliseconds. When presenting timestamps to the user, always use a programmatic method (e.g., a date conversion tool or function) to convert them to human-readable format. Do NOT attempt mental arithmetic or manual offset calculations — this is error-prone and leads to incorrect times being reported.
 
-6. **Do not generate SigNoz frontend links.** Never guess or build a clickable SigNoz URL from IDs, names, or the base domain. Only return a link if a tool or resource explicitly provides the full frontend URL; otherwise say MCP cannot generate a reliable link.
+6. **Use the webUrl field for SigNoz links.** Resource tool outputs (dashboards, alerts, services, traces) include a webUrl field with a deep link to the resource in the SigNoz UI. When linking to a resource, use that field verbatim. Never construct a SigNoz URL by hand from IDs, names, or the base domain.
 `

--- a/pkg/types/alerts.go
+++ b/pkg/types/alerts.go
@@ -30,6 +30,7 @@ type Alert struct {
 	StartsAt  string `json:"startsAt"`
 	EndsAt    string `json:"endsAt"`
 	State     string `json:"state"`
+	WebURL    string `json:"webUrl,omitempty"`
 }
 
 type APIAlertLabels struct {
@@ -67,6 +68,7 @@ type AlertRuleSummary struct {
 	Labels      map[string]string `json:"labels,omitempty"`
 	CreatedAt   string            `json:"createdAt,omitempty"`
 	UpdatedAt   string            `json:"updatedAt,omitempty"`
+	WebURL      string            `json:"webUrl,omitempty"`
 }
 
 // APIAlertRule mirrors the compact fields used from GET /api/v2/rules.

--- a/pkg/util/weburl.go
+++ b/pkg/util/weburl.go
@@ -1,6 +1,8 @@
 package util
 
 import (
+	"bytes"
+	"encoding/json"
 	"net/url"
 	"strings"
 )
@@ -32,4 +34,39 @@ func ResourceWebURL(base, resourceType, id string) (string, bool) {
 	default:
 		return "", false
 	}
+}
+
+// InjectWebURL adds a webUrl deep link to a single-resource passthrough JSON
+// body. When the body is wrapped as {"data": {...}} the field is set on the
+// inner object; otherwise it is set at the top level.
+//
+// It decodes with UseNumber so large int64 fields (e.g. trace durationNano,
+// span ids, epoch-nanosecond timestamps) are preserved verbatim rather than
+// being coerced through float64 and rounded. On any failure — empty base,
+// unsupported type, or unparseable body — it returns the original bytes
+// unchanged so enrichment can never corrupt a working response.
+func InjectWebURL(data []byte, base, resourceType, id string) []byte {
+	webURL, ok := ResourceWebURL(base, resourceType, id)
+	if !ok {
+		return data
+	}
+
+	dec := json.NewDecoder(bytes.NewReader(data))
+	dec.UseNumber()
+	var obj map[string]any
+	if err := dec.Decode(&obj); err != nil {
+		return data
+	}
+
+	if inner, ok := obj["data"].(map[string]any); ok {
+		inner["webUrl"] = webURL
+	} else {
+		obj["webUrl"] = webURL
+	}
+
+	out, err := json.Marshal(obj)
+	if err != nil {
+		return data
+	}
+	return out
 }

--- a/pkg/util/weburl.go
+++ b/pkg/util/weburl.go
@@ -1,7 +1,6 @@
 package util
 
 import (
-	"bytes"
 	"encoding/json"
 	"net/url"
 	"strings"
@@ -40,28 +39,38 @@ func ResourceWebURL(base, resourceType, id string) (string, bool) {
 // body. When the body is wrapped as {"data": {...}} the field is set on the
 // inner object; otherwise it is set at the top level.
 //
-// It decodes with UseNumber so large int64 fields (e.g. trace durationNano,
-// span ids, epoch-nanosecond timestamps) are preserved verbatim rather than
-// being coerced through float64 and rounded. On any failure — empty base,
-// unsupported type, or unparseable body — it returns the original bytes
-// unchanged so enrichment can never corrupt a working response.
+// The body is decoded only one level deep (two for the {"data": {...}} wrap)
+// into map[string]json.RawMessage, so everything below the injection level —
+// span trees, large int64 fields like durationNano, number formatting, key
+// order — passes through as verbatim bytes rather than being re-encoded. On
+// any failure — empty base, unsupported type, or a body that is not a JSON
+// object — it returns the original bytes unchanged so enrichment can never
+// corrupt a working response.
 func InjectWebURL(data []byte, base, resourceType, id string) []byte {
 	webURL, ok := ResourceWebURL(base, resourceType, id)
 	if !ok {
 		return data
 	}
 
-	dec := json.NewDecoder(bytes.NewReader(data))
-	dec.UseNumber()
-	var obj map[string]any
-	if err := dec.Decode(&obj); err != nil {
+	obj, ok := decodeShallowObject(data)
+	if !ok {
 		return data
 	}
 
-	if inner, ok := obj["data"].(map[string]any); ok {
-		inner["webUrl"] = webURL
+	urlJSON, err := json.Marshal(webURL)
+	if err != nil {
+		return data
+	}
+
+	if inner, ok := decodeShallowObject(obj["data"]); ok {
+		inner["webUrl"] = urlJSON
+		innerJSON, err := json.Marshal(inner)
+		if err != nil {
+			return data
+		}
+		obj["data"] = innerJSON
 	} else {
-		obj["webUrl"] = webURL
+		obj["webUrl"] = urlJSON
 	}
 
 	out, err := json.Marshal(obj)
@@ -69,4 +78,16 @@ func InjectWebURL(data []byte, base, resourceType, id string) []byte {
 		return data
 	}
 	return out
+}
+
+// decodeShallowObject decodes raw as a JSON object one level deep: values stay
+// verbatim json.RawMessage bytes. ok is false when raw is empty, "null", or
+// not a JSON object (Unmarshal leaves the map nil for "null", so the nil check
+// also guards writes into a nil map).
+func decodeShallowObject(raw json.RawMessage) (map[string]json.RawMessage, bool) {
+	var m map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &m); err != nil || m == nil {
+		return nil, false
+	}
+	return m, true
 }

--- a/pkg/util/weburl.go
+++ b/pkg/util/weburl.go
@@ -1,0 +1,33 @@
+package util
+
+import (
+	"net/url"
+	"strings"
+)
+
+// ResourceWebURL builds an absolute SigNoz web-UI deep link for a single-id
+// resource type from a normalized base origin (scheme://host[:port]).
+//
+// Supported resourceType values: "dashboard", "alert", "service". Any other
+// type, an empty base, or an empty id returns ("", false) so callers omit the
+// field rather than emitting a broken link. Path/query segments are URL-encoded.
+func ResourceWebURL(base, resourceType, id string) (string, bool) {
+	base = strings.TrimRight(strings.TrimSpace(base), "/")
+	if base == "" || strings.TrimSpace(id) == "" {
+		return "", false
+	}
+
+	switch resourceType {
+	case "dashboard":
+		return base + "/dashboard/" + url.PathEscape(id), true
+	case "alert":
+		q := url.Values{}
+		q.Set("ruleId", id)
+		q.Set("tab", "AlertRules")
+		return base + "/alerts/overview?" + q.Encode(), true
+	case "service":
+		return base + "/services/" + url.PathEscape(id), true
+	default:
+		return "", false
+	}
+}

--- a/pkg/util/weburl.go
+++ b/pkg/util/weburl.go
@@ -8,9 +8,10 @@ import (
 // ResourceWebURL builds an absolute SigNoz web-UI deep link for a single-id
 // resource type from a normalized base origin (scheme://host[:port]).
 //
-// Supported resourceType values: "dashboard", "alert", "service". Any other
-// type, an empty base, or an empty id returns ("", false) so callers omit the
-// field rather than emitting a broken link. Path/query segments are URL-encoded.
+// Supported resourceType values: "dashboard", "alert", "service", "trace". Any
+// other type, an empty base, or an empty id returns ("", false) so callers omit
+// the field rather than emitting a broken link. Path/query segments are
+// URL-encoded.
 func ResourceWebURL(base, resourceType, id string) (string, bool) {
 	base = strings.TrimRight(strings.TrimSpace(base), "/")
 	if base == "" || strings.TrimSpace(id) == "" {
@@ -26,6 +27,8 @@ func ResourceWebURL(base, resourceType, id string) (string, bool) {
 		return base + "/alerts/overview?" + q.Encode(), true
 	case "service":
 		return base + "/services/" + url.PathEscape(id), true
+	case "trace":
+		return base + "/trace/" + url.PathEscape(id), true
 	default:
 		return "", false
 	}

--- a/pkg/util/weburl.go
+++ b/pkg/util/weburl.go
@@ -23,7 +23,6 @@ func ResourceWebURL(base, resourceType, id string) (string, bool) {
 	case "alert":
 		q := url.Values{}
 		q.Set("ruleId", id)
-		q.Set("tab", "AlertRules")
 		return base + "/alerts/overview?" + q.Encode(), true
 	case "service":
 		return base + "/services/" + url.PathEscape(id), true

--- a/pkg/util/weburl_inject_test.go
+++ b/pkg/util/weburl_inject_test.go
@@ -8,7 +8,8 @@ import (
 func TestInjectWebURL_PreservesLargeInt64(t *testing.T) {
 	// A durationNano-style int64 that exceeds float64's exact-integer range
 	// (2^53). A naive Unmarshal->map[string]any->Marshal round-trip would coerce
-	// it through float64 and round it; UseNumber must preserve it verbatim.
+	// it through float64 and round it; the shallow RawMessage decode must pass
+	// it through as verbatim bytes.
 	const bigInt = "9007199254740993" // 2^53 + 1, not exactly representable as float64
 	in := []byte(`{"data":{"durationNano":` + bigInt + `,"name":"GET /cart"}}`)
 
@@ -31,6 +32,53 @@ func TestInjectWebURL_BareBody(t *testing.T) {
 	out := InjectWebURL(in, "https://signoz.example.com", "dashboard", "x")
 	if !strings.Contains(string(out), `"webUrl":"https://signoz.example.com/dashboard/x"`) {
 		t.Fatalf("webUrl not injected at top level: %s", out)
+	}
+}
+
+func TestInjectWebURL_PreservesInnerBytesVerbatim(t *testing.T) {
+	// Values nested below the injection level must pass through as verbatim
+	// bytes: a full-tree decode/re-marshal would sort zKey/aKey alphabetically.
+	in := []byte(`{"data":{"spans":[{"zKey":1,"aKey":2.50}],"durationNano":9007199254740993}}`)
+	out := InjectWebURL(in, "https://signoz.example.com", "trace", "abc-123")
+	s := string(out)
+
+	if !strings.Contains(s, `[{"zKey":1,"aKey":2.50}]`) {
+		t.Fatalf("inner bytes were re-encoded (key order or number formatting changed): %s", s)
+	}
+	if !strings.Contains(s, `"webUrl":"https://signoz.example.com/trace/abc-123"`) {
+		t.Fatalf("webUrl not injected on inner data object: %s", s)
+	}
+}
+
+func TestInjectWebURL_NullBodyReturnsOriginal(t *testing.T) {
+	in := []byte(`null`)
+	out := InjectWebURL(in, "https://signoz.example.com", "trace", "abc-123")
+	if string(out) != string(in) {
+		t.Fatalf("expected original bytes for null body, got: %s", out)
+	}
+}
+
+func TestInjectWebURL_NullDataInjectsTopLevel(t *testing.T) {
+	in := []byte(`{"data":null}`)
+	out := InjectWebURL(in, "https://signoz.example.com", "trace", "abc-123")
+	s := string(out)
+	if !strings.Contains(s, `"webUrl":"https://signoz.example.com/trace/abc-123"`) {
+		t.Fatalf("webUrl not injected at top level when data is null: %s", s)
+	}
+	if !strings.Contains(s, `"data":null`) {
+		t.Fatalf("null data value not preserved: %s", s)
+	}
+}
+
+func TestInjectWebURL_ArrayDataInjectsTopLevel(t *testing.T) {
+	in := []byte(`{"data":[1,2]}`)
+	out := InjectWebURL(in, "https://signoz.example.com", "trace", "abc-123")
+	s := string(out)
+	if !strings.Contains(s, `"webUrl":"https://signoz.example.com/trace/abc-123"`) {
+		t.Fatalf("webUrl not injected at top level when data is an array: %s", s)
+	}
+	if !strings.Contains(s, `"data":[1,2]`) {
+		t.Fatalf("array data value not preserved: %s", s)
 	}
 }
 

--- a/pkg/util/weburl_inject_test.go
+++ b/pkg/util/weburl_inject_test.go
@@ -1,0 +1,59 @@
+package util
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestInjectWebURL_PreservesLargeInt64(t *testing.T) {
+	// A durationNano-style int64 that exceeds float64's exact-integer range
+	// (2^53). A naive Unmarshal->map[string]any->Marshal round-trip would coerce
+	// it through float64 and round it; UseNumber must preserve it verbatim.
+	const bigInt = "9007199254740993" // 2^53 + 1, not exactly representable as float64
+	in := []byte(`{"data":{"durationNano":` + bigInt + `,"name":"GET /cart"}}`)
+
+	out := InjectWebURL(in, "https://signoz.example.com", "trace", "abc-123")
+	s := string(out)
+
+	if !strings.Contains(s, bigInt) {
+		t.Fatalf("large int64 lost precision: %s", s)
+	}
+	if strings.Contains(s, "9.007") || strings.Contains(s, "e+") || strings.Contains(s, "E+") {
+		t.Fatalf("int64 was coerced to float: %s", s)
+	}
+	if !strings.Contains(s, `"webUrl":"https://signoz.example.com/trace/abc-123"`) {
+		t.Fatalf("webUrl not injected on inner data object: %s", s)
+	}
+}
+
+func TestInjectWebURL_BareBody(t *testing.T) {
+	in := []byte(`{"uuid":"x","spans":[]}`)
+	out := InjectWebURL(in, "https://signoz.example.com", "dashboard", "x")
+	if !strings.Contains(string(out), `"webUrl":"https://signoz.example.com/dashboard/x"`) {
+		t.Fatalf("webUrl not injected at top level: %s", out)
+	}
+}
+
+func TestInjectWebURL_NoBaseReturnsOriginal(t *testing.T) {
+	in := []byte(`{"data":{"durationNano":9007199254740993}}`)
+	out := InjectWebURL(in, "", "trace", "abc-123")
+	if string(out) != string(in) {
+		t.Fatalf("expected original bytes when base empty, got: %s", out)
+	}
+}
+
+func TestInjectWebURL_UnknownTypeReturnsOriginal(t *testing.T) {
+	in := []byte(`{"data":{"x":1}}`)
+	out := InjectWebURL(in, "https://signoz.example.com", "log", "id")
+	if string(out) != string(in) {
+		t.Fatalf("expected original bytes for unknown type, got: %s", out)
+	}
+}
+
+func TestInjectWebURL_MalformedReturnsOriginal(t *testing.T) {
+	in := []byte(`not json`)
+	out := InjectWebURL(in, "https://signoz.example.com", "trace", "abc-123")
+	if string(out) != string(in) {
+		t.Fatalf("expected original bytes for malformed body, got: %s", out)
+	}
+}

--- a/pkg/util/weburl_test.go
+++ b/pkg/util/weburl_test.go
@@ -13,7 +13,7 @@ func TestResourceWebURL(t *testing.T) {
 	}{
 		{"dashboard", "https://signoz.example.com", "dashboard", "019a2e3d-uuid", "https://signoz.example.com/dashboard/019a2e3d-uuid", true},
 		{"trailing slash base", "https://signoz.example.com/", "dashboard", "x", "https://signoz.example.com/dashboard/x", true},
-		{"alert", "https://signoz.example.com", "alert", "rule-123", "https://signoz.example.com/alerts/overview?ruleId=rule-123&tab=AlertRules", true},
+		{"alert", "https://signoz.example.com", "alert", "rule-123", "https://signoz.example.com/alerts/overview?ruleId=rule-123", true},
 		{"service with space", "https://signoz.example.com", "service", "cart service", "https://signoz.example.com/services/cart%20service", true},
 		{"service with slash", "https://signoz.example.com", "service", "a/b", "https://signoz.example.com/services/a%2Fb", true},
 		{"empty base omits", "", "dashboard", "x", "", false},

--- a/pkg/util/weburl_test.go
+++ b/pkg/util/weburl_test.go
@@ -1,0 +1,33 @@
+package util
+
+import "testing"
+
+func TestResourceWebURL(t *testing.T) {
+	cases := []struct {
+		name         string
+		base         string
+		resourceType string
+		id           string
+		want         string
+		wantOK       bool
+	}{
+		{"dashboard", "https://signoz.example.com", "dashboard", "019a2e3d-uuid", "https://signoz.example.com/dashboard/019a2e3d-uuid", true},
+		{"alert", "https://signoz.example.com", "alert", "rule-123", "https://signoz.example.com/alerts/overview?ruleId=rule-123&tab=AlertRules", true},
+		{"service with space", "https://signoz.example.com", "service", "cart service", "https://signoz.example.com/services/cart%20service", true},
+		{"service with slash", "https://signoz.example.com", "service", "a/b", "https://signoz.example.com/services/a%2Fb", true},
+		{"empty base omits", "", "dashboard", "x", "", false},
+		{"empty id omits", "https://signoz.example.com", "dashboard", "", "", false},
+		{"unknown type omits", "https://signoz.example.com", "trace", "x", "", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := ResourceWebURL(tc.base, tc.resourceType, tc.id)
+			if ok != tc.wantOK {
+				t.Fatalf("ok = %v, want %v", ok, tc.wantOK)
+			}
+			if got != tc.want {
+				t.Fatalf("url = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}

--- a/pkg/util/weburl_test.go
+++ b/pkg/util/weburl_test.go
@@ -12,6 +12,7 @@ func TestResourceWebURL(t *testing.T) {
 		wantOK       bool
 	}{
 		{"dashboard", "https://signoz.example.com", "dashboard", "019a2e3d-uuid", "https://signoz.example.com/dashboard/019a2e3d-uuid", true},
+		{"trailing slash base", "https://signoz.example.com/", "dashboard", "x", "https://signoz.example.com/dashboard/x", true},
 		{"alert", "https://signoz.example.com", "alert", "rule-123", "https://signoz.example.com/alerts/overview?ruleId=rule-123&tab=AlertRules", true},
 		{"service with space", "https://signoz.example.com", "service", "cart service", "https://signoz.example.com/services/cart%20service", true},
 		{"service with slash", "https://signoz.example.com", "service", "a/b", "https://signoz.example.com/services/a%2Fb", true},

--- a/pkg/util/weburl_test.go
+++ b/pkg/util/weburl_test.go
@@ -16,9 +16,10 @@ func TestResourceWebURL(t *testing.T) {
 		{"alert", "https://signoz.example.com", "alert", "rule-123", "https://signoz.example.com/alerts/overview?ruleId=rule-123", true},
 		{"service with space", "https://signoz.example.com", "service", "cart service", "https://signoz.example.com/services/cart%20service", true},
 		{"service with slash", "https://signoz.example.com", "service", "a/b", "https://signoz.example.com/services/a%2Fb", true},
+		{"trace", "https://signoz.example.com", "trace", "e4dfc429fd5655656d46a0e9db386296", "https://signoz.example.com/trace/e4dfc429fd5655656d46a0e9db386296", true},
 		{"empty base omits", "", "dashboard", "x", "", false},
 		{"empty id omits", "https://signoz.example.com", "dashboard", "", "", false},
-		{"unknown type omits", "https://signoz.example.com", "trace", "x", "", false},
+		{"unknown type omits", "https://signoz.example.com", "log", "x", "", false},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/plans/resource-web-urls.context.md
+++ b/plans/resource-web-urls.context.md
@@ -47,7 +47,24 @@
 - Frontend companion adds a `trace` case to `ResourceType`/`resourceRoute()` so the
   `open_resource` chip routes to `/trace/:id`.
 
-## Open Questions
+### 2026-06-11 — InjectWebURL rewritten to shallow RawMessage decode (#245)
+- Design review compared the webUrl approach against alternatives (MCP
+  `resource_link` content blocks, `structuredContent`, client-side route
+  construction, a `get_resource_url` tool, `_meta`). Kept in-band `webUrl`: it is
+  the only option visible to the LLM in every MCP host. One implementation
+  improvement accepted: stop full-tree decoding passthrough bodies.
+- `InjectWebURL` now decodes one level deep into `map[string]json.RawMessage`
+  (two levels for the `{"data":{…}}` wrap). Everything below the injection level
+  passes through as verbatim bytes, so:
+  - int64 precision is preserved by construction — the `UseNumber` guard became
+    unnecessary and was removed;
+  - nested key order / number formatting are untouched;
+  - multi-MiB trace bodies (response cap is 64 MiB) no longer pay the ~3–5×
+    allocation cost of a full `map[string]any` tree decode + re-marshal.
+- Fixed a latent panic found during the rewrite: a literal `null` body decoded
+  to a nil map and the subsequent `obj["webUrl"]=` write panicked
+  (`assignment to entry in nil map`). Now fails open. New tests cover verbatim
+  inner bytes, `null` body, `"data":null`, and `"data":[…]`.
 - [x] Should saved views get a `webUrl`? — No; no id-only frontend route exists
   (the URL requires the full encoded `compositeQuery`).
 - [x] Where should the origin come from? — `util.GetSigNozURL(ctx)`; omit `webUrl`

--- a/plans/resource-web-urls.context.md
+++ b/plans/resource-web-urls.context.md
@@ -37,8 +37,20 @@
   `AlertRules` is a tab on the `/alerts` list page, not the overview detail page.
   Removed it so the deep link is clean.
 
+### 2026-06-10 — add trace deep link (#245)
+- Added a fourth single-id type: `trace` → `/trace/<traceId>`. Verified against a
+  live staging instance (`https://<base>/trace/<trace_id>`).
+- Enriches `signoz_get_trace_details` (passthrough body → `enrichTraceWebURL`,
+  wrapped `{"data":{…}}` + bare, fail-open). `search_traces` is NOT enriched: its
+  rows put `traceId` in dynamic query columns, not a stable top-level key, so
+  per-row enrichment is fragile — `get_trace_details` is the deep-link use case.
+- Frontend companion adds a `trace` case to `ResourceType`/`resourceRoute()` so the
+  `open_resource` chip routes to `/trace/:id`.
+
 ## Open Questions
 - [x] Should saved views get a `webUrl`? — No; no id-only frontend route exists
   (the URL requires the full encoded `compositeQuery`).
 - [x] Where should the origin come from? — `util.GetSigNozURL(ctx)`; omit `webUrl`
   when empty.
+- [x] Should traces get a `webUrl`? — Yes; `/trace/<traceId>` is a clean single-id
+  route. Scoped to `get_trace_details` (not `search_traces`).

--- a/plans/resource-web-urls.context.md
+++ b/plans/resource-web-urls.context.md
@@ -1,0 +1,37 @@
+# Feature: Resource Web URLs — Context & Discussion
+
+## Original Prompt
+> Add an absolute deep-link (`webUrl`) field to the resource read-tool outputs so
+> the AI assistant can hand users a clickable link to a dashboard, alert, or
+> service in the SigNoz web UI.
+
+## Reference Links
+- Issue: [SigNoz/signoz-ai-assistant#245](https://github.com/SigNoz/signoz-ai-assistant/issues/245) (resource links)
+
+## Key Decisions & Discussion Log
+### 2026-06-10 — why and where the link is built
+- The AI assistant needs an absolute deep link per resource so it can hand users a
+  clickable link.
+- Decision: build the link in the MCP server (single source of truth; benefits all
+  MCP clients incl. Cursor/Claude Desktop which are not same-origin as SigNoz).
+- Scope: dashboard, alert, service (single-id). Saved views dropped — they require
+  the full encoded `compositeQuery` in the URL; there is no id-only frontend route.
+- Templates:
+  - `/dashboard/<uuid>`
+  - `/alerts/overview?ruleId=<id>&tab=AlertRules`
+  - `/services/<url-encoded-name>`
+- Origin comes from `util.GetSigNozURL(ctx)`; `webUrl` is omitted on an empty base.
+- Helper: `pkg/util/weburl.go` `ResourceWebURL(base, type, id) -> (url, ok)`.
+
+### 2026-06-10 — docs sync (Task A5)
+- Added this plan-file pair and a README note under "Available Tools" documenting
+  the new `webUrl` output field on the six resource read tools.
+- `manifest.json` left unchanged: it documents tool `name`/`description` only (not
+  output shapes), and no tool descriptions changed in A1–A4 — only outputs gained a
+  field.
+
+## Open Questions
+- [x] Should saved views get a `webUrl`? — No; no id-only frontend route exists
+  (the URL requires the full encoded `compositeQuery`).
+- [x] Where should the origin come from? — `util.GetSigNozURL(ctx)`; omit `webUrl`
+  when empty.

--- a/plans/resource-web-urls.context.md
+++ b/plans/resource-web-urls.context.md
@@ -18,7 +18,7 @@
   the full encoded `compositeQuery` in the URL; there is no id-only frontend route.
 - Templates:
   - `/dashboard/<uuid>`
-  - `/alerts/overview?ruleId=<id>&tab=AlertRules`
+  - `/alerts/overview?ruleId=<id>`
   - `/services/<url-encoded-name>`
 - Origin comes from `util.GetSigNozURL(ctx)`; `webUrl` is omitted on an empty base.
 - Helper: `pkg/util/weburl.go` `ResourceWebURL(base, type, id) -> (url, ok)`.
@@ -29,6 +29,13 @@
 - `manifest.json` left unchanged: it documents tool `name`/`description` only (not
   output shapes), and no tool descriptions changed in A1–A4 — only outputs gained a
   field.
+
+### 2026-06-10 — drop inert `tab=AlertRules` from alert webUrl (#245)
+- Alert template changed from `/alerts/overview?ruleId=<id>&tab=AlertRules` to
+  `/alerts/overview?ruleId=<id>`. The `tab=AlertRules` param is inert on the
+  `/alerts/overview` route — that page uses `AlertDetailsTab` (OVERVIEW/HISTORY);
+  `AlertRules` is a tab on the `/alerts` list page, not the overview detail page.
+  Removed it so the deep link is clean.
 
 ## Open Questions
 - [x] Should saved views get a `webUrl`? — No; no id-only frontend route exists

--- a/plans/resource-web-urls.plan.md
+++ b/plans/resource-web-urls.plan.md
@@ -1,0 +1,68 @@
+# Plan: Resource Web URLs
+
+## Status
+Done
+
+## Context
+The AI assistant (SigNoz/signoz-ai-assistant#245) needs an absolute deep link per
+resource so it can hand users a clickable link into the SigNoz web UI. Building the
+link in the MCP server keeps a single source of truth and benefits all MCP clients
+(including Cursor / Claude Desktop, which are not same-origin as the SigNoz
+instance).
+
+This adds a `webUrl` deep-link field to the dashboard, alert, and service resource
+read-tool outputs.
+
+## Approach
+
+### `pkg/util/weburl.go`
+- `ResourceWebURL(base, resourceType, id string) (string, bool)`.
+- Supports `dashboard`, `alert`, `service`; returns `("", false)` on an empty
+  base/id or an unknown type so callers omit the field rather than emit a broken
+  link.
+- Templates: `/dashboard/<uuid>`, `/alerts/overview?ruleId=<id>&tab=AlertRules`,
+  `/services/<url-encoded-name>`. Path/query segments are URL-encoded; the base
+  origin is trimmed of a trailing slash.
+
+### `internal/handler/tools/dashboards.go`
+- Enrich list items in `handleListDashboards`.
+- Enrich the single-get body in `handleGetDashboard` via `enrichDashboardWebURL`.
+
+### `internal/handler/tools/services.go`
+- Enrich list items in `handleListServices` using the service name as the id.
+
+### `internal/handler/tools/alerts.go` + `pkg/types/alerts.go`
+- Add a `WebURL` field on `Alert` / `AlertRuleSummary` (`json:"webUrl,omitempty"`).
+- Enrich `handleListAlerts`, `handleListAlertRules`, and the `handleGetAlert`
+  passthrough (`enrichAlertWebURL`).
+
+### Omission rule
+- `webUrl` is omitted when `util.GetSigNozURL(ctx)` is empty (no instance URL on the
+  request).
+
+## Files to Modify
+- `pkg/util/weburl.go` — new `ResourceWebURL` deep-link builder
+- `pkg/util/weburl_test.go` — builder unit tests (incl. trailing-slash trim)
+- `internal/handler/tools/dashboards.go` — enrich list + single-get
+- `internal/handler/tools/services.go` — enrich list
+- `internal/handler/tools/alerts.go` — enrich list/list-rules/get
+- `pkg/types/alerts.go` — `WebURL` field on `Alert` / `AlertRuleSummary`
+- `README.md` — note on the `webUrl` output field
+- `plans/resource-web-urls.*` — this pair
+
+`manifest.json` intentionally unchanged: it documents tool `name`/`description`
+only (not output shapes), and no tool descriptions changed.
+
+## Verification
+```
+go build ./...
+go test ./...
+go vet ./...
+gofmt -l pkg/util/weburl.go internal/handler/tools/dashboards.go \
+  internal/handler/tools/services.go internal/handler/tools/alerts.go \
+  pkg/types/alerts.go
+```
+- Unit: `ResourceWebURL` builds each template, URL-encodes ids, trims trailing
+  slash, and returns `ok=false` on empty base/id or unknown type.
+- Handler: list/get outputs carry `webUrl` when the request has an instance URL and
+  omit it when the base is empty.

--- a/plans/resource-web-urls.plan.md
+++ b/plans/resource-web-urls.plan.md
@@ -20,7 +20,7 @@ read-tool outputs.
 - Supports `dashboard`, `alert`, `service`; returns `("", false)` on an empty
   base/id or an unknown type so callers omit the field rather than emit a broken
   link.
-- Templates: `/dashboard/<uuid>`, `/alerts/overview?ruleId=<id>&tab=AlertRules`,
+- Templates: `/dashboard/<uuid>`, `/alerts/overview?ruleId=<id>`,
   `/services/<url-encoded-name>`. Path/query segments are URL-encoded; the base
   origin is trimmed of a trailing slash.
 

--- a/plans/resource-web-urls.plan.md
+++ b/plans/resource-web-urls.plan.md
@@ -23,6 +23,11 @@ read-tool outputs.
 - Templates: `/dashboard/<uuid>`, `/alerts/overview?ruleId=<id>`,
   `/services/<url-encoded-name>`, `/trace/<traceId>`. Path/query segments are
   URL-encoded; the base origin is trimmed of a trailing slash.
+- `InjectWebURL(data, base, type, id) []byte` for passthrough bodies: shallow
+  decode into `map[string]json.RawMessage` — one level deep, two for the
+  `{"data":{…}}` wrap — so nested values (span trees, int64 fields, number
+  formatting, key order) pass through as verbatim bytes with no re-encoding.
+  Fails open on any non-object or unparseable body, including literal `null`.
 
 ### `internal/handler/tools/dashboards.go`
 - Enrich list items in `handleListDashboards`.

--- a/plans/resource-web-urls.plan.md
+++ b/plans/resource-web-urls.plan.md
@@ -17,12 +17,12 @@ read-tool outputs.
 
 ### `pkg/util/weburl.go`
 - `ResourceWebURL(base, resourceType, id string) (string, bool)`.
-- Supports `dashboard`, `alert`, `service`; returns `("", false)` on an empty
-  base/id or an unknown type so callers omit the field rather than emit a broken
-  link.
+- Supports `dashboard`, `alert`, `service`, `trace`; returns `("", false)` on an
+  empty base/id or an unknown type so callers omit the field rather than emit a
+  broken link.
 - Templates: `/dashboard/<uuid>`, `/alerts/overview?ruleId=<id>`,
-  `/services/<url-encoded-name>`. Path/query segments are URL-encoded; the base
-  origin is trimmed of a trailing slash.
+  `/services/<url-encoded-name>`, `/trace/<traceId>`. Path/query segments are
+  URL-encoded; the base origin is trimmed of a trailing slash.
 
 ### `internal/handler/tools/dashboards.go`
 - Enrich list items in `handleListDashboards`.
@@ -36,6 +36,12 @@ read-tool outputs.
 - Enrich `handleListAlerts`, `handleListAlertRules`, and the `handleGetAlert`
   passthrough (`enrichAlertWebURL`).
 
+### `internal/handler/tools/traces.go`
+- Enrich the `handleGetTraceDetails` passthrough body via `enrichTraceWebURL`
+  (wrapped `{"data":{…}}` + bare, fail-open), using the `traceId` arg.
+- `search_traces` is not enriched (trace id lives in dynamic query rows, not a
+  stable top-level key).
+
 ### Omission rule
 - `webUrl` is omitted when `util.GetSigNozURL(ctx)` is empty (no instance URL on the
   request).
@@ -47,6 +53,7 @@ read-tool outputs.
 - `internal/handler/tools/services.go` — enrich list
 - `internal/handler/tools/alerts.go` — enrich list/list-rules/get
 - `pkg/types/alerts.go` — `WebURL` field on `Alert` / `AlertRuleSummary`
+- `internal/handler/tools/traces.go` — enrich `get_trace_details`
 - `README.md` — note on the `webUrl` output field
 - `plans/resource-web-urls.*` — this pair
 


### PR DESCRIPTION
## Summary

Stamps an absolute `webUrl` deep link onto resource tool outputs so any MCP client (the AI assistant, Cursor, Claude Desktop, …) can hand users a clickable link to a resource.

- New `pkg/util/weburl.go` — `ResourceWebURL(base, type, id)` builds the absolute UI link from the tenant origin (`util.GetSigNozURL(ctx)`), for three single-id types:
  - dashboard → `<base>/dashboard/<uuid>`
  - alert → `<base>/alerts/overview?ruleId=<ruleId>`
  - service → `<base>/services/<url-encoded-name>`
- Enriches outputs of `signoz_list_dashboards`, `signoz_get_dashboard`, `signoz_list_alerts`, `signoz_list_alert_rules`, `signoz_get_alert`, `signoz_list_services` with a `webUrl` field.
- `webUrl` is omitted when the request carries no SigNoz instance URL — never a broken/relative link.
- Saved views are intentionally out of scope (no id-only frontend route; they need the full encoded `compositeQuery`).

URL templates were verified against the live SigNoz frontend + backend. `/alerts/overview?ruleId=` loads the rule via `GET /api/v2/rules/:id`; `compositeQuery`/`tab` are not required.

## Test Plan

- [x] `go build ./...`, `go test ./...`, `go vet ./...` all green
- [x] Unit tests: `ResourceWebURL` (each type, URL-encoding, empty base/id, trailing-slash trim)
- [x] Handler tests: `webUrl` present in enriched list/get outputs (dashboards, alerts incl. triggered + rules + get, services); omitted when context has no base URL; wrapped `{"data":{…}}` vs bare passthrough bodies covered

🤖 Generated with [Claude Code](https://claude.com/claude-code)