### PR TITLE
feat(traces): add per-row webUrl deep links to signoz_search_traces (#245)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,3 +76,13 @@ Planning
 ## End-to-End / Live Verification
 
 Verifying against a live SigNoz instance — creating/reading/updating/deleting real alerts, dashboards, or views, or any multi-step API probing with credentials — should be delegated to a subagent (Agent tool), not run inline. The subagent must: delete every resource it creates and confirm it's gone; never print or persist credentials; report which fields round-tripped server-side; and prefer copying an existing resource's shape over hand-crafting one.
+
+## Testing across external contracts
+
+This server sits between external parties: it consumes the SigNoz backend / query-builder (QB) API (upstream) and produces tool outputs that MCP clients and the AI assistant consume (downstream). Unit tests that assert behavior against hard-coded fixtures only prove our code matches our *assumption* of those contracts — they do not catch the contract drifting out from under us (a renamed field, a changed QB response envelope, a new route/output shape).
+
+For any code that parses an upstream response or shapes a tool output:
+
+- **Pin the contract, and test against reality where you can.** Beyond fixture-based unit tests, add a periodic/integration test against a live SigNoz instance (or a recorded real response) so upstream drift fails a test, not a user. Per-PR fixture tests are necessary but not sufficient.
+- **When tests can't catch it, observability must.** If a break only manifests against real data, add a metric or WARN log that fires when the contract appears violated (e.g. a passthrough enrichment that found rows but could not locate the expected field). Silent degradation that no test and no signal can catch is the failure mode to design against.
+- **Fail open, but never fail silent.** Prefer fail-open behavior for cross-boundary parsing, but always pair it with a detectable signal so "fail-open" does not become "fail-silent."

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,6 +29,14 @@ go test ./...
 
 For documentation-only changes, at minimum ensure formatting and links are sensible, and run `go test ./...` when the local environment allows it. Mention what was validated in the PR.
 
+## Testing across external contracts
+
+This server depends on external parties — it consumes the SigNoz backend / query-builder (QB) API (upstream) and produces tool outputs that MCP clients and the AI assistant consume (downstream). Fixture-based unit tests only prove our code matches our *assumption* of those contracts; they do not catch the contract drifting out from under us (a renamed field, a changed QB response envelope, a new output shape). When you parse an upstream response or shape a tool output:
+
+- **Pin the contract, and test against reality where you can.** Beyond fixture unit tests, add a periodic/integration test against a live instance (or a recorded real response) so upstream drift fails a test, not a user.
+- **When tests can't catch it, observability must.** If a break only manifests against real data, add a metric or WARN log that fires when the contract appears violated (e.g. a passthrough that found rows but could not locate the expected field), so silent degradation is detectable in production.
+- **Fail open, but never fail silent.** Pair every fail-open cross-boundary parse with a detectable signal.
+
 ## Pull request checklist
 
 - [ ] Code/tests updated as needed

--- a/README.md
+++ b/README.md
@@ -378,7 +378,7 @@ HTTP mode exposes unauthenticated probe endpoints. New Kubernetes deployments sh
 
 For detailed usage and examples, see the [full documentation](https://signoz.io/docs/ai/signoz-mcp-server/).
 
-> **Resource deep links:** the resource read tools (`signoz_list_dashboards`, `signoz_get_dashboard`, `signoz_list_alerts`, `signoz_list_alert_rules`, `signoz_get_alert`, `signoz_list_services`, `signoz_get_trace_details`) include a `webUrl` field — an absolute deep link to the resource in the SigNoz web UI — when the request carries a SigNoz instance URL.
+> **Resource deep links:** the resource read tools (`signoz_list_dashboards`, `signoz_get_dashboard`, `signoz_list_alerts`, `signoz_list_alert_rules`, `signoz_get_alert`, `signoz_list_services`, `signoz_search_traces`, `signoz_get_trace_details`) include a `webUrl` field — an absolute deep link to the resource in the SigNoz web UI (per result row for `signoz_search_traces`) — when the request carries a SigNoz instance URL.
 
 ### Agent Routing Guidance
 

--- a/internal/handler/tools/traces.go
+++ b/internal/handler/tools/traces.go
@@ -157,7 +157,7 @@ func (h *Handler) handleSearchTraces(ctx context.Context, req mcp.CallToolReques
 		return mcp.NewToolResultError(err.Error()), nil
 	}
 
-	result = enrichSearchTracesWebURL(ctx, result)
+	result = h.enrichSearchTracesWebURL(ctx, result)
 	return rawSearchResult(result, reqData.LimitClamped), nil
 }
 
@@ -210,7 +210,19 @@ func enrichTraceWebURL(ctx context.Context, data []byte, traceID string) []byte 
 // traces passthrough body, one per result row keyed off each row's traceID.
 // Delegates to util.InjectRowsWebURL, which preserves large int64 fields
 // (e.g. durationNano) and fails open on unparseable input.
-func enrichSearchTracesWebURL(ctx context.Context, data []byte) []byte {
+//
+// Enrichment is fail-open, so a change to the upstream v5 raw response shape (or
+// to the traceID column alias) would silently stop producing links. To make that
+// drift detectable, we WARN when rows were present but none could be enriched —
+// the signature of a shape change. A result with no rows is ordinary "no data"
+// and stays silent.
+func (h *Handler) enrichSearchTracesWebURL(ctx context.Context, data []byte) []byte {
 	base, _ := util.GetSigNozURL(ctx)
-	return util.InjectRowsWebURL(data, base, "trace", "traceID")
+	out, res := util.InjectRowsWebURL(data, base, "trace", "traceID")
+	if res.RowsSeen > 0 && res.RowsEnriched == 0 {
+		h.logger.WarnContext(ctx,
+			"search_traces webUrl enrichment found rows but enriched none; the upstream v5 raw response shape or the traceID column alias may have changed",
+			slog.Int("rowsSeen", res.RowsSeen))
+	}
+	return out
 }

--- a/internal/handler/tools/traces.go
+++ b/internal/handler/tools/traces.go
@@ -214,9 +214,10 @@ func enrichTraceWebURL(ctx context.Context, data []byte, traceID string) []byte 
 // Enrichment is fail-open, so a change to the upstream response would silently
 // stop producing links. The handler only runs on a 2xx /api/v5/query_range body
 // (doRequest errors on non-2xx), so anything we can't walk is a real anomaly,
-// not an error response. We WARN on both drift modes so the silent degradation
-// is detectable: envelope drift (results[] not reachable) and column-alias drift
-// (rows present but none enrichable). An ordinary empty result stays silent.
+// not an error response. We WARN on all three drift modes so the silent
+// degradation is detectable: envelope drift (results[] not reachable), rows-key
+// drift (result objects present but no readable rows[] array), and column-alias
+// drift (rows present but none enrichable). An ordinary empty result stays silent.
 func (h *Handler) enrichSearchTracesWebURL(ctx context.Context, data []byte) []byte {
 	base, ok := util.GetSigNozURL(ctx)
 	if !ok || base == "" {
@@ -228,6 +229,10 @@ func (h *Handler) enrichSearchTracesWebURL(ctx context.Context, data []byte) []b
 	case !res.ResultsReached:
 		h.logger.WarnContext(ctx,
 			"search_traces webUrl enrichment could not locate results[] in the v5 response; the upstream response envelope may have changed")
+	case res.ResultCount > 0 && res.RowsArraysReached == 0:
+		h.logger.WarnContext(ctx,
+			"search_traces webUrl enrichment found result objects but no readable rows[] array; the per-result rows key may have changed",
+			slog.Int("resultCount", res.ResultCount))
 	case res.RowsSeen > 0 && res.RowsEnriched == 0:
 		h.logger.WarnContext(ctx,
 			"search_traces webUrl enrichment found rows but enriched none; the traceID column alias may have changed",

--- a/internal/handler/tools/traces.go
+++ b/internal/handler/tools/traces.go
@@ -211,17 +211,26 @@ func enrichTraceWebURL(ctx context.Context, data []byte, traceID string) []byte 
 // Delegates to util.InjectRowsWebURL, which preserves large int64 fields
 // (e.g. durationNano) and fails open on unparseable input.
 //
-// Enrichment is fail-open, so a change to the upstream v5 raw response shape (or
-// to the traceID column alias) would silently stop producing links. To make that
-// drift detectable, we WARN when rows were present but none could be enriched —
-// the signature of a shape change. A result with no rows is ordinary "no data"
-// and stays silent.
+// Enrichment is fail-open, so a change to the upstream response would silently
+// stop producing links. The handler only runs on a 2xx /api/v5/query_range body
+// (doRequest errors on non-2xx), so anything we can't walk is a real anomaly,
+// not an error response. We WARN on both drift modes so the silent degradation
+// is detectable: envelope drift (results[] not reachable) and column-alias drift
+// (rows present but none enrichable). An ordinary empty result stays silent.
 func (h *Handler) enrichSearchTracesWebURL(ctx context.Context, data []byte) []byte {
-	base, _ := util.GetSigNozURL(ctx)
+	base, ok := util.GetSigNozURL(ctx)
+	if !ok || base == "" {
+		return data // no instance URL on the request — nothing to enrich, nothing to warn about
+	}
+
 	out, res := util.InjectRowsWebURL(data, base, "trace", "traceID")
-	if res.RowsSeen > 0 && res.RowsEnriched == 0 {
+	switch {
+	case !res.ResultsReached:
 		h.logger.WarnContext(ctx,
-			"search_traces webUrl enrichment found rows but enriched none; the upstream v5 raw response shape or the traceID column alias may have changed",
+			"search_traces webUrl enrichment could not locate results[] in the v5 response; the upstream response envelope may have changed")
+	case res.RowsSeen > 0 && res.RowsEnriched == 0:
+		h.logger.WarnContext(ctx,
+			"search_traces webUrl enrichment found rows but enriched none; the traceID column alias may have changed",
 			slog.Int("rowsSeen", res.RowsSeen))
 	}
 	return out

--- a/internal/handler/tools/traces.go
+++ b/internal/handler/tools/traces.go
@@ -157,6 +157,7 @@ func (h *Handler) handleSearchTraces(ctx context.Context, req mcp.CallToolReques
 		return mcp.NewToolResultError(err.Error()), nil
 	}
 
+	result = enrichSearchTracesWebURL(ctx, result)
 	return rawSearchResult(result, reqData.LimitClamped), nil
 }
 
@@ -203,4 +204,13 @@ func (h *Handler) handleGetTraceDetails(ctx context.Context, req mcp.CallToolReq
 func enrichTraceWebURL(ctx context.Context, data []byte, traceID string) []byte {
 	base, _ := util.GetSigNozURL(ctx)
 	return util.InjectWebURL(data, base, "trace", traceID)
+}
+
+// enrichSearchTracesWebURL injects a per-row webUrl deep link into a search
+// traces passthrough body, one per result row keyed off each row's traceID.
+// Delegates to util.InjectRowsWebURL, which preserves large int64 fields
+// (e.g. durationNano) and fails open on unparseable input.
+func enrichSearchTracesWebURL(ctx context.Context, data []byte) []byte {
+	base, _ := util.GetSigNozURL(ctx)
+	return util.InjectRowsWebURL(data, base, "trace", "traceID")
 }

--- a/internal/handler/tools/traces_test.go
+++ b/internal/handler/tools/traces_test.go
@@ -459,7 +459,22 @@ func TestHandleSearchTraces_WarnsOnProbableShapeDrift(t *testing.T) {
 func TestHandleSearchTraces_NoWarnWhenNoRows(t *testing.T) {
 	// No rows -> ordinary "no data" -> no false drift warning.
 	out := searchTracesWithCapturedLogs(t, emptySearchTracesBody)
-	if strings.Contains(out, "enriched none") {
+	if strings.Contains(out, "enriched none") || strings.Contains(out, "locate results") {
 		t.Fatalf("expected NO drift WARN for an empty result, got logs: %q", out)
+	}
+}
+
+// envelopeDriftSearchTracesBody is a 2xx v5 response whose results[] array is
+// renamed ("rezults"), so the envelope can't be walked even though it carries
+// rows — a simulated upstream envelope-shape change.
+const envelopeDriftSearchTracesBody = `{"status":"success","data":{"type":"raw","data":{"rezults":[{"queryName":"A","rows":[` +
+	`{"timestamp":"t","data":{"traceID":"abc-123"}}` +
+	`]}]},"meta":{}}}`
+
+func TestHandleSearchTraces_WarnsWhenEnvelopeUnwalkable(t *testing.T) {
+	// results[] not reachable -> envelope drift -> WARN (distinct from no-data).
+	out := searchTracesWithCapturedLogs(t, envelopeDriftSearchTracesBody)
+	if !strings.Contains(out, "locate results") {
+		t.Fatalf("expected an envelope-drift WARN, got logs: %q", out)
 	}
 }

--- a/internal/handler/tools/traces_test.go
+++ b/internal/handler/tools/traces_test.go
@@ -361,3 +361,59 @@ func TestHandleGetTraceDetails_OmitsWebURLWhenNoBaseURL(t *testing.T) {
 		t.Fatalf("expected NO webUrl without base URL, got: %s", body)
 	}
 }
+
+// rawSearchTracesBody is a realistic query-builder v5 "raw" response (a
+// render.Success envelope wrapping QueryRangeResponse) with two rows. The second
+// row's durationNano exceeds float64's exact-integer range to guard precision.
+const rawSearchTracesBody = `{"status":"success","data":{"type":"raw","data":{"results":[{"queryName":"A","rows":[` +
+	`{"timestamp":"2026-06-19T10:00:00Z","data":{"traceID":"abc-123","durationNano":9007199254740993,"name":"GET /cart"}},` +
+	`{"timestamp":"2026-06-19T10:00:01Z","data":{"traceID":"def-456","durationNano":42,"name":"POST /checkout"}}` +
+	`]}]},"meta":{}}}`
+
+func TestHandleSearchTraces_RowsGetWebURL(t *testing.T) {
+	mock := &client.MockClient{
+		QueryBuilderV5Fn: func(ctx context.Context, body []byte) (json.RawMessage, error) {
+			return json.RawMessage(rawSearchTracesBody), nil
+		},
+	}
+	h := newTestHandler(mock)
+	req := makeToolRequest("signoz_search_traces", map[string]any{"service": "cart-svc", "timeRange": "1h"})
+
+	result, err := h.handleSearchTraces(ctxWithURL(), req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("handler returned error result: %v", result.Content)
+	}
+	body := textContent(t, result)
+	if !strings.Contains(body, `"webUrl":"https://signoz.example.com/trace/abc-123"`) {
+		t.Fatalf("expected first row webUrl, got: %s", body)
+	}
+	if !strings.Contains(body, `"webUrl":"https://signoz.example.com/trace/def-456"`) {
+		t.Fatalf("expected second row webUrl, got: %s", body)
+	}
+	// durationNano (> 2^53) must survive the enrichment round-trip exactly.
+	if !strings.Contains(body, "9007199254740993") {
+		t.Fatalf("durationNano lost precision: %s", body)
+	}
+}
+
+func TestHandleSearchTraces_OmitsWebURLWhenNoBaseURL(t *testing.T) {
+	mock := &client.MockClient{
+		QueryBuilderV5Fn: func(ctx context.Context, body []byte) (json.RawMessage, error) {
+			return json.RawMessage(rawSearchTracesBody), nil
+		},
+	}
+	h := newTestHandler(mock)
+	req := makeToolRequest("signoz_search_traces", map[string]any{"service": "cart-svc", "timeRange": "1h"})
+
+	result, err := h.handleSearchTraces(testCtx(), req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	body := textContent(t, result)
+	if strings.Contains(body, "webUrl") {
+		t.Fatalf("expected NO webUrl without base URL, got: %s", body)
+	}
+}

--- a/internal/handler/tools/traces_test.go
+++ b/internal/handler/tools/traces_test.go
@@ -1,8 +1,10 @@
 package tools
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
+	"log/slog"
 	"strings"
 	"testing"
 
@@ -415,5 +417,49 @@ func TestHandleSearchTraces_OmitsWebURLWhenNoBaseURL(t *testing.T) {
 	body := textContent(t, result)
 	if strings.Contains(body, "webUrl") {
 		t.Fatalf("expected NO webUrl without base URL, got: %s", body)
+	}
+}
+
+// driftSearchTracesBody is a v5 raw response whose rows carry "trace_id" instead
+// of the "traceID" key the enrichment looks for — i.e. a simulated upstream shape
+// change. Rows are present but none are enrichable.
+const driftSearchTracesBody = `{"status":"success","data":{"type":"raw","data":{"results":[{"queryName":"A","rows":[` +
+	`{"timestamp":"t","data":{"trace_id":"abc-123","name":"GET /cart"}}` +
+	`]}]},"meta":{}}}`
+
+// emptySearchTracesBody is an ordinary "no data" response: results present, zero rows.
+const emptySearchTracesBody = `{"status":"success","data":{"type":"raw","data":{"results":[{"queryName":"A","rows":[]}]}},"meta":{}}`
+
+func searchTracesWithCapturedLogs(t *testing.T, responseBody string) string {
+	t.Helper()
+	mock := &client.MockClient{
+		QueryBuilderV5Fn: func(ctx context.Context, body []byte) (json.RawMessage, error) {
+			return json.RawMessage(responseBody), nil
+		},
+	}
+	h := newTestHandler(mock)
+	var logs bytes.Buffer
+	h.logger = slog.New(slog.NewTextHandler(&logs, &slog.HandlerOptions{Level: slog.LevelWarn}))
+	req := makeToolRequest("signoz_search_traces", map[string]any{"service": "cart-svc", "timeRange": "1h"})
+
+	if _, err := h.handleSearchTraces(ctxWithURL(), req); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	return logs.String()
+}
+
+func TestHandleSearchTraces_WarnsOnProbableShapeDrift(t *testing.T) {
+	// Rows present but none enrichable -> WARN so the silent fail-open is detectable.
+	out := searchTracesWithCapturedLogs(t, driftSearchTracesBody)
+	if !strings.Contains(out, "enriched none") || !strings.Contains(out, "rowsSeen=1") {
+		t.Fatalf("expected a shape-drift WARN with rowsSeen, got logs: %q", out)
+	}
+}
+
+func TestHandleSearchTraces_NoWarnWhenNoRows(t *testing.T) {
+	// No rows -> ordinary "no data" -> no false drift warning.
+	out := searchTracesWithCapturedLogs(t, emptySearchTracesBody)
+	if strings.Contains(out, "enriched none") {
+		t.Fatalf("expected NO drift WARN for an empty result, got logs: %q", out)
 	}
 }

--- a/internal/handler/tools/traces_test.go
+++ b/internal/handler/tools/traces_test.go
@@ -457,10 +457,25 @@ func TestHandleSearchTraces_WarnsOnProbableShapeDrift(t *testing.T) {
 }
 
 func TestHandleSearchTraces_NoWarnWhenNoRows(t *testing.T) {
-	// No rows -> ordinary "no data" -> no false drift warning.
+	// Present-but-empty rows[] -> ordinary "no data" -> no drift warning of any mode.
 	out := searchTracesWithCapturedLogs(t, emptySearchTracesBody)
-	if strings.Contains(out, "enriched none") || strings.Contains(out, "locate results") {
+	if strings.Contains(out, "webUrl enrichment") {
 		t.Fatalf("expected NO drift WARN for an empty result, got logs: %q", out)
+	}
+}
+
+// rowsKeyDriftSearchTracesBody is a 2xx v5 response whose results[] is reachable
+// and non-empty, but the per-result "rows" key is renamed ("records") so no rows
+// array can be read — a simulated per-result shape change.
+const rowsKeyDriftSearchTracesBody = `{"status":"success","data":{"type":"raw","data":{"results":[{"queryName":"A","records":[` +
+	`{"timestamp":"t","data":{"traceID":"abc-123"}}` +
+	`]}]},"meta":{}}}`
+
+func TestHandleSearchTraces_WarnsWhenRowsKeyMissing(t *testing.T) {
+	// results[] reachable but no readable rows[] -> rows-key drift -> WARN.
+	out := searchTracesWithCapturedLogs(t, rowsKeyDriftSearchTracesBody)
+	if !strings.Contains(out, "no readable rows") {
+		t.Fatalf("expected a rows-key-drift WARN, got logs: %q", out)
 	}
 }
 

--- a/pkg/util/weburl.go
+++ b/pkg/util/weburl.go
@@ -80,8 +80,20 @@ func InjectWebURL(data []byte, base, resourceType, id string) []byte {
 	return out
 }
 
+// InjectRowsResult reports what InjectRowsWebURL observed while walking a v5 raw
+// body, so callers can tell an ordinary empty result (RowsSeen == 0) apart from a
+// probable upstream shape change (RowsSeen > 0 but RowsEnriched == 0 — rows were
+// present yet none carried a linkable id). Because enrichment fails open, that
+// drift is otherwise silent; these counts give callers a signal to surface.
+type InjectRowsResult struct {
+	RowsSeen     int
+	RowsEnriched int
+}
+
 // InjectRowsWebURL adds a per-row webUrl deep link to a query-builder v5 "raw"
-// passthrough body, one link per result row built from the row's id field.
+// passthrough body, one link per result row built from the row's id field. It
+// returns the (possibly enriched) body and an InjectRowsResult describing how
+// many rows it saw versus enriched.
 //
 // The expected nesting (a render.Success envelope wrapping a QueryRangeResponse)
 // is data.data.results[].rows[].data, with the id under rows[].data[idKey]; for
@@ -91,27 +103,28 @@ func InjectWebURL(data []byte, base, resourceType, id string) []byte {
 // empty, or non-string are left untouched. On any failure — empty base or a body
 // that does not match the expected shape — it returns the original bytes
 // unchanged so enrichment can never corrupt a working response.
-func InjectRowsWebURL(data []byte, base, resourceType, idKey string) []byte {
+func InjectRowsWebURL(data []byte, base, resourceType, idKey string) ([]byte, InjectRowsResult) {
+	var res InjectRowsResult
 	if strings.TrimSpace(base) == "" {
-		return data
+		return data, res
 	}
 
 	envelope, ok := decodeShallowObject(data)
 	if !ok {
-		return data
+		return data, res
 	}
 	qrr, ok := decodeShallowObject(envelope["data"])
 	if !ok {
-		return data
+		return data, res
 	}
 	queryData, ok := decodeShallowObject(qrr["data"])
 	if !ok {
-		return data
+		return data, res
 	}
 
 	var results []json.RawMessage
 	if err := json.Unmarshal(queryData["results"], &results); err != nil || results == nil {
-		return data
+		return data, res
 	}
 
 	changed := false
@@ -127,11 +140,13 @@ func InjectRowsWebURL(data []byte, base, resourceType, idKey string) []byte {
 
 		rowsChanged := false
 		for i, rawRow := range rows {
+			res.RowsSeen++
 			injected, ok := injectRowWebURL(rawRow, base, resourceType, idKey)
 			if !ok {
 				continue
 			}
 			rows[i] = injected
+			res.RowsEnriched++
 			rowsChanged = true
 		}
 		if !rowsChanged {
@@ -140,35 +155,35 @@ func InjectRowsWebURL(data []byte, base, resourceType, idKey string) []byte {
 
 		rowsJSON, err := json.Marshal(rows)
 		if err != nil {
-			return data
+			return data, res
 		}
 		result["rows"] = rowsJSON
 		resultJSON, err := json.Marshal(result)
 		if err != nil {
-			return data
+			return data, res
 		}
 		results[ri] = resultJSON
 		changed = true
 	}
 
 	if !changed {
-		return data
+		return data, res
 	}
 
 	resultsJSON, err := json.Marshal(results)
 	if err != nil {
-		return data
+		return data, res
 	}
 	queryData["results"] = resultsJSON
 	if !remarshalUp(envelope, qrr, queryData) {
-		return data
+		return data, res
 	}
 
 	out, err := json.Marshal(envelope)
 	if err != nil {
-		return data
+		return data, res
 	}
-	return out
+	return out, res
 }
 
 // injectRowWebURL adds a webUrl sibling to a single raw row's inner "data"

--- a/pkg/util/weburl.go
+++ b/pkg/util/weburl.go
@@ -80,6 +80,154 @@ func InjectWebURL(data []byte, base, resourceType, id string) []byte {
 	return out
 }
 
+// InjectRowsWebURL adds a per-row webUrl deep link to a query-builder v5 "raw"
+// passthrough body, one link per result row built from the row's id field.
+//
+// The expected nesting (a render.Success envelope wrapping a QueryRangeResponse)
+// is data.data.results[].rows[].data, with the id under rows[].data[idKey]; for
+// traces that is data.traceID. Like InjectWebURL it decodes only as deep as each
+// mutated level, leaving siblings — large int64 fields like durationNano, number
+// formatting, key order — as verbatim json.RawMessage. Rows whose id is missing,
+// empty, or non-string are left untouched. On any failure — empty base or a body
+// that does not match the expected shape — it returns the original bytes
+// unchanged so enrichment can never corrupt a working response.
+func InjectRowsWebURL(data []byte, base, resourceType, idKey string) []byte {
+	if strings.TrimSpace(base) == "" {
+		return data
+	}
+
+	envelope, ok := decodeShallowObject(data)
+	if !ok {
+		return data
+	}
+	qrr, ok := decodeShallowObject(envelope["data"])
+	if !ok {
+		return data
+	}
+	queryData, ok := decodeShallowObject(qrr["data"])
+	if !ok {
+		return data
+	}
+
+	var results []json.RawMessage
+	if err := json.Unmarshal(queryData["results"], &results); err != nil || results == nil {
+		return data
+	}
+
+	changed := false
+	for ri, rawResult := range results {
+		result, ok := decodeShallowObject(rawResult)
+		if !ok {
+			continue
+		}
+		var rows []json.RawMessage
+		if err := json.Unmarshal(result["rows"], &rows); err != nil || rows == nil {
+			continue
+		}
+
+		rowsChanged := false
+		for i, rawRow := range rows {
+			injected, ok := injectRowWebURL(rawRow, base, resourceType, idKey)
+			if !ok {
+				continue
+			}
+			rows[i] = injected
+			rowsChanged = true
+		}
+		if !rowsChanged {
+			continue
+		}
+
+		rowsJSON, err := json.Marshal(rows)
+		if err != nil {
+			return data
+		}
+		result["rows"] = rowsJSON
+		resultJSON, err := json.Marshal(result)
+		if err != nil {
+			return data
+		}
+		results[ri] = resultJSON
+		changed = true
+	}
+
+	if !changed {
+		return data
+	}
+
+	resultsJSON, err := json.Marshal(results)
+	if err != nil {
+		return data
+	}
+	queryData["results"] = resultsJSON
+	if !remarshalUp(envelope, qrr, queryData) {
+		return data
+	}
+
+	out, err := json.Marshal(envelope)
+	if err != nil {
+		return data
+	}
+	return out
+}
+
+// injectRowWebURL adds a webUrl sibling to a single raw row's inner "data"
+// object using rows[].data[idKey] as the resource id. ok is false (and the row
+// is left untouched) when the row shape is unexpected, the id is missing/empty,
+// or no link can be built for the type.
+func injectRowWebURL(rawRow json.RawMessage, base, resourceType, idKey string) (json.RawMessage, bool) {
+	row, ok := decodeShallowObject(rawRow)
+	if !ok {
+		return nil, false
+	}
+	rowData, ok := decodeShallowObject(row["data"])
+	if !ok {
+		return nil, false
+	}
+
+	var id string
+	if err := json.Unmarshal(rowData[idKey], &id); err != nil {
+		return nil, false
+	}
+	webURL, ok := ResourceWebURL(base, resourceType, id)
+	if !ok {
+		return nil, false
+	}
+	urlJSON, err := json.Marshal(webURL)
+	if err != nil {
+		return nil, false
+	}
+
+	rowData["webUrl"] = urlJSON
+	rowDataJSON, err := json.Marshal(rowData)
+	if err != nil {
+		return nil, false
+	}
+	row["data"] = rowDataJSON
+	rowJSON, err := json.Marshal(row)
+	if err != nil {
+		return nil, false
+	}
+	return rowJSON, true
+}
+
+// remarshalUp re-encodes the queryData -> qrr -> envelope nesting after results
+// have been mutated, keeping every untouched sibling verbatim. Returns false on
+// any marshal failure so the caller can fall open to the original bytes.
+func remarshalUp(envelope, qrr, queryData map[string]json.RawMessage) bool {
+	queryDataJSON, err := json.Marshal(queryData)
+	if err != nil {
+		return false
+	}
+	qrr["data"] = queryDataJSON
+	qrrJSON, err := json.Marshal(qrr)
+	if err != nil {
+		return false
+	}
+	envelope["data"] = qrrJSON
+	return true
+}
+
 // decodeShallowObject decodes raw as a JSON object one level deep: values stay
 // verbatim json.RawMessage bytes. ok is false when raw is empty, "null", or
 // not a JSON object (Unmarshal leaves the map nil for "null", so the nil check

--- a/pkg/util/weburl.go
+++ b/pkg/util/weburl.go
@@ -81,13 +81,21 @@ func InjectWebURL(data []byte, base, resourceType, id string) []byte {
 }
 
 // InjectRowsResult reports what InjectRowsWebURL observed while walking a v5 raw
-// body, so callers can tell an ordinary empty result (RowsSeen == 0) apart from a
-// probable upstream shape change (RowsSeen > 0 but RowsEnriched == 0 — rows were
-// present yet none carried a linkable id). Because enrichment fails open, that
-// drift is otherwise silent; these counts give callers a signal to surface.
+// body, so callers can distinguish ordinary "no data" from a probable upstream
+// shape change. Because enrichment fails open, that drift is otherwise silent;
+// these fields give callers a signal to surface. Two drift modes:
+//   - envelope drift: ResultsReached == false — the data.data.results[] array
+//     could not be walked (the envelope nesting changed or was renamed);
+//   - column-alias drift: RowsSeen > 0 but RowsEnriched == 0 — rows were present
+//     yet none carried a linkable id (the id column was renamed).
+//
+// An ordinary empty result is ResultsReached == true with RowsSeen == 0.
+// ResultsReached is meaningful only when a base was supplied (an empty base
+// returns early with the zero value, since enrichment was not attempted).
 type InjectRowsResult struct {
-	RowsSeen     int
-	RowsEnriched int
+	ResultsReached bool
+	RowsSeen       int
+	RowsEnriched   int
 }
 
 // InjectRowsWebURL adds a per-row webUrl deep link to a query-builder v5 "raw"
@@ -126,6 +134,7 @@ func InjectRowsWebURL(data []byte, base, resourceType, idKey string) ([]byte, In
 	if err := json.Unmarshal(queryData["results"], &results); err != nil || results == nil {
 		return data, res
 	}
+	res.ResultsReached = true
 
 	changed := false
 	for ri, rawResult := range results {

--- a/pkg/util/weburl.go
+++ b/pkg/util/weburl.go
@@ -83,19 +83,27 @@ func InjectWebURL(data []byte, base, resourceType, id string) []byte {
 // InjectRowsResult reports what InjectRowsWebURL observed while walking a v5 raw
 // body, so callers can distinguish ordinary "no data" from a probable upstream
 // shape change. Because enrichment fails open, that drift is otherwise silent;
-// these fields give callers a signal to surface. Two drift modes:
+// these fields give callers a signal to surface. Three drift modes, each at a
+// deeper level of the nesting:
 //   - envelope drift: ResultsReached == false — the data.data.results[] array
 //     could not be walked (the envelope nesting changed or was renamed);
+//   - rows-key drift: ResultCount > 0 but RowsArraysReached == 0 — result objects
+//     were present, but none exposed a readable rows[] array (the per-result
+//     "rows" key was renamed/removed). The v5 contract always emits a "rows" key
+//     (an array, or null when empty), so this only happens on a shape change;
 //   - column-alias drift: RowsSeen > 0 but RowsEnriched == 0 — rows were present
-//     yet none carried a linkable id (the id column was renamed).
+//     yet none carried a linkable id (the id column alias was renamed).
 //
-// An ordinary empty result is ResultsReached == true with RowsSeen == 0.
-// ResultsReached is meaningful only when a base was supplied (an empty base
-// returns early with the zero value, since enrichment was not attempted).
+// An ordinary empty result is ResultsReached == true with either ResultCount == 0
+// or RowsArraysReached > 0 && RowsSeen == 0 (a present-but-empty rows[]). All
+// fields are meaningful only when a base was supplied (an empty base returns
+// early with the zero value, since enrichment was not attempted).
 type InjectRowsResult struct {
-	ResultsReached bool
-	RowsSeen       int
-	RowsEnriched   int
+	ResultsReached    bool
+	ResultCount       int
+	RowsArraysReached int
+	RowsSeen          int
+	RowsEnriched      int
 }
 
 // InjectRowsWebURL adds a per-row webUrl deep link to a query-builder v5 "raw"
@@ -135,6 +143,7 @@ func InjectRowsWebURL(data []byte, base, resourceType, idKey string) ([]byte, In
 		return data, res
 	}
 	res.ResultsReached = true
+	res.ResultCount = len(results)
 
 	changed := false
 	for ri, rawResult := range results {
@@ -142,10 +151,18 @@ func InjectRowsWebURL(data []byte, base, resourceType, idKey string) ([]byte, In
 		if !ok {
 			continue
 		}
-		var rows []json.RawMessage
-		if err := json.Unmarshal(result["rows"], &rows); err != nil || rows == nil {
-			continue
+		rawRows, present := result["rows"]
+		if !present {
+			continue // "rows" key absent — always present in the v5 contract, so this is drift
 		}
+		var rows []json.RawMessage
+		if err := json.Unmarshal(rawRows, &rows); err != nil {
+			continue // "rows" present but not an array (renamed to a different type) — drift
+		}
+		// A present "rows" that decodes as an array or null (rows == nil) means the
+		// per-result shape is intact even when empty — count it so an ordinary
+		// empty result is not mistaken for rows-key drift.
+		res.RowsArraysReached++
 
 		rowsChanged := false
 		for i, rawRow := range rows {

--- a/pkg/util/weburl_inject_test.go
+++ b/pkg/util/weburl_inject_test.go
@@ -119,7 +119,7 @@ func rawTracesBody() []byte {
 }
 
 func TestInjectRowsWebURL_InjectsPerRow(t *testing.T) {
-	out := InjectRowsWebURL(rawTracesBody(), "https://signoz.example.com", "trace", "traceID")
+	out, _ := InjectRowsWebURL(rawTracesBody(), "https://signoz.example.com", "trace", "traceID")
 	s := string(out)
 
 	if !strings.Contains(s, `"webUrl":"https://signoz.example.com/trace/abc-123"`) {
@@ -134,7 +134,7 @@ func TestInjectRowsWebURL_PreservesLargeInt64(t *testing.T) {
 	// 2^53 + 1: a durationNano-style int64 that loses precision if coerced
 	// through float64. The shallow RawMessage decode must pass it through verbatim.
 	const bigInt = "9007199254740993"
-	out := InjectRowsWebURL(rawTracesBody(), "https://signoz.example.com", "trace", "traceID")
+	out, _ := InjectRowsWebURL(rawTracesBody(), "https://signoz.example.com", "trace", "traceID")
 	s := string(out)
 
 	if !strings.Contains(s, bigInt) {
@@ -147,7 +147,7 @@ func TestInjectRowsWebURL_PreservesLargeInt64(t *testing.T) {
 
 func TestInjectRowsWebURL_NoBaseReturnsOriginal(t *testing.T) {
 	in := rawTracesBody()
-	out := InjectRowsWebURL(in, "", "trace", "traceID")
+	out, _ := InjectRowsWebURL(in, "", "trace", "traceID")
 	if string(out) != string(in) {
 		t.Fatalf("expected original bytes when base empty, got: %s", out)
 	}
@@ -160,7 +160,7 @@ func TestInjectRowsWebURL_MissingOrEmptyIDLeftUntouched(t *testing.T) {
 		`{"timestamp":"t","data":{"traceID":"","name":"empty-id"}},` +
 		`{"timestamp":"t","data":{"traceID":"ok-789","name":"good"}}` +
 		`]}]},"meta":{}}}`)
-	out := InjectRowsWebURL(in, "https://signoz.example.com", "trace", "traceID")
+	out, _ := InjectRowsWebURL(in, "https://signoz.example.com", "trace", "traceID")
 	s := string(out)
 
 	if strings.Count(s, `"webUrl"`) != 1 {
@@ -181,7 +181,7 @@ func TestInjectRowsWebURL_PreservesSiblingBytesVerbatim(t *testing.T) {
 	in := []byte(`{"status":"success","data":{"type":"raw","data":{"results":[{"queryName":"A","nextCursor":"zKey","rows":[` +
 		`{"timestamp":"t","data":{"traceID":"abc-123","durationNano":9007199254740993}}` +
 		`]}]},"meta":{"rowsScanned":2.50}}}`)
-	out := InjectRowsWebURL(in, "https://signoz.example.com", "trace", "traceID")
+	out, _ := InjectRowsWebURL(in, "https://signoz.example.com", "trace", "traceID")
 	s := string(out)
 
 	if !strings.Contains(s, `"nextCursor":"zKey"`) {
@@ -210,7 +210,7 @@ func TestInjectRowsWebURL_MalformedReturnsOriginal(t *testing.T) {
 	}
 	for name, in := range cases {
 		t.Run(name, func(t *testing.T) {
-			out := InjectRowsWebURL(in, "https://signoz.example.com", "trace", "traceID")
+			out, _ := InjectRowsWebURL(in, "https://signoz.example.com", "trace", "traceID")
 			if string(out) != string(in) {
 				t.Fatalf("expected original bytes unchanged, got: %s", out)
 			}
@@ -224,7 +224,7 @@ func TestInjectRowsWebURL_OverwritesExistingWebURL(t *testing.T) {
 	in := []byte(`{"status":"success","data":{"type":"raw","data":{"results":[{"rows":[` +
 		`{"data":{"traceID":"abc-123","webUrl":"https://stale.example.com/trace/old"}}` +
 		`]}]},"meta":{}}}`)
-	out := InjectRowsWebURL(in, "https://signoz.example.com", "trace", "traceID")
+	out, _ := InjectRowsWebURL(in, "https://signoz.example.com", "trace", "traceID")
 	s := string(out)
 
 	if strings.Count(s, `"webUrl"`) != 1 {
@@ -244,7 +244,7 @@ func TestInjectRowsWebURL_EscapesTraceID(t *testing.T) {
 	in := []byte(`{"status":"success","data":{"type":"raw","data":{"results":[{"rows":[` +
 		`{"data":{"traceID":"a/b c"}}` +
 		`]}]},"meta":{}}}`)
-	out := InjectRowsWebURL(in, "https://signoz.example.com", "trace", "traceID")
+	out, _ := InjectRowsWebURL(in, "https://signoz.example.com", "trace", "traceID")
 	s := string(out)
 
 	if !strings.Contains(s, `"webUrl":"https://signoz.example.com/trace/a%2Fb%20c"`) {
@@ -259,7 +259,7 @@ func TestInjectRowsWebURL_MultipleResultsMixed(t *testing.T) {
 		`{"queryName":"A","rows":[{"data":{"traceID":"a-1"}},{"data":{"name":"no-id"}}]},` +
 		`{"queryName":"B","rows":[{"data":{"traceID":"b-1"}}]}` +
 		`]},"meta":{}}}`)
-	out := InjectRowsWebURL(in, "https://signoz.example.com", "trace", "traceID")
+	out, _ := InjectRowsWebURL(in, "https://signoz.example.com", "trace", "traceID")
 	s := string(out)
 
 	if !strings.Contains(s, `"webUrl":"https://signoz.example.com/trace/a-1"`) {
@@ -270,5 +270,35 @@ func TestInjectRowsWebURL_MultipleResultsMixed(t *testing.T) {
 	}
 	if strings.Count(s, `"webUrl"`) != 2 {
 		t.Fatalf("expected exactly two webUrls (one per good row across results), got: %s", s)
+	}
+}
+
+func TestInjectRowsWebURL_ReportsCounts(t *testing.T) {
+	// Happy path: two rows seen, two enriched.
+	_, res := InjectRowsWebURL(rawTracesBody(), "https://signoz.example.com", "trace", "traceID")
+	if res.RowsSeen != 2 || res.RowsEnriched != 2 {
+		t.Fatalf("happy path: got RowsSeen=%d RowsEnriched=%d, want 2/2", res.RowsSeen, res.RowsEnriched)
+	}
+}
+
+func TestInjectRowsWebURL_ReportsShapeDriftVsNoData(t *testing.T) {
+	// Probable upstream shape change: rows ARE present but none carry the
+	// expected id key, so RowsSeen > 0 while RowsEnriched == 0. This is the
+	// signal the handler turns into a WARN. The body is still returned verbatim.
+	drift := rawTracesBody()
+	out, res := InjectRowsWebURL(drift, "https://signoz.example.com", "trace", "trace_id") // wrong key
+	if res.RowsSeen == 0 || res.RowsEnriched != 0 {
+		t.Fatalf("drift: got RowsSeen=%d RowsEnriched=%d, want RowsSeen>0 and RowsEnriched==0", res.RowsSeen, res.RowsEnriched)
+	}
+	if string(out) != string(drift) {
+		t.Fatalf("drift must return original bytes unchanged, got: %s", out)
+	}
+
+	// Ordinary "no data": no rows at all, so RowsSeen == 0 — the handler stays
+	// silent (no false drift warning).
+	noData := []byte(`{"status":"success","data":{"type":"raw","data":{"results":[{"queryName":"A","rows":[]}]}},"meta":{}}`)
+	_, res = InjectRowsWebURL(noData, "https://signoz.example.com", "trace", "traceID")
+	if res.RowsSeen != 0 || res.RowsEnriched != 0 {
+		t.Fatalf("no-data: got RowsSeen=%d RowsEnriched=%d, want 0/0", res.RowsSeen, res.RowsEnriched)
 	}
 }

--- a/pkg/util/weburl_inject_test.go
+++ b/pkg/util/weburl_inject_test.go
@@ -274,31 +274,56 @@ func TestInjectRowsWebURL_MultipleResultsMixed(t *testing.T) {
 }
 
 func TestInjectRowsWebURL_ReportsCounts(t *testing.T) {
-	// Happy path: two rows seen, two enriched.
+	// Happy path: results reached, two rows seen, two enriched.
 	_, res := InjectRowsWebURL(rawTracesBody(), "https://signoz.example.com", "trace", "traceID")
-	if res.RowsSeen != 2 || res.RowsEnriched != 2 {
-		t.Fatalf("happy path: got RowsSeen=%d RowsEnriched=%d, want 2/2", res.RowsSeen, res.RowsEnriched)
+	if !res.ResultsReached || res.RowsSeen != 2 || res.RowsEnriched != 2 {
+		t.Fatalf("happy path: got ResultsReached=%v RowsSeen=%d RowsEnriched=%d, want true/2/2",
+			res.ResultsReached, res.RowsSeen, res.RowsEnriched)
 	}
 }
 
-func TestInjectRowsWebURL_ReportsShapeDriftVsNoData(t *testing.T) {
-	// Probable upstream shape change: rows ARE present but none carry the
-	// expected id key, so RowsSeen > 0 while RowsEnriched == 0. This is the
-	// signal the handler turns into a WARN. The body is still returned verbatim.
+func TestInjectRowsWebURL_ReportsColumnAliasDriftVsNoData(t *testing.T) {
+	// Column-alias drift: results reached and rows ARE present, but none carry
+	// the expected id key, so RowsSeen > 0 while RowsEnriched == 0. The handler
+	// turns this into a WARN. The body is still returned verbatim.
 	drift := rawTracesBody()
 	out, res := InjectRowsWebURL(drift, "https://signoz.example.com", "trace", "trace_id") // wrong key
-	if res.RowsSeen == 0 || res.RowsEnriched != 0 {
-		t.Fatalf("drift: got RowsSeen=%d RowsEnriched=%d, want RowsSeen>0 and RowsEnriched==0", res.RowsSeen, res.RowsEnriched)
+	if !res.ResultsReached || res.RowsSeen == 0 || res.RowsEnriched != 0 {
+		t.Fatalf("drift: got ResultsReached=%v RowsSeen=%d RowsEnriched=%d, want true/>0/0",
+			res.ResultsReached, res.RowsSeen, res.RowsEnriched)
 	}
 	if string(out) != string(drift) {
 		t.Fatalf("drift must return original bytes unchanged, got: %s", out)
 	}
 
-	// Ordinary "no data": no rows at all, so RowsSeen == 0 — the handler stays
+	// Ordinary "no data": results reached but zero rows — the handler stays
 	// silent (no false drift warning).
 	noData := []byte(`{"status":"success","data":{"type":"raw","data":{"results":[{"queryName":"A","rows":[]}]}},"meta":{}}`)
 	_, res = InjectRowsWebURL(noData, "https://signoz.example.com", "trace", "traceID")
-	if res.RowsSeen != 0 || res.RowsEnriched != 0 {
-		t.Fatalf("no-data: got RowsSeen=%d RowsEnriched=%d, want 0/0", res.RowsSeen, res.RowsEnriched)
+	if !res.ResultsReached || res.RowsSeen != 0 || res.RowsEnriched != 0 {
+		t.Fatalf("no-data: got ResultsReached=%v RowsSeen=%d RowsEnriched=%d, want true/0/0",
+			res.ResultsReached, res.RowsSeen, res.RowsEnriched)
+	}
+}
+
+func TestInjectRowsWebURL_FlagsUnwalkableEnvelope(t *testing.T) {
+	// Envelope drift: the response carries data, but results[] is renamed/moved
+	// so the expected nesting can't be walked. ResultsReached must be false
+	// (distinct from an empty result), and the body is returned verbatim.
+	cases := map[string][]byte{
+		"results renamed":    []byte(`{"status":"success","data":{"type":"raw","data":{"rezults":[{"rows":[{"data":{"traceID":"x"}}]}]}},"meta":{}}`),
+		"inner data renamed": []byte(`{"status":"success","data":{"type":"raw","payload":{"results":[{"rows":[{"data":{"traceID":"x"}}]}]}},"meta":{}}`),
+		"results not array":  []byte(`{"status":"success","data":{"type":"raw","data":{"results":{"rows":[]}}}}`),
+	}
+	for name, in := range cases {
+		t.Run(name, func(t *testing.T) {
+			out, res := InjectRowsWebURL(in, "https://signoz.example.com", "trace", "traceID")
+			if res.ResultsReached {
+				t.Fatalf("expected ResultsReached=false for unwalkable envelope, got true")
+			}
+			if string(out) != string(in) {
+				t.Fatalf("expected original bytes unchanged, got: %s", out)
+			}
+		})
 	}
 }

--- a/pkg/util/weburl_inject_test.go
+++ b/pkg/util/weburl_inject_test.go
@@ -105,3 +105,170 @@ func TestInjectWebURL_MalformedReturnsOriginal(t *testing.T) {
 		t.Fatalf("expected original bytes for malformed body, got: %s", out)
 	}
 }
+
+// rawTracesBody returns a realistic query-builder v5 "raw" passthrough body — a
+// render.Success envelope wrapping QueryRangeResponse — with two rows. The
+// second row's durationNano exceeds float64's exact-integer range to guard the
+// precision bug. The selected trace-id field is "traceID", matching the column
+// alias the backend emits for the traceID select field.
+func rawTracesBody() []byte {
+	return []byte(`{"status":"success","data":{"type":"raw","data":{"results":[{"queryName":"A","rows":[` +
+		`{"timestamp":"2026-06-19T10:00:00Z","data":{"traceID":"abc-123","durationNano":9007199254740993,"name":"GET /cart"}},` +
+		`{"timestamp":"2026-06-19T10:00:01Z","data":{"traceID":"def-456","durationNano":42,"name":"POST /checkout"}}` +
+		`]}]},"meta":{}}}`)
+}
+
+func TestInjectRowsWebURL_InjectsPerRow(t *testing.T) {
+	out := InjectRowsWebURL(rawTracesBody(), "https://signoz.example.com", "trace", "traceID")
+	s := string(out)
+
+	if !strings.Contains(s, `"webUrl":"https://signoz.example.com/trace/abc-123"`) {
+		t.Fatalf("first row webUrl missing: %s", s)
+	}
+	if !strings.Contains(s, `"webUrl":"https://signoz.example.com/trace/def-456"`) {
+		t.Fatalf("second row webUrl missing: %s", s)
+	}
+}
+
+func TestInjectRowsWebURL_PreservesLargeInt64(t *testing.T) {
+	// 2^53 + 1: a durationNano-style int64 that loses precision if coerced
+	// through float64. The shallow RawMessage decode must pass it through verbatim.
+	const bigInt = "9007199254740993"
+	out := InjectRowsWebURL(rawTracesBody(), "https://signoz.example.com", "trace", "traceID")
+	s := string(out)
+
+	if !strings.Contains(s, bigInt) {
+		t.Fatalf("large int64 lost precision: %s", s)
+	}
+	if strings.Contains(s, "9.007") || strings.Contains(s, "e+") || strings.Contains(s, "E+") {
+		t.Fatalf("int64 was coerced to float: %s", s)
+	}
+}
+
+func TestInjectRowsWebURL_NoBaseReturnsOriginal(t *testing.T) {
+	in := rawTracesBody()
+	out := InjectRowsWebURL(in, "", "trace", "traceID")
+	if string(out) != string(in) {
+		t.Fatalf("expected original bytes when base empty, got: %s", out)
+	}
+}
+
+func TestInjectRowsWebURL_MissingOrEmptyIDLeftUntouched(t *testing.T) {
+	// One row has no traceID, one has an empty traceID, one is well-formed.
+	in := []byte(`{"status":"success","data":{"type":"raw","data":{"results":[{"queryName":"A","rows":[` +
+		`{"timestamp":"t","data":{"name":"no-id"}},` +
+		`{"timestamp":"t","data":{"traceID":"","name":"empty-id"}},` +
+		`{"timestamp":"t","data":{"traceID":"ok-789","name":"good"}}` +
+		`]}]},"meta":{}}}`)
+	out := InjectRowsWebURL(in, "https://signoz.example.com", "trace", "traceID")
+	s := string(out)
+
+	if strings.Count(s, `"webUrl"`) != 1 {
+		t.Fatalf("expected exactly one webUrl (only the well-formed row), got: %s", s)
+	}
+	if !strings.Contains(s, `"webUrl":"https://signoz.example.com/trace/ok-789"`) {
+		t.Fatalf("well-formed row webUrl missing: %s", s)
+	}
+	if strings.Contains(s, `/trace/"`) {
+		t.Fatalf("emitted a broken empty-id webUrl: %s", s)
+	}
+}
+
+func TestInjectRowsWebURL_PreservesSiblingBytesVerbatim(t *testing.T) {
+	// Fields outside the mutated row "data" object — and sibling rows — must pass
+	// through verbatim; a full-tree re-marshal would reorder keys or reformat
+	// numbers. nextCursor and the meta block sit alongside the mutated results.
+	in := []byte(`{"status":"success","data":{"type":"raw","data":{"results":[{"queryName":"A","nextCursor":"zKey","rows":[` +
+		`{"timestamp":"t","data":{"traceID":"abc-123","durationNano":9007199254740993}}` +
+		`]}]},"meta":{"rowsScanned":2.50}}}`)
+	out := InjectRowsWebURL(in, "https://signoz.example.com", "trace", "traceID")
+	s := string(out)
+
+	if !strings.Contains(s, `"nextCursor":"zKey"`) {
+		t.Fatalf("sibling nextCursor not preserved verbatim: %s", s)
+	}
+	if !strings.Contains(s, `"meta":{"rowsScanned":2.50}`) {
+		t.Fatalf("sibling meta not preserved verbatim (number reformatted?): %s", s)
+	}
+	if !strings.Contains(s, `"webUrl":"https://signoz.example.com/trace/abc-123"`) {
+		t.Fatalf("row webUrl missing: %s", s)
+	}
+}
+
+func TestInjectRowsWebURL_MalformedReturnsOriginal(t *testing.T) {
+	cases := map[string][]byte{
+		"not json":            []byte(`not json`),
+		"null body":           []byte(`null`),
+		"array body":          []byte(`[1,2,3]`),
+		"no data envelope":    []byte(`{"status":"success"}`),
+		"no inner data":       []byte(`{"status":"success","data":{"type":"raw"}}`),
+		"results not array":   []byte(`{"status":"success","data":{"type":"raw","data":{"results":{}}}}`),
+		"rows missing":        []byte(`{"status":"success","data":{"type":"raw","data":{"results":[{"queryName":"A"}]}}}`),
+		"empty results array": []byte(`{"status":"success","data":{"type":"raw","data":{"results":[]}}}`),
+		"row not object":      []byte(`{"status":"success","data":{"type":"raw","data":{"results":[{"rows":[1,2]}]}}}`),
+		"row data not object": []byte(`{"status":"success","data":{"type":"raw","data":{"results":[{"rows":[{"data":5}]}]}}}`),
+	}
+	for name, in := range cases {
+		t.Run(name, func(t *testing.T) {
+			out := InjectRowsWebURL(in, "https://signoz.example.com", "trace", "traceID")
+			if string(out) != string(in) {
+				t.Fatalf("expected original bytes unchanged, got: %s", out)
+			}
+		})
+	}
+}
+
+func TestInjectRowsWebURL_OverwritesExistingWebURL(t *testing.T) {
+	// A row that already carries a (stale) webUrl must end up with the freshly
+	// built one and exactly one webUrl key — never a duplicate.
+	in := []byte(`{"status":"success","data":{"type":"raw","data":{"results":[{"rows":[` +
+		`{"data":{"traceID":"abc-123","webUrl":"https://stale.example.com/trace/old"}}` +
+		`]}]},"meta":{}}}`)
+	out := InjectRowsWebURL(in, "https://signoz.example.com", "trace", "traceID")
+	s := string(out)
+
+	if strings.Count(s, `"webUrl"`) != 1 {
+		t.Fatalf("expected exactly one webUrl after overwrite, got: %s", s)
+	}
+	if !strings.Contains(s, `"webUrl":"https://signoz.example.com/trace/abc-123"`) {
+		t.Fatalf("stale webUrl not overwritten: %s", s)
+	}
+	if strings.Contains(s, "stale.example.com") {
+		t.Fatalf("stale webUrl still present: %s", s)
+	}
+}
+
+func TestInjectRowsWebURL_EscapesTraceID(t *testing.T) {
+	// Trace ids flow through url.PathEscape in ResourceWebURL; a value with
+	// reserved characters must be percent-encoded in the row's webUrl.
+	in := []byte(`{"status":"success","data":{"type":"raw","data":{"results":[{"rows":[` +
+		`{"data":{"traceID":"a/b c"}}` +
+		`]}]},"meta":{}}}`)
+	out := InjectRowsWebURL(in, "https://signoz.example.com", "trace", "traceID")
+	s := string(out)
+
+	if !strings.Contains(s, `"webUrl":"https://signoz.example.com/trace/a%2Fb%20c"`) {
+		t.Fatalf("trace id not escaped in webUrl: %s", s)
+	}
+}
+
+func TestInjectRowsWebURL_MultipleResultsMixed(t *testing.T) {
+	// Enrichment must span every result in the array (not just the first) and
+	// skip malformed rows within each result independently.
+	in := []byte(`{"status":"success","data":{"type":"raw","data":{"results":[` +
+		`{"queryName":"A","rows":[{"data":{"traceID":"a-1"}},{"data":{"name":"no-id"}}]},` +
+		`{"queryName":"B","rows":[{"data":{"traceID":"b-1"}}]}` +
+		`]},"meta":{}}}`)
+	out := InjectRowsWebURL(in, "https://signoz.example.com", "trace", "traceID")
+	s := string(out)
+
+	if !strings.Contains(s, `"webUrl":"https://signoz.example.com/trace/a-1"`) {
+		t.Fatalf("first result row not linked: %s", s)
+	}
+	if !strings.Contains(s, `"webUrl":"https://signoz.example.com/trace/b-1"`) {
+		t.Fatalf("second result (queryName B) row not linked: %s", s)
+	}
+	if strings.Count(s, `"webUrl"`) != 2 {
+		t.Fatalf("expected exactly two webUrls (one per good row across results), got: %s", s)
+	}
+}

--- a/pkg/util/weburl_inject_test.go
+++ b/pkg/util/weburl_inject_test.go
@@ -327,3 +327,43 @@ func TestInjectRowsWebURL_FlagsUnwalkableEnvelope(t *testing.T) {
 		})
 	}
 }
+
+func TestInjectRowsWebURL_FlagsRowsKeyDrift(t *testing.T) {
+	// results[] IS reachable and non-empty, but the per-result "rows" key is
+	// renamed/removed/wrong-type so no rows array can be read. This must read as
+	// drift (ResultCount > 0, RowsArraysReached == 0), distinct from an empty
+	// result. The body is returned verbatim.
+	drift := map[string][]byte{
+		"rows renamed": []byte(`{"status":"success","data":{"type":"raw","data":{"results":[{"queryName":"A","records":[{"data":{"traceID":"x"}}]}]}},"meta":{}}`),
+		"rows absent":  []byte(`{"status":"success","data":{"type":"raw","data":{"results":[{"queryName":"A"}]}},"meta":{}}`),
+		"rows object":  []byte(`{"status":"success","data":{"type":"raw","data":{"results":[{"queryName":"A","rows":{"0":{"data":{"traceID":"x"}}}}]}},"meta":{}}`),
+	}
+	for name, in := range drift {
+		t.Run(name, func(t *testing.T) {
+			out, res := InjectRowsWebURL(in, "https://signoz.example.com", "trace", "traceID")
+			if !res.ResultsReached || res.ResultCount == 0 || res.RowsArraysReached != 0 {
+				t.Fatalf("%s: got ResultsReached=%v ResultCount=%d RowsArraysReached=%d, want true/>0/0",
+					name, res.ResultsReached, res.ResultCount, res.RowsArraysReached)
+			}
+			if string(out) != string(in) {
+				t.Fatalf("%s: expected original bytes unchanged, got: %s", name, out)
+			}
+		})
+	}
+
+	// Genuinely empty results (present-but-empty or null rows[]) must NOT read as
+	// drift: the "rows" key is present, so RowsArraysReached > 0 and RowsSeen == 0.
+	empty := map[string][]byte{
+		"rows empty array": []byte(`{"status":"success","data":{"type":"raw","data":{"results":[{"queryName":"A","rows":[]}]}},"meta":{}}`),
+		"rows null":        []byte(`{"status":"success","data":{"type":"raw","data":{"results":[{"queryName":"A","rows":null}]}},"meta":{}}`),
+	}
+	for name, in := range empty {
+		t.Run(name, func(t *testing.T) {
+			_, res := InjectRowsWebURL(in, "https://signoz.example.com", "trace", "traceID")
+			if res.RowsArraysReached == 0 || res.RowsSeen != 0 {
+				t.Fatalf("%s: got RowsArraysReached=%d RowsSeen=%d, want >0/0 (not drift)",
+					name, res.RowsArraysReached, res.RowsSeen)
+			}
+		})
+	}
+}

--- a/plans/resource-web-urls.context.md
+++ b/plans/resource-web-urls.context.md
@@ -71,3 +71,31 @@
   when empty.
 - [x] Should traces get a `webUrl`? — Yes; `/trace/<traceId>` is a clean single-id
   route. Scoped to `get_trace_details` (not `search_traces`).
+
+### 2026-06-19 — enrich search_traces with per-row webUrl (#245, signoz-mcp-server#206)
+- Reverses the earlier "`search_traces` is NOT enriched" decision (2026-06-10
+  trace entry above; append-only, so that entry stays as the record of why we
+  initially scoped it out).
+- The original concern was that `traceId` lived in "dynamic query columns, not a
+  stable top-level key." On inspection the key IS stable: the v5 raw response
+  nests as `data.data.results[].rows[].data.traceID`, and the trace field-mapper
+  aliases each selected column to its `field.Name`, so the `traceID` select
+  field always yields a `traceID` row-data key. Confirmed against the SigNoz
+  backend: `querybuildertypesv5/resp.go` (`QueryRangeResponse`/`RawData`/`RawRow`),
+  `querier/consume.go` (`readAsRaw`), `telemetrytraces/field_mapper.go`
+  (`ColumnExpressionFor`), `http/render/render.go` (`Success` envelope).
+- Why now: the AI assistant only links a `webUrl` a tool returned and never
+  hand-builds URLs, so the common trace path (`search_traces` → "show me slow /
+  error traces") produced no clickable links; `get_trace_details` alone was
+  insufficient.
+- Implementation: new `util.InjectRowsWebURL(data, base, type, idKey)` walks the
+  rows and injects a per-row `webUrl` sibling, reusing `ResourceWebURL`. Same
+  shallow-RawMessage decode as `InjectWebURL` (preserves `durationNano` int64
+  precision, sibling bytes, and key order). Whole-body fail-open on shape
+  mismatch / empty base; per-row best-effort skips a row whose id is
+  missing/empty/non-string rather than dropping links for the whole result.
+  Wired via `enrichSearchTracesWebURL` in `handleSearchTraces`.
+- [x] Should `search_traces` rows get a `webUrl`? — Yes (reverses 2026-06-10);
+  the `traceID` row-data key is stable and enrichment fails open per row.
+- [x] Should `search_logs` get the same? — No; logs have no single-resource deep
+  link in `ResourceWebURL`, so there is nothing to inject.

--- a/plans/resource-web-urls.plan.md
+++ b/plans/resource-web-urls.plan.md
@@ -10,8 +10,8 @@ link in the MCP server keeps a single source of truth and benefits all MCP clien
 (including Cursor / Claude Desktop, which are not same-origin as the SigNoz
 instance).
 
-This adds a `webUrl` deep-link field to the dashboard, alert, and service resource
-read-tool outputs.
+This adds a `webUrl` deep-link field to the dashboard, alert, service, and trace
+resource read-tool outputs.
 
 ## Approach
 
@@ -28,6 +28,11 @@ read-tool outputs.
   `{"data":{…}}` wrap — so nested values (span trees, int64 fields, number
   formatting, key order) pass through as verbatim bytes with no re-encoding.
   Fails open on any non-object or unparseable body, including literal `null`.
+- `InjectRowsWebURL(data, base, type, idKey) []byte` for v5 raw list bodies:
+  walks `data.data.results[].rows[]` and injects a per-row `webUrl` built from
+  `rows[].data[idKey]`, with the same shallow-decode guarantees. Whole-body
+  fail-open on shape mismatch / empty base; per-row best-effort skips a row whose
+  id is missing/empty/non-string rather than dropping links for the whole result.
 
 ### `internal/handler/tools/dashboards.go`
 - Enrich list items in `handleListDashboards`.
@@ -44,8 +49,13 @@ read-tool outputs.
 ### `internal/handler/tools/traces.go`
 - Enrich the `handleGetTraceDetails` passthrough body via `enrichTraceWebURL`
   (wrapped `{"data":{…}}` + bare, fail-open), using the `traceId` arg.
-- `search_traces` is not enriched (trace id lives in dynamic query rows, not a
-  stable top-level key).
+- Enrich the `handleSearchTraces` passthrough body via `enrichSearchTracesWebURL`
+  (delegates to `util.InjectRowsWebURL`), injecting a per-row `webUrl` into each
+  v5 raw result row at `data.data.results[].rows[].data.traceID`. The `traceID`
+  row-data key is stable: the trace field-mapper aliases each selected column to
+  its `field.Name`, so the `traceID` select field always yields a `traceID` key.
+  Per-row best-effort + whole-body fail-open keep a malformed row from corrupting
+  the response.
 
 ### Omission rule
 - `webUrl` is omitted when `util.GetSigNozURL(ctx)` is empty (no instance URL on the
@@ -58,7 +68,7 @@ read-tool outputs.
 - `internal/handler/tools/services.go` — enrich list
 - `internal/handler/tools/alerts.go` — enrich list/list-rules/get
 - `pkg/types/alerts.go` — `WebURL` field on `Alert` / `AlertRuleSummary`
-- `internal/handler/tools/traces.go` — enrich `get_trace_details`
+- `internal/handler/tools/traces.go` — enrich `get_trace_details` + `search_traces`
 - `README.md` — note on the `webUrl` output field
 - `plans/resource-web-urls.*` — this pair
 


### PR DESCRIPTION
## Summary

`signoz_get_trace_details` already stamps a `webUrl` deep link onto its single-trace result (#197), but `signoz_search_traces` did not — it returned the raw query-builder v5 rows untouched. The downstream SigNoz AI assistant only links a `webUrl` that a tool returned and is forbidden from hand-building URLs, so the **most common trace path** ("show me slow / error traces" → `signoz_search_traces`) produced no clickable trace links and the agent would say it couldn't create one.

This adds a per-row `webUrl` to `signoz_search_traces` results, mirroring the existing single-trace enrichment.

## Changes

- **`pkg/util/weburl.go`** — new `InjectRowsWebURL(data, base, resourceType, idKey)`. Walks the v5 raw response (`data.data.results[].rows[].data`), reads each row's id (`traceID`), and injects a `webUrl` sibling of the form `<base>/trace/<traceID>` via the existing `util.ResourceWebURL`. Decodes only as deep as each mutated level — siblings (large int64s like `durationNano`, number formatting, key order) stay verbatim `json.RawMessage`. Fails open: empty base, shape mismatch, missing/empty/non-string id, or any marshal error returns the original bytes unchanged, so enrichment can never corrupt a working response.
- **`internal/handler/tools/traces.go`** — `enrichSearchTracesWebURL(ctx, data)` (mirrors `enrichTraceWebURL` → `InjectWebURL`), wired into `handleSearchTraces` right before `rawSearchResult(...)`.

### Response-shape provenance

The v5 raw passthrough is a `render.Success` envelope wrapping `QueryRangeResponse`, nesting as `data.data.results[].rows[].data.traceID`. The row-data key is exactly `traceID` (not `trace_id`) because the trace field-mapper aliases each selected column to its `field.Name`. Confirmed against the SigNoz backend: `querybuildertypesv5/resp.go` (`QueryRangeResponse`/`RawData`/`RawRow`), `querier/consume.go` (`readAsRaw`), `telemetrytraces/field_mapper.go` (`ColumnExpressionFor`), and `http/render/render.go` (`Success`).

## Tests

`pkg/util/weburl_inject_test.go` (8 cases) + `internal/handler/tools/traces_test.go` (2 handler cases):

- per-row injection across one and **multiple** results; bad/good rows skipped independently
- large int64 (`durationNano` > 2^53) round-trips with exact precision
- sibling bytes (`nextCursor`, `2.50`) preserved verbatim — no full-tree reformat
- missing / empty / non-string id left untouched (no broken `/trace/` link)
- **idempotency** — a pre-existing `webUrl` is overwritten, exactly one per row
- **escaping** — `traceID` flows through `url.PathEscape`
- 10 malformed / shape-mismatch bodies all return original bytes unchanged

`gofmt -l`, `go vet ./...`, `go build ./...`, `go test ./...` all clean.

Reviewed with Codex (gpt-5.5, xhigh): independently confirmed the response-shape derivation, precision preservation, escaping, and no-input-mutation; no real bugs found.

## Notes

- Scope is traces only. `signoz_search_logs` has the same missing-`webUrl` pattern, but logs have no single-resource deep link in `ResourceWebURL`, so there's nothing to inject — left untouched intentionally.

https://claude.ai/code/session_017VzwTwX2Zv5g4S7NXcpJSj
