### PR TITLE
[codex] Align docs tool registration parity

### DIFF
--- a/internal/handler/tools/docs.go
+++ b/internal/handler/tools/docs.go
@@ -28,7 +28,7 @@ func (h *Handler) RegisterDocsHandlers(s *server.MCPServer) {
 		mcp.WithNumber("limit", mcp.Description("Maximum results to return. Default 10, max 25.")),
 		mcp.WithString("section_slug", mcp.Description(`Optional exact top-level docs section filter, for example "setup", "logs-management", "apm-distributed-tracing", "metrics", "alerts", "dashboards", "signoz-apis", "querying", or "collection-agents".`)),
 	)
-	s.AddTool(searchTool, h.handleSearchDocs)
+	addTool(s, searchTool, h.handleSearchDocs)
 
 	fetchTool := mcp.NewTool("signoz_fetch_doc",
 		mcp.WithReadOnlyHintAnnotation(true),
@@ -38,7 +38,7 @@ func (h *Handler) RegisterDocsHandlers(s *server.MCPServer) {
 		mcp.WithString("url", mcp.Required(), mcp.Description("Full https://signoz.io/docs/... URL or /docs/... path.")),
 		mcp.WithString("heading", mcp.Description(`Optional heading anchor ID or heading text, for example "prerequisites" or "## Prerequisites".`)),
 	)
-	s.AddTool(fetchTool, h.handleFetchDoc)
+	addTool(s, fetchTool, h.handleFetchDoc)
 
 	sitemap := mcp.NewResource(
 		docsindex.DocsSitemapURI,

--- a/internal/mcp-server/integration_test.go
+++ b/internal/mcp-server/integration_test.go
@@ -3,6 +3,11 @@ package mcp_server
 import (
 	"context"
 	"encoding/json"
+	"os"
+	"path/filepath"
+	"reflect"
+	"runtime"
+	"sort"
 	"strconv"
 	"strings"
 	"testing"
@@ -46,6 +51,7 @@ func buildTestServer(t *testing.T) *server.MCPServer {
 	handler.RegisterQueryBuilderV5Handlers(s)
 	handler.RegisterLogsHandlers(s)
 	handler.RegisterViewHandlers(s)
+	handler.RegisterDocsHandlers(s)
 	handler.RegisterTracesHandlers(s)
 	handler.RegisterNotificationChannelHandlers(s)
 	handler.RegisterResourceTemplates(s)
@@ -83,29 +89,73 @@ func TestIntegration_InitializeAndListTools(t *testing.T) {
 		t.Error("expected tools capability to be present")
 	}
 
-	// List tools and verify count
+	// List tools and verify parity with manifest metadata.
 	toolsResult, err := c.ListTools(ctx, mcp.ListToolsRequest{})
 	if err != nil {
 		t.Fatalf("ListTools failed: %v", err)
 	}
 
-	const expectedToolCount = 36
-	if len(toolsResult.Tools) != expectedToolCount {
-		t.Errorf("expected %d tools, got %d", expectedToolCount, len(toolsResult.Tools))
-		for _, tool := range toolsResult.Tools {
-			t.Logf("  tool: %s", tool.Name)
+	expectedToolNames := manifestToolNames(t)
+	actualToolNames := listedToolNames(t, toolsResult.Tools)
+	if !reflect.DeepEqual(actualToolNames, expectedToolNames) {
+		t.Errorf("tools/list names differ from manifest.json\nexpected (%d): %v\nactual (%d): %v",
+			len(expectedToolNames), expectedToolNames, len(actualToolNames), actualToolNames)
+	}
+}
+
+func manifestToolNames(t *testing.T) []string {
+	t.Helper()
+
+	_, filename, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("failed to locate test file")
+	}
+	b, err := os.ReadFile(filepath.Join(filepath.Dir(filename), "..", "..", "manifest.json"))
+	if err != nil {
+		t.Fatalf("read manifest.json: %v", err)
+	}
+	var manifest struct {
+		Tools []struct {
+			Name string `json:"name"`
+		} `json:"tools"`
+	}
+	if err := json.Unmarshal(b, &manifest); err != nil {
+		t.Fatalf("parse manifest.json: %v", err)
+	}
+
+	names := make([]string, 0, len(manifest.Tools))
+	seen := make(map[string]struct{}, len(manifest.Tools))
+	for _, tool := range manifest.Tools {
+		if tool.Name == "" {
+			t.Fatal("manifest.json contains a tool without a name")
 		}
-	}
-	foundAlertRulesTool := false
-	for _, tool := range toolsResult.Tools {
-		if tool.Name == "signoz_list_alert_rules" {
-			foundAlertRulesTool = true
-			break
+		if _, ok := seen[tool.Name]; ok {
+			t.Fatalf("manifest.json contains duplicate tool name %q", tool.Name)
 		}
+		seen[tool.Name] = struct{}{}
+		names = append(names, tool.Name)
 	}
-	if !foundAlertRulesTool {
-		t.Error("expected signoz_list_alert_rules tool to be registered")
+	sort.Strings(names)
+	return names
+}
+
+func listedToolNames(t *testing.T, listedTools []mcp.Tool) []string {
+	t.Helper()
+
+	names := make([]string, 0, len(listedTools))
+	seen := make(map[string]struct{}, len(listedTools))
+	for _, tool := range listedTools {
+		if tool.Name == "" {
+			t.Fatal("tools/list returned a tool without a name")
+		}
+		if _, ok := seen[tool.Name]; ok {
+			t.Fatalf("tools/list returned duplicate tool name %q", tool.Name)
+		}
+		seen[tool.Name] = struct{}{}
+		names = append(names, tool.Name)
 	}
+	sort.Strings(names)
+	return names
 }
 
 func TestIntegration_ListToolsInputSchemasAreOpenAPICompatible(t *testing.T) {

--- a/plans/docs-tool-registration-parity.context.md
+++ b/plans/docs-tool-registration-parity.context.md
@@ -1,0 +1,19 @@
+# Feature: Docs Tool Registration Parity - Context & Discussion
+
+## Reference Links
+- None.
+
+## Key Decisions & Discussion Log
+### 2026-06-17 - Initial plan
+- No existing plan covered this parity fix.
+- Keep the change scoped to test-server registration, tools-list parity assertion, and docs handler registration helper usage.
+- README.md and manifest.json require no content changes because no tools/resources/configuration are added, renamed, or removed.
+
+### 2026-06-17 - Implementation complete
+- `buildTestServer` now registers docs handlers, matching production registration.
+- `tools/list` integration coverage now compares registered tool names against `manifest.json` instead of a hard-coded count.
+- Docs tools now use the shared `addTool` registration helper.
+- Verification passed with `go test ./internal/mcp-server ./internal/handler/tools`.
+
+## Open Questions
+- [x] Should docs/metadata files change? Resolved: no; this PR preserves the existing MCP surface and only makes registration/tests match the already-advertised manifest.

--- a/plans/docs-tool-registration-parity.plan.md
+++ b/plans/docs-tool-registration-parity.plan.md
@@ -1,0 +1,23 @@
+# Plan: Docs Tool Registration Parity
+
+## Status
+Done
+
+## Context
+Production MCP server registration includes docs handlers, but the in-process integration test server omitted them and asserted only a hard-coded tool count. The docs tools also bypassed the shared `addTool` helper, so their schemas skipped the same normalization path used by other tools.
+
+## Approach
+- Register docs handlers in `buildTestServer` in the same position as production registration.
+- Replace the hard-coded tools-list count with exact name parity against `manifest.json`.
+- Register `signoz_search_docs` and `signoz_fetch_doc` via `addTool`.
+- Leave README.md and manifest.json unchanged because this preserves the existing MCP surface.
+
+## Files to Modify
+- `internal/mcp-server/integration_test.go` - add docs handler registration and manifest parity assertion.
+- `internal/handler/tools/docs.go` - use shared tool registration helper for docs tools.
+- `plans/docs-tool-registration-parity.context.md` - append-only context log.
+- `plans/docs-tool-registration-parity.plan.md` - current plan/status.
+
+## Verification
+- `gofmt` touched Go files.
+- `go test ./internal/mcp-server ./internal/handler/tools`.


### PR DESCRIPTION
## Summary
- Register docs handlers in the in-process integration test server so `tools/list` mirrors production registration for `signoz_search_docs` and `signoz_fetch_doc`.
- Replace the hard-coded tool-count assertion with exact tool-name parity against `manifest.json`, so future registration/metadata drift fails loudly.
- Route docs tools through the shared `addTool` helper so their advertised schemas pass through the same normalization path as other tools.

## Docs / Metadata Sync
- No README.md or manifest.json content changes were needed: this PR does not add, rename, or remove MCP tools/resources/configuration.
- The integration test now uses `manifest.json` as the metadata source of truth for tool-name parity.

## Tests
- `go test ./internal/mcp-server ./internal/handler/tools`