### PR TITLE
fix(tools): prevent nil-Arguments panic in MCP tool handlers

### DIFF
--- a/internal/handler/tools/alerts.go
+++ b/internal/handler/tools/alerts.go
@@ -138,7 +138,7 @@ func parseBoolParam(args map[string]any, key string) *bool {
 
 func (h *Handler) handleListAlerts(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	h.logger.DebugContext(ctx, "Tool called: signoz_list_alerts")
-	args := req.Params.Arguments.(map[string]any)
+	args := req.GetArguments()
 	limit, offset := paginate.ParseParams(args)
 
 	params := types.ListAlertsParams{
@@ -271,7 +271,7 @@ func (h *Handler) handleListAlertRules(ctx context.Context, req mcp.CallToolRequ
 }
 
 func (h *Handler) handleGetAlert(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-	ruleID, ok := req.Params.Arguments.(map[string]any)["ruleId"].(string)
+	ruleID, ok := req.GetArguments()["ruleId"].(string)
 	if !ok {
 		h.logger.WarnContext(ctx, "Invalid ruleId parameter type", slog.Any("type", req.Params.Arguments))
 		return mcp.NewToolResultError(`Parameter validation failed: "ruleId" must be a string. Example: {"ruleId": "0196634d-5d66-75c4-b778-e317f49dab7a"}`), nil
@@ -305,7 +305,7 @@ func enrichAlertWebURL(ctx context.Context, data []byte, ruleID string) []byte {
 }
 
 func (h *Handler) handleGetAlertHistory(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-	args := req.Params.Arguments.(map[string]any)
+	args := req.GetArguments()
 
 	ruleID, ok := args["ruleId"].(string)
 	if !ok || ruleID == "" {

--- a/internal/handler/tools/dashboards.go
+++ b/internal/handler/tools/dashboards.go
@@ -206,7 +206,7 @@ func (h *Handler) handleListDashboards(ctx context.Context, req mcp.CallToolRequ
 }
 
 func (h *Handler) handleGetDashboard(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-	uuid, ok := req.Params.Arguments.(map[string]any)["uuid"].(string)
+	uuid, ok := req.GetArguments()["uuid"].(string)
 	if !ok {
 		h.logger.WarnContext(ctx, "Invalid uuid parameter type", slog.Any("type", req.Params.Arguments))
 		return mcp.NewToolResultError(`Parameter validation failed: "uuid" must be a string. Example: {"uuid": "a1b2c3d4-e5f6-7890-abcd-ef1234567890"}`), nil
@@ -405,7 +405,7 @@ func (h *Handler) handleUpdateDashboard(ctx context.Context, req mcp.CallToolReq
 }
 
 func (h *Handler) handleDeleteDashboard(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-	uuid, ok := req.Params.Arguments.(map[string]any)["uuid"].(string)
+	uuid, ok := req.GetArguments()["uuid"].(string)
 	if !ok {
 		h.logger.WarnContext(ctx, "Invalid uuid parameter type", slog.Any("type", req.Params.Arguments))
 		return mcp.NewToolResultError(`Parameter validation failed: "uuid" must be a string. Example: {"uuid": "a1b2c3d4-e5f6-7890-abcd-ef1234567890"}`), nil

--- a/internal/handler/tools/metrics.go
+++ b/internal/handler/tools/metrics.go
@@ -84,7 +84,7 @@ func (h *Handler) RegisterMetricsHandlers(s *server.MCPServer) {
 }
 
 func (h *Handler) handleListMetrics(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-	args := req.Params.Arguments.(map[string]any)
+	args := req.GetArguments()
 
 	searchText, _ := args["searchText"].(string)
 	source, _ := args["source"].(string)

--- a/internal/handler/tools/metrics_query.go
+++ b/internal/handler/tools/metrics_query.go
@@ -22,7 +22,7 @@ type metricMetadata struct {
 }
 
 func (h *Handler) handleQueryMetrics(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-	args := req.Params.Arguments.(map[string]any)
+	args := req.GetArguments()
 
 	mqr, err := parseMetricsQueryArgs(args)
 	if err != nil {

--- a/internal/handler/tools/nil_arguments_test.go
+++ b/internal/handler/tools/nil_arguments_test.go
@@ -1,0 +1,106 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/mark3labs/mcp-go/mcp"
+
+	"github.com/SigNoz/signoz-mcp-server/internal/client"
+	"github.com/SigNoz/signoz-mcp-server/pkg/types"
+)
+
+// requestWithNilArguments builds a CallToolRequest whose Arguments field is an
+// untyped nil interface — exactly what the MCP framework delivers when a client
+// invokes a tool with no "arguments" object at all. This is distinct from an
+// empty map[string]any{}: an untyped nil fails a bare
+// req.Params.Arguments.(map[string]any) assertion and previously panicked with
+// "interface conversion: interface {} is nil, not map[string]interface {}".
+func requestWithNilArguments(toolName string) mcp.CallToolRequest {
+	return mcp.CallToolRequest{
+		Params: mcp.CallToolParams{Name: toolName},
+	}
+}
+
+// TestHandlers_NilArguments_NoPanic is a regression guard for the nil-Arguments
+// panic observed in production (signoz_get_alert / signoz_get_dashboard tool
+// handlers). Every handler that requires at least one argument must return a
+// validation error result — never panic — when invoked with no arguments.
+func TestHandlers_NilArguments_NoPanic(t *testing.T) {
+	h := newTestHandler(&client.MockClient{})
+
+	cases := []struct {
+		tool    string
+		handler func(context.Context, mcp.CallToolRequest) (*mcp.CallToolResult, error)
+	}{
+		{"signoz_get_alert", h.handleGetAlert},
+		{"signoz_get_alert_history", h.handleGetAlertHistory},
+		{"signoz_get_dashboard", h.handleGetDashboard},
+		{"signoz_delete_dashboard", h.handleDeleteDashboard},
+		{"signoz_get_trace_details", h.handleGetTraceDetails},
+		{"signoz_get_service_top_operations", h.handleGetServiceTopOperations},
+		{"signoz_query_metrics", h.handleQueryMetrics},
+		{"signoz_create_notification_channel", h.handleCreateNotificationChannel},
+		{"signoz_update_notification_channel", h.handleUpdateNotificationChannel},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.tool, func(t *testing.T) {
+			// A panic here fails the test, which is the primary thing we guard.
+			result, err := tc.handler(testCtx(), requestWithNilArguments(tc.tool))
+			if err != nil {
+				t.Fatalf("unexpected transport error: %v", err)
+			}
+			if result == nil {
+				t.Fatal("expected a non-nil result")
+			}
+			if !result.IsError {
+				t.Fatalf("expected a validation error result for missing arguments, got a success result")
+			}
+		})
+	}
+}
+
+// TestListHandlers_NilArguments_UseDefaults locks in the behavior that list-style
+// tools (whose arguments are all optional) succeed via their defaults when called
+// with no arguments — they must NOT be turned into a validation error by the
+// nil-Arguments fix. Same untyped-nil Arguments that previously panicked.
+func TestListHandlers_NilArguments_UseDefaults(t *testing.T) {
+	mock := &client.MockClient{
+		ListAlertsFn: func(ctx context.Context, params types.ListAlertsParams) (json.RawMessage, error) {
+			return json.RawMessage(`{"status":"success","data":[{"labels":{"alertname":"A","ruleId":"1","severity":"critical"},"startsAt":"","endsAt":"","status":{"state":"firing"}}]}`), nil
+		},
+		ListServicesFn: func(ctx context.Context, start, end string) (json.RawMessage, error) {
+			return json.RawMessage(`[{"serviceName":"svc"}]`), nil
+		},
+		ListMetricsFn: func(ctx context.Context, start, end int64, limit int, searchText, source string) (json.RawMessage, error) {
+			return json.RawMessage(`{"data":[]}`), nil
+		},
+	}
+	h := newTestHandler(mock)
+
+	cases := []struct {
+		tool    string
+		handler func(context.Context, mcp.CallToolRequest) (*mcp.CallToolResult, error)
+	}{
+		{"signoz_list_alerts", h.handleListAlerts},
+		{"signoz_list_services", h.handleListServices},
+		{"signoz_list_metrics", h.handleListMetrics},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.tool, func(t *testing.T) {
+			result, err := tc.handler(testCtx(), requestWithNilArguments(tc.tool))
+			if err != nil {
+				t.Fatalf("unexpected transport error: %v", err)
+			}
+			if result == nil {
+				t.Fatal("expected a non-nil result")
+			}
+			if result.IsError {
+				t.Fatalf("list tool with no arguments must succeed via defaults, got error result: %v", result.Content)
+			}
+		})
+	}
+}

--- a/internal/handler/tools/notification_channels.go
+++ b/internal/handler/tools/notification_channels.go
@@ -289,7 +289,7 @@ func (h *Handler) handleListNotificationChannels(ctx context.Context, req mcp.Ca
 func (h *Handler) handleCreateNotificationChannel(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	h.logger.DebugContext(ctx, "Tool called: signoz_create_notification_channel")
 
-	args := req.Params.Arguments.(map[string]any)
+	args := req.GetArguments()
 
 	// Validate required fields
 	channelType, _ := args["type"].(string)
@@ -369,7 +369,7 @@ func (h *Handler) handleCreateNotificationChannel(ctx context.Context, req mcp.C
 func (h *Handler) handleUpdateNotificationChannel(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	h.logger.DebugContext(ctx, "Tool called: signoz_update_notification_channel")
 
-	args := req.Params.Arguments.(map[string]any)
+	args := req.GetArguments()
 
 	// Validate id
 	id, _ := args["id"].(string)

--- a/internal/handler/tools/services.go
+++ b/internal/handler/tools/services.go
@@ -47,7 +47,7 @@ func (h *Handler) RegisterServiceHandlers(s *server.MCPServer) {
 }
 
 func (h *Handler) handleListServices(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-	args := req.Params.Arguments.(map[string]any)
+	args := req.GetArguments()
 
 	start, end := timeutil.GetTimestampsWithDefaults(args, "ns")
 	limit, offset := paginate.ParseParams(req.Params.Arguments)
@@ -95,7 +95,7 @@ func (h *Handler) handleListServices(ctx context.Context, req mcp.CallToolReques
 }
 
 func (h *Handler) handleGetServiceTopOperations(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-	args := req.Params.Arguments.(map[string]any)
+	args := req.GetArguments()
 
 	service, ok := args["service"].(string)
 	if !ok {

--- a/internal/handler/tools/traces.go
+++ b/internal/handler/tools/traces.go
@@ -162,7 +162,7 @@ func (h *Handler) handleSearchTraces(ctx context.Context, req mcp.CallToolReques
 }
 
 func (h *Handler) handleGetTraceDetails(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-	args := req.Params.Arguments.(map[string]any)
+	args := req.GetArguments()
 
 	traceID, ok := args["traceId"].(string)
 	if !ok || traceID == "" {

--- a/internal/mcp-server/nil_arguments_e2e_test.go
+++ b/internal/mcp-server/nil_arguments_e2e_test.go
@@ -1,0 +1,68 @@
+package mcp_server
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	mcpclient "github.com/mark3labs/mcp-go/client"
+	"github.com/mark3labs/mcp-go/mcp"
+
+	"github.com/SigNoz/signoz-mcp-server/pkg/version"
+)
+
+// TestE2E_GetAlert_NoArguments_ReturnsValidationError reproduces the exact
+// production crash end-to-end, through the real MCP pipeline: the in-process
+// client JSON-marshals the request, the server deserializes it via
+// HandleMessage, runs the middleware chain (recovery enabled, as in prod), and
+// dispatches to the handler.
+//
+// A tools/call for signoz_get_alert with no "arguments" object is encoded as
+// JSON with the key omitted (json:"arguments,omitempty"), so the server
+// deserializes Params.Arguments to an untyped nil — the precise condition that
+// panicked in production (interface conversion: interface {} is nil, not
+// map[string]interface {}).
+//
+// Pre-fix, WithRecovery turned that panic into the JSON-RPC error
+// "panic recovered in signoz_get_alert tool handler: ..." (CallTool returns a
+// non-nil error). Post-fix, the handler must return a normal tool result
+// carrying the parameter-validation message — no panic, no transport error.
+func TestE2E_GetAlert_NoArguments_ReturnsValidationError(t *testing.T) {
+	s := buildTestServer(t)
+	ctx := context.Background()
+
+	c, err := mcpclient.NewInProcessClient(s)
+	if err != nil {
+		t.Fatalf("failed to create in-process client: %v", err)
+	}
+	if _, err := c.Initialize(ctx, mcp.InitializeRequest{
+		Params: mcp.InitializeParams{
+			ProtocolVersion: mcp.LATEST_PROTOCOL_VERSION,
+			ClientInfo:      mcp.Implementation{Name: "test-client", Version: version.Version},
+		},
+	}); err != nil {
+		t.Fatalf("Initialize failed: %v", err)
+	}
+
+	// Deliberately leave Arguments unset — this is what a client sending no
+	// "arguments" object produces after a JSON round-trip.
+	res, err := c.CallTool(ctx, mcp.CallToolRequest{
+		Params: mcp.CallToolParams{Name: "signoz_get_alert"},
+	})
+
+	// Pre-fix the recovered panic surfaces here as a non-nil transport error.
+	if err != nil {
+		t.Fatalf("CallTool returned a transport error (handler panicked): %v", err)
+	}
+	if res == nil || !res.IsError {
+		t.Fatalf("expected a validation error tool result, got: %+v", res)
+	}
+
+	text := firstTextContent(t, res.Content)
+	if !strings.Contains(text, "ruleId") {
+		t.Fatalf("expected a ruleId validation message, got: %s", text)
+	}
+	if strings.Contains(strings.ToLower(text), "panic") {
+		t.Fatalf("response still surfaces a panic instead of a clean validation error: %s", text)
+	}
+}

--- a/plans/nil-arguments-panic-fix.context.md
+++ b/plans/nil-arguments-panic-fix.context.md
@@ -1,0 +1,32 @@
+# Feature: Nil-Arguments Panic Fix — Context & Discussion
+
+## Original Prompt
+> Fix the bug, get review from codex
+
+Follow-up to a panic investigation: "Explore more MCP server panics and crashes ... categorize/list issues", which found that 30 days of production panics were all one class — nil-map interface-conversion panics in the `signoz_get_alert` and `signoz_get_dashboard` tool handlers.
+
+## Reference Links
+- Dashboard "SigNoz MCP Server" (panic panel): https://nightswatch.signoz.cloud/dashboard/019e44b4-0cee-7e38-8290-5b438baf3f34
+- Production panic signature: `interface conversion: interface {} is nil, not map[string]interface {}`
+
+## Key Decisions & Discussion Log
+### 2026-06-21 — root cause + scope
+- Root cause: an unchecked `req.Params.Arguments.(map[string]any)` assertion. In the reported handlers the `, ok` guarded the *outer* `.(string)`, leaving the inner map assertion bare — so when a client calls a tool with no `arguments` object, `req.Params.Arguments` is an untyped-nil interface and the bare assertion panics.
+- Scope: 12 panic-prone sites total, not just the 2 that fired in the 30d window — 9 bare `args := req.Params.Arguments.(map[string]any)` and 3 compound `x, ok := …(map[string]any)[key]`. Comma-ok sites (e.g. `handleAggregateLogs`, `handleCreateDashboard`, the views handlers) already guard `if !ok { return }` and were left untouched.
+- Fix: replace the unguarded assertion with the library's nil-safe `req.GetArguments()` (mcp-go v0.49.0).
+- Subtlety verified: `GetArguments()` returns `nil` (not an empty map, despite its doc comment) on non-map input. Reads on a nil map are safe in Go; only writes panic. Confirmed all 12 changed sites are read-only downstream (the only map writers — `views.go`, `aggregate_helper.go:resolveTimestamps` — are reached only via comma-ok-guarded handlers).
+- Behavior: list-style tools (optional args) now fall through to their defaults path; required-field tools return their existing validation error instead of panicking. No tool schema/name/description change → no README/manifest doc-sync needed.
+- Test: added `requestWithNilArguments` (untyped-nil `Arguments`) regression test. Proved it reproduces the exact production panic when the fix is reverted, and passes with the fix.
+
+### 2026-06-21 — Codex review (gpt-5.5 / xhigh)
+- Verdict: **no runtime defect; fix complete and safe.** Codex independently confirmed: no remaining panic-prone sites in `internal/`; nil-map reads are safe at every changed site; the only map-writer (`resolveTimestamps`, aggregate_helper.go) is reached only after `metricName` validation on the `query_metrics` path; list tools still flow to defaults with no args.
+- One LOW finding: the regression test covered only the 7 required-field handlers, not the 5 list/create/update sites. Resolved: extended the test to all 12 touched handlers — added create/update notification channel to the error-path table, and a new `TestListHandlers_NilArguments_UseDefaults` that locks in list-tool defaults (list_alerts / list_services / list_metrics succeed with nil args rather than erroring).
+- `go build ./...`, `go vet`, and `go test ./internal/handler/tools/` all green.
+
+### 2026-06-21 — end-to-end verification (does this fix the real user-facing bug?)
+- Question raised: the unit test constructs the request struct directly, so it only proves our handler survives a nil `Arguments` — it assumes the real transport produces nil `Arguments` for a no-args call. Closed that gap with an e2e test through the real in-process MCP pipeline (client JSON-marshal → server `HandleMessage` deserialize → recovery middleware → dispatch), recovery enabled exactly as in prod.
+- Result: with the bug reverted, the e2e test reproduces the **byte-for-byte production error** — `internal error: panic recovered in signoz_get_alert tool handler: interface conversion: interface {} is nil, not map[string]interface {}` — and with the fix it returns a clean `ruleId` validation result. This confirms the fix resolves the actual client-facing path, not just a unit-level assumption.
+- Caveat: we still cannot replay tenant `momentic.us`'s exact request, and the fix is verified against the real transport but not yet on the live deployment (can only confirm post-deploy).
+
+## Open Questions
+- [x] Codex review feedback — **resolved**: verdict was "sound and complete"; the one LOW test-coverage gap was closed by extending the regression test to all 12 handlers.

--- a/plans/nil-arguments-panic-fix.plan.md
+++ b/plans/nil-arguments-panic-fix.plan.md
@@ -1,0 +1,29 @@
+# Plan: Nil-Arguments Panic Fix
+
+## Status
+In Progress
+
+## Context
+Over the last 30 days, every production panic on the SigNoz MCP server was one class: an unchecked `req.Params.Arguments.(map[string]any)` type assertion in tool handlers. When a client invokes a tool with no `arguments` object, `req.Params.Arguments` is an untyped-nil interface and the bare assertion panics with `interface conversion: interface {} is nil, not map[string]interface {}`. The recover middleware caught it (the server stayed up), but the client got a generic error and a crash was logged.
+
+## Approach
+Replace the unguarded assertion with mcp-go's nil-safe `req.GetArguments()` at all 12 panic-prone sites. Comma-ok sites already handle the failure and are left as-is. Downstream of every changed site is read-only (no map writes), so `GetArguments()` returning `nil` is safe.
+
+## Files to Modify
+- `internal/handler/tools/alerts.go` — handleListAlerts, handleGetAlert, handleGetAlertHistory
+- `internal/handler/tools/dashboards.go` — handleGetDashboard, handleDeleteDashboard
+- `internal/handler/tools/services.go` — handleListServices, handleGetServiceTopOperations
+- `internal/handler/tools/metrics.go` — handleListMetrics
+- `internal/handler/tools/metrics_query.go` — handleQueryMetrics
+- `internal/handler/tools/traces.go` — handleGetTraceDetails
+- `internal/handler/tools/notification_channels.go` — handleCreateNotificationChannel, handleUpdateNotificationChannel
+- `internal/handler/tools/nil_arguments_test.go` — unit regression test (untyped-nil `Arguments`), covering all 12 touched handlers: error-path (9 required-field incl. notification create/update) + success-path defaults (3 list tools)
+- `internal/mcp-server/nil_arguments_e2e_test.go` — end-to-end test through the real in-process MCP pipeline (JSON marshal → server deserialize → recovery middleware → dispatch), proving a no-arguments `signoz_get_alert` returns a clean validation result instead of a recovered panic
+
+## Verification
+- `go build ./...`, `gofmt -l`, and `go vet ./internal/handler/tools/` clean.
+- `go test ./internal/handler/tools/` passes.
+- Unit regression test reproduces the exact production panic when the fix is reverted (verified by temporarily restoring the bare assertion → `interface conversion: interface {} is nil` panic), passes with the fix.
+- End-to-end test through the real MCP transport reproduces the **byte-for-byte** production error when reverted (`internal error: panic recovered in signoz_get_alert tool handler: interface conversion: interface {} is nil, not map[string]interface {}`) and passes with the fix — confirming the fix addresses the real client-facing path, not just an isolated unit assumption.
+- Codex review (gpt-5.5/xhigh): no runtime defect; complete and safe.
+- No tool schema/name/description changes → README.md and manifest.json unchanged.


### PR DESCRIPTION
## What
Fixes the only class of panic seen on SigNoz Cloud MCP over the last 30 days:
an unchecked `req.Params.Arguments.(map[string]any)` assertion in tool handlers.
When a client calls a tool with no `arguments` object, `Arguments` deserializes
to an untyped nil and the bare assertion panics:

    interface conversion: interface {} is nil, not map[string]interface {}

The mcp-go recovery middleware caught it (server stayed up), but the client got
a recovered-panic error instead of a clean validation message.

## Fix
Replace the unguarded assertion with the nil-safe `req.GetArguments()` at all
**12 panic-prone sites** — 9 bare `args := …(map[string]any)` and 3 compound
`x, ok := …(map[string]any)[key].(T)` where `, ok` guarded the outer assertion.
Comma-ok-guarded sites already handle failure and are unchanged.

- Required-field tools (get_alert, get_dashboard, get_trace_details, …) return
  their existing parameter-validation error.
- List tools (list_alerts/services/metrics) fall through to defaults — no
  behavior change beyond "no longer panics".

No tool schema/name/description changes → README/manifest untouched.

## Tests
- `internal/handler/tools/nil_arguments_test.go` — unit regression across all 12
  handlers, using an untyped-nil `Arguments` (a typed-nil map would not panic).
- `internal/mcp-server/nil_arguments_e2e_test.go` — end-to-end through the real
  in-process MCP pipeline. Reverting the fix reproduces the byte-for-byte
  production error; with the fix it returns a clean `ruleId` validation result.

Both proven non-vacuous (fail with the bug, pass with the fix). build/vet/gofmt/
test green. Reviewed by Codex (gpt-5.5/xhigh): no runtime defect, complete and safe.

Plan & discussion: `plans/nil-arguments-panic-fix.{context,plan}.md`
