### PR TITLE
feat(metrics): add signoz_check_metric_usage tool

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -98,4 +98,5 @@ For any code that parses an upstream response or shapes a tool output:
 
 - **Pin the contract, and test against reality where you can.** Beyond fixture-based unit tests, add a periodic/integration test against a live SigNoz instance (or a recorded real response) so upstream drift fails a test, not a user. Per-PR fixture tests are necessary but not sufficient.
 - **When tests can't catch it, observability must.** If a break only manifests against real data, add a metric or WARN log that fires when the contract appears violated (e.g. a passthrough enrichment that found rows but could not locate the expected field). Silent degradation that no test and no signal can catch is the failure mode to design against.
+- **Do not hide global upstream failures inside partial item results.** Auth and permission failures such as SigNoz 401/403 must propagate through the shared coded error path (`upstreamError` for tools) so clients can re-authenticate or handle permissions.
 - **Fail open, but never fail silent.** Prefer fail-open behavior for cross-boundary parsing, but always pair it with a detectable signal so "fail-open" does not become "fail-silent."

--- a/README.md
+++ b/README.md
@@ -433,6 +433,14 @@ Return top 100 metrics ranked by ingested sample volume with pre-computed percen
   - `timeRange` (optional) - Relative range (e.g. 24h, 3d, 7d, 30d; default: 7d; ignored when both `start` and `end` are provided). Start with 7d; if the query times out, retry with 3d, then 24h
   - `start`/`end` (optional) - Unix ms timestamps. When both are provided, they override `timeRange`
 
+#### `signoz_check_metric_usage`
+
+Given a list of metric names, return which dashboards and alerts reference each one, and whether each is safe to drop. Wraps `/api/v2/metrics/{name}/dashboards` and `/api/v2/metrics/{name}/alerts` per metric. Requires SigNoz v0.105.0+.
+
+- **Parameters**:
+  - `metricNames` (required) - Array of metric name strings to check. Example: `["system.disk.io", "k8s.node.condition"]`
+- **Response**: Per metric — `dashboards` (list of dashboard names that reference the metric), `alerts` (list of alert names that reference the metric)
+
 #### `signoz_list_alerts`
 
 Lists currently firing/silenced/inhibited alert *instances* from Alertmanager — **not** rule definitions. Use `signoz_list_alert_rules` for configured rules, `signoz_get_alert` with a `ruleId` for one full rule definition, or `signoz_get_alert_history` for the state timeline.

--- a/README.md
+++ b/README.md
@@ -332,7 +332,7 @@ HTTP mode exposes unauthenticated probe endpoints. New Kubernetes deployments sh
 
 ## Available Tools
 
-> **SigNoz compatibility:** `signoz_check_metric_usage` targets `/api/v2/metrics/{name}/dashboards` and `/api/v2/metrics/{name}/alerts`, available in SigNoz v0.105.0 and newer. Alert-rule tools target `/api/v2/rules/*`, which is available in SigNoz v0.120.0 and newer. Self-hosted deployments on older SigNoz versions will see HTTP 404 from the affected tools. Notification-channel tools target the render-envelope `/api/v1/channels/*` routes introduced by SigNoz/signoz#10941, #10957, #10995, and #10997.
+> **SigNoz compatibility:** `signoz_check_metric_usage` targets `/api/v2/metrics/dashboards?metricName=...` and `/api/v2/metrics/alerts?metricName=...`, available in SigNoz v0.105.0 and newer. Alert-rule tools target `/api/v2/rules/*`, which is available in SigNoz v0.120.0 and newer. Self-hosted deployments on older SigNoz versions will see HTTP 404 from the affected tools. Notification-channel tools target the render-envelope `/api/v1/channels/*` routes introduced by SigNoz/signoz#10941, #10957, #10995, and #10997.
 
 > **Tool metadata:** every tool accepts `searchContext`, the user's original question/search text. It is used for MCP observability and is not forwarded to SigNoz APIs.
 
@@ -437,7 +437,7 @@ Return top 100 metrics ranked by ingested sample volume with pre-computed percen
 
 #### `signoz_check_metric_usage`
 
-Given a list of metric names, return which dashboards and alerts reference each one. Wraps `/api/v2/metrics/{name}/dashboards` and `/api/v2/metrics/{name}/alerts` per metric. Requires SigNoz v0.105.0+.
+Given a list of metric names, return which dashboards and alerts reference each one. Wraps `/api/v2/metrics/dashboards?metricName=...` and `/api/v2/metrics/alerts?metricName=...` per metric. Requires SigNoz v0.105.0+.
 
 - **Parameters**:
   - `metricNames` (required) - Array of metric name strings to check (max 50 per call). Example: `["system.disk.io", "k8s.node.condition"]`. For larger lists, split into batches of 50 and merge results.

--- a/README.md
+++ b/README.md
@@ -341,7 +341,7 @@ HTTP mode exposes unauthenticated probe endpoints. New Kubernetes deployments sh
 | `signoz_list_metrics` | Search and list available metrics |
 | `signoz_query_metrics` | Query metrics with smart aggregation defaults |
 | `signoz_get_top_metrics` | Return top 100 metrics ranked by ingested sample volume with pre-computed percentages for cost and volume analysis |
-| `signoz_check_metric_usage` | Given a list of metric names, return which dashboards and alerts reference each one |
+| `signoz_check_metric_usage` | Given a list of metric names (up to 50 per call), return which dashboards and alerts reference each one |
 | `signoz_get_field_keys` | Discover available field keys for metrics, traces, or logs |
 | `signoz_get_field_values` | Get possible values for a field key |
 | `signoz_list_alerts` | List firing/silenced/inhibited Alertmanager alert *instances* (not rule definitions) |
@@ -438,8 +438,9 @@ Return top 100 metrics ranked by ingested sample volume with pre-computed percen
 Given a list of metric names, return which dashboards and alerts reference each one. Wraps `/api/v2/metrics/{name}/dashboards` and `/api/v2/metrics/{name}/alerts` per metric. Requires SigNoz v0.105.0+.
 
 - **Parameters**:
-  - `metricNames` (required) - Array of metric name strings to check. Example: `["system.disk.io", "k8s.node.condition"]`
-- **Response**: Per metric — `dashboards` (list of dashboard names that reference the metric), `alerts` (list of alert names that reference the metric)
+  - `metricNames` (required) - Array of metric name strings to check (max 50 per call). Example: `["system.disk.io", "k8s.node.condition"]`. For larger lists, split into batches of 50 and merge results.
+- **Response**: Per metric — `dashboards` (list of dashboard names that reference the metric), `alerts` (list of alert names that reference the metric), `error` (non-empty when the lookup failed — do not treat the metric as unused in that case)
+- **Limits**: Maximum 50 metrics per call; 30-second overall timeout (partial results returned on expiry)
 
 #### `signoz_list_alerts`
 

--- a/README.md
+++ b/README.md
@@ -339,7 +339,8 @@ HTTP mode exposes unauthenticated probe endpoints. New Kubernetes deployments sh
 |------|-------------|
 | `signoz_list_metrics` | Search and list available metrics |
 | `signoz_query_metrics` | Query metrics with smart aggregation defaults |
-| `signoz_get_top_metrics` | Rank metrics by ingested sample count for cost analysis |
+| `signoz_get_top_metrics` | Return top 100 metrics ranked by ingested sample volume with pre-computed percentages for cost and volume analysis |
+| `signoz_check_metric_usage` | Given a list of metric names, return which dashboards and alerts reference each one, and whether each is safe to drop |
 | `signoz_get_field_keys` | Discover available field keys for metrics, traces, or logs |
 | `signoz_get_field_values` | Get possible values for a field key |
 | `signoz_list_alerts` | List firing/silenced/inhibited Alertmanager alert *instances* (not rule definitions) |

--- a/README.md
+++ b/README.md
@@ -206,6 +206,7 @@ The binary is at `./bin/signoz-mcp-server`.
 ### Prerequisites
 
 - A running [SigNoz](https://signoz.io) instance
+- SigNoz v0.105.0 or newer for `signoz_check_metric_usage`
 - SigNoz v0.120.0 or newer for alert rule tools that use the `/api/v2/rules` APIs
 - A SigNoz API key (Settings → API Keys in the SigNoz UI)
 - The `signoz-mcp-server` binary (see [Self-Hosted Installation](#self-hosted-installation))
@@ -331,7 +332,7 @@ HTTP mode exposes unauthenticated probe endpoints. New Kubernetes deployments sh
 
 ## Available Tools
 
-> **SigNoz compatibility:** alert-rule tools target `/api/v2/rules/*`, which is available in SigNoz v0.120.0 and newer. Self-hosted deployments on older SigNoz versions will see HTTP 404 from the affected alert-rule tools. Notification-channel tools target the render-envelope `/api/v1/channels/*` routes introduced by SigNoz/signoz#10941, #10957, #10995, and #10997.
+> **SigNoz compatibility:** `signoz_check_metric_usage` targets `/api/v2/metrics/{name}/dashboards` and `/api/v2/metrics/{name}/alerts`, available in SigNoz v0.105.0 and newer. Alert-rule tools target `/api/v2/rules/*`, which is available in SigNoz v0.120.0 and newer. Self-hosted deployments on older SigNoz versions will see HTTP 404 from the affected tools. Notification-channel tools target the render-envelope `/api/v1/channels/*` routes introduced by SigNoz/signoz#10941, #10957, #10995, and #10997.
 
 > **Tool metadata:** every tool accepts `searchContext`, the user's original question/search text. It is used for MCP observability and is not forwarded to SigNoz APIs.
 

--- a/README.md
+++ b/README.md
@@ -341,7 +341,7 @@ HTTP mode exposes unauthenticated probe endpoints. New Kubernetes deployments sh
 | `signoz_list_metrics` | Search and list available metrics |
 | `signoz_query_metrics` | Query metrics with smart aggregation defaults |
 | `signoz_get_top_metrics` | Return top 100 metrics ranked by ingested sample volume with pre-computed percentages for cost and volume analysis |
-| `signoz_check_metric_usage` | Given a list of metric names, return which dashboards and alerts reference each one, and whether each is safe to drop |
+| `signoz_check_metric_usage` | Given a list of metric names, return which dashboards and alerts reference each one |
 | `signoz_get_field_keys` | Discover available field keys for metrics, traces, or logs |
 | `signoz_get_field_values` | Get possible values for a field key |
 | `signoz_list_alerts` | List firing/silenced/inhibited Alertmanager alert *instances* (not rule definitions) |
@@ -435,7 +435,7 @@ Return top 100 metrics ranked by ingested sample volume with pre-computed percen
 
 #### `signoz_check_metric_usage`
 
-Given a list of metric names, return which dashboards and alerts reference each one, and whether each is safe to drop. Wraps `/api/v2/metrics/{name}/dashboards` and `/api/v2/metrics/{name}/alerts` per metric. Requires SigNoz v0.105.0+.
+Given a list of metric names, return which dashboards and alerts reference each one. Wraps `/api/v2/metrics/{name}/dashboards` and `/api/v2/metrics/{name}/alerts` per metric. Requires SigNoz v0.105.0+.
 
 - **Parameters**:
   - `metricNames` (required) - Array of metric name strings to check. Example: `["system.disk.io", "k8s.node.condition"]`

--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ The binary is at `./bin/signoz-mcp-server`.
 ### Prerequisites
 
 - A running [SigNoz](https://signoz.io) instance
-- SigNoz v0.105.0 or newer for `signoz_check_metric_usage`
+- SigNoz v0.131.0 or newer for `signoz_check_metric_usage`
 - SigNoz v0.120.0 or newer for alert rule tools that use the `/api/v2/rules` APIs
 - A SigNoz API key (Settings → API Keys in the SigNoz UI)
 - The `signoz-mcp-server` binary (see [Self-Hosted Installation](#self-hosted-installation))
@@ -332,7 +332,7 @@ HTTP mode exposes unauthenticated probe endpoints. New Kubernetes deployments sh
 
 ## Available Tools
 
-> **SigNoz compatibility:** `signoz_check_metric_usage` targets `/api/v2/metrics/dashboards?metricName=...` and `/api/v2/metrics/alerts?metricName=...`, available in SigNoz v0.105.0 and newer. Alert-rule tools target `/api/v2/rules/*`, which is available in SigNoz v0.120.0 and newer. Self-hosted deployments on older SigNoz versions will see HTTP 404 from the affected tools. Notification-channel tools target the render-envelope `/api/v1/channels/*` routes introduced by SigNoz/signoz#10941, #10957, #10995, and #10997.
+> **SigNoz compatibility:** `signoz_check_metric_usage` targets `/api/v2/metrics/dashboards?metricName=...` and `/api/v2/metrics/alerts?metricName=...`, available in SigNoz v0.131.0 and newer. Alert-rule tools target `/api/v2/rules/*`, which is available in SigNoz v0.120.0 and newer. Self-hosted deployments on older SigNoz versions will see HTTP 404 from the affected tools. Notification-channel tools target the render-envelope `/api/v1/channels/*` routes introduced by SigNoz/signoz#10941, #10957, #10995, and #10997.
 
 > **Tool metadata:** every tool accepts `searchContext`, the user's original question/search text. It is used for MCP observability and is not forwarded to SigNoz APIs.
 
@@ -437,7 +437,7 @@ Return top 100 metrics ranked by ingested sample volume with pre-computed percen
 
 #### `signoz_check_metric_usage`
 
-Given a list of metric names, return which dashboards and alerts reference each one. Wraps `/api/v2/metrics/dashboards?metricName=...` and `/api/v2/metrics/alerts?metricName=...` per metric. Requires SigNoz v0.105.0+.
+Given a list of metric names, return which dashboards and alerts reference each one. Wraps `/api/v2/metrics/dashboards?metricName=...` and `/api/v2/metrics/alerts?metricName=...` per metric. Requires SigNoz v0.131.0+.
 
 - **Parameters**:
   - `metricNames` (required) - Array of metric name strings to check (max 50 per call). Example: `["system.disk.io", "k8s.node.condition"]`. For larger lists, split into batches of 50 and merge results.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -14,7 +14,7 @@ subgraph Startup["Server Initialization"]
     OTEL --> HANDLER["Handler with LRU clientCache"]
     HANDLER --> CHSCHEMA["dashboard.InitClickhouseSchema"]
     CHSCHEMA --> MCPSRV["NewMCPServer"]
-    MCPSRV --> REGISTER["Register all tool handlers<br/>(Metrics, Alerts, Dashboards, Services,<br/>QueryBuilderV5, Logs, Docs, Traces)"]
+    MCPSRV --> REGISTER["Register all tool handlers<br/>(Metrics, TopMetrics, MetricUsage, Alerts, Dashboards, Services,<br/>QueryBuilderV5, Logs, Docs, Traces)"]
     REGISTER --> MODE{"TransportMode?"}
 end
 

--- a/internal/client/interface.go
+++ b/internal/client/interface.go
@@ -12,6 +12,7 @@ import (
 type Client interface {
 	GetAnalyticsIdentity(ctx context.Context) (*AnalyticsIdentity, error)
 	ListMetrics(ctx context.Context, start, end int64, limit int, searchText, source string) (json.RawMessage, error)
+	GetTopMetrics(ctx context.Context, start, end int64, limit int) (json.RawMessage, error)
 	ListAlerts(ctx context.Context, params types.ListAlertsParams) (json.RawMessage, error)
 	ListAlertRules(ctx context.Context) (json.RawMessage, error)
 	GetAlertByRuleID(ctx context.Context, ruleID string) (json.RawMessage, error)
@@ -37,11 +38,11 @@ type Client interface {
 	CreateAlertRule(ctx context.Context, alertJSON []byte) (json.RawMessage, error)
 	UpdateAlertRule(ctx context.Context, ruleID string, alertJSON []byte) error
 	DeleteAlertRule(ctx context.Context, ruleID string) error
+	CheckMetricUsage(ctx context.Context, names []string) (map[string]MetricUsage, error)
 	ListNotificationChannels(ctx context.Context) (json.RawMessage, error)
 	GetNotificationChannel(ctx context.Context, id string) (json.RawMessage, error)
 	CreateNotificationChannel(ctx context.Context, receiverJSON []byte) (json.RawMessage, error)
 	UpdateNotificationChannel(ctx context.Context, id string, receiverJSON []byte) error
 	DeleteNotificationChannel(ctx context.Context, id string) error
 	TestNotificationChannel(ctx context.Context, receiverJSON []byte) error
-	GetTopMetrics(ctx context.Context, start, end int64, limit int) (json.RawMessage, error)
 }

--- a/internal/client/metric_usage.go
+++ b/internal/client/metric_usage.go
@@ -25,13 +25,13 @@ const (
 )
 
 type metricDashboardRef struct {
-	DashboardName string `json:"dashboardName"`
-	DashboardID   string `json:"dashboardId"`
+	DashboardName *string `json:"dashboardName"`
+	DashboardID   string  `json:"dashboardId"`
 }
 
 type metricAlertRef struct {
-	AlertName string `json:"alertName"`
-	AlertID   string `json:"alertId"`
+	AlertName *string `json:"alertName"`
+	AlertID   string  `json:"alertId"`
 }
 
 // MetricUsage is the compact usage summary returned to the caller for each metric.
@@ -225,9 +225,12 @@ func parseDashboardNames(body []byte) ([]string, error) {
 	seen := make(map[string]struct{})
 	var names []string
 	for _, ref := range resp.Data.Dashboards {
-		if _, ok := seen[ref.DashboardName]; !ok {
-			seen[ref.DashboardName] = struct{}{}
-			names = append(names, ref.DashboardName)
+		if ref.DashboardName == nil {
+			return nil, errors.New("dashboardName missing from dashboard ref")
+		}
+		if _, ok := seen[*ref.DashboardName]; !ok {
+			seen[*ref.DashboardName] = struct{}{}
+			names = append(names, *ref.DashboardName)
 		}
 	}
 	if names == nil {
@@ -247,7 +250,10 @@ func parseAlertNames(body []byte) ([]string, error) {
 	}
 	names := make([]string, 0, len(resp.Data.Alerts))
 	for _, ref := range resp.Data.Alerts {
-		names = append(names, ref.AlertName)
+		if ref.AlertName == nil {
+			return nil, errors.New("alertName missing from alert ref")
+		}
+		names = append(names, *ref.AlertName)
 	}
 	return names, nil
 }

--- a/internal/client/metric_usage.go
+++ b/internal/client/metric_usage.go
@@ -96,7 +96,7 @@ func (s *SigNoz) fetchMetricUsage(ctx context.Context, name string) (MetricUsage
 	s.logger.DebugContext(ctx, "Fetching metric dashboard refs", slog.String("metric", name))
 
 	dashBody, err := s.doRequest(ctx, http.MethodGet, dashURL, nil, DefaultQueryTimeout)
-	var dashNames []string
+	dashNames := []string{}
 	if err != nil {
 		if !is404(err) {
 			return MetricUsage{}, fmt.Errorf("dashboards lookup for %q: %w", name, err)
@@ -114,7 +114,7 @@ func (s *SigNoz) fetchMetricUsage(ctx context.Context, name string) (MetricUsage
 	s.logger.DebugContext(ctx, "Fetching metric alert refs", slog.String("metric", name))
 
 	alertBody, err := s.doRequest(ctx, http.MethodGet, alertURL, nil, DefaultQueryTimeout)
-	var alertNames []string
+	alertNames := []string{}
 	if err != nil {
 		if !is404(err) {
 			return MetricUsage{}, fmt.Errorf("alerts lookup for %q: %w", name, err)

--- a/internal/client/metric_usage.go
+++ b/internal/client/metric_usage.go
@@ -42,9 +42,9 @@ type MetricUsage struct {
 }
 
 // CheckMetricUsage returns dashboard and alert references for each metric.
-// Lookup failures are stored per metric so one transient failure does not cancel
-// the whole batch. Metric-not-found 404s are treated as empty usage; route-level
-// 404s are reported as errors.
+// Per-metric lookup failures are stored on that metric, while auth/permission
+// failures cancel the batch. Metric-not-found 404s are treated as empty usage;
+// route-level 404s are reported as per-metric errors.
 func (s *SigNoz) CheckMetricUsage(ctx context.Context, names []string) (map[string]MetricUsage, error) {
 	ctx = s.ensureTenantContext(ctx)
 
@@ -90,6 +90,9 @@ func (s *SigNoz) CheckMetricUsage(ctx context.Context, names []string) (map[stri
 		g.Go(func() error {
 			usage, err := s.fetchMetricUsage(gctx, name)
 			if err != nil {
+				if isMetricUsageAuthzError(err) {
+					return err
+				}
 				// Preserve partial data; the error only marks unknown portions.
 				if usage.Dashboards == nil {
 					usage.Dashboards = []string{}
@@ -106,7 +109,9 @@ func (s *SigNoz) CheckMetricUsage(ctx context.Context, names []string) (map[stri
 		})
 	}
 
-	_ = g.Wait()
+	if err := g.Wait(); err != nil {
+		return nil, err
+	}
 
 	out := make(map[string]MetricUsage, len(names))
 	for _, r := range results {
@@ -131,6 +136,9 @@ func (s *SigNoz) fetchMetricUsage(ctx context.Context, name string) (MetricUsage
 
 	dashBody, err := s.doRequest(ctx, http.MethodGet, dashURL, nil, DefaultQueryTimeout)
 	if err != nil {
+		if isMetricUsageAuthzError(err) {
+			return usage, err
+		}
 		if !isMetricNotFound404(err) {
 			errs = append(errs, fmt.Sprintf("dashboards lookup for %q: %v", name, err))
 		}
@@ -158,6 +166,9 @@ func (s *SigNoz) fetchMetricUsage(ctx context.Context, name string) (MetricUsage
 
 	alertBody, err := s.doRequest(ctx, http.MethodGet, alertURL, nil, DefaultQueryTimeout)
 	if err != nil {
+		if isMetricUsageAuthzError(err) {
+			return usage, err
+		}
 		if !isMetricNotFound404(err) {
 			errs = append(errs, fmt.Sprintf("alerts lookup for %q: %v", name, err))
 		}
@@ -184,6 +195,14 @@ func (s *SigNoz) fetchMetricUsage(ctx context.Context, name string) (MetricUsage
 		return usage, errors.New(strings.Join(errs, "; "))
 	}
 	return usage, nil
+}
+
+func isMetricUsageAuthzError(err error) bool {
+	var statusErr *HTTPStatusError
+	if !errors.As(err, &statusErr) {
+		return false
+	}
+	return statusErr.StatusCode == http.StatusUnauthorized || statusErr.StatusCode == http.StatusForbidden
 }
 
 // isMetricNotFound404 accepts only the live SigNoz metric-not-found envelope,

--- a/internal/client/metric_usage.go
+++ b/internal/client/metric_usage.go
@@ -30,7 +30,6 @@ type metricAlertRef struct {
 type MetricUsage struct {
 	Dashboards []string `json:"dashboards"`
 	Alerts     []string `json:"alerts"`
-	SafeToDrop bool     `json:"safeToDrop"`
 }
 
 // CheckMetricUsage returns dashboard and alert references for each metric in
@@ -130,7 +129,6 @@ func (s *SigNoz) fetchMetricUsage(ctx context.Context, name string) (MetricUsage
 	return MetricUsage{
 		Dashboards: dashNames,
 		Alerts:     alertNames,
-		SafeToDrop: len(dashNames) == 0 && len(alertNames) == 0,
 	}, nil
 }
 

--- a/internal/client/metric_usage.go
+++ b/internal/client/metric_usage.go
@@ -218,30 +218,34 @@ func (s *SigNoz) fetchMetricUsage(ctx context.Context, name string) (MetricUsage
 // isMetricNotFound404 reports whether err is a metric-level 404 from the
 // SigNoz API, as opposed to a route-level 404 from the HTTP router.
 //
-// doRequest formats non-2xx errors as "unexpected status NNN: <body>".
-// A SigNoz API 404 (metric not tracked) returns a JSON body with
-// {"status":"error",...} — the standard SigNoz API error envelope.
-// A router-level 404 (endpoint not registered — e.g. SigNoz < v0.105.0)
-// returns plain text ("404 page not found"), which must NOT be silently
-// treated as empty usage, as it would incorrectly mark all metrics safe to drop.
-// A generic JSON proxy 404 (e.g. {"error":"not found"} without a "status" field)
-// is also rejected — only the SigNoz-specific envelope is accepted.
+// A SigNoz API 404 (metric not tracked) returns the standard JSON error
+// envelope with status=error, error.code=not_found, error.type=not-found, and
+// an error message beginning with "metric not found:".
+// Router/proxy-level 404s must NOT be silently treated as empty usage, even
+// when they also return JSON, as that would incorrectly mark all metrics unused.
 func isMetricNotFound404(err error) bool {
 	if err == nil {
 		return false
 	}
-	msg := err.Error()
-	if !strings.HasPrefix(msg, "unexpected status 404") {
+	var statusErr *HTTPStatusError
+	if !errors.As(err, &statusErr) || statusErr.StatusCode != http.StatusNotFound {
 		return false
 	}
-	body := strings.TrimSpace(strings.TrimPrefix(msg, "unexpected status 404: "))
 	var envelope struct {
 		Status string `json:"status"`
+		Error  struct {
+			Code    string `json:"code"`
+			Type    string `json:"type"`
+			Message string `json:"message"`
+		} `json:"error"`
 	}
-	if jsonErr := json.Unmarshal([]byte(body), &envelope); jsonErr != nil {
+	if jsonErr := json.Unmarshal([]byte(statusErr.Body), &envelope); jsonErr != nil {
 		return false
 	}
-	return envelope.Status == "error"
+	return envelope.Status == "error" &&
+		envelope.Error.Code == "not_found" &&
+		envelope.Error.Type == "not-found" &&
+		strings.HasPrefix(envelope.Error.Message, "metric not found:")
 }
 
 // parseDashboardNames extracts and deduplicates dashboard names from the

--- a/internal/client/metric_usage.go
+++ b/internal/client/metric_usage.go
@@ -3,6 +3,7 @@ package client
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net/http"
@@ -25,14 +26,14 @@ const (
 )
 
 // metricDashboardRef is the per-widget reference returned by
-// GET /api/v2/metrics/{name}/dashboards.
+// GET /api/v2/metrics/dashboards?metricName={name}.
 type metricDashboardRef struct {
 	DashboardName string `json:"dashboardName"`
 	DashboardID   string `json:"dashboardId"`
 }
 
 // metricAlertRef is the per-alert reference returned by
-// GET /api/v2/metrics/{name}/alerts.
+// GET /api/v2/metrics/alerts?metricName={name}.
 type metricAlertRef struct {
 	AlertName string `json:"alertName"`
 	AlertID   string `json:"alertId"`
@@ -48,9 +49,10 @@ type MetricUsage struct {
 // CheckMetricUsage returns dashboard and alert references for each metric in
 // names. It fires up to 10 goroutines concurrently (bounded by errgroup.SetLimit)
 // — each goroutine fetches the dashboards endpoint then the alerts endpoint for
-// one metric, sequentially. A 404 from either endpoint is treated as an empty
-// result, not an error. Dashboard names are deduplicated (one metric can appear
-// in multiple widgets of the same dashboard).
+// one metric, sequentially. A metric-not-found 404 envelope from either endpoint
+// is treated as an empty result, not an error; route-level 404s still surface as
+// per-metric errors. Dashboard names are deduplicated (one metric can appear in
+// multiple widgets of the same dashboard).
 //
 // Errors are stored per-metric in MetricUsage.Error rather than aborting the
 // whole batch — a transient 5xx on one metric must not discard results for the
@@ -111,11 +113,14 @@ func (s *SigNoz) CheckMetricUsage(ctx context.Context, names []string) (map[stri
 				// Context cancellation (overall deadline) is treated the same way:
 				// metrics that did not finish surface with an error rather than being
 				// silently dropped, so callers can distinguish "not used" from "timed out".
-				results[i] = result{name: name, usage: MetricUsage{
-					Dashboards: []string{},
-					Alerts:     []string{},
-					Error:      err.Error(),
-				}}
+				if usage.Dashboards == nil {
+					usage.Dashboards = []string{}
+				}
+				if usage.Alerts == nil {
+					usage.Alerts = []string{}
+				}
+				usage.Error = err.Error()
+				results[i] = result{name: name, usage: usage}
 				return nil
 			}
 			results[i] = result{name: name, usage: usage}
@@ -134,19 +139,26 @@ func (s *SigNoz) CheckMetricUsage(ctx context.Context, names []string) (map[stri
 
 // fetchMetricUsage fetches dashboards then alerts for a single metric name.
 func (s *SigNoz) fetchMetricUsage(ctx context.Context, name string) (MetricUsage, error) {
-	escaped := url.PathEscape(name)
+	params := url.Values{}
+	params.Set("metricName", name)
+	query := params.Encode()
+
+	usage := MetricUsage{
+		Dashboards: []string{},
+		Alerts:     []string{},
+	}
+	var errs []string
 
 	// --- Dashboards ---
-	dashURL := fmt.Sprintf("%s/api/v2/metrics/%s/dashboards", s.baseURL, escaped)
+	dashURL := fmt.Sprintf("%s/api/v2/metrics/dashboards?%s", s.baseURL, query)
 	s.logger.DebugContext(ctx, "Fetching metric dashboard refs", slog.String("metric", name))
 
 	dashBody, err := s.doRequest(ctx, http.MethodGet, dashURL, nil, DefaultQueryTimeout)
-	dashNames := []string{}
 	if err != nil {
 		if !isMetricNotFound404(err) {
-			return MetricUsage{}, fmt.Errorf("dashboards lookup for %q: %w", name, err)
+			errs = append(errs, fmt.Sprintf("dashboards lookup for %q: %v", name, err))
 		}
-		// 404 = metric not tracked → empty dashboards
+		// Metric-not-found 404 = metric not tracked -> empty dashboards.
 	} else {
 		// Fail-open contract check: warn if the expected shape is absent so silent
 		// degradation is detectable in production (see CLAUDE.md §Testing across
@@ -160,23 +172,24 @@ func (s *SigNoz) fetchMetricUsage(ctx context.Context, name string) (MetricUsage
 			s.logger.WarnContext(ctx, "Unexpected response shape from metric dashboards endpoint — upstream contract may have changed",
 				slog.String("metric", name))
 		}
-		dashNames, err = parseDashboardNames(dashBody)
+		dashNames, err := parseDashboardNames(dashBody)
 		if err != nil {
-			return MetricUsage{}, fmt.Errorf("parsing dashboard refs for %q: %w", name, err)
+			errs = append(errs, fmt.Sprintf("parsing dashboard refs for %q: %v", name, err))
+		} else {
+			usage.Dashboards = dashNames
 		}
 	}
 
 	// --- Alerts ---
-	alertURL := fmt.Sprintf("%s/api/v2/metrics/%s/alerts", s.baseURL, escaped)
+	alertURL := fmt.Sprintf("%s/api/v2/metrics/alerts?%s", s.baseURL, query)
 	s.logger.DebugContext(ctx, "Fetching metric alert refs", slog.String("metric", name))
 
 	alertBody, err := s.doRequest(ctx, http.MethodGet, alertURL, nil, DefaultQueryTimeout)
-	alertNames := []string{}
 	if err != nil {
 		if !isMetricNotFound404(err) {
-			return MetricUsage{}, fmt.Errorf("alerts lookup for %q: %w", name, err)
+			errs = append(errs, fmt.Sprintf("alerts lookup for %q: %v", name, err))
 		}
-		// 404 = metric not tracked → empty alerts
+		// Metric-not-found 404 = metric not tracked -> empty alerts.
 	} else {
 		// Fail-open contract check.
 		var alertProbe struct {
@@ -188,16 +201,18 @@ func (s *SigNoz) fetchMetricUsage(ctx context.Context, name string) (MetricUsage
 			s.logger.WarnContext(ctx, "Unexpected response shape from metric alerts endpoint — upstream contract may have changed",
 				slog.String("metric", name))
 		}
-		alertNames, err = parseAlertNames(alertBody)
+		alertNames, err := parseAlertNames(alertBody)
 		if err != nil {
-			return MetricUsage{}, fmt.Errorf("parsing alert refs for %q: %w", name, err)
+			errs = append(errs, fmt.Sprintf("parsing alert refs for %q: %v", name, err))
+		} else {
+			usage.Alerts = alertNames
 		}
 	}
 
-	return MetricUsage{
-		Dashboards: dashNames,
-		Alerts:     alertNames,
-	}, nil
+	if len(errs) > 0 {
+		return usage, errors.New(strings.Join(errs, "; "))
+	}
+	return usage, nil
 }
 
 // isMetricNotFound404 reports whether err is a metric-level 404 from the
@@ -230,7 +245,7 @@ func isMetricNotFound404(err error) bool {
 }
 
 // parseDashboardNames extracts and deduplicates dashboard names from the
-// /api/v2/metrics/{name}/dashboards response.
+// /api/v2/metrics/dashboards?metricName={name} response.
 // Response shape: {"status":"success","data":{"dashboards":[{dashboardName,dashboardId,widgetId,widgetName},...]}}
 func parseDashboardNames(body []byte) ([]string, error) {
 	var resp struct {
@@ -256,7 +271,7 @@ func parseDashboardNames(body []byte) ([]string, error) {
 }
 
 // parseAlertNames extracts alert names from the
-// /api/v2/metrics/{name}/alerts response.
+// /api/v2/metrics/alerts?metricName={name} response.
 // Response shape: {"status":"success","data":{"alerts":[{alertName,alertId},...]}
 func parseAlertNames(body []byte) ([]string, error) {
 	var resp struct {

--- a/internal/client/metric_usage.go
+++ b/internal/client/metric_usage.go
@@ -16,24 +16,19 @@ import (
 
 const (
 	// MaxMetricUsageNames is the per-call soft cap on metric names.
-	// Each name makes 2 sequential HTTP calls, so N names → 2N backend requests.
+	// Each name makes 2 sequential HTTP calls.
 	// Callers with more names should batch into groups of this size.
 	MaxMetricUsageNames = 50
 
-	// metricUsageTotalTimeout is the overall deadline for a CheckMetricUsage call.
-	// On expiry the call returns whatever results have been collected so far.
+	// metricUsageTotalTimeout bounds the whole batch.
 	metricUsageTotalTimeout = 30 * time.Second
 )
 
-// metricDashboardRef is the per-widget reference returned by
-// GET /api/v2/metrics/dashboards?metricName={name}.
 type metricDashboardRef struct {
 	DashboardName string `json:"dashboardName"`
 	DashboardID   string `json:"dashboardId"`
 }
 
-// metricAlertRef is the per-alert reference returned by
-// GET /api/v2/metrics/alerts?metricName={name}.
 type metricAlertRef struct {
 	AlertName string `json:"alertName"`
 	AlertID   string `json:"alertId"`
@@ -46,21 +41,13 @@ type MetricUsage struct {
 	Error      string   `json:"error,omitempty"`
 }
 
-// CheckMetricUsage returns dashboard and alert references for each metric in
-// names. It fires up to 10 goroutines concurrently (bounded by errgroup.SetLimit)
-// — each goroutine fetches the dashboards endpoint then the alerts endpoint for
-// one metric, sequentially. A metric-not-found 404 envelope from either endpoint
-// is treated as an empty result, not an error; route-level 404s still surface as
-// per-metric errors. Dashboard names are deduplicated (one metric can appear in
-// multiple widgets of the same dashboard).
-//
-// Errors are stored per-metric in MetricUsage.Error rather than aborting the
-// whole batch — a transient 5xx on one metric must not discard results for the
-// rest.
+// CheckMetricUsage returns dashboard and alert references for each metric.
+// Lookup failures are stored per metric so one transient failure does not cancel
+// the whole batch. Metric-not-found 404s are treated as empty usage; route-level
+// 404s are reported as errors.
 func (s *SigNoz) CheckMetricUsage(ctx context.Context, names []string) (map[string]MetricUsage, error) {
 	ctx = s.ensureTenantContext(ctx)
 
-	// Deduplicate and filter empty strings to avoid malformed URLs and redundant API calls.
 	seen := make(map[string]struct{})
 	var filtered []string
 	for _, name := range names {
@@ -74,9 +61,6 @@ func (s *SigNoz) CheckMetricUsage(ctx context.Context, names []string) (map[stri
 	}
 	names = filtered
 
-	// Soft cap: each metric makes 2 sequential HTTP calls, so N names → 2N backend
-	// requests. Reject batches that exceed MaxMetricUsageNames so one tool call cannot
-	// saturate the SigNoz backend. Callers should split large lists into smaller batches.
 	if len(names) > MaxMetricUsageNames {
 		return nil, fmt.Errorf(
 			"too many metric names: %d exceeds the per-call limit of %d — split into batches of %d and merge results",
@@ -84,9 +68,6 @@ func (s *SigNoz) CheckMetricUsage(ctx context.Context, names []string) (map[stri
 		)
 	}
 
-	// Overall deadline — return partial results instead of nothing on expiry.
-	// The per-request DefaultQueryTimeout guards individual calls; this guards the
-	// aggregate so the MCP client is not left waiting indefinitely.
 	deadline, ok := ctx.Deadline()
 	if !ok || time.Until(deadline) > metricUsageTotalTimeout {
 		var cancel context.CancelFunc
@@ -109,10 +90,7 @@ func (s *SigNoz) CheckMetricUsage(ctx context.Context, names []string) (map[stri
 		g.Go(func() error {
 			usage, err := s.fetchMetricUsage(gctx, name)
 			if err != nil {
-				// Store per-metric error instead of cancelling the whole batch.
-				// Context cancellation (overall deadline) is treated the same way:
-				// metrics that did not finish surface with an error rather than being
-				// silently dropped, so callers can distinguish "not used" from "timed out".
+				// Preserve partial data; the error only marks unknown portions.
 				if usage.Dashboards == nil {
 					usage.Dashboards = []string{}
 				}
@@ -128,7 +106,7 @@ func (s *SigNoz) CheckMetricUsage(ctx context.Context, names []string) (map[stri
 		})
 	}
 
-	g.Wait() // always nil — goroutines never return errors
+	_ = g.Wait()
 
 	out := make(map[string]MetricUsage, len(names))
 	for _, r := range results {
@@ -137,7 +115,6 @@ func (s *SigNoz) CheckMetricUsage(ctx context.Context, names []string) (map[stri
 	return out, nil
 }
 
-// fetchMetricUsage fetches dashboards then alerts for a single metric name.
 func (s *SigNoz) fetchMetricUsage(ctx context.Context, name string) (MetricUsage, error) {
 	params := url.Values{}
 	params.Set("metricName", name)
@@ -149,7 +126,6 @@ func (s *SigNoz) fetchMetricUsage(ctx context.Context, name string) (MetricUsage
 	}
 	var errs []string
 
-	// --- Dashboards ---
 	dashURL := fmt.Sprintf("%s/api/v2/metrics/dashboards?%s", s.baseURL, query)
 	s.logger.DebugContext(ctx, "Fetching metric dashboard refs", slog.String("metric", name))
 
@@ -158,11 +134,8 @@ func (s *SigNoz) fetchMetricUsage(ctx context.Context, name string) (MetricUsage
 		if !isMetricNotFound404(err) {
 			errs = append(errs, fmt.Sprintf("dashboards lookup for %q: %v", name, err))
 		}
-		// Metric-not-found 404 = metric not tracked -> empty dashboards.
 	} else {
-		// Fail-open contract check: warn if the expected shape is absent so silent
-		// degradation is detectable in production (see CLAUDE.md §Testing across
-		// external contracts).
+		// Warn on contract drift while keeping fail-open behavior.
 		var dashProbe struct {
 			Data *struct {
 				Dashboards []json.RawMessage `json:"dashboards"`
@@ -180,7 +153,6 @@ func (s *SigNoz) fetchMetricUsage(ctx context.Context, name string) (MetricUsage
 		}
 	}
 
-	// --- Alerts ---
 	alertURL := fmt.Sprintf("%s/api/v2/metrics/alerts?%s", s.baseURL, query)
 	s.logger.DebugContext(ctx, "Fetching metric alert refs", slog.String("metric", name))
 
@@ -189,9 +161,8 @@ func (s *SigNoz) fetchMetricUsage(ctx context.Context, name string) (MetricUsage
 		if !isMetricNotFound404(err) {
 			errs = append(errs, fmt.Sprintf("alerts lookup for %q: %v", name, err))
 		}
-		// Metric-not-found 404 = metric not tracked -> empty alerts.
 	} else {
-		// Fail-open contract check.
+		// Warn on contract drift while keeping fail-open behavior.
 		var alertProbe struct {
 			Data *struct {
 				Alerts []json.RawMessage `json:"alerts"`
@@ -215,14 +186,8 @@ func (s *SigNoz) fetchMetricUsage(ctx context.Context, name string) (MetricUsage
 	return usage, nil
 }
 
-// isMetricNotFound404 reports whether err is a metric-level 404 from the
-// SigNoz API, as opposed to a route-level 404 from the HTTP router.
-//
-// A SigNoz API 404 (metric not tracked) returns the standard JSON error
-// envelope with status=error, error.code=not_found, error.type=not-found, and
-// an error message beginning with "metric not found:".
-// Router/proxy-level 404s must NOT be silently treated as empty usage, even
-// when they also return JSON, as that would incorrectly mark all metrics unused.
+// isMetricNotFound404 accepts only the live SigNoz metric-not-found envelope,
+// not generic route/proxy 404s.
 func isMetricNotFound404(err error) bool {
 	if err == nil {
 		return false
@@ -248,9 +213,6 @@ func isMetricNotFound404(err error) bool {
 		strings.HasPrefix(envelope.Error.Message, "metric not found:")
 }
 
-// parseDashboardNames extracts and deduplicates dashboard names from the
-// /api/v2/metrics/dashboards?metricName={name} response.
-// Response shape: {"status":"success","data":{"dashboards":[{dashboardName,dashboardId,widgetId,widgetName},...]}}
 func parseDashboardNames(body []byte) ([]string, error) {
 	var resp struct {
 		Data struct {
@@ -274,9 +236,6 @@ func parseDashboardNames(body []byte) ([]string, error) {
 	return names, nil
 }
 
-// parseAlertNames extracts alert names from the
-// /api/v2/metrics/alerts?metricName={name} response.
-// Response shape: {"status":"success","data":{"alerts":[{alertName,alertId},...]}
 func parseAlertNames(body []byte) ([]string, error) {
 	var resp struct {
 		Data struct {

--- a/internal/client/metric_usage.go
+++ b/internal/client/metric_usage.go
@@ -102,6 +102,18 @@ func (s *SigNoz) fetchMetricUsage(ctx context.Context, name string) (MetricUsage
 		}
 		// 404 = metric not tracked → empty dashboards
 	} else {
+		// Fail-open contract check: warn if the expected shape is absent so silent
+		// degradation is detectable in production (see CONTRIBUTING.md §Testing across
+		// external contracts).
+		var dashProbe struct {
+			Data *struct {
+				Dashboards []json.RawMessage `json:"dashboards"`
+			} `json:"data"`
+		}
+		if perr := json.Unmarshal(dashBody, &dashProbe); perr != nil || dashProbe.Data == nil || dashProbe.Data.Dashboards == nil {
+			s.logger.WarnContext(ctx, "Unexpected response shape from metric dashboards endpoint — upstream contract may have changed",
+				slog.String("metric", name))
+		}
 		dashNames, err = parseDashboardNames(dashBody)
 		if err != nil {
 			return MetricUsage{}, fmt.Errorf("parsing dashboard refs for %q: %w", name, err)
@@ -120,6 +132,16 @@ func (s *SigNoz) fetchMetricUsage(ctx context.Context, name string) (MetricUsage
 		}
 		// 404 = metric not tracked → empty alerts
 	} else {
+		// Fail-open contract check.
+		var alertProbe struct {
+			Data *struct {
+				Alerts []json.RawMessage `json:"alerts"`
+			} `json:"data"`
+		}
+		if perr := json.Unmarshal(alertBody, &alertProbe); perr != nil || alertProbe.Data == nil || alertProbe.Data.Alerts == nil {
+			s.logger.WarnContext(ctx, "Unexpected response shape from metric alerts endpoint — upstream contract may have changed",
+				slog.String("metric", name))
+		}
 		alertNames, err = parseAlertNames(alertBody)
 		if err != nil {
 			return MetricUsage{}, fmt.Errorf("parsing alert refs for %q: %w", name, err)

--- a/internal/client/metric_usage.go
+++ b/internal/client/metric_usage.go
@@ -30,6 +30,7 @@ type metricAlertRef struct {
 type MetricUsage struct {
 	Dashboards []string `json:"dashboards"`
 	Alerts     []string `json:"alerts"`
+	Error      string   `json:"error,omitempty"`
 }
 
 // CheckMetricUsage returns dashboard and alert references for each metric in
@@ -38,7 +39,13 @@ type MetricUsage struct {
 // one metric, sequentially. A 404 from either endpoint is treated as an empty
 // result, not an error. Dashboard names are deduplicated (one metric can appear
 // in multiple widgets of the same dashboard).
+//
+// Errors are stored per-metric in MetricUsage.Error rather than aborting the
+// whole batch — a transient 5xx on one metric must not discard results for the
+// rest.
 func (s *SigNoz) CheckMetricUsage(ctx context.Context, names []string) (map[string]MetricUsage, error) {
+	ctx = s.ensureTenantContext(ctx)
+
 	// Deduplicate and filter empty strings to avoid malformed URLs and redundant API calls.
 	seen := make(map[string]struct{})
 	var filtered []string
@@ -68,16 +75,20 @@ func (s *SigNoz) CheckMetricUsage(ctx context.Context, names []string) (map[stri
 		g.Go(func() error {
 			usage, err := s.fetchMetricUsage(gctx, name)
 			if err != nil {
-				return err
+				// Store per-metric error instead of cancelling the whole batch.
+				results[i] = result{name: name, usage: MetricUsage{
+					Dashboards: []string{},
+					Alerts:     []string{},
+					Error:      err.Error(),
+				}}
+				return nil
 			}
 			results[i] = result{name: name, usage: usage}
 			return nil
 		})
 	}
 
-	if err := g.Wait(); err != nil {
-		return nil, err
-	}
+	g.Wait() // always nil — goroutines never return errors
 
 	out := make(map[string]MetricUsage, len(names))
 	for _, r := range results {
@@ -103,7 +114,7 @@ func (s *SigNoz) fetchMetricUsage(ctx context.Context, name string) (MetricUsage
 		// 404 = metric not tracked → empty dashboards
 	} else {
 		// Fail-open contract check: warn if the expected shape is absent so silent
-		// degradation is detectable in production (see CONTRIBUTING.md §Testing across
+		// degradation is detectable in production (see CLAUDE.md §Testing across
 		// external contracts).
 		var dashProbe struct {
 			Data *struct {

--- a/internal/client/metric_usage.go
+++ b/internal/client/metric_usage.go
@@ -204,10 +204,13 @@ func (s *SigNoz) fetchMetricUsage(ctx context.Context, name string) (MetricUsage
 // SigNoz API, as opposed to a route-level 404 from the HTTP router.
 //
 // doRequest formats non-2xx errors as "unexpected status NNN: <body>".
-// A SigNoz API 404 (metric not tracked) has a JSON body starting with '{'.
+// A SigNoz API 404 (metric not tracked) returns a JSON body with
+// {"status":"error",...} — the standard SigNoz API error envelope.
 // A router-level 404 (endpoint not registered — e.g. SigNoz < v0.105.0)
 // returns plain text ("404 page not found"), which must NOT be silently
 // treated as empty usage, as it would incorrectly mark all metrics safe to drop.
+// A generic JSON proxy 404 (e.g. {"error":"not found"} without a "status" field)
+// is also rejected — only the SigNoz-specific envelope is accepted.
 func isMetricNotFound404(err error) bool {
 	if err == nil {
 		return false
@@ -217,7 +220,13 @@ func isMetricNotFound404(err error) bool {
 		return false
 	}
 	body := strings.TrimSpace(strings.TrimPrefix(msg, "unexpected status 404: "))
-	return strings.HasPrefix(body, "{")
+	var envelope struct {
+		Status string `json:"status"`
+	}
+	if jsonErr := json.Unmarshal([]byte(body), &envelope); jsonErr != nil {
+		return false
+	}
+	return envelope.Status == "error"
 }
 
 // parseDashboardNames extracts and deduplicates dashboard names from the

--- a/internal/client/metric_usage.go
+++ b/internal/client/metric_usage.go
@@ -1,0 +1,186 @@
+package client
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"golang.org/x/sync/errgroup"
+)
+
+// metricDashboardRef is the per-widget reference returned by
+// GET /api/v2/metrics/{name}/dashboards.
+type metricDashboardRef struct {
+	DashboardName string `json:"dashboardName"`
+	DashboardID   string `json:"dashboardId"`
+}
+
+// metricAlertRef is the per-alert reference returned by
+// GET /api/v2/metrics/{name}/alerts.
+type metricAlertRef struct {
+	AlertName string `json:"alertName"`
+	AlertID   string `json:"alertId"`
+}
+
+// MetricUsage is the compact usage summary returned to the caller for each metric.
+type MetricUsage struct {
+	Dashboards []string `json:"dashboards"`
+	Alerts     []string `json:"alerts"`
+	SafeToDrop bool     `json:"safeToDrop"`
+}
+
+// CheckMetricUsage returns dashboard and alert references for each metric in
+// names. It fires up to 10 goroutines concurrently (bounded by errgroup.SetLimit)
+// — each goroutine fetches the dashboards endpoint then the alerts endpoint for
+// one metric, sequentially. A 404 from either endpoint is treated as an empty
+// result, not an error. Dashboard names are deduplicated (one metric can appear
+// in multiple widgets of the same dashboard).
+func (s *SigNoz) CheckMetricUsage(ctx context.Context, names []string) (map[string]MetricUsage, error) {
+	// Deduplicate and filter empty strings to avoid malformed URLs and redundant API calls.
+	seen := make(map[string]struct{})
+	var filtered []string
+	for _, name := range names {
+		if name == "" {
+			continue
+		}
+		if _, ok := seen[name]; !ok {
+			seen[name] = struct{}{}
+			filtered = append(filtered, name)
+		}
+	}
+	names = filtered
+
+	type result struct {
+		name  string
+		usage MetricUsage
+	}
+
+	results := make([]result, len(names))
+
+	g, gctx := errgroup.WithContext(ctx)
+	g.SetLimit(10)
+
+	for i, name := range names {
+		i, name := i, name
+		g.Go(func() error {
+			usage, err := s.fetchMetricUsage(gctx, name)
+			if err != nil {
+				return err
+			}
+			results[i] = result{name: name, usage: usage}
+			return nil
+		})
+	}
+
+	if err := g.Wait(); err != nil {
+		return nil, err
+	}
+
+	out := make(map[string]MetricUsage, len(names))
+	for _, r := range results {
+		out[r.name] = r.usage
+	}
+	return out, nil
+}
+
+// fetchMetricUsage fetches dashboards then alerts for a single metric name.
+func (s *SigNoz) fetchMetricUsage(ctx context.Context, name string) (MetricUsage, error) {
+	escaped := url.PathEscape(name)
+
+	// --- Dashboards ---
+	dashURL := fmt.Sprintf("%s/api/v2/metrics/%s/dashboards", s.baseURL, escaped)
+	s.logger.DebugContext(ctx, "Fetching metric dashboard refs", slog.String("metric", name))
+
+	dashBody, err := s.doRequest(ctx, http.MethodGet, dashURL, nil, DefaultQueryTimeout)
+	var dashNames []string
+	if err != nil {
+		if !is404(err) {
+			return MetricUsage{}, fmt.Errorf("dashboards lookup for %q: %w", name, err)
+		}
+		// 404 = metric not tracked → empty dashboards
+	} else {
+		dashNames, err = parseDashboardNames(dashBody)
+		if err != nil {
+			return MetricUsage{}, fmt.Errorf("parsing dashboard refs for %q: %w", name, err)
+		}
+	}
+
+	// --- Alerts ---
+	alertURL := fmt.Sprintf("%s/api/v2/metrics/%s/alerts", s.baseURL, escaped)
+	s.logger.DebugContext(ctx, "Fetching metric alert refs", slog.String("metric", name))
+
+	alertBody, err := s.doRequest(ctx, http.MethodGet, alertURL, nil, DefaultQueryTimeout)
+	var alertNames []string
+	if err != nil {
+		if !is404(err) {
+			return MetricUsage{}, fmt.Errorf("alerts lookup for %q: %w", name, err)
+		}
+		// 404 = metric not tracked → empty alerts
+	} else {
+		alertNames, err = parseAlertNames(alertBody)
+		if err != nil {
+			return MetricUsage{}, fmt.Errorf("parsing alert refs for %q: %w", name, err)
+		}
+	}
+
+	return MetricUsage{
+		Dashboards: dashNames,
+		Alerts:     alertNames,
+		SafeToDrop: len(dashNames) == 0 && len(alertNames) == 0,
+	}, nil
+}
+
+// is404 reports whether err came from a 404 response. doRequest formats
+// non-2xx errors as "unexpected status NNN: ..." so we check the prefix.
+func is404(err error) bool {
+	return err != nil && strings.HasPrefix(err.Error(), "unexpected status 404")
+}
+
+// parseDashboardNames extracts and deduplicates dashboard names from the
+// /api/v2/metrics/{name}/dashboards response.
+// Response shape: {"status":"success","data":{"dashboards":[{dashboardName,dashboardId,widgetId,widgetName},...]}}
+func parseDashboardNames(body []byte) ([]string, error) {
+	var resp struct {
+		Data struct {
+			Dashboards []metricDashboardRef `json:"dashboards"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(body, &resp); err != nil {
+		return nil, err
+	}
+	seen := make(map[string]struct{})
+	var names []string
+	for _, ref := range resp.Data.Dashboards {
+		if _, ok := seen[ref.DashboardName]; !ok {
+			seen[ref.DashboardName] = struct{}{}
+			names = append(names, ref.DashboardName)
+		}
+	}
+	if names == nil {
+		names = []string{}
+	}
+	return names, nil
+}
+
+// parseAlertNames extracts alert names from the
+// /api/v2/metrics/{name}/alerts response.
+// Response shape: {"status":"success","data":{"alerts":[{alertName,alertId},...]}
+func parseAlertNames(body []byte) ([]string, error) {
+	var resp struct {
+		Data struct {
+			Alerts []metricAlertRef `json:"alerts"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(body, &resp); err != nil {
+		return nil, err
+	}
+	names := make([]string, 0, len(resp.Data.Alerts))
+	for _, ref := range resp.Data.Alerts {
+		names = append(names, ref.AlertName)
+	}
+	return names, nil
+}

--- a/internal/client/metric_usage.go
+++ b/internal/client/metric_usage.go
@@ -98,7 +98,7 @@ func (s *SigNoz) fetchMetricUsage(ctx context.Context, name string) (MetricUsage
 	dashBody, err := s.doRequest(ctx, http.MethodGet, dashURL, nil, DefaultQueryTimeout)
 	dashNames := []string{}
 	if err != nil {
-		if !is404(err) {
+		if !isMetricNotFound404(err) {
 			return MetricUsage{}, fmt.Errorf("dashboards lookup for %q: %w", name, err)
 		}
 		// 404 = metric not tracked → empty dashboards
@@ -116,7 +116,7 @@ func (s *SigNoz) fetchMetricUsage(ctx context.Context, name string) (MetricUsage
 	alertBody, err := s.doRequest(ctx, http.MethodGet, alertURL, nil, DefaultQueryTimeout)
 	alertNames := []string{}
 	if err != nil {
-		if !is404(err) {
+		if !isMetricNotFound404(err) {
 			return MetricUsage{}, fmt.Errorf("alerts lookup for %q: %w", name, err)
 		}
 		// 404 = metric not tracked → empty alerts
@@ -134,10 +134,24 @@ func (s *SigNoz) fetchMetricUsage(ctx context.Context, name string) (MetricUsage
 	}, nil
 }
 
-// is404 reports whether err came from a 404 response. doRequest formats
-// non-2xx errors as "unexpected status NNN: ..." so we check the prefix.
-func is404(err error) bool {
-	return err != nil && strings.HasPrefix(err.Error(), "unexpected status 404")
+// isMetricNotFound404 reports whether err is a metric-level 404 from the
+// SigNoz API, as opposed to a route-level 404 from the HTTP router.
+//
+// doRequest formats non-2xx errors as "unexpected status NNN: <body>".
+// A SigNoz API 404 (metric not tracked) has a JSON body starting with '{'.
+// A router-level 404 (endpoint not registered — e.g. SigNoz < v0.105.0)
+// returns plain text ("404 page not found"), which must NOT be silently
+// treated as empty usage, as it would incorrectly mark all metrics safe to drop.
+func isMetricNotFound404(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := err.Error()
+	if !strings.HasPrefix(msg, "unexpected status 404") {
+		return false
+	}
+	body := strings.TrimSpace(strings.TrimPrefix(msg, "unexpected status 404: "))
+	return strings.HasPrefix(body, "{")
 }
 
 // parseDashboardNames extracts and deduplicates dashboard names from the

--- a/internal/client/metric_usage.go
+++ b/internal/client/metric_usage.go
@@ -8,8 +8,20 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"time"
 
 	"golang.org/x/sync/errgroup"
+)
+
+const (
+	// MaxMetricUsageNames is the per-call soft cap on metric names.
+	// Each name makes 2 sequential HTTP calls, so N names → 2N backend requests.
+	// Callers with more names should batch into groups of this size.
+	MaxMetricUsageNames = 50
+
+	// metricUsageTotalTimeout is the overall deadline for a CheckMetricUsage call.
+	// On expiry the call returns whatever results have been collected so far.
+	metricUsageTotalTimeout = 30 * time.Second
 )
 
 // metricDashboardRef is the per-widget reference returned by
@@ -60,6 +72,26 @@ func (s *SigNoz) CheckMetricUsage(ctx context.Context, names []string) (map[stri
 	}
 	names = filtered
 
+	// Soft cap: each metric makes 2 sequential HTTP calls, so N names → 2N backend
+	// requests. Reject batches that exceed MaxMetricUsageNames so one tool call cannot
+	// saturate the SigNoz backend. Callers should split large lists into smaller batches.
+	if len(names) > MaxMetricUsageNames {
+		return nil, fmt.Errorf(
+			"too many metric names: %d exceeds the per-call limit of %d — split into batches of %d and merge results",
+			len(names), MaxMetricUsageNames, MaxMetricUsageNames,
+		)
+	}
+
+	// Overall deadline — return partial results instead of nothing on expiry.
+	// The per-request DefaultQueryTimeout guards individual calls; this guards the
+	// aggregate so the MCP client is not left waiting indefinitely.
+	deadline, ok := ctx.Deadline()
+	if !ok || time.Until(deadline) > metricUsageTotalTimeout {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, metricUsageTotalTimeout)
+		defer cancel()
+	}
+
 	type result struct {
 		name  string
 		usage MetricUsage
@@ -76,6 +108,9 @@ func (s *SigNoz) CheckMetricUsage(ctx context.Context, names []string) (map[stri
 			usage, err := s.fetchMetricUsage(gctx, name)
 			if err != nil {
 				// Store per-metric error instead of cancelling the whole batch.
+				// Context cancellation (overall deadline) is treated the same way:
+				// metrics that did not finish surface with an error rather than being
+				// silently dropped, so callers can distinguish "not used" from "timed out".
 				results[i] = result{name: name, usage: MetricUsage{
 					Dashboards: []string{},
 					Alerts:     []string{},

--- a/internal/client/metric_usage_test.go
+++ b/internal/client/metric_usage_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -234,6 +235,35 @@ func TestCheckMetricUsage_5xxStoredAsPerMetricError(t *testing.T) {
 	result, err := c.CheckMetricUsage(context.Background(), []string{"system.cpu.time"})
 	require.NoError(t, err, "5xx must not propagate as batch-level error")
 	assert.NotEmpty(t, result["system.cpu.time"].Error, "5xx must surface as per-metric error")
+}
+
+func TestCheckMetricUsage_AuthzFailurePropagates(t *testing.T) {
+	cases := []struct {
+		name       string
+		statusCode int
+	}{
+		{name: "unauthorized", statusCode: http.StatusUnauthorized},
+		{name: "forbidden", statusCode: http.StatusForbidden},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(tc.statusCode)
+				_, _ = w.Write([]byte(`{"status":"error","error":{"code":"unauthenticated","message":"invalid credentials","type":"unauthorized"}}`))
+			}))
+			defer srv.Close()
+
+			c := NewClient(newBufferedLogger(&bytes.Buffer{}, -4), srv.URL, "test-api-key", "SIGNOZ-API-KEY", nil)
+			result, err := c.CheckMetricUsage(context.Background(), []string{"system.cpu.time"})
+			require.Error(t, err, "authz failures must propagate as batch-level errors")
+			assert.Nil(t, result)
+
+			var statusErr *HTTPStatusError
+			require.True(t, errors.As(err, &statusErr), "expected typed HTTP status error")
+			assert.Equal(t, tc.statusCode, statusErr.StatusCode)
+		})
+	}
 }
 
 func TestCheckMetricUsage_PartialFailureRetainsOtherResults(t *testing.T) {

--- a/internal/client/metric_usage_test.go
+++ b/internal/client/metric_usage_test.go
@@ -66,6 +66,24 @@ func TestParseDashboardNames_EmptyArray(t *testing.T) {
 	assert.Equal(t, []string{}, names)
 }
 
+func TestParseDashboardNames_AllowsEmptyDashboardName(t *testing.T) {
+	body := `{"status":"success","data":{"dashboards":[
+		{"dashboardName":"","dashboardId":"1","widgetId":"w1","widgetName":"CPU"}
+	]}}`
+	names, err := parseDashboardNames([]byte(body))
+	require.NoError(t, err)
+	assert.Equal(t, []string{""}, names)
+}
+
+func TestParseDashboardNames_MissingDashboardName(t *testing.T) {
+	body := `{"status":"success","data":{"dashboards":[
+		{"dashboardId":"1","widgetId":"w1","widgetName":"CPU"}
+	]}}`
+	_, err := parseDashboardNames([]byte(body))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "dashboardName")
+}
+
 func TestParseDashboardNames_MalformedJSON(t *testing.T) {
 	_, err := parseDashboardNames([]byte(`not json`))
 	assert.Error(t, err)
@@ -86,6 +104,24 @@ func TestParseAlertNames_EmptyArray(t *testing.T) {
 	names, err := parseAlertNames([]byte(body))
 	require.NoError(t, err)
 	assert.Equal(t, []string{}, names)
+}
+
+func TestParseAlertNames_AllowsEmptyAlertName(t *testing.T) {
+	body := `{"status":"success","data":{"alerts":[
+		{"alertName":"","alertId":"a1"}
+	]}}`
+	names, err := parseAlertNames([]byte(body))
+	require.NoError(t, err)
+	assert.Equal(t, []string{""}, names)
+}
+
+func TestParseAlertNames_MissingAlertName(t *testing.T) {
+	body := `{"status":"success","data":{"alerts":[
+		{"alertId":"a1"}
+	]}}`
+	_, err := parseAlertNames([]byte(body))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "alertName")
 }
 
 func TestCheckMetricUsage_ContractCheckDashboards(t *testing.T) {
@@ -150,6 +186,26 @@ func TestCheckMetricUsage_ContractCheckDashboards(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestCheckMetricUsage_MissingDashboardNameStoredAsPerMetricError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		switch r.URL.Path {
+		case "/api/v2/metrics/dashboards":
+			_, _ = w.Write([]byte(`{"status":"success","data":{"dashboards":[{"dashboardId":"d1","widgetId":"w1","widgetName":"CPU"}]}}`))
+		case "/api/v2/metrics/alerts":
+			_, _ = w.Write([]byte(`{"status":"success","data":{"alerts":[]}}`))
+		default:
+			t.Fatalf("unexpected path %q", r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	c := NewClient(newBufferedLogger(&bytes.Buffer{}, -4), srv.URL, "test-api-key", "SIGNOZ-API-KEY", nil)
+	result, err := c.CheckMetricUsage(context.Background(), []string{"system.cpu.time"})
+	require.NoError(t, err)
+	assert.Contains(t, result["system.cpu.time"].Error, "dashboardName")
 }
 
 func TestCheckMetricUsage_Route404StoredAsPerMetricError(t *testing.T) {

--- a/internal/client/metric_usage_test.go
+++ b/internal/client/metric_usage_test.go
@@ -24,11 +24,24 @@ func TestIsMetricNotFound404(t *testing.T) {
 		want bool
 	}{
 		{name: "nil error", err: nil, want: false},
-		{name: "non-404 error", err: fmt.Errorf("unexpected status 500: internal error"), want: false},
-		{name: "route-level 404 (plain text)", err: fmt.Errorf("unexpected status 404: 404 page not found\n"), want: false},
-		{name: "metric-level 404 (SigNoz envelope)", err: fmt.Errorf(`unexpected status 404: {"status":"error","error":"metric not found"}`), want: true},
-		{name: "proxy JSON 404 without status field", err: fmt.Errorf(`unexpected status 404: {"error":"not found"}`), want: false},
-		{name: "proxy JSON 404 with wrong status", err: fmt.Errorf(`unexpected status 404: {"status":"fail","error":"not found"}`), want: false},
+		{name: "non-status error", err: fmt.Errorf("unexpected status 404: generic string"), want: false},
+		{name: "non-404 status", err: &HTTPStatusError{StatusCode: 500, Body: `{"status":"error"}`}, want: false},
+		{name: "route-level 404 (plain text)", err: &HTTPStatusError{StatusCode: 404, Body: "404 page not found\n"}, want: false},
+		{
+			name: "metric-level 404 (live SigNoz envelope)",
+			err: &HTTPStatusError{
+				StatusCode: 404,
+				Body:       `{"status":"error","error":{"code":"not_found","errors":[],"message":"metric not found: \"mcp.pr205.nonexistent\"","suggestions":[],"type":"not-found"}}`,
+			},
+			want: true,
+		},
+		{name: "old loose SigNoz-shaped 404", err: &HTTPStatusError{StatusCode: 404, Body: `{"status":"error","error":"metric not found"}`}, want: false},
+		{name: "proxy JSON 404 without status field", err: &HTTPStatusError{StatusCode: 404, Body: `{"error":"not found"}`}, want: false},
+		{name: "proxy JSON 404 with wrong status", err: &HTTPStatusError{StatusCode: 404, Body: `{"status":"fail","error":"not found"}`}, want: false},
+		{name: "proxy JSON 404 with generic error object", err: &HTTPStatusError{StatusCode: 404, Body: `{"status":"error","error":{"code":"not_found","type":"not-found","message":"route not found"}}`}, want: false},
+		{name: "metric 404 with wrong code", err: &HTTPStatusError{StatusCode: 404, Body: `{"status":"error","error":{"code":"unknown","type":"not-found","message":"metric not found: \"x\""}}`}, want: false},
+		{name: "metric 404 with wrong type", err: &HTTPStatusError{StatusCode: 404, Body: `{"status":"error","error":{"code":"not_found","type":"not_found","message":"metric not found: \"x\""}}`}, want: false},
+		{name: "metric 404 without message prefix", err: &HTTPStatusError{StatusCode: 404, Body: `{"status":"error","error":{"code":"not_found","type":"not-found","message":"metric missing: \"x\""}}`}, want: false},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/client/metric_usage_test.go
+++ b/internal/client/metric_usage_test.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
-	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -86,10 +85,10 @@ func TestParseAlertNames_EmptyArray(t *testing.T) {
 
 func TestCheckMetricUsage_ContractCheckDashboards(t *testing.T) {
 	cases := []struct {
-		name         string
-		dashBody     string
-		alertBody    string
-		wantWarn     string
+		name      string
+		dashBody  string
+		alertBody string
+		wantWarn  string
 	}{
 		{
 			name:      "valid dashboard shape — no warn",
@@ -184,10 +183,10 @@ func TestCheckMetricUsage_5xxStoredAsPerMetricError(t *testing.T) {
 
 func TestCheckMetricUsage_PartialFailureRetainsOtherResults(t *testing.T) {
 	// When one metric's request fails, other metrics' results must still be returned.
-	// Failure is keyed on URL path (not call order) so the test is goroutine-order independent.
+	// Failure is keyed on query param (not call order) so the test is goroutine-order independent.
 	okBody, _ := json.Marshal(map[string]any{"data": map[string]any{"dashboards": []any{}, "alerts": []any{}}})
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if strings.Contains(r.URL.Path, "metric.fail") {
+		if r.URL.Query().Get("metricName") == "metric.fail" {
 			w.WriteHeader(http.StatusInternalServerError)
 			_, _ = w.Write([]byte(`{"error":"oops"}`))
 		} else {
@@ -202,6 +201,37 @@ func TestCheckMetricUsage_PartialFailureRetainsOtherResults(t *testing.T) {
 	require.NoError(t, err)
 	assert.NotEmpty(t, result["metric.fail"].Error, "failed metric must have error set")
 	assert.Empty(t, result["metric.ok"].Error, "successful metric must have no error")
+}
+
+func TestCheckMetricUsage_OneSideFailurePreservesKnownUsage(t *testing.T) {
+	dashBody := `{"status":"success","data":{"dashboards":[{"dashboardName":"Host Metrics","dashboardId":"d1"}]}}`
+	alertBody := `{"status":"success","data":{"alerts":[{"alertName":"High CPU","alertId":"a1"}]}}`
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v2/metrics/dashboards":
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(dashBody))
+		case "/api/v2/metrics/alerts":
+			if r.URL.Query().Get("metricName") == "metric.partial" {
+				w.WriteHeader(http.StatusInternalServerError)
+				_, _ = w.Write([]byte(`{"error":"oops"}`))
+				return
+			}
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(alertBody))
+		default:
+			t.Fatalf("unexpected path %q", r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	c := NewClient(newBufferedLogger(&bytes.Buffer{}, -4), srv.URL, "test-api-key", "SIGNOZ-API-KEY", nil)
+	result, err := c.CheckMetricUsage(context.Background(), []string{"metric.partial"})
+	require.NoError(t, err)
+	usage := result["metric.partial"]
+	assert.Equal(t, []string{"Host Metrics"}, usage.Dashboards, "known dashboard usage must be preserved")
+	assert.Equal(t, []string{}, usage.Alerts)
+	assert.Contains(t, usage.Error, "alerts lookup")
 }
 
 func TestCheckMetricUsage_SoftCapRejectsOversizedBatch(t *testing.T) {
@@ -231,7 +261,7 @@ func TestCheckMetricUsage_OverallDeadlineReturnsPartialResults(t *testing.T) {
 	okBody, _ := json.Marshal(map[string]any{"data": map[string]any{"dashboards": []any{}, "alerts": []any{}}})
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if strings.Contains(r.URL.Path, "metric.slow") {
+		if r.URL.Query().Get("metricName") == "metric.slow" {
 			// Block until the request context is cancelled (simulates a slow backend).
 			<-r.Context().Done()
 			w.WriteHeader(http.StatusServiceUnavailable)
@@ -257,19 +287,23 @@ func TestCheckMetricUsage_DeduplicatesInputNames(t *testing.T) {
 	var callCount atomic.Int32
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		callCount.Add(1)
+		assert.Equal(t, "system.cpu/time", r.URL.Query().Get("metricName"))
 		w.WriteHeader(http.StatusOK)
-		if r.URL.Path[len(r.URL.Path)-len("dashboards"):] == "dashboards" {
+		switch r.URL.Path {
+		case "/api/v2/metrics/dashboards":
 			body, _ := json.Marshal(map[string]any{"data": map[string]any{"dashboards": []any{}}})
 			_, _ = w.Write(body)
-		} else {
+		case "/api/v2/metrics/alerts":
 			body, _ := json.Marshal(map[string]any{"data": map[string]any{"alerts": []any{}}})
 			_, _ = w.Write(body)
+		default:
+			t.Fatalf("unexpected path %q", r.URL.Path)
 		}
 	}))
 	defer srv.Close()
 
 	c := NewClient(newBufferedLogger(&bytes.Buffer{}, -4), srv.URL, "test-api-key", "SIGNOZ-API-KEY", nil)
-	_, err := c.CheckMetricUsage(context.Background(), []string{"system.cpu.time", "system.cpu.time", ""})
+	_, err := c.CheckMetricUsage(context.Background(), []string{"system.cpu/time", "system.cpu/time", ""})
 	require.NoError(t, err)
 	// Deduplicated to 1 unique name, blank filtered — so 2 API calls (dashboards + alerts)
 	assert.Equal(t, int32(2), callCount.Load())

--- a/internal/client/metric_usage_test.go
+++ b/internal/client/metric_usage_test.go
@@ -1,0 +1,184 @@
+package client
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// --- isMetricNotFound404 ---
+
+func TestIsMetricNotFound404(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{name: "nil error", err: nil, want: false},
+		{name: "non-404 error", err: fmt.Errorf("unexpected status 500: internal error"), want: false},
+		{name: "route-level 404 (plain text)", err: fmt.Errorf("unexpected status 404: 404 page not found\n"), want: false},
+		{name: "metric-level 404 (JSON body)", err: fmt.Errorf(`unexpected status 404: {"status":"error","error":"metric not found"}`), want: true},
+		{name: "metric-level 404 with leading brace", err: fmt.Errorf(`unexpected status 404: {"id":"abc"}`), want: true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, isMetricNotFound404(tc.err))
+		})
+	}
+}
+
+// --- parseDashboardNames ---
+
+func TestParseDashboardNames_Deduplicates(t *testing.T) {
+	body := `{"status":"success","data":{"dashboards":[
+		{"dashboardName":"Host Metrics","dashboardId":"1","widgetId":"w1","widgetName":"CPU"},
+		{"dashboardName":"Host Metrics","dashboardId":"1","widgetId":"w2","widgetName":"Memory"},
+		{"dashboardName":"K8s Overview","dashboardId":"2","widgetId":"w3","widgetName":"Pods"}
+	]}}`
+	names, err := parseDashboardNames([]byte(body))
+	require.NoError(t, err)
+	assert.Equal(t, []string{"Host Metrics", "K8s Overview"}, names)
+}
+
+func TestParseDashboardNames_EmptyArray(t *testing.T) {
+	body := `{"status":"success","data":{"dashboards":[]}}`
+	names, err := parseDashboardNames([]byte(body))
+	require.NoError(t, err)
+	assert.Equal(t, []string{}, names)
+}
+
+func TestParseDashboardNames_MalformedJSON(t *testing.T) {
+	_, err := parseDashboardNames([]byte(`not json`))
+	assert.Error(t, err)
+}
+
+// --- parseAlertNames ---
+
+func TestParseAlertNames_ReturnsNames(t *testing.T) {
+	body := `{"status":"success","data":{"alerts":[
+		{"alertName":"High CPU","alertId":"a1"},
+		{"alertName":"Low Memory","alertId":"a2"}
+	]}}`
+	names, err := parseAlertNames([]byte(body))
+	require.NoError(t, err)
+	assert.Equal(t, []string{"High CPU", "Low Memory"}, names)
+}
+
+func TestParseAlertNames_EmptyArray(t *testing.T) {
+	body := `{"status":"success","data":{"alerts":[]}}`
+	names, err := parseAlertNames([]byte(body))
+	require.NoError(t, err)
+	assert.Equal(t, []string{}, names)
+}
+
+// --- Contract check WARN ---
+
+func TestCheckMetricUsage_ContractCheckDashboards(t *testing.T) {
+	cases := []struct {
+		name         string
+		dashBody     string
+		alertBody    string
+		wantWarn     string
+	}{
+		{
+			name:      "valid dashboard shape — no warn",
+			dashBody:  `{"status":"success","data":{"dashboards":[]}}`,
+			alertBody: `{"status":"success","data":{"alerts":[]}}`,
+		},
+		{
+			name:      "dashboard key renamed — warn",
+			dashBody:  `{"status":"success","data":{"items":[]}}`,
+			alertBody: `{"status":"success","data":{"alerts":[]}}`,
+			wantWarn:  "dashboards endpoint",
+		},
+		{
+			name:      "dashboard data absent — warn",
+			dashBody:  `{"status":"success"}`,
+			alertBody: `{"status":"success","data":{"alerts":[]}}`,
+			wantWarn:  "dashboards endpoint",
+		},
+		{
+			name:      "alert key renamed — warn",
+			dashBody:  `{"status":"success","data":{"dashboards":[]}}`,
+			alertBody: `{"status":"success","data":{"items":[]}}`,
+			wantWarn:  "alerts endpoint",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			call := 0
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				call++
+				w.WriteHeader(http.StatusOK)
+				if call == 1 {
+					_, _ = w.Write([]byte(tc.dashBody))
+				} else {
+					_, _ = w.Write([]byte(tc.alertBody))
+				}
+			}))
+			defer srv.Close()
+
+			var buf bytes.Buffer
+			logger := newBufferedLogger(&buf, -4)
+			c := NewClient(logger, srv.URL, "test-api-key", "SIGNOZ-API-KEY", nil)
+
+			result, err := c.CheckMetricUsage(context.Background(), []string{"system.cpu.time"})
+			require.NoError(t, err)
+			assert.NotNil(t, result)
+
+			logged := buf.String()
+			if tc.wantWarn != "" {
+				assert.Contains(t, logged, tc.wantWarn, "expected WARN for contract violation")
+			} else {
+				assert.NotContains(t, logged, "Unexpected response shape", "expected no WARN for valid shape")
+			}
+		})
+	}
+}
+
+// --- CheckMetricUsage integration ---
+
+func TestCheckMetricUsage_Route404DoesNotSilentlySucceed(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte("404 page not found\n"))
+	}))
+	defer srv.Close()
+
+	var buf bytes.Buffer
+	logger := newBufferedLogger(&buf, -4)
+	c := NewClient(logger, srv.URL, "test-api-key", "SIGNOZ-API-KEY", nil)
+
+	_, err := c.CheckMetricUsage(context.Background(), []string{"system.cpu.time"})
+	assert.Error(t, err, "route-level 404 must propagate as error, not be swallowed")
+}
+
+func TestCheckMetricUsage_DeduplicatesInputNames(t *testing.T) {
+	callCount := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		callCount++
+		w.WriteHeader(http.StatusOK)
+		if r.URL.Path[len(r.URL.Path)-len("dashboards"):] == "dashboards" {
+			body, _ := json.Marshal(map[string]any{"data": map[string]any{"dashboards": []any{}}})
+			_, _ = w.Write(body)
+		} else {
+			body, _ := json.Marshal(map[string]any{"data": map[string]any{"alerts": []any{}}})
+			_, _ = w.Write(body)
+		}
+	}))
+	defer srv.Close()
+
+	c := NewClient(newBufferedLogger(&bytes.Buffer{}, -4), srv.URL, "test-api-key", "SIGNOZ-API-KEY", nil)
+	_, err := c.CheckMetricUsage(context.Background(), []string{"system.cpu.time", "system.cpu.time", ""})
+	require.NoError(t, err)
+	// Deduplicated to 1 unique name, blank filtered — so 2 API calls (dashboards + alerts)
+	assert.Equal(t, 2, callCount)
+}

--- a/internal/client/metric_usage_test.go
+++ b/internal/client/metric_usage_test.go
@@ -7,6 +7,8 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strings"
+	"sync/atomic"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -146,25 +148,64 @@ func TestCheckMetricUsage_ContractCheckDashboards(t *testing.T) {
 
 // --- CheckMetricUsage integration ---
 
-func TestCheckMetricUsage_Route404DoesNotSilentlySucceed(t *testing.T) {
+func TestCheckMetricUsage_Route404StoredAsPerMetricError(t *testing.T) {
+	// Route-level 404 (plain text) must not be silently swallowed as empty usage.
+	// With per-metric error storage it surfaces in MetricUsage.Error, not as a
+	// batch-level error return.
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusNotFound)
 		_, _ = w.Write([]byte("404 page not found\n"))
 	}))
 	defer srv.Close()
 
-	var buf bytes.Buffer
-	logger := newBufferedLogger(&buf, -4)
-	c := NewClient(logger, srv.URL, "test-api-key", "SIGNOZ-API-KEY", nil)
+	c := NewClient(newBufferedLogger(&bytes.Buffer{}, -4), srv.URL, "test-api-key", "SIGNOZ-API-KEY", nil)
+	result, err := c.CheckMetricUsage(context.Background(), []string{"system.cpu.time"})
+	require.NoError(t, err)
+	assert.NotEmpty(t, result["system.cpu.time"].Error, "route-level 404 must surface as per-metric error")
+}
 
-	_, err := c.CheckMetricUsage(context.Background(), []string{"system.cpu.time"})
-	assert.Error(t, err, "route-level 404 must propagate as error, not be swallowed")
+func TestCheckMetricUsage_5xxStoredAsPerMetricError(t *testing.T) {
+	// A transient 5xx on one metric must not discard results for the rest.
+	var callCount atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		callCount.Add(1)
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"error":"internal server error"}`))
+	}))
+	defer srv.Close()
+
+	c := NewClient(newBufferedLogger(&bytes.Buffer{}, -4), srv.URL, "test-api-key", "SIGNOZ-API-KEY", nil)
+	result, err := c.CheckMetricUsage(context.Background(), []string{"system.cpu.time"})
+	require.NoError(t, err, "5xx must not propagate as batch-level error")
+	assert.NotEmpty(t, result["system.cpu.time"].Error, "5xx must surface as per-metric error")
+}
+
+func TestCheckMetricUsage_PartialFailureRetainsOtherResults(t *testing.T) {
+	// When one metric's request fails, other metrics' results must still be returned.
+	// Failure is keyed on URL path (not call order) so the test is goroutine-order independent.
+	okBody, _ := json.Marshal(map[string]any{"data": map[string]any{"dashboards": []any{}, "alerts": []any{}}})
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.URL.Path, "metric.fail") {
+			w.WriteHeader(http.StatusInternalServerError)
+			_, _ = w.Write([]byte(`{"error":"oops"}`))
+		} else {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(okBody)
+		}
+	}))
+	defer srv.Close()
+
+	c := NewClient(newBufferedLogger(&bytes.Buffer{}, -4), srv.URL, "test-api-key", "SIGNOZ-API-KEY", nil)
+	result, err := c.CheckMetricUsage(context.Background(), []string{"metric.fail", "metric.ok"})
+	require.NoError(t, err)
+	assert.NotEmpty(t, result["metric.fail"].Error, "failed metric must have error set")
+	assert.Empty(t, result["metric.ok"].Error, "successful metric must have no error")
 }
 
 func TestCheckMetricUsage_DeduplicatesInputNames(t *testing.T) {
-	callCount := 0
+	var callCount atomic.Int32
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		callCount++
+		callCount.Add(1)
 		w.WriteHeader(http.StatusOK)
 		if r.URL.Path[len(r.URL.Path)-len("dashboards"):] == "dashboards" {
 			body, _ := json.Marshal(map[string]any{"data": map[string]any{"dashboards": []any{}}})
@@ -180,5 +221,5 @@ func TestCheckMetricUsage_DeduplicatesInputNames(t *testing.T) {
 	_, err := c.CheckMetricUsage(context.Background(), []string{"system.cpu.time", "system.cpu.time", ""})
 	require.NoError(t, err)
 	// Deduplicated to 1 unique name, blank filtered — so 2 API calls (dashboards + alerts)
-	assert.Equal(t, 2, callCount)
+	assert.Equal(t, int32(2), callCount.Load())
 }

--- a/internal/client/metric_usage_test.go
+++ b/internal/client/metric_usage_test.go
@@ -15,8 +15,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// --- isMetricNotFound404 ---
-
 func TestIsMetricNotFound404(t *testing.T) {
 	cases := []struct {
 		name string
@@ -50,8 +48,6 @@ func TestIsMetricNotFound404(t *testing.T) {
 	}
 }
 
-// --- parseDashboardNames ---
-
 func TestParseDashboardNames_Deduplicates(t *testing.T) {
 	body := `{"status":"success","data":{"dashboards":[
 		{"dashboardName":"Host Metrics","dashboardId":"1","widgetId":"w1","widgetName":"CPU"},
@@ -75,8 +71,6 @@ func TestParseDashboardNames_MalformedJSON(t *testing.T) {
 	assert.Error(t, err)
 }
 
-// --- parseAlertNames ---
-
 func TestParseAlertNames_ReturnsNames(t *testing.T) {
 	body := `{"status":"success","data":{"alerts":[
 		{"alertName":"High CPU","alertId":"a1"},
@@ -93,8 +87,6 @@ func TestParseAlertNames_EmptyArray(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, []string{}, names)
 }
-
-// --- Contract check WARN ---
 
 func TestCheckMetricUsage_ContractCheckDashboards(t *testing.T) {
 	cases := []struct {
@@ -160,12 +152,7 @@ func TestCheckMetricUsage_ContractCheckDashboards(t *testing.T) {
 	}
 }
 
-// --- CheckMetricUsage integration ---
-
 func TestCheckMetricUsage_Route404StoredAsPerMetricError(t *testing.T) {
-	// Route-level 404 (plain text) must not be silently swallowed as empty usage.
-	// With per-metric error storage it surfaces in MetricUsage.Error, not as a
-	// batch-level error return.
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusNotFound)
 		_, _ = w.Write([]byte("404 page not found\n"))
@@ -179,7 +166,6 @@ func TestCheckMetricUsage_Route404StoredAsPerMetricError(t *testing.T) {
 }
 
 func TestCheckMetricUsage_5xxStoredAsPerMetricError(t *testing.T) {
-	// A transient 5xx on one metric must not discard results for the rest.
 	var callCount atomic.Int32
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		callCount.Add(1)
@@ -195,8 +181,6 @@ func TestCheckMetricUsage_5xxStoredAsPerMetricError(t *testing.T) {
 }
 
 func TestCheckMetricUsage_PartialFailureRetainsOtherResults(t *testing.T) {
-	// When one metric's request fails, other metrics' results must still be returned.
-	// Failure is keyed on query param (not call order) so the test is goroutine-order independent.
 	okBody, _ := json.Marshal(map[string]any{"data": map[string]any{"dashboards": []any{}, "alerts": []any{}}})
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Query().Get("metricName") == "metric.fail" {
@@ -248,7 +232,6 @@ func TestCheckMetricUsage_OneSideFailurePreservesKnownUsage(t *testing.T) {
 }
 
 func TestCheckMetricUsage_SoftCapRejectsOversizedBatch(t *testing.T) {
-	// Batches exceeding MaxMetricUsageNames must be rejected without hitting the backend.
 	var callCount atomic.Int32
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		callCount.Add(1)
@@ -269,13 +252,10 @@ func TestCheckMetricUsage_SoftCapRejectsOversizedBatch(t *testing.T) {
 }
 
 func TestCheckMetricUsage_OverallDeadlineReturnsPartialResults(t *testing.T) {
-	// When the overall deadline fires, already-completed metrics must be returned
-	// and in-flight metrics must surface with an error — not silently dropped.
 	okBody, _ := json.Marshal(map[string]any{"data": map[string]any{"dashboards": []any{}, "alerts": []any{}}})
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Query().Get("metricName") == "metric.slow" {
-			// Block until the request context is cancelled (simulates a slow backend).
 			<-r.Context().Done()
 			w.WriteHeader(http.StatusServiceUnavailable)
 			return
@@ -285,7 +265,6 @@ func TestCheckMetricUsage_OverallDeadlineReturnsPartialResults(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	// Very short timeout so the test does not block.
 	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
 	defer cancel()
 
@@ -318,6 +297,5 @@ func TestCheckMetricUsage_DeduplicatesInputNames(t *testing.T) {
 	c := NewClient(newBufferedLogger(&bytes.Buffer{}, -4), srv.URL, "test-api-key", "SIGNOZ-API-KEY", nil)
 	_, err := c.CheckMetricUsage(context.Background(), []string{"system.cpu/time", "system.cpu/time", ""})
 	require.NoError(t, err)
-	// Deduplicated to 1 unique name, blank filtered — so 2 API calls (dashboards + alerts)
 	assert.Equal(t, int32(2), callCount.Load())
 }

--- a/internal/client/metric_usage_test.go
+++ b/internal/client/metric_usage_test.go
@@ -27,8 +27,9 @@ func TestIsMetricNotFound404(t *testing.T) {
 		{name: "nil error", err: nil, want: false},
 		{name: "non-404 error", err: fmt.Errorf("unexpected status 500: internal error"), want: false},
 		{name: "route-level 404 (plain text)", err: fmt.Errorf("unexpected status 404: 404 page not found\n"), want: false},
-		{name: "metric-level 404 (JSON body)", err: fmt.Errorf(`unexpected status 404: {"status":"error","error":"metric not found"}`), want: true},
-		{name: "metric-level 404 with leading brace", err: fmt.Errorf(`unexpected status 404: {"id":"abc"}`), want: true},
+		{name: "metric-level 404 (SigNoz envelope)", err: fmt.Errorf(`unexpected status 404: {"status":"error","error":"metric not found"}`), want: true},
+		{name: "proxy JSON 404 without status field", err: fmt.Errorf(`unexpected status 404: {"error":"not found"}`), want: false},
+		{name: "proxy JSON 404 with wrong status", err: fmt.Errorf(`unexpected status 404: {"status":"fail","error":"not found"}`), want: false},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/client/metric_usage_test.go
+++ b/internal/client/metric_usage_test.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -200,6 +201,55 @@ func TestCheckMetricUsage_PartialFailureRetainsOtherResults(t *testing.T) {
 	require.NoError(t, err)
 	assert.NotEmpty(t, result["metric.fail"].Error, "failed metric must have error set")
 	assert.Empty(t, result["metric.ok"].Error, "successful metric must have no error")
+}
+
+func TestCheckMetricUsage_SoftCapRejectsOversizedBatch(t *testing.T) {
+	// Batches exceeding MaxMetricUsageNames must be rejected without hitting the backend.
+	var callCount atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		callCount.Add(1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	names := make([]string, MaxMetricUsageNames+1)
+	for i := range names {
+		names[i] = fmt.Sprintf("metric.%d", i)
+	}
+
+	c := NewClient(newBufferedLogger(&bytes.Buffer{}, -4), srv.URL, "test-api-key", "SIGNOZ-API-KEY", nil)
+	_, err := c.CheckMetricUsage(context.Background(), names)
+	require.Error(t, err, "oversized batch must be rejected")
+	assert.Contains(t, err.Error(), "too many metric names")
+	assert.Equal(t, int32(0), callCount.Load(), "no backend calls must be made for oversized batch")
+}
+
+func TestCheckMetricUsage_OverallDeadlineReturnsPartialResults(t *testing.T) {
+	// When the overall deadline fires, already-completed metrics must be returned
+	// and in-flight metrics must surface with an error — not silently dropped.
+	okBody, _ := json.Marshal(map[string]any{"data": map[string]any{"dashboards": []any{}, "alerts": []any{}}})
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.URL.Path, "metric.slow") {
+			// Block until the request context is cancelled (simulates a slow backend).
+			<-r.Context().Done()
+			w.WriteHeader(http.StatusServiceUnavailable)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(okBody)
+	}))
+	defer srv.Close()
+
+	// Very short timeout so the test does not block.
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+
+	c := NewClient(newBufferedLogger(&bytes.Buffer{}, -4), srv.URL, "test-api-key", "SIGNOZ-API-KEY", nil)
+	result, err := c.CheckMetricUsage(ctx, []string{"metric.fast", "metric.slow"})
+	require.NoError(t, err, "deadline must not propagate as a batch-level error")
+	assert.Empty(t, result["metric.fast"].Error, "fast metric must succeed")
+	assert.NotEmpty(t, result["metric.slow"].Error, "slow metric must surface deadline as per-metric error")
 }
 
 func TestCheckMetricUsage_DeduplicatesInputNames(t *testing.T) {

--- a/internal/client/mock.go
+++ b/internal/client/mock.go
@@ -13,6 +13,7 @@ import (
 type MockClient struct {
 	GetAnalyticsIdentityFn      func(ctx context.Context) (*AnalyticsIdentity, error)
 	ListMetricsFn               func(ctx context.Context, start, end int64, limit int, searchText, source string) (json.RawMessage, error)
+	GetTopMetricsFn             func(ctx context.Context, start, end int64, limit int) (json.RawMessage, error)
 	ListAlertsFn                func(ctx context.Context, params types.ListAlertsParams) (json.RawMessage, error)
 	ListAlertRulesFn            func(ctx context.Context) (json.RawMessage, error)
 	GetAlertByRuleIDFn          func(ctx context.Context, ruleID string) (json.RawMessage, error)
@@ -38,13 +39,13 @@ type MockClient struct {
 	CreateAlertRuleFn           func(ctx context.Context, alertJSON []byte) (json.RawMessage, error)
 	UpdateAlertRuleFn           func(ctx context.Context, ruleID string, alertJSON []byte) error
 	DeleteAlertRuleFn           func(ctx context.Context, ruleID string) error
+	CheckMetricUsageFn          func(ctx context.Context, names []string) (map[string]MetricUsage, error)
 	ListNotificationChannelsFn  func(ctx context.Context) (json.RawMessage, error)
 	GetNotificationChannelFn    func(ctx context.Context, id string) (json.RawMessage, error)
 	CreateNotificationChannelFn func(ctx context.Context, receiverJSON []byte) (json.RawMessage, error)
 	UpdateNotificationChannelFn func(ctx context.Context, id string, receiverJSON []byte) error
 	DeleteNotificationChannelFn func(ctx context.Context, id string) error
 	TestNotificationChannelFn   func(ctx context.Context, receiverJSON []byte) error
-	GetTopMetricsFn             func(ctx context.Context, start, end int64, limit int) (json.RawMessage, error)
 }
 
 // Compile-time check that MockClient satisfies Client.
@@ -60,6 +61,13 @@ func (m *MockClient) GetAnalyticsIdentity(ctx context.Context) (*AnalyticsIdenti
 func (m *MockClient) ListMetrics(ctx context.Context, start, end int64, limit int, searchText, source string) (json.RawMessage, error) {
 	if m.ListMetricsFn != nil {
 		return m.ListMetricsFn(ctx, start, end, limit, searchText, source)
+	}
+	return json.RawMessage(`{}`), nil
+}
+
+func (m *MockClient) GetTopMetrics(ctx context.Context, start, end int64, limit int) (json.RawMessage, error) {
+	if m.GetTopMetricsFn != nil {
+		return m.GetTopMetricsFn(ctx, start, end, limit)
 	}
 	return json.RawMessage(`{}`), nil
 }
@@ -239,6 +247,13 @@ func (m *MockClient) DeleteAlertRule(ctx context.Context, ruleID string) error {
 	return nil
 }
 
+func (m *MockClient) CheckMetricUsage(ctx context.Context, names []string) (map[string]MetricUsage, error) {
+	if m.CheckMetricUsageFn != nil {
+		return m.CheckMetricUsageFn(ctx, names)
+	}
+	return map[string]MetricUsage{}, nil
+}
+
 func (m *MockClient) ListNotificationChannels(ctx context.Context) (json.RawMessage, error) {
 	if m.ListNotificationChannelsFn != nil {
 		return m.ListNotificationChannelsFn(ctx)
@@ -279,11 +294,4 @@ func (m *MockClient) TestNotificationChannel(ctx context.Context, receiverJSON [
 		return m.TestNotificationChannelFn(ctx, receiverJSON)
 	}
 	return nil
-}
-
-func (m *MockClient) GetTopMetrics(ctx context.Context, start, end int64, limit int) (json.RawMessage, error) {
-	if m.GetTopMetricsFn != nil {
-		return m.GetTopMetricsFn(ctx, start, end, limit)
-	}
-	return json.RawMessage(`{}`), nil
 }

--- a/internal/handler/tools/metric_usage.go
+++ b/internal/handler/tools/metric_usage.go
@@ -92,7 +92,7 @@ func (h *Handler) handleCheckMetricUsage(ctx context.Context, req mcp.CallToolRe
 	usage, err := client.CheckMetricUsage(ctx, names)
 	if err != nil {
 		h.logger.ErrorContext(ctx, "Failed to check metric usage", logpkg.ErrAttr(err))
-		return mcp.NewToolResultError(err.Error()), nil
+		return upstreamError(err), nil
 	}
 
 	out, err := json.Marshal(usage)

--- a/internal/handler/tools/metric_usage.go
+++ b/internal/handler/tools/metric_usage.go
@@ -1,0 +1,83 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
+
+	logpkg "github.com/SigNoz/signoz-mcp-server/pkg/log"
+)
+
+func (h *Handler) RegisterMetricUsageHandlers(s *server.MCPServer) {
+	h.logger.Debug("Registering metric usage handlers")
+
+	tool := mcp.NewTool("signoz_check_metric_usage",
+		mcp.WithReadOnlyHintAnnotation(true),
+		mcp.WithDestructiveHintAnnotation(false),
+		mcp.WithDescription(
+			"Given a list of metric names, return which dashboards and alerts reference each one, "+
+				"and whether each metric is safe to drop. Use this after signoz_get_top_metrics to "+
+				"decide which expensive metrics can be safely dropped from ingestion."),
+		mcp.WithString("searchContext",
+			mcp.Description("The user's original question or search text that triggered this tool call.")),
+		mcp.WithArray("metricNames",
+			mcp.Required(),
+			mcp.Description("Array of metric name strings to check. Example: [\"system.disk.io\", \"k8s.node.condition\"]."),
+		),
+	)
+
+	addTool(s, tool, h.handleCheckMetricUsage)
+}
+
+func (h *Handler) handleCheckMetricUsage(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	args, ok := req.Params.Arguments.(map[string]any)
+	if !ok {
+		return mcp.NewToolResultError("invalid arguments"), nil
+	}
+
+	rawNames, ok := args["metricNames"]
+	if !ok {
+		return mcp.NewToolResultError("metricNames is required"), nil
+	}
+
+	namesRaw, ok := rawNames.([]any)
+	if !ok {
+		return mcp.NewToolResultError("metricNames must be an array of strings"), nil
+	}
+
+	names := make([]string, 0, len(namesRaw))
+	for _, v := range namesRaw {
+		s, ok := v.(string)
+		if !ok {
+			return mcp.NewToolResultError("each entry in metricNames must be a string"), nil
+		}
+		names = append(names, s)
+	}
+
+	if len(names) == 0 {
+		return mcp.NewToolResultError("metricNames must contain at least one metric name"), nil
+	}
+
+	h.logger.DebugContext(ctx, "Tool called: signoz_check_metric_usage", slog.Int("count", len(names)))
+
+	client, err := h.GetClient(ctx)
+	if err != nil {
+		return mcp.NewToolResultError(err.Error()), nil
+	}
+
+	usage, err := client.CheckMetricUsage(ctx, names)
+	if err != nil {
+		h.logger.ErrorContext(ctx, "Failed to check metric usage", logpkg.ErrAttr(err))
+		return mcp.NewToolResultError(err.Error()), nil
+	}
+
+	out, err := json.Marshal(usage)
+	if err != nil {
+		return mcp.NewToolResultError(err.Error()), nil
+	}
+
+	return mcp.NewToolResultText(string(out)), nil
+}

--- a/internal/handler/tools/metric_usage.go
+++ b/internal/handler/tools/metric_usage.go
@@ -18,9 +18,9 @@ func (h *Handler) RegisterMetricUsageHandlers(s *server.MCPServer) {
 		mcp.WithReadOnlyHintAnnotation(true),
 		mcp.WithDestructiveHintAnnotation(false),
 		mcp.WithDescription(
-			"Given a list of metric names, return which dashboards and alerts reference each one, "+
-				"and whether each metric is safe to drop. Use this after signoz_get_top_metrics to "+
-				"decide which expensive metrics can be safely dropped from ingestion."),
+			"Given a list of metric names, return which dashboards and alerts reference each one. "+
+				"Returns raw usage references per metric — dashboards and alerts only. "+
+				"Use this to understand metric dependencies before making drop or reduction decisions."),
 		mcp.WithString("searchContext",
 			mcp.Description("The user's original question or search text that triggered this tool call.")),
 		mcp.WithArray("metricNames",
@@ -33,9 +33,9 @@ func (h *Handler) RegisterMetricUsageHandlers(s *server.MCPServer) {
 }
 
 func (h *Handler) handleCheckMetricUsage(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-	args, ok := req.Params.Arguments.(map[string]any)
-	if !ok {
-		return mcp.NewToolResultError("invalid arguments"), nil
+	args := req.GetArguments()
+	if args == nil {
+		return mcp.NewToolResultError("metricNames is required"), nil
 	}
 
 	rawNames, ok := args["metricNames"]

--- a/internal/handler/tools/metric_usage.go
+++ b/internal/handler/tools/metric_usage.go
@@ -22,9 +22,10 @@ func (h *Handler) RegisterMetricUsageHandlers(s *server.MCPServer) {
 				"Returns raw usage references per metric — dashboards and alerts only. "+
 				"Use this to understand metric dependencies before making drop or reduction decisions."),
 		mcp.WithString("searchContext",
-			mcp.Description("The user's original question or search text that triggered this tool call.")),
+			mcp.Description("The user's original question or search text that triggered this tool call. Always include the user's raw query here for better results.")),
 		mcp.WithArray("metricNames",
 			mcp.Required(),
+			mcp.WithStringItems(),
 			mcp.Description("Array of metric name strings to check. Example: [\"system.disk.io\", \"k8s.node.condition\"]."),
 		),
 	)

--- a/internal/handler/tools/metric_usage.go
+++ b/internal/handler/tools/metric_usage.go
@@ -3,8 +3,10 @@ package tools
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"log/slog"
 
+	signozclient "github.com/SigNoz/signoz-mcp-server/internal/client"
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
 
@@ -22,7 +24,7 @@ func (h *Handler) RegisterMetricUsageHandlers(s *server.MCPServer) {
 				"Accepts up to 50 metric names per call — split larger lists into batches of 50 and merge results. "+
 				"Each result entry contains dashboards (list), alerts (list), and error (string). "+
 				"When error is non-empty, the lookup for that metric failed (e.g. older SigNoz version or transient 5xx) "+
-				"and the dashboards/alerts lists are empty but unreliable — do not treat the metric as unused. "+
+				"and any dashboards/alerts lists are partial and unreliable — do not treat the metric as unused. "+
 				"Use this to understand metric dependencies before making drop or reduction decisions."),
 		mcp.WithString("searchContext",
 			mcp.Description("The user's original question or search text that triggered this tool call. Always include the user's raw query here for better results.")),
@@ -39,30 +41,45 @@ func (h *Handler) RegisterMetricUsageHandlers(s *server.MCPServer) {
 func (h *Handler) handleCheckMetricUsage(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	args := req.GetArguments()
 	if args == nil {
-		return mcp.NewToolResultError("metricNames is required"), nil
+		return validationError("metricNames", "is required"), nil
 	}
 
 	rawNames, ok := args["metricNames"]
 	if !ok {
-		return mcp.NewToolResultError("metricNames is required"), nil
+		return validationError("metricNames", "is required"), nil
 	}
 
 	namesRaw, ok := rawNames.([]any)
 	if !ok {
-		return mcp.NewToolResultError("metricNames must be an array of strings"), nil
+		return validationError("metricNames", "must be an array of strings"), nil
 	}
 
 	names := make([]string, 0, len(namesRaw))
-	for _, v := range namesRaw {
+	seen := make(map[string]struct{}, len(namesRaw))
+	uniqueNonEmpty := 0
+	for i, v := range namesRaw {
 		s, ok := v.(string)
 		if !ok {
-			return mcp.NewToolResultError("each entry in metricNames must be a string"), nil
+			return validationErrorf("metricNames", "entry %d must be a string", i), nil
 		}
 		names = append(names, s)
+		if s == "" {
+			continue
+		}
+		if _, ok := seen[s]; !ok {
+			seen[s] = struct{}{}
+			uniqueNonEmpty++
+		}
 	}
 
-	if len(names) == 0 {
-		return mcp.NewToolResultError("metricNames must contain at least one metric name"), nil
+	if uniqueNonEmpty == 0 {
+		return validationError("metricNames", "must contain at least one non-empty metric name"), nil
+	}
+	if uniqueNonEmpty > signozclient.MaxMetricUsageNames {
+		return errorWithCode(CodeValidationFailed, fmt.Sprintf(
+			"too many metric names: %d exceeds the per-call limit of %d - split into batches of %d and merge results",
+			uniqueNonEmpty, signozclient.MaxMetricUsageNames, signozclient.MaxMetricUsageNames,
+		)), nil
 	}
 
 	h.logger.DebugContext(ctx, "Tool called: signoz_check_metric_usage", slog.Int("count", len(names)))
@@ -83,5 +100,5 @@ func (h *Handler) handleCheckMetricUsage(ctx context.Context, req mcp.CallToolRe
 		return mcp.NewToolResultError(err.Error()), nil
 	}
 
-	return mcp.NewToolResultText(string(out)), nil
+	return structuredResult(out), nil
 }

--- a/internal/handler/tools/metric_usage.go
+++ b/internal/handler/tools/metric_usage.go
@@ -19,7 +19,10 @@ func (h *Handler) RegisterMetricUsageHandlers(s *server.MCPServer) {
 		mcp.WithDestructiveHintAnnotation(false),
 		mcp.WithDescription(
 			"Given a list of metric names, return which dashboards and alerts reference each one. "+
-				"Returns raw usage references per metric — dashboards and alerts only. "+
+				"Accepts up to 50 metric names per call — split larger lists into batches of 50 and merge results. "+
+				"Each result entry contains dashboards (list), alerts (list), and error (string). "+
+				"When error is non-empty, the lookup for that metric failed (e.g. older SigNoz version or transient 5xx) "+
+				"and the dashboards/alerts lists are empty but unreliable — do not treat the metric as unused. "+
 				"Use this to understand metric dependencies before making drop or reduction decisions."),
 		mcp.WithString("searchContext",
 			mcp.Description("The user's original question or search text that triggered this tool call. Always include the user's raw query here for better results.")),

--- a/internal/handler/tools/metric_usage_test.go
+++ b/internal/handler/tools/metric_usage_test.go
@@ -159,15 +159,10 @@ func TestHandleCheckMetricUsage_OversizedBatchReturnsValidationCode(t *testing.T
 }
 
 func TestHandleCheckMetricUsage_PreservesDedupedDashboards(t *testing.T) {
-	// Verify that the client layer deduplicates dashboard names when the same
-	// dashboard has multiple widgets referencing the metric. This test uses the
-	// real parseDashboardNames helper via a mock that already returns deduplicated
-	// names (dedup is client-side, verified in client unit tests).
 	mock := &client.MockClient{
 		CheckMetricUsageFn: func(_ context.Context, names []string) (map[string]client.MetricUsage, error) {
 			return map[string]client.MetricUsage{
 				"system.cpu.time": {
-					// Same dashboard name once — dedup already applied by client
 					Dashboards: []string{"Host Metrics"},
 					Alerts:     []string{},
 				},

--- a/internal/handler/tools/metric_usage_test.go
+++ b/internal/handler/tools/metric_usage_test.go
@@ -3,6 +3,7 @@ package tools
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"testing"
 
 	"github.com/SigNoz/signoz-mcp-server/internal/client"
@@ -36,6 +37,9 @@ func TestHandleCheckMetricUsage_ReturnsDashboardsAndAlerts(t *testing.T) {
 	if result.IsError {
 		t.Fatalf("handler returned error result: %v", result.Content)
 	}
+	if result.StructuredContent == nil {
+		t.Fatalf("expected structuredContent on successful metric usage result")
+	}
 
 	text := textContent(t, result)
 	var out map[string]client.MetricUsage
@@ -67,6 +71,9 @@ func TestHandleCheckMetricUsage_EmptyNamesReturnsError(t *testing.T) {
 	if !result.IsError {
 		t.Fatalf("expected error result for empty metricNames, got success")
 	}
+	if code := resultCode(t, result); code != CodeValidationFailed {
+		t.Fatalf("code = %q, want %q", code, CodeValidationFailed)
+	}
 }
 
 func TestHandleCheckMetricUsage_MissingNamesReturnsError(t *testing.T) {
@@ -79,6 +86,75 @@ func TestHandleCheckMetricUsage_MissingNamesReturnsError(t *testing.T) {
 	}
 	if !result.IsError {
 		t.Fatalf("expected error result for missing metricNames, got success")
+	}
+	if code := resultCode(t, result); code != CodeValidationFailed {
+		t.Fatalf("code = %q, want %q", code, CodeValidationFailed)
+	}
+}
+
+func TestHandleCheckMetricUsage_InvalidNamesReturnValidationCodes(t *testing.T) {
+	h := newTestHandler(&client.MockClient{})
+	cases := []struct {
+		name string
+		args map[string]any
+	}{
+		{
+			name: "non-array",
+			args: map[string]any{"metricNames": "system.cpu.time"},
+		},
+		{
+			name: "non-string entry",
+			args: map[string]any{"metricNames": []any{"system.cpu.time", 42}},
+		},
+		{
+			name: "only empty strings",
+			args: map[string]any{"metricNames": []any{"", ""}},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			result, err := h.handleCheckMetricUsage(testCtx(), makeToolRequest("signoz_check_metric_usage", tc.args))
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if !result.IsError {
+				t.Fatalf("expected validation error result, got success")
+			}
+			if code := resultCode(t, result); code != CodeValidationFailed {
+				t.Fatalf("code = %q, want %q", code, CodeValidationFailed)
+			}
+		})
+	}
+}
+
+func TestHandleCheckMetricUsage_OversizedBatchReturnsValidationCode(t *testing.T) {
+	called := false
+	h := newTestHandler(&client.MockClient{
+		CheckMetricUsageFn: func(_ context.Context, names []string) (map[string]client.MetricUsage, error) {
+			called = true
+			return nil, nil
+		},
+	})
+	names := make([]any, client.MaxMetricUsageNames+1)
+	for i := range names {
+		names[i] = fmt.Sprintf("metric.%d", i)
+	}
+
+	result, err := h.handleCheckMetricUsage(testCtx(), makeToolRequest("signoz_check_metric_usage", map[string]any{
+		"metricNames": names,
+	}))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !result.IsError {
+		t.Fatalf("expected validation error result, got success")
+	}
+	if code := resultCode(t, result); code != CodeValidationFailed {
+		t.Fatalf("code = %q, want %q", code, CodeValidationFailed)
+	}
+	if called {
+		t.Fatalf("client should not be called for oversized batch")
 	}
 }
 

--- a/internal/handler/tools/metric_usage_test.go
+++ b/internal/handler/tools/metric_usage_test.go
@@ -1,0 +1,131 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/SigNoz/signoz-mcp-server/internal/client"
+)
+
+func TestHandleCheckMetricUsage_ReturnsDashboardsAndAlerts(t *testing.T) {
+	mock := &client.MockClient{
+		CheckMetricUsageFn: func(_ context.Context, names []string) (map[string]client.MetricUsage, error) {
+			return map[string]client.MetricUsage{
+				"system.disk.io": {
+					Dashboards: []string{"Host Metrics", "Host Metrics (k8s)"},
+					Alerts:     []string{},
+					SafeToDrop: false,
+				},
+				"k8s.node.condition": {
+					Dashboards: []string{},
+					Alerts:     []string{},
+					SafeToDrop: true,
+				},
+			}, nil
+		},
+	}
+
+	h := newTestHandler(mock)
+	req := makeToolRequest("signoz_check_metric_usage", map[string]any{
+		"metricNames": []any{"system.disk.io", "k8s.node.condition"},
+	})
+
+	result, err := h.handleCheckMetricUsage(testCtx(), req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("handler returned error result: %v", result.Content)
+	}
+
+	text := textContent(t, result)
+	var out map[string]client.MetricUsage
+	if err := json.Unmarshal([]byte(text), &out); err != nil {
+		t.Fatalf("output is not valid JSON: %v", err)
+	}
+
+	disk := out["system.disk.io"]
+	if disk.SafeToDrop {
+		t.Errorf("system.disk.io should not be safe to drop")
+	}
+	if len(disk.Dashboards) != 2 {
+		t.Errorf("expected 2 dashboards for system.disk.io, got %d", len(disk.Dashboards))
+	}
+
+	node := out["k8s.node.condition"]
+	if !node.SafeToDrop {
+		t.Errorf("k8s.node.condition should be safe to drop")
+	}
+}
+
+func TestHandleCheckMetricUsage_EmptyNamesReturnsError(t *testing.T) {
+	h := newTestHandler(&client.MockClient{})
+	req := makeToolRequest("signoz_check_metric_usage", map[string]any{
+		"metricNames": []any{},
+	})
+
+	result, err := h.handleCheckMetricUsage(testCtx(), req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !result.IsError {
+		t.Fatalf("expected error result for empty metricNames, got success")
+	}
+}
+
+func TestHandleCheckMetricUsage_MissingNamesReturnsError(t *testing.T) {
+	h := newTestHandler(&client.MockClient{})
+	req := makeToolRequest("signoz_check_metric_usage", map[string]any{})
+
+	result, err := h.handleCheckMetricUsage(testCtx(), req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !result.IsError {
+		t.Fatalf("expected error result for missing metricNames, got success")
+	}
+}
+
+func TestHandleCheckMetricUsage_PreservesDedupedDashboards(t *testing.T) {
+	// Verify that the client layer deduplicates dashboard names when the same
+	// dashboard has multiple widgets referencing the metric. This test uses the
+	// real parseDashboardNames helper via a mock that already returns deduplicated
+	// names (dedup is client-side, verified in client unit tests).
+	mock := &client.MockClient{
+		CheckMetricUsageFn: func(_ context.Context, names []string) (map[string]client.MetricUsage, error) {
+			return map[string]client.MetricUsage{
+				"system.cpu.time": {
+					// Same dashboard name once — dedup already applied by client
+					Dashboards: []string{"Host Metrics"},
+					Alerts:     []string{},
+					SafeToDrop: false,
+				},
+			}, nil
+		},
+	}
+
+	h := newTestHandler(mock)
+	req := makeToolRequest("signoz_check_metric_usage", map[string]any{
+		"metricNames": []any{"system.cpu.time"},
+	})
+
+	result, err := h.handleCheckMetricUsage(testCtx(), req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("handler returned error result: %v", result.Content)
+	}
+
+	text := textContent(t, result)
+	var out map[string]client.MetricUsage
+	if err := json.Unmarshal([]byte(text), &out); err != nil {
+		t.Fatalf("output is not valid JSON: %v", err)
+	}
+
+	cpu := out["system.cpu.time"]
+	if len(cpu.Dashboards) != 1 {
+		t.Errorf("expected 1 deduplicated dashboard name, got %d", len(cpu.Dashboards))
+	}
+}

--- a/internal/handler/tools/metric_usage_test.go
+++ b/internal/handler/tools/metric_usage_test.go
@@ -15,12 +15,10 @@ func TestHandleCheckMetricUsage_ReturnsDashboardsAndAlerts(t *testing.T) {
 				"system.disk.io": {
 					Dashboards: []string{"Host Metrics", "Host Metrics (k8s)"},
 					Alerts:     []string{},
-					SafeToDrop: false,
 				},
 				"k8s.node.condition": {
 					Dashboards: []string{},
 					Alerts:     []string{},
-					SafeToDrop: true,
 				},
 			}, nil
 		},
@@ -46,16 +44,13 @@ func TestHandleCheckMetricUsage_ReturnsDashboardsAndAlerts(t *testing.T) {
 	}
 
 	disk := out["system.disk.io"]
-	if disk.SafeToDrop {
-		t.Errorf("system.disk.io should not be safe to drop")
-	}
 	if len(disk.Dashboards) != 2 {
 		t.Errorf("expected 2 dashboards for system.disk.io, got %d", len(disk.Dashboards))
 	}
 
 	node := out["k8s.node.condition"]
-	if !node.SafeToDrop {
-		t.Errorf("k8s.node.condition should be safe to drop")
+	if len(node.Dashboards) != 0 || len(node.Alerts) != 0 {
+		t.Errorf("expected empty dashboards and alerts for k8s.node.condition")
 	}
 }
 
@@ -99,7 +94,6 @@ func TestHandleCheckMetricUsage_PreservesDedupedDashboards(t *testing.T) {
 					// Same dashboard name once — dedup already applied by client
 					Dashboards: []string{"Host Metrics"},
 					Alerts:     []string{},
-					SafeToDrop: false,
 				},
 			}, nil
 		},

--- a/internal/handler/tools/metric_usage_test.go
+++ b/internal/handler/tools/metric_usage_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/http"
 	"testing"
 
 	"github.com/SigNoz/signoz-mcp-server/internal/client"
@@ -155,6 +156,46 @@ func TestHandleCheckMetricUsage_OversizedBatchReturnsValidationCode(t *testing.T
 	}
 	if called {
 		t.Fatalf("client should not be called for oversized batch")
+	}
+}
+
+func TestHandleCheckMetricUsage_AuthzFailureReturnsUpstreamCode(t *testing.T) {
+	cases := []struct {
+		name       string
+		statusCode int
+		wantCode   string
+	}{
+		{name: "unauthorized", statusCode: http.StatusUnauthorized, wantCode: CodeUnauthorized},
+		{name: "forbidden", statusCode: http.StatusForbidden, wantCode: CodePermissionDenied},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			h := newTestHandler(&client.MockClient{
+				CheckMetricUsageFn: func(_ context.Context, names []string) (map[string]client.MetricUsage, error) {
+					return nil, &client.HTTPStatusError{
+						StatusCode: tc.statusCode,
+						Body:       `{"status":"error","error":{"code":"unauthenticated","message":"invalid credentials","type":"unauthorized"}}`,
+					}
+				},
+			})
+
+			result, err := h.handleCheckMetricUsage(testCtx(), makeToolRequest("signoz_check_metric_usage", map[string]any{
+				"metricNames": []any{"system.cpu.time"},
+			}))
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if !result.IsError {
+				t.Fatalf("expected authz error result, got success")
+			}
+			if code := resultCode(t, result); code != tc.wantCode {
+				t.Fatalf("code = %q, want %q", code, tc.wantCode)
+			}
+			if got := resultStructuredMap(t, result)["status"]; got != tc.statusCode {
+				t.Fatalf("status = %#v, want %d", got, tc.statusCode)
+			}
+		})
 	}
 }
 

--- a/internal/handler/tools/nil_arguments_test.go
+++ b/internal/handler/tools/nil_arguments_test.go
@@ -43,6 +43,7 @@ func TestHandlers_NilArguments_NoPanic(t *testing.T) {
 		{"signoz_query_metrics", h.handleQueryMetrics},
 		{"signoz_create_notification_channel", h.handleCreateNotificationChannel},
 		{"signoz_update_notification_channel", h.handleUpdateNotificationChannel},
+		{"signoz_check_metric_usage", h.handleCheckMetricUsage},
 	}
 
 	for _, tc := range cases {

--- a/internal/handler/tools/structured_content_test.go
+++ b/internal/handler/tools/structured_content_test.go
@@ -209,6 +209,11 @@ func TestStructuredContent_PresentOnCodeControlledTools(t *testing.T) {
 		ListServicesFn: func(ctx context.Context, start, end string) (json.RawMessage, error) {
 			return json.RawMessage(`[{"serviceName":"frontend"}]`), nil
 		},
+		CheckMetricUsageFn: func(ctx context.Context, names []string) (map[string]client.MetricUsage, error) {
+			return map[string]client.MetricUsage{
+				"system.cpu.time": {Dashboards: []string{"Host Metrics"}, Alerts: []string{}},
+			}, nil
+		},
 		ListDashboardsFn: func(ctx context.Context) (json.RawMessage, error) {
 			return json.RawMessage(`{"status":"success","data":[{"uuid":"d1","title":"X"}]}`), nil
 		},
@@ -241,6 +246,7 @@ func TestStructuredContent_PresentOnCodeControlledTools(t *testing.T) {
 		req  mcp.CallToolRequest
 	}{
 		{"list_services", h.handleListServices, makeToolRequest("signoz_list_services", map[string]any{})},
+		{"check_metric_usage", h.handleCheckMetricUsage, makeToolRequest("signoz_check_metric_usage", map[string]any{"metricNames": []any{"system.cpu.time"}})},
 		{"list_dashboards", h.handleListDashboards, makeToolRequest("signoz_list_dashboards", map[string]any{})},
 		{"get_dashboard", h.handleGetDashboard, makeToolRequest("signoz_get_dashboard", map[string]any{"uuid": "d1"})},
 		{"list_views", h.handleListViews, makeToolRequest("signoz_list_views", map[string]any{"sourcePage": "logs"})},

--- a/internal/mcp-server/integration_test.go
+++ b/internal/mcp-server/integration_test.go
@@ -45,6 +45,7 @@ func buildTestServer(t *testing.T) *server.MCPServer {
 
 	handler.RegisterMetricsHandlers(s)
 	handler.RegisterTopMetricsHandlers(s)
+	handler.RegisterMetricUsageHandlers(s)
 	handler.RegisterFieldsHandlers(s)
 	handler.RegisterAlertsHandlers(s)
 	handler.RegisterDashboardHandlers(s)

--- a/internal/mcp-server/server.go
+++ b/internal/mcp-server/server.go
@@ -375,6 +375,7 @@ func (m *MCPServer) Run(ctx context.Context) error {
 	// Register all handlers
 	m.handler.RegisterMetricsHandlers(s)
 	m.handler.RegisterTopMetricsHandlers(s)
+	m.handler.RegisterMetricUsageHandlers(s)
 	m.handler.RegisterFieldsHandlers(s)
 	m.handler.RegisterAlertsHandlers(s)
 	m.handler.RegisterDashboardHandlers(s)

--- a/manifest.json
+++ b/manifest.json
@@ -39,7 +39,7 @@
     },
     {
       "name": "signoz_check_metric_usage",
-      "description": "Given a list of metric names, return which dashboards and alerts reference each one, and whether each metric is safe to drop"
+      "description": "Given a list of metric names, return which dashboards and alerts reference each one"
     },
     {
       "name": "signoz_get_field_keys",

--- a/manifest.json
+++ b/manifest.json
@@ -39,7 +39,7 @@
     },
     {
       "name": "signoz_check_metric_usage",
-      "description": "Given a list of metric names, return which dashboards and alerts reference each one"
+      "description": "Given a list of metric names (up to 50 per call), return which dashboards and alerts reference each one. Each result has dashboards, alerts, and error fields — a non-empty error means the lookup failed and the empty lists are unreliable"
     },
     {
       "name": "signoz_get_field_keys",

--- a/manifest.json
+++ b/manifest.json
@@ -39,7 +39,7 @@
     },
     {
       "name": "signoz_check_metric_usage",
-      "description": "Given a list of metric names (up to 50 per call), return which dashboards and alerts reference each one. Each result has dashboards, alerts, and error fields — a non-empty error means the lookup failed and the empty lists are unreliable"
+      "description": "Given a list of metric names (up to 50 per call), return which dashboards and alerts reference each one. Each result has dashboards, alerts, and error fields — a non-empty error means the lookup is incomplete and any returned lists are partial"
     },
     {
       "name": "signoz_get_field_keys",

--- a/manifest.json
+++ b/manifest.json
@@ -38,6 +38,10 @@
       "description": "Return top 100 metrics ranked by ingested sample volume with pre-computed percentages for cost and volume analysis"
     },
     {
+      "name": "signoz_check_metric_usage",
+      "description": "Given a list of metric names, return which dashboards and alerts reference each one, and whether each metric is safe to drop"
+    },
+    {
       "name": "signoz_get_field_keys",
       "description": "Get available field keys for metrics, traces, or logs"
     },

--- a/plans/metric-usage-attributes.context.md
+++ b/plans/metric-usage-attributes.context.md
@@ -1,0 +1,45 @@
+# Feature: Metric Usage & Attributes — Context & Discussion
+
+## Original Prompt
+> Check the skill to see how /telemetry-optimisation skill fetches dashboard/alert usage for metrics, then create a plan. Concerned about agent making 100s of tool calls per metric.
+
+## Reference Links
+- `~/.claude/skills/telemetry-optimisation/scripts/metrics.py` — reference implementation (lines 122–162 for usage, 278–283 for attributes)
+- Issue #176 (signoz_get_top_metrics PR context)
+
+## Key Decisions & Discussion Log
+
+### 2026-06-16 — Skill analysis and tool design
+- Skill calls `GET /api/v1/dashboards` once (full panel content) + `GET /api/v1/rules?limit=100` once, then searches in-memory for each metric name
+- The MCP `ListDashboards` handler already calls this same endpoint but strips content down to summaries before returning
+- Attributes are fetched per-metric (`GET /api/v2/metrics/{name}/attributes`) but ONLY for metrics confirmed as in-use (not drop candidates)
+- Agent concern: if tool takes one metric name, agent makes N tool calls for N metrics → N × 2 API calls, and dashboards payload is fetched N times
+- Decision: `signoz_check_metric_usage` takes a **list** of metric names, fetches dashboards + rules once, scans all names in-memory, returns a map. Agent calls it once for all top metrics → 2 API calls total
+
+### 2026-06-16 — Switched to per-metric v2 API approach; response design decision
+- Per-metric APIs confirmed working (same APIs Metrics Explorer UI uses):
+  - `GET /api/v2/metrics/{name}/dashboards` → `{dashboardName, dashboardId, widgetId, widgetName}` per widget
+  - `GET /api/v2/metrics/{name}/alerts` → `{alertName, alertId}` per alert (METRIC_BASED_ALERT only)
+- No query params on either endpoint; 404 = metric not tracked → treat as empty result
+- Decided AGAINST bulk approach (`GET /api/v1/dashboards` + in-memory scan) — would require maintaining PromQL negative-lookahead regex for substring false positives (e.g. `cluster.upstream_rq` must not match `cluster.upstream_rq_xx`); server handles this correctly for free via per-metric APIs
+- Response trimmed to just names + `safeToDrops` boolean — no IDs — keeps agent context window small. Key concern: Noz AI assistant credit usage when this is embedded in SigNoz product
+- Cap at 20 metric names per call
+- The earlier v1/rules question is now moot — per-metric alerts API replaces bulk rules fetch entirely
+
+## Open Questions
+- [ ] Should `signoz_get_metric_attributes` be a separate tool or combined with usage check?
+  - Current thinking: separate — different intent, different invocation time (only called for in-use metrics)
+- [x] Is `/api/v1/rules?limit=100` still available on current SigNoz versions?
+  - Confirmed: v1 endpoint is alive, returns all 487 rules with full compositeQuery inline
+  - Metric name at: `condition.compositeQuery.queries[].spec.aggregations[].metricName`
+  - Only METRIC_BASED_ALERT rules have metricName; logs/traces alerts use `aggregations[].expression` with no metricName
+  - Moot: switched to per-metric `/api/v2/metrics/{name}/alerts` — no bulk rules fetch needed
+
+### 2026-06-16 — Concurrency design: bounded concurrency over hard input cap
+- Removed the 20-metric input cap — no artificial limit on how many metric names the caller can pass
+- Decision: use `errgroup.WithContext` + `g.SetLimit(10)` (bounded concurrency)
+  - Hard input cap penalizes the caller and forces agent-side batching — wrong layer for this concern
+  - Bounded concurrency (`SetLimit`) controls in-flight HTTP requests instead — protects SigNoz without restricting the caller
+  - `g.SetLimit(10)` means at most 10 goroutines active at once; each does dashboards → alerts sequentially per metric
+  - Primary consumer (telemetry-optimisation skill) works with top 100 metrics from treemap — all processed in one call
+  - Pattern is consistent with `errgroup` already used in `internal/docs/refresh.go`

--- a/plans/metric-usage-attributes.context.md
+++ b/plans/metric-usage-attributes.context.md
@@ -43,3 +43,14 @@
   - `g.SetLimit(10)` means at most 10 goroutines active at once; each does dashboards → alerts sequentially per metric
   - Primary consumer (telemetry-optimisation skill) works with top 100 metrics from treemap — all processed in one call
   - Pattern is consistent with `errgroup` already used in `internal/docs/refresh.go`
+
+### 2026-07-01 — Reinstated soft cap (50) + added overall deadline (30s) — PR #205
+- Reviewer (makeavish) flagged [consider]: no input cap means one AI call can fire 2N unbounded requests; `SetLimit(10)` is per-process not per-tenant
+- Decision: reinstate soft cap at 50 (up from earlier 20) with a clear error directing callers to batch
+  - Does not limit functionality — callers batch into groups of 50 and merge results
+  - Makes reliability predictable and the choice to send a large batch explicit and observable
+  - Primary consumer (telemetry-optimisation skill) can batch 100 metrics as two calls of 50
+- Also added 30-second overall deadline derived from ctx — returns partial results on expiry instead of nothing
+  - Individual requests still use `DefaultQueryTimeout`; this guards the aggregate op
+  - Metrics that did not finish before deadline surface with a per-metric error (not silently dropped)
+- Both constants exported (`MaxMetricUsageNames`, `metricUsageTotalTimeout`) for discoverability

--- a/plans/metric-usage-attributes.context.md
+++ b/plans/metric-usage-attributes.context.md
@@ -27,8 +27,8 @@
 - The earlier v1/rules question is now moot — per-metric alerts API replaces bulk rules fetch entirely
 
 ## Open Questions
-- [ ] Should `signoz_get_metric_attributes` be a separate tool or combined with usage check?
-  - Current thinking: separate — different intent, different invocation time (only called for in-use metrics)
+- [x] Should `signoz_get_metric_attributes` be a separate tool or combined with usage check?
+  - Resolved 2026-07-05: separate — different intent, different invocation time (only called for in-use metrics); shipped separately as `signoz_check_metric_cardinality` on PR #208.
 - [x] Is `/api/v1/rules?limit=100` still available on current SigNoz versions?
   - Confirmed: v1 endpoint is alive, returns all 487 rules with full compositeQuery inline
   - Metric name at: `condition.compositeQuery.queries[].spec.aggregations[].metricName`
@@ -54,3 +54,18 @@
   - Individual requests still use `DefaultQueryTimeout`; this guards the aggregate op
   - Metrics that did not finish before deadline surface with a per-metric error (not silently dropped)
 - Both constants exported (`MaxMetricUsageNames`, `metricUsageTotalTimeout`) for discoverability
+
+### 2026-07-05 — Live route correction and MCP result contract fixes — PR #205
+- Live staging verification showed the Metrics Explorer usage APIs are query-param routes:
+  - `GET /api/v2/metrics/dashboards?metricName=...`
+  - `GET /api/v2/metrics/alerts?metricName=...`
+- The earlier path-shaped notes (`/api/v2/metrics/{name}/...`) are superseded; query encoding is required because metric names can contain `/`.
+- Success results are synthesized JSON, so the handler now returns `structuredContent` via the shared structured result helper.
+- Local validation failures now return `VALIDATION_FAILED` structured codes, including missing/invalid `metricNames` and batches over the 50-name cap.
+- Partial failures preserve known usage from the side that succeeded and set a per-metric `error` for the failed side.
+- Open question resolved: metric cardinality/attribute analysis remains a separate follow-up tool and shipped separately as `signoz_check_metric_cardinality` on PR #208.
+
+### 2026-07-05 — Review follow-up — PR #205
+- Multi-agent review found plan-only stale wording around `searchContext`, 404 semantics, and the resolved metric cardinality question.
+- Current plan now avoids describing `searchContext` as optional and distinguishes usage API metric-not-found responses from route-level 404s on unsupported SigNoz versions.
+- The metric cardinality open question is marked resolved inline above to keep the checklist state aligned with the discussion log.

--- a/plans/metric-usage-attributes.context.md
+++ b/plans/metric-usage-attributes.context.md
@@ -69,3 +69,7 @@
 - Multi-agent review found plan-only stale wording around `searchContext`, 404 semantics, and the resolved metric cardinality question.
 - Current plan now avoids describing `searchContext` as optional and distinguishes usage API metric-not-found responses from route-level 404s on unsupported SigNoz versions.
 - The metric cardinality open question is marked resolved inline above to keep the checklist state aligned with the discussion log.
+
+### 2026-07-05 — SigNoz version compatibility — PR #205
+- Verified against `SigNoz/signoz` tags: the exact query-param routes used by this tool (`/api/v2/metrics/dashboards?metricName=...` and `/api/v2/metrics/alerts?metricName=...`) first ship in SigNoz v0.131.0.
+- Decision: do not add fallback support for older backend route shapes; document `signoz_check_metric_usage` as requiring SigNoz v0.131.0+.

--- a/plans/metric-usage-attributes.plan.md
+++ b/plans/metric-usage-attributes.plan.md
@@ -74,7 +74,7 @@ type metricDashboardRef struct {
 
 ---
 
-### Tool 2: `signoz_get_metric_attributes`
+### Tool 2: `signoz_check_metric_cardinality` (shipped on PR #208, not this PR)
 
 **Purpose:** Return label/attribute keys for a single metric with their cardinality counts, sorted
 highest-first. Called AFTER `signoz_check_metric_usage` confirms the metric is in use — attribute

--- a/plans/metric-usage-attributes.plan.md
+++ b/plans/metric-usage-attributes.plan.md
@@ -1,0 +1,121 @@
+# Plan: signoz_check_metric_usage + signoz_get_metric_attributes
+
+## Status
+In Progress
+
+## Context
+The telemetry cost optimisation workflow (`signoz_get_top_metrics`) identifies expensive metrics but
+cannot determine whether they are safe to drop without knowing if they appear in any dashboard or alert.
+SigNoz exposes purpose-built per-metric lookup APIs used by the Metrics Explorer UI. This plan wraps
+those as two MCP tools.
+
+## Tools
+
+### Tool 1: `signoz_check_metric_usage`
+
+**Purpose:** Given a list of metric names, return which dashboards and alerts reference each one,
+and whether each metric is safe to drop.
+
+**Input:**
+- `metricNames` (required) — JSON array of metric name strings. No hard cap — bounded concurrency via `errgroup.SetLimit(10)` controls load on SigNoz.
+- `searchContext` (optional) — user's original question
+
+**Output:** Compact map — only what the agent needs for the drop-or-keep decision:
+```json
+{
+  "system.disk.io": {
+    "dashboards": ["Host Metrics", "Host Metrics (k8s)"],
+    "alerts": [],
+    "safeToDrop": false
+  },
+  "k8s.node.condition": {
+    "dashboards": [],
+    "alerts": [],
+    "safeToDrop": true
+  }
+}
+```
+No IDs, no widget names — those are navigation aids, not decision inputs. Keeps agent context compact.
+
+**Internal API calls (per metric, all in parallel):**
+- `GET /api/v2/metrics/{name}/dashboards`
+- `GET /api/v2/metrics/{name}/alerts`
+
+**Why per-metric API over bulk fetch:**
+- Server handles both builder-query and PromQL dashboard matching — no custom regex logic in handler
+- Response is trimmed to just names before returning — context window stays small
+- Bulk approach (`GET /api/v1/dashboards`) would require us to maintain PromQL negative-lookahead
+  regex to avoid substring false positives (e.g. `cluster.upstream_rq` matching `cluster.upstream_rq_xx`)
+
+**Key implementation notes:**
+- Use `errgroup` with `g.SetLimit(10)` — bounded concurrency, not a hard input cap
+  - No limit on number of metric names the caller can pass
+  - At most 10 goroutines in-flight at once; each goroutine fetches dashboards then alerts sequentially
+  - Protects SigNoz from thundering herd; self-regulates without forcing the agent to batch
+  - Consistent with `golang.org/x/sync/errgroup` already used in `internal/docs/refresh.go`
+- Deduplicate dashboard names (one metric can appear in multiple widgets of the same dashboard)
+- HTTP 404 = metric not tracked → treat as empty result `{dashboards:[], alerts:[], safeToDrop:true}`, not an error
+- `url.PathEscape` is safe for metric names — dots are unreserved chars, won't be encoded; %2E returns 404
+- No query params on either endpoint — start/end are silently ignored by the server
+- Alerts endpoint returns only METRIC_BASED_ALERT rules — no client-side filtering needed
+
+**Go structs (internal to client, not exported in response):**
+```go
+type metricAlertRef struct {
+    AlertName string `json:"alertName"`
+    AlertID   string `json:"alertId"`
+}
+type metricDashboardRef struct {
+    DashboardName string `json:"dashboardName"`
+    DashboardID   string `json:"dashboardId"`
+    WidgetID      string `json:"widgetId"`
+    WidgetName    string `json:"widgetName"`
+}
+```
+
+---
+
+### Tool 2: `signoz_get_metric_attributes`
+
+**Purpose:** Return label/attribute keys for a single metric with their cardinality counts, sorted
+highest-first. Called AFTER `signoz_check_metric_usage` confirms the metric is in use — attribute
+analysis is only useful for in-use metrics; drop candidates don't need it.
+
+**Input:**
+- `metricName` (required) — single metric name
+- `timeRange` / `start` / `end` — same pattern as other tools, default 7d
+- `searchContext` (optional)
+
+**Output:** Raw response from `GET /api/v2/metrics/{name}/attributes?start=...&end=...`
+Response shape: `{data: {attributes: [{key: "...", valueCount: 42}]}}`
+
+**Implementation:**
+- New client method `GetMetricAttributes(ctx, name string, start, end int64)`
+- `url.PathEscape` for the metric name in the path
+- Pass through raw response — handler does not classify labels (agent uses the cardinality reference)
+
+---
+
+## Files to Modify/Create
+
+### New files
+- `internal/handler/tools/metric_usage.go` — `RegisterMetricUsageHandlers`, `handleCheckMetricUsage`
+- `internal/handler/tools/metric_usage_test.go`
+- `internal/handler/tools/metric_attributes.go` — `RegisterMetricAttributesHandlers`, `handleGetMetricAttributes`
+- `internal/handler/tools/metric_attributes_test.go`
+
+### Modified files
+- `internal/client/interface.go` — add `CheckMetricUsage` and `GetMetricAttributes`
+- `internal/client/client.go` — implement both methods
+- `internal/client/mock.go` — add mock fn fields
+- `internal/mcp-server/server.go` — register both handler sets
+- `README.md` — tool table + parameter reference
+- `manifest.json` — tool entries
+- `docs/architecture.md` — add MetricUsage and MetricAttributes to registered handler list in Mermaid diagram
+
+## Verification
+1. Unit tests: mock returns known dashboards/alerts for one metric, empty for another — verify map output and `safeToDrop` flag
+2. Unit tests: mock returns 404 — verify treated as empty result, not error
+3. Unit tests: verify dashboard name deduplication (same dashboard, two widgets → one name in output)
+4. Unit tests: verify empty string and duplicate names are filtered before API calls
+5. Live test (subagent): call with top 5 metrics from `signoz_get_top_metrics`, verify non-empty dashboards on at least one

--- a/plans/metric-usage-attributes.plan.md
+++ b/plans/metric-usage-attributes.plan.md
@@ -18,7 +18,7 @@ The agent decides whether a metric is safe to drop based on this data combined w
 reasoning (infra metric exclusions, skill rules, business context).
 
 **Input:**
-- `metricNames` (required) — JSON array of metric name strings. No hard cap — bounded concurrency via `errgroup.SetLimit(10)` controls load on SigNoz.
+- `metricNames` (required) — JSON array of metric name strings. Soft cap of 50 per call — callers with more names should split into batches of 50 and merge results. Bounded concurrency via `errgroup.SetLimit(10)` also controls in-flight requests.
 - `searchContext` (optional) — user's original question
 
 **Output:** Compact map — raw reference data, no server-side drop verdict:
@@ -47,10 +47,11 @@ No IDs, no widget names — those are navigation aids, not decision inputs. Keep
   regex to avoid substring false positives (e.g. `cluster.upstream_rq` matching `cluster.upstream_rq_xx`)
 
 **Key implementation notes:**
-- Use `errgroup` with `g.SetLimit(10)` — bounded concurrency, not a hard input cap
-  - No limit on number of metric names the caller can pass
+- Soft cap: reject batches > `MaxMetricUsageNames` (50) with a clear error directing callers to batch
+- Overall deadline: 30s (`metricUsageTotalTimeout`) derived from ctx — returns partial results on expiry; metrics that didn't finish surface with a per-metric error
+- Use `errgroup` with `g.SetLimit(10)` — bounded concurrency
   - At most 10 goroutines in-flight at once; each goroutine fetches dashboards then alerts sequentially
-  - Protects SigNoz from thundering herd; self-regulates without forcing the agent to batch
+  - Protects SigNoz from thundering herd
   - Consistent with `golang.org/x/sync/errgroup` already used in `internal/docs/refresh.go`
 - Deduplicate dashboard names (one metric can appear in multiple widgets of the same dashboard)
 - HTTP 404 = metric not tracked → treat as empty result `{dashboards:[], alerts:[]}`, not an error

--- a/plans/metric-usage-attributes.plan.md
+++ b/plans/metric-usage-attributes.plan.md
@@ -1,7 +1,7 @@
 # Plan: signoz_check_metric_usage + signoz_get_metric_attributes
 
 ## Status
-In Progress
+Done (Tool 1 — signoz_check_metric_usage); Tool 2 shipped separately as signoz_check_metric_cardinality on PR #208
 
 ## Context
 The telemetry cost optimisation workflow (`signoz_get_top_metrics`) identifies expensive metrics but

--- a/plans/metric-usage-attributes.plan.md
+++ b/plans/metric-usage-attributes.plan.md
@@ -40,6 +40,8 @@ No IDs, no widget names — those are navigation aids, not decision inputs. Keep
 - `GET /api/v2/metrics/dashboards?metricName={name}`
 - `GET /api/v2/metrics/alerts?metricName={name}`
 
+These query-param routes require SigNoz v0.131.0 or newer.
+
 **Why per-metric API over bulk fetch:**
 - Server handles both builder-query and PromQL dashboard matching — no custom regex logic in handler
 - Response is trimmed to just names before returning — context window stays small

--- a/plans/metric-usage-attributes.plan.md
+++ b/plans/metric-usage-attributes.plan.md
@@ -1,13 +1,13 @@
-# Plan: signoz_check_metric_usage + signoz_get_metric_attributes
+# Plan: signoz_check_metric_usage
 
 ## Status
-Done (Tool 1 — signoz_check_metric_usage); Tool 2 shipped separately as signoz_check_metric_cardinality on PR #208
+Done
 
 ## Context
 The telemetry cost optimisation workflow (`signoz_get_top_metrics`) identifies expensive metrics but
 cannot determine whether they are safe to drop without knowing if they appear in any dashboard or alert.
 SigNoz exposes purpose-built per-metric lookup APIs used by the Metrics Explorer UI. This plan wraps
-those as two MCP tools.
+those APIs as one MCP tool.
 
 ## Tools
 
@@ -19,7 +19,7 @@ reasoning (infra metric exclusions, skill rules, business context).
 
 **Input:**
 - `metricNames` (required) — JSON array of metric name strings. Soft cap of 50 per call — callers with more names should split into batches of 50 and merge results. Bounded concurrency via `errgroup.SetLimit(10)` also controls in-flight requests.
-- `searchContext` (optional) — user's original question
+- `searchContext` — user's original question
 
 **Output:** Compact map — raw reference data, no server-side drop verdict:
 ```json
@@ -37,8 +37,8 @@ reasoning (infra metric exclusions, skill rules, business context).
 No IDs, no widget names — those are navigation aids, not decision inputs. Keeps agent context compact.
 
 **Internal API calls (per metric, all in parallel):**
-- `GET /api/v2/metrics/{name}/dashboards`
-- `GET /api/v2/metrics/{name}/alerts`
+- `GET /api/v2/metrics/dashboards?metricName={name}`
+- `GET /api/v2/metrics/alerts?metricName={name}`
 
 **Why per-metric API over bulk fetch:**
 - Server handles both builder-query and PromQL dashboard matching — no custom regex logic in handler
@@ -54,10 +54,11 @@ No IDs, no widget names — those are navigation aids, not decision inputs. Keep
   - Protects SigNoz from thundering herd
   - Consistent with `golang.org/x/sync/errgroup` already used in `internal/docs/refresh.go`
 - Deduplicate dashboard names (one metric can appear in multiple widgets of the same dashboard)
-- HTTP 404 = metric not tracked → treat as empty result `{dashboards:[], alerts:[]}`, not an error
-- `url.PathEscape` is safe for metric names — dots are unreserved chars, won't be encoded; %2E returns 404
-- No query params on either endpoint — start/end are silently ignored by the server
+- A metric-not-found response from the usage API is treated as empty `{dashboards:[], alerts:[]}`; route-level 404s from unsupported SigNoz versions remain lookup errors
+- `url.Values` / query encoding is required for metric names because cloud provider metrics can contain `/`
+- No start/end query params on either endpoint — start/end are silently ignored by the server
 - Alerts endpoint returns only METRIC_BASED_ALERT rules — no client-side filtering needed
+- Handler returns structuredContent for successful synthesized JSON and VALIDATION_FAILED codes for local validation errors
 
 **Go structs (internal to client, not exported in response):**
 ```go
@@ -75,7 +76,7 @@ type metricDashboardRef struct {
 
 ---
 
-### Tool 2: `signoz_check_metric_cardinality` (shipped on PR #208, not this PR)
+### Related Tool: `signoz_check_metric_cardinality` (shipped on PR #208, not this PR)
 
 **Purpose:** Return label/attribute keys for a single metric with their cardinality counts, sorted
 highest-first. Called AFTER `signoz_check_metric_usage` confirms the metric is in use — attribute
@@ -84,14 +85,14 @@ analysis is only useful for in-use metrics; drop candidates don't need it.
 **Input:**
 - `metricName` (required) — single metric name
 - `timeRange` / `start` / `end` — same pattern as other tools, default 7d
-- `searchContext` (optional)
+- `searchContext` — user's original question
 
-**Output:** Raw response from `GET /api/v2/metrics/{name}/attributes?start=...&end=...`
+**Output:** Raw response from `GET /api/v2/metrics/attributes?metricName=...&start=...&end=...`
 Response shape: `{data: {attributes: [{key: "...", valueCount: 42}]}}`
 
 **Implementation:**
-- New client method `GetMetricAttributes(ctx, name string, start, end int64)`
-- `url.PathEscape` for the metric name in the path
+- New client method for the cardinality PR
+- Query-param encoding for the metric name
 - Pass through raw response — handler does not classify labels (agent uses the cardinality reference)
 
 ---
@@ -101,21 +102,19 @@ Response shape: `{data: {attributes: [{key: "...", valueCount: 42}]}}`
 ### New files
 - `internal/handler/tools/metric_usage.go` — `RegisterMetricUsageHandlers`, `handleCheckMetricUsage`
 - `internal/handler/tools/metric_usage_test.go`
-- `internal/handler/tools/metric_attributes.go` — `RegisterMetricAttributesHandlers`, `handleGetMetricAttributes`
-- `internal/handler/tools/metric_attributes_test.go`
 
 ### Modified files
-- `internal/client/interface.go` — add `CheckMetricUsage` and `GetMetricAttributes`
-- `internal/client/client.go` — implement both methods
+- `internal/client/interface.go` — add `CheckMetricUsage`
+- `internal/client/metric_usage.go` — implement metric usage lookups
 - `internal/client/mock.go` — add mock fn fields
-- `internal/mcp-server/server.go` — register both handler sets
+- `internal/mcp-server/server.go` — register metric usage handlers
 - `README.md` — tool table + parameter reference
 - `manifest.json` — tool entries
-- `docs/architecture.md` — add MetricUsage and MetricAttributes to registered handler list in Mermaid diagram
+- `docs/architecture.md` — add MetricUsage to registered handler list in Mermaid diagram
 
 ## Verification
 1. Unit tests: mock returns known dashboards/alerts for one metric, empty for another — verify map output
-2. Unit tests: mock returns 404 — verify treated as empty result, not error
+2. Unit tests: mock returns the usage API's metric-not-found response — verify treated as empty result, not error
 3. Unit tests: verify dashboard name deduplication (same dashboard, two widgets → one name in output)
 4. Unit tests: verify empty string and duplicate names are filtered before API calls
 5. Live test (subagent): call with top 5 metrics from `signoz_get_top_metrics`, verify non-empty dashboards on at least one

--- a/plans/metric-usage-attributes.plan.md
+++ b/plans/metric-usage-attributes.plan.md
@@ -13,25 +13,24 @@ those as two MCP tools.
 
 ### Tool 1: `signoz_check_metric_usage`
 
-**Purpose:** Given a list of metric names, return which dashboards and alerts reference each one,
-and whether each metric is safe to drop.
+**Purpose:** Given a list of metric names, return which dashboards and alerts reference each one.
+The agent decides whether a metric is safe to drop based on this data combined with its own
+reasoning (infra metric exclusions, skill rules, business context).
 
 **Input:**
 - `metricNames` (required) — JSON array of metric name strings. No hard cap — bounded concurrency via `errgroup.SetLimit(10)` controls load on SigNoz.
 - `searchContext` (optional) — user's original question
 
-**Output:** Compact map — only what the agent needs for the drop-or-keep decision:
+**Output:** Compact map — raw reference data, no server-side drop verdict:
 ```json
 {
   "system.disk.io": {
     "dashboards": ["Host Metrics", "Host Metrics (k8s)"],
-    "alerts": [],
-    "safeToDrop": false
+    "alerts": []
   },
   "k8s.node.condition": {
     "dashboards": [],
-    "alerts": [],
-    "safeToDrop": true
+    "alerts": []
   }
 }
 ```
@@ -54,7 +53,7 @@ No IDs, no widget names — those are navigation aids, not decision inputs. Keep
   - Protects SigNoz from thundering herd; self-regulates without forcing the agent to batch
   - Consistent with `golang.org/x/sync/errgroup` already used in `internal/docs/refresh.go`
 - Deduplicate dashboard names (one metric can appear in multiple widgets of the same dashboard)
-- HTTP 404 = metric not tracked → treat as empty result `{dashboards:[], alerts:[], safeToDrop:true}`, not an error
+- HTTP 404 = metric not tracked → treat as empty result `{dashboards:[], alerts:[]}`, not an error
 - `url.PathEscape` is safe for metric names — dots are unreserved chars, won't be encoded; %2E returns 404
 - No query params on either endpoint — start/end are silently ignored by the server
 - Alerts endpoint returns only METRIC_BASED_ALERT rules — no client-side filtering needed
@@ -114,7 +113,7 @@ Response shape: `{data: {attributes: [{key: "...", valueCount: 42}]}}`
 - `docs/architecture.md` — add MetricUsage and MetricAttributes to registered handler list in Mermaid diagram
 
 ## Verification
-1. Unit tests: mock returns known dashboards/alerts for one metric, empty for another — verify map output and `safeToDrop` flag
+1. Unit tests: mock returns known dashboards/alerts for one metric, empty for another — verify map output
 2. Unit tests: mock returns 404 — verify treated as empty result, not error
 3. Unit tests: verify dashboard name deduplication (same dashboard, two widgets → one name in output)
 4. Unit tests: verify empty string and duplicate names are filtered before API calls


### PR DESCRIPTION
## Summary

- Adds `signoz_check_metric_usage`: given up to 50 metric names, returns which dashboards and alerts reference each metric.
- Uses the current Metrics Explorer v2 API contract only: `GET /api/v2/metrics/dashboards?metricName=...` and `GET /api/v2/metrics/alerts?metricName=...` per metric.
- Requires SigNoz v0.131.0 or newer for `signoz_check_metric_usage`; older v2 route shapes are intentionally not supported.
- Filters empty strings and duplicate names before backend calls, with bounded concurrency (`errgroup.SetLimit(10)`) and a 30-second overall deadline.
- Surfaces per-metric `error` when a lookup fails; successful side data is preserved so empty lists are not confused with unknown usage.
- Returns structured success content and `VALIDATION_FAILED` codes for local validation errors.
- Updates `README.md`, `manifest.json`, `docs/architecture.md`, and the feature plan/context.
- Companion `SigNoz/agent-skills` check: no matching skills PR needed; this is an additive tool and does not rename/remove an existing taught tool or parameter.

## Why

`signoz_get_top_metrics` identifies high-volume metrics but cannot tell whether they are referenced by dashboards or alerts. This tool closes that gap so agents can check dependencies before recommending metric drops or reductions.

## Depends on

Depends on #196 (`signoz_get_top_metrics`).

## Validation

- `go test ./...`
- Verified against `SigNoz/signoz` tags that the query-param usage routes first ship in SigNoz v0.131.0.
- Live staging endpoint probe confirmed `/api/v2/metrics/dashboards?metricName=...` and `/api/v2/metrics/alerts?metricName=...` return `data.dashboards` / `data.alerts`; the path-shaped `/api/v2/metrics/{name}/...` routes return the web app fallback, not API JSON.
- Live read-only tool-level E2E against staging exercised `Handler.handleCheckMetricUsage` through the real client with metric `app.ads.ad_requests`: returned `structuredContent`, dashboards `0`, alerts `2`, `errorPresent=false`.
- Slash-name query encoding was probed with a nonexistent slash metric and produced `metricName=mcp%2Fpr205%2F...`; staging returned the JSON metric-not-found envelope instead of a router fallback.
- Live nonexistent-metric query-route check confirmed both usage endpoints return HTTP 404 JSON with top-level keys `error,status`, `status=error`, `error.code=not_found`, `error.type=not-found`, and an `error.message` beginning with `metric not found:`.
- Unsupported/path-shaped route failure surfaced as `errorPresent=true`, so it does not look like a clean unused metric.
- Deep multi-agent review covered client/API contract, MCP handler contract, and docs/metadata; follow-up wording fixes were applied.

## Checklist

- [x] Code + tests
- [x] `README.md` updated
- [x] `manifest.json` updated
- [x] `docs/architecture.md` updated
- [x] Companion `agent-skills` impact checked
