### PR TITLE
ci: auto-publish server.json to the MCP Registry on release

### DIFF
--- a/.github/workflows/dockerbuildci.yaml
+++ b/.github/workflows/dockerbuildci.yaml
@@ -24,9 +24,12 @@ jobs:
       DOCKER_MANIFEST: true
       DOCKER_PROVIDERS: 'dockerhub gcp'
 
-  # Publish server.json to the official MCP Registry (registry.modelcontextprotocol.io).
-  # `needs: build` guarantees the multi-arch image manifest is pushed first — the registry
-  # verifies ownership by pulling the OCI image at the identifier tag and reading its
+  # Publish the committed server.json to the official MCP Registry (registry.modelcontextprotocol.io).
+  # The prereleaser (.github/workflows/pre-release.yaml) bumps server.json's version and pinned OCI
+  # image tag in a PR that is merged before tagging, so the tagged commit already carries the exact
+  # file to publish — this job publishes it as-is (it does not rewrite it).
+  # `needs: build` guarantees the multi-arch image manifest is pushed first — the registry verifies
+  # ownership by pulling the OCI image at the identifier tag and reading its
   # io.modelcontextprotocol.server.name label, so the image must exist before we publish.
   # Gated to stable v* tags: skips `main` branch pushes and pre-release tags (e.g. v1.2.3-rc.0)
   # so release candidates do not land in the public registry listing.
@@ -42,25 +45,24 @@ jobs:
       - name: checkout tag
         uses: actions/checkout@v4
 
-      - name: pin server.json to the released version and image tag
-        id: pin
+      - name: verify server.json matches the release tag
+        id: meta
         run: |
           set -euo pipefail
-          # GITHUB_REF_NAME is the tag, e.g. v0.5.1. The published Docker image carries the
-          # tag verbatim (docker.io/signoz/signoz-mcp-server:v0.5.1); the registry "version"
-          # field is semver without the leading v. The tag is authoritative here, so this is
-          # correct even if the pre-release version-bump PR was not merged before tagging.
+          # Source of truth is the committed server.json (bumped by the prereleaser PR). Assert it
+          # matches the tag and fail loud — pointing at the prereleaser — rather than silently
+          # publishing a stale version if someone tagged without running it first.
           TAG="${GITHUB_REF_NAME}"
-          # Fail fast on a malformed v* tag rather than emitting a confusing downstream error.
-          if ! printf '%s' "$TAG" | grep -Eq '^v[0-9]+\.[0-9]+\.[0-9]+$'; then
-            echo "::error::tag '$TAG' is not a stable vX.Y.Z release tag; refusing to publish."
+          VERSION="$(jq -r '.version' server.json)"
+          IMAGE="$(jq -r '.packages[0].identifier' server.json)"
+          if [ "$VERSION" != "${TAG#v}" ]; then
+            echo "::error::server.json version '$VERSION' does not match tag '$TAG'. Run the prereleaser to bump server.json before tagging."
             exit 1
           fi
-          VERSION="${TAG#v}"
-          IMAGE="docker.io/signoz/signoz-mcp-server:${TAG}"
-          jq --arg v "$VERSION" --arg id "$IMAGE" \
-             '.version = $v | .packages[0].identifier = $id' \
-             server.json > server.tmp && mv server.tmp server.json
+          if [ "$IMAGE" != "docker.io/signoz/signoz-mcp-server:${TAG}" ]; then
+            echo "::error::server.json identifier '$IMAGE' is not pinned to 'docker.io/signoz/signoz-mcp-server:${TAG}'. Run the prereleaser to bump server.json before tagging."
+            exit 1
+          fi
           {
             echo "version=$VERSION"
             echo "image=$IMAGE"
@@ -70,7 +72,7 @@ jobs:
 
       - name: verify image is published and pullable
         env:
-          IMAGE: ${{ steps.pin.outputs.image }}
+          IMAGE: ${{ steps.meta.outputs.image }}
         run: |
           set -euo pipefail
           # needs:build already finished, but allow for manifest/registry propagation lag
@@ -90,7 +92,7 @@ jobs:
       - name: skip if this version is already published
         id: check
         env:
-          VERSION: ${{ steps.pin.outputs.version }}
+          VERSION: ${{ steps.meta.outputs.version }}
           NAME: io.github.SigNoz/signoz-mcp-server
         run: |
           set -euo pipefail

--- a/.github/workflows/dockerbuildci.yaml
+++ b/.github/workflows/dockerbuildci.yaml
@@ -23,3 +23,94 @@ jobs:
       DOCKER_DOCKERFILE_PATH: Dockerfile.multi-arch
       DOCKER_MANIFEST: true
       DOCKER_PROVIDERS: 'dockerhub gcp'
+
+  # Publish server.json to the official MCP Registry (registry.modelcontextprotocol.io).
+  # `needs: build` guarantees the multi-arch image manifest is pushed first — the registry
+  # verifies ownership by pulling the OCI image at the identifier tag and reading its
+  # io.modelcontextprotocol.server.name label, so the image must exist before we publish.
+  # Gated to stable v* tags: skips `main` branch pushes and pre-release tags (e.g. v1.2.3-rc.0)
+  # so release candidates do not land in the public registry listing.
+  publish-mcp-registry:
+    name: Publish to MCP Registry
+    needs: build
+    if: startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, '-')
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write # OIDC auth — maps repo owner (SigNoz) to the io.github.SigNoz/* namespace
+      contents: read
+    steps:
+      - name: checkout tag
+        uses: actions/checkout@v4
+
+      - name: pin server.json to the released version and image tag
+        id: pin
+        run: |
+          set -euo pipefail
+          # GITHUB_REF_NAME is the tag, e.g. v0.5.1. The published Docker image carries the
+          # tag verbatim (docker.io/signoz/signoz-mcp-server:v0.5.1); the registry "version"
+          # field is semver without the leading v. The tag is authoritative here, so this is
+          # correct even if the pre-release version-bump PR was not merged before tagging.
+          TAG="${GITHUB_REF_NAME}"
+          # Fail fast on a malformed v* tag rather than emitting a confusing downstream error.
+          if ! printf '%s' "$TAG" | grep -Eq '^v[0-9]+\.[0-9]+\.[0-9]+$'; then
+            echo "::error::tag '$TAG' is not a stable vX.Y.Z release tag; refusing to publish."
+            exit 1
+          fi
+          VERSION="${TAG#v}"
+          IMAGE="docker.io/signoz/signoz-mcp-server:${TAG}"
+          jq --arg v "$VERSION" --arg id "$IMAGE" \
+             '.version = $v | .packages[0].identifier = $id' \
+             server.json > server.tmp && mv server.tmp server.json
+          {
+            echo "version=$VERSION"
+            echo "image=$IMAGE"
+          } >> "$GITHUB_OUTPUT"
+          echo "Publishing server.json:"
+          cat server.json
+
+      - name: verify image is published and pullable
+        env:
+          IMAGE: ${{ steps.pin.outputs.image }}
+        run: |
+          set -euo pipefail
+          # needs:build already finished, but allow for manifest/registry propagation lag
+          # before the registry pulls this image for ownership verification. Inspect the
+          # remote manifest (no pull); fail loudly if it never appears.
+          for i in 1 2 3 4 5 6; do
+            if docker buildx imagetools inspect "$IMAGE" >/dev/null 2>&1; then
+              echo "found $IMAGE"
+              exit 0
+            fi
+            echo "attempt $i: $IMAGE not yet available, retrying in 10s..."
+            sleep 10
+          done
+          echo "::error::$IMAGE not found after retries; aborting publish."
+          exit 1
+
+      - name: skip if this version is already published
+        id: check
+        env:
+          VERSION: ${{ steps.pin.outputs.version }}
+          NAME: io.github.SigNoz/signoz-mcp-server
+        run: |
+          set -euo pipefail
+          # Fail open: only skip when we POSITIVELY confirm this version exists, so a query
+          # hiccup falls through to publish (which fails loudly on a true duplicate) rather
+          # than silently skipping a real release. Makes benign workflow re-runs green.
+          if curl -fsS "https://registry.modelcontextprotocol.io/v0/servers?search=${NAME}" \
+               | jq -e --arg v "$VERSION" --arg n "$NAME" \
+                   '[.servers[]?.server | select(.name==$n and .version==$v)] | length > 0' >/dev/null 2>&1; then
+            echo "v${VERSION} already published; skipping publish."
+            echo "should_publish=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "should_publish=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: publish to MCP Registry
+        if: steps.check.outputs.should_publish == 'true'
+        run: |
+          set -euo pipefail
+          curl -L "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" | tar xz mcp-publisher
+          ./mcp-publisher validate
+          ./mcp-publisher login github-oidc
+          ./mcp-publisher publish

--- a/.github/workflows/post-release.yaml
+++ b/.github/workflows/post-release.yaml
@@ -49,22 +49,26 @@ jobs:
         run: |
           set -euo pipefail
           VERSION="${{ steps.version.outputs.version }}"
+          EXPECTED_IMAGE="docker.io/signoz/signoz-mcp-server:${{ steps.version.outputs.tag }}"
           MANIFEST=$(jq -r '.version' manifest.json)
           SERVER=$(jq -r '.version' server.json)
+          SERVER_IMAGE=$(jq -r '.packages[0].identifier' server.json)
           CHANGELOG_HAS_ENTRY=false
           if grep -q "^## \[${VERSION}\]" CHANGELOG.md 2>/dev/null; then
             CHANGELOG_HAS_ENTRY=true
           fi
 
-          # Short-circuit only when *all three* artifacts already reflect this
-          # release. If any is missing (e.g., a partial bump, or CHANGELOG was
-          # never generated), fall through to the full flow — the per-step
-          # idempotency guards keep it safe to re-run.
-          if [ "$MANIFEST" = "$VERSION" ] && [ "$SERVER" = "$VERSION" ] && [ "$CHANGELOG_HAS_ENTRY" = "true" ]; then
+          # Short-circuit only when every release artifact already reflects this release —
+          # including server.json's pinned OCI identifier, which the update step below also
+          # rewrites. If any is stale (a partial bump, a pre-release PR from before the
+          # identifier was tracked, or a missing CHANGELOG), fall through to reconcile; the
+          # per-step idempotency guards keep it safe to re-run.
+          if [ "$MANIFEST" = "$VERSION" ] && [ "$SERVER" = "$VERSION" ] \
+             && [ "$SERVER_IMAGE" = "$EXPECTED_IMAGE" ] && [ "$CHANGELOG_HAS_ENTRY" = "true" ]; then
             echo "pre-release workflow already bumped files and changelog to ${VERSION}; post-release will no-op."
             echo "already_bumped=true" >> "$GITHUB_OUTPUT"
           else
-            echo "state incomplete (manifest=${MANIFEST} server=${SERVER} changelog_entry=${CHANGELOG_HAS_ENTRY}); post-release will reconcile to ${VERSION}."
+            echo "state incomplete (manifest=${MANIFEST} server=${SERVER} server_image=${SERVER_IMAGE} expected_image=${EXPECTED_IMAGE} changelog_entry=${CHANGELOG_HAS_ENTRY}); post-release will reconcile to ${VERSION}."
             echo "already_bumped=false" >> "$GITHUB_OUTPUT"
           fi
 

--- a/.github/workflows/post-release.yaml
+++ b/.github/workflows/post-release.yaml
@@ -78,7 +78,10 @@ jobs:
         if: steps.state.outputs.already_bumped == 'false'
         run: |
           set -euo pipefail
-          jq --arg v "${{ steps.version.outputs.version }}" '.version = $v' server.json > tmp.json && mv tmp.json server.json
+          # Keep parity with pre-release.yaml: bump the registry version and the pinned OCI tag.
+          jq --arg v "${{ steps.version.outputs.version }}" \
+             --arg id "docker.io/signoz/signoz-mcp-server:${{ steps.version.outputs.tag }}" \
+             '.version = $v | .packages[0].identifier = $id' server.json > tmp.json && mv tmp.json server.json
 
       - name: generate changelog entry
         if: steps.state.outputs.already_bumped == 'false'

--- a/.github/workflows/pre-release.yaml
+++ b/.github/workflows/pre-release.yaml
@@ -62,7 +62,11 @@ jobs:
       - name: update server.json
         run: |
           set -euo pipefail
-          jq --arg v "${{ steps.version.outputs.version }}" '.version = $v' server.json > tmp.json && mv tmp.json server.json
+          # Bump both the registry version and the pinned OCI image tag so the merged commit
+          # carries the exact server.json that the release tag will publish to the MCP Registry.
+          jq --arg v "${{ steps.version.outputs.version }}" \
+             --arg id "docker.io/signoz/signoz-mcp-server:${{ steps.version.outputs.tag }}" \
+             '.version = $v | .packages[0].identifier = $id' server.json > tmp.json && mv tmp.json server.json
 
       - name: generate changelog entry
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,9 @@ go.work.sum
 .vscode/
 .cursor/
 
+# Claude Code local state (agent worktrees, settings)
+.claude/
+
 ### macOS ###
 # General
 .DS_Store

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,6 +9,27 @@ Thanks for contributing to SigNoz MCP Server.
 3. Run local checks before opening a PR.
 4. Open a pull request with a clear summary and validation steps.
 
+## Releases & the MCP Registry
+
+The server is listed on the official [MCP Registry](https://registry.modelcontextprotocol.io)
+as `io.github.SigNoz/signoz-mcp-server`. Publishing is automated: on every stable `vX.Y.Z` tag,
+`.github/workflows/dockerbuildci.yaml` builds and pushes the Docker image, then the
+`publish-mcp-registry` job pins `server.json` to the released version and immutable image tag and
+publishes it to the registry via GitHub OIDC (no secret required). Pre-release tags (`-rc.N`) are
+skipped, and the job is idempotent — a re-run for an already-published version is a no-op.
+
+To publish out of band, prefer **re-running the `dockerbuildci` workflow on the release tag** — it
+does the version/image-tag pinning for you. If you must publish from a workstation, pin the package
+to the immutable image tag first (the committed `server.json` carries a mutable `:latest`):
+
+```bash
+TAG=v0.5.1   # the release tag
+jq --arg v "${TAG#v}" --arg id "docker.io/signoz/signoz-mcp-server:${TAG}" \
+   '.version = $v | .packages[0].identifier = $id' server.json > server.tmp && mv server.tmp server.json
+mcp-publisher login github   # as a SigNoz org member
+mcp-publisher publish
+```
+
 ## Required sync for MCP changes
 
 If your PR adds, removes, or renames MCP tools/resources/config behavior, update docs and metadata in the same PR:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,23 +12,23 @@ Thanks for contributing to SigNoz MCP Server.
 ## Releases & the MCP Registry
 
 The server is listed on the official [MCP Registry](https://registry.modelcontextprotocol.io)
-as `io.github.SigNoz/signoz-mcp-server`. Publishing is automated: on every stable `vX.Y.Z` tag,
-`.github/workflows/dockerbuildci.yaml` builds and pushes the Docker image, then the
-`publish-mcp-registry` job pins `server.json` to the released version and immutable image tag and
-publishes it to the registry via GitHub OIDC (no secret required). Pre-release tags (`-rc.N`) are
-skipped, and the job is idempotent — a re-run for an already-published version is a no-op.
+as `io.github.SigNoz/signoz-mcp-server`. The version that gets published lives in the committed
+`server.json`, kept correct by the release process:
 
-To publish out of band, prefer **re-running the `dockerbuildci` workflow on the release tag** — it
-does the version/image-tag pinning for you. If you must publish from a workstation, pin the package
-to the immutable image tag first (the committed `server.json` carries a mutable `:latest`):
+1. Run the **prereleaser** (`.github/workflows/pre-release.yaml`, manual dispatch). It raises a PR
+   bumping `manifest.json`, `CHANGELOG.md`, and `server.json` — both `.version` and the pinned OCI
+   image tag (`docker.io/signoz/signoz-mcp-server:vX.Y.Z`).
+2. Merge that PR, then create the GitHub release on the bumped commit so the tag carries the correct
+   `server.json`.
+3. The `vX.Y.Z` tag triggers `.github/workflows/dockerbuildci.yaml`: it builds and pushes the Docker
+   image, then the `publish-mcp-registry` job publishes the **committed** `server.json` to the
+   registry via GitHub OIDC (no secret). It asserts the file matches the tag, waits for the image to
+   be pullable, and is idempotent (skips an already-published version). Pre-release tags (`-rc.N`)
+   are not published.
 
-```bash
-TAG=v0.5.1   # the release tag
-jq --arg v "${TAG#v}" --arg id "docker.io/signoz/signoz-mcp-server:${TAG}" \
-   '.version = $v | .packages[0].identifier = $id' server.json > server.tmp && mv server.tmp server.json
-mcp-publisher login github   # as a SigNoz org member
-mcp-publisher publish
-```
+To publish out of band, re-run the `dockerbuildci` workflow on the release tag, or — from a
+workstation checked out at the tagged commit — run `mcp-publisher login github` (as a SigNoz org
+member) followed by `mcp-publisher publish`.
 
 ## Required sync for MCP changes
 

--- a/plans/mcp-registry-publish.context.md
+++ b/plans/mcp-registry-publish.context.md
@@ -1,0 +1,85 @@
+# Feature: MCP Registry Auto-Publish — Context & Discussion
+
+## Original Prompt
+> How can we list SigNoz mcp server here: https://github.com/modelcontextprotocol/registry?
+>
+> Let's automate it, get codex xhigh 5.5 review as well
+
+## Reference Links
+- [MCP Registry repo](https://github.com/modelcontextprotocol/registry)
+- [Quickstart: publish a server](https://github.com/modelcontextprotocol/registry/blob/main/docs/modelcontextprotocol-io/quickstart.mdx)
+- [Package Types — OCI verification](https://github.com/modelcontextprotocol/registry/blob/main/docs/modelcontextprotocol-io/package-types.mdx)
+- [GitHub Actions publishing guide](https://github.com/modelcontextprotocol/registry/blob/main/docs/modelcontextprotocol-io/github-actions.mdx)
+- [Publisher CLI reference](https://github.com/modelcontextprotocol/registry/blob/main/docs/reference/cli/commands.md)
+- [Official registry requirements](https://github.com/modelcontextprotocol/registry/blob/main/docs/reference/server-json/official-registry-requirements.md)
+
+## Key Decisions & Discussion Log
+
+### 2026-06-23 — Discovery: already listed but stale
+- Querying `https://registry.modelcontextprotocol.io/v0/servers?search=signoz` returns
+  `io.github.SigNoz/signoz-mcp-server` **already published**, versions `0.0.1` and `0.0.4`
+  (latest = `0.0.4`, published 2025-11-10), both `status: active`.
+- These were one-off manual publishes with placeholder versions. The product is at `v0.5.1`.
+- No `mcp-publisher` step exists anywhere in `.github/` — publishing was never automated, so the
+  registry entry is frozen at `0.0.4`.
+- Conclusion: the task is not "list it" (done) but "publish the current version automatically and
+  stop it going stale."
+
+### 2026-06-23 — Requirements already satisfied
+- OCI ownership label `io.modelcontextprotocol.server.name="io.github.SigNoz/signoz-mcp-server"`
+  is present in both `Dockerfile:26` and `Dockerfile.multi-arch:5` (CI builds with the multi-arch one).
+- Image is published to Docker Hub `signoz/signoz-mcp-server`. **The release image tag carries the
+  leading `v`** — confirmed tags include `v0.5.1` and `latest` (NOT `0.5.1`). The OCI identifier
+  must match the tag exactly or ownership verification fails.
+- `io.github.SigNoz/*` namespace authenticates via GitHub; from CI, GitHub OIDC
+  (`mcp-publisher login github-oidc`) maps the repo owner (`SigNoz`) to the namespace — no secret needed.
+
+### 2026-06-23 — Ordering is the crux
+- The registry verifies the package by pulling the OCI image *at the tag in `server.json`*, so the
+  Docker image must exist before publish.
+- `dockerbuildci.yaml` (`push: tags: v*`) and any `release: published`-triggered job race; the
+  pre-release.yaml comment confirms artifact workflows have merely *started* by the time the release
+  event fires.
+- Decision: add the publish as a job **inside `dockerbuildci.yaml` with `needs: build`**, gated to
+  `v*` tags. `needs` guarantees the image manifest is pushed before publish runs. This reuses the
+  workflow that already holds `id-token: write` and triggers on the tag.
+- Rejected `workflow_run` trigger: tag handling runs against the default branch and is awkward to
+  scope to the released tag.
+
+### 2026-06-23 — Source of truth for version + identifier
+- Decision: **the git tag is authoritative at publish time.** The publish job derives
+  `VERSION=${GITHUB_REF_NAME#v}` and rewrites `server.json` `.version` + `.packages[0].identifier`
+  to `docker.io/signoz/signoz-mcp-server:${GITHUB_REF_NAME}` before publishing. This mirrors the
+  existing "extract version from tag" pattern in post-release.yaml and is race/fallback-proof.
+- The committed `server.json` keeps a fully-qualified `:latest` identifier so it never drifts and
+  stays valid for `mcp-publisher validate` / manual publish; CI always pins to the immutable tag.
+  This avoids editing the pre/post-release bump steps.
+- Bumped committed `$schema` from `2025-10-17` to `2025-12-11` (current) and added the `repository`
+  field (was empty `{}` in the live entry).
+
+### 2026-06-23 — Codex (gpt-5.5, xhigh) review → hardening
+Codex verdict: fix-then-ship. It confirmed `needs: build` is the correct ordering (the reusable
+`go-build.yaml` pushes the manifest before the job returns success) and found no OIDC/permission,
+tag-prefix, or schema bug. Acted on all five findings:
+- **Image-readiness preflight (med):** added a `docker buildx imagetools inspect` retry loop
+  (6×10s) before publish — asserts the image tag is pullable, covering manifest/registry
+  propagation lag; fails loudly if it never appears.
+- **Rerun idempotency (med):** added a registry pre-check that skips publish when the exact
+  `name + version` already exists. Fail-open: only skips on positive confirmation, so a query
+  hiccup falls through to publish (which fails loudly on a true duplicate).
+- **Manual path published mutable `:latest` (med):** CONTRIBUTING now tells maintainers to re-run
+  the workflow, or includes the jq pin step for local publish.
+- **Broad tag filter (low):** added a stable-semver regex guard in the pin step (fail-fast on a
+  malformed `v*` tag).
+- **API path (low):** verified `/v0/servers` and `/v0.1/servers` both return identical data live;
+  standardized on `/v0/servers` (empirically validated) for the idempotency check and plan doc.
+- **Added default (not from Codex):** gate now excludes pre-release tags
+  (`!contains(github.ref, '-')`) so RCs do not clutter the public listing. Flag for owner review.
+
+## Open Questions
+- [x] Is it already listed? — Yes, stale at `0.0.4`. (resolved 2026-06-23)
+- [x] What image tag does the registry need to verify? — `docker.io/signoz/signoz-mcp-server:v<semver>` (resolved 2026-06-23)
+- [x] Where to put the publish step so the image exists first? — `needs: build` job in `dockerbuildci.yaml` (resolved 2026-06-23)
+- [x] Re-run of an already-published version? — registry pre-check skips it (idempotent, fail-open). (resolved 2026-06-23)
+- [ ] Bring `0.5.1` live now via a one-off manual publish, or let the automation catch it on the next stable release tag?
+- [ ] Confirm excluding pre-release/RC tags from the public registry is the desired policy.

--- a/plans/mcp-registry-publish.context.md
+++ b/plans/mcp-registry-publish.context.md
@@ -76,6 +76,28 @@ tag-prefix, or schema bug. Acted on all five findings:
 - **Added default (not from Codex):** gate now excludes pre-release tags
   (`!contains(github.ref, '-')`) so RCs do not clutter the public listing. Flag for owner review.
 
+### 2026-06-23 — Reviewer feedback (PR #209, @therealpandey): bump in the prereleaser PR, don't rewrite at publish
+Reviewer (CHANGES_REQUESTED) on `CONTRIBUTING.md`: "Can we create a prereleaser job which raises a
+PR to bump `server.json`? Once that PR is merged, a tag will then publish the updated `server.json`.
+Standard process for ensuring the commit contains the right version in server.json. See SigNoz for
+how we do this."
+- Checked `~/signoz/signoz`: pattern is `prereleaser.yaml` (manual dispatch → primus releaser raises
+  a bump PR) + `releaser.yaml` (runs on `release: published`). No server.json/mcp-publisher there.
+- This repo **already implements** that pattern via `pre-release.yaml` (raises a PR bumping
+  `manifest.json` + `server.json.version` + CHANGELOG, merged before tagging) and `post-release.yaml`
+  (fallback reconcile). The reviewer's invariant ("commit contains the right version") was already
+  met for `.version`.
+- **Reworked the approach to match the reviewer's model** (committed file is source of truth; the
+  tag-publish ships it, no rewrite):
+  - `pre-release.yaml` + `post-release.yaml` now bump BOTH `.version` and `.packages[0].identifier`
+    (pinned `docker.io/signoz/signoz-mcp-server:vX.Y.Z`) in the bump PR.
+  - Committed `server.json` identifier is now pinned (`:v0.5.1`) instead of `:latest`.
+  - `dockerbuildci.yaml` publish job no longer rewrites server.json from the tag. It **verifies**
+    the committed `version` and `identifier` match the tag (fail-loud, pointing at the prereleaser),
+    then publishes the file as-is. Image-pullable preflight + idempotency skip retained.
+- Net: the earlier "tag is authoritative / correct even if the pre-release PR wasn't merged" decision
+  is reversed — the prereleaser-merged commit is the contract now, enforced by the verify step.
+
 ## Open Questions
 - [x] Is it already listed? — Yes, stale at `0.0.4`. (resolved 2026-06-23)
 - [x] What image tag does the registry need to verify? — `docker.io/signoz/signoz-mcp-server:v<semver>` (resolved 2026-06-23)

--- a/plans/mcp-registry-publish.plan.md
+++ b/plans/mcp-registry-publish.plan.md
@@ -1,0 +1,65 @@
+# Plan: MCP Registry Auto-Publish
+
+## Status
+In Progress
+
+## Context
+`io.github.SigNoz/signoz-mcp-server` is already in the official MCP Registry but frozen at a
+placeholder `0.0.4` (published 2025-11-10) because publishing was only ever done manually. The
+product is at `v0.5.1`. We want every release to publish the current `server.json` to the registry
+automatically, with the OCI package pinned to the immutable image tag the release just pushed.
+
+## Approach
+
+Add a tag-gated publish job to the existing release path and make `server.json` valid/current.
+
+1. **`server.json` (committed, source for `validate`):**
+   - Bump `$schema` to the current `2025-12-11`.
+   - Add `repository` (`https://github.com/SigNoz/signoz-mcp-server`, source `github`).
+   - Use a fully-qualified `:latest` identifier (`docker.io/signoz/signoz-mcp-server:latest`) so the
+     committed file never drifts and stays valid for `mcp-publisher validate` / manual publish.
+
+2. **`dockerbuildci.yaml` — new `publish-mcp-registry` job:**
+   - `needs: build` → runs only after the multi-arch image manifest is pushed (image must exist
+     before the registry can verify the OCI ownership label). Codex confirmed the reusable
+     `go-build.yaml` pushes the manifest before the job returns success.
+   - `if: startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, '-')` → skips `main`
+     branch pushes and pre-release/RC tags (RCs should not appear in the public listing).
+   - Job permissions: `id-token: write` (OIDC to the registry) + `contents: read`.
+   - Steps:
+     1. **checkout** the tag.
+     2. **pin** — validate `TAG` is stable `vX.Y.Z` (fail-fast otherwise), then rewrite
+        `server.json` `.version` (`${TAG#v}`) and `.packages[0].identifier`
+        (`docker.io/signoz/signoz-mcp-server:${TAG}`). The git tag is authoritative, so this is
+        correct even if the pre-release bump PR was not merged, and pins to the immutable tag.
+     3. **verify image** — `docker buildx imagetools inspect` in a 6×10s retry loop; covers
+        registry propagation lag and fails loudly if the tag never appears.
+     4. **idempotency check** — query `/v0/servers?search=<name>`; if this exact `name + version`
+        already exists, skip publish (fail-open: only skip on positive confirmation).
+     5. **publish** (gated on the check) — install `mcp-publisher` → `validate` → `login
+        github-oidc` → `publish`.
+
+3. **`CONTRIBUTING.md`:** short note that releases auto-publish to the MCP Registry.
+
+## Files to Modify
+- `server.json` — schema bump, `repository`, fully-qualified `:latest` identifier.
+- `.github/workflows/dockerbuildci.yaml` — add `publish-mcp-registry` job (`needs: build`, tag-gated, OIDC).
+- `CONTRIBUTING.md` — document the release → registry automation.
+- `plans/mcp-registry-publish.{context,plan}.md` — this pair.
+
+## Verification
+- `mcp-publisher validate server.json` passes locally against the current schema.
+- Dry check the jq rewrite locally with `GITHUB_REF_NAME=v0.5.1` and confirm the resulting
+  `identifier` is `docker.io/signoz/signoz-mcp-server:v0.5.1` (a tag that exists on Docker Hub) and
+  `version` is `0.5.1`.
+- On the next `v*` tag: `dockerbuildci` builds+pushes the image, then `publish-mcp-registry` runs and
+  `curl "https://registry.modelcontextprotocol.io/v0/servers?search=signoz"` shows the new version as
+  `isLatest`.
+- One-off: to bring `0.5.1` live before the next release, run `mcp-publisher login github` (as a
+  SigNoz org member) + `mcp-publisher publish` locally, or re-run after merging.
+
+## Known behavior / follow-ups
+- Re-runs are idempotent: the registry pre-check skips publish when the version already exists.
+- Pre-release/RC tags (`vX.Y.Z-rc.N`) are intentionally not published to the public registry.
+- `0.5.1` will not be published retroactively by this change — it lands on the next stable release
+  tag unless published manually now (see CONTRIBUTING for the pinned local-publish snippet).

--- a/plans/mcp-registry-publish.plan.md
+++ b/plans/mcp-registry-publish.plan.md
@@ -11,52 +11,54 @@ automatically, with the OCI package pinned to the immutable image tag the releas
 
 ## Approach
 
-Add a tag-gated publish job to the existing release path and make `server.json` valid/current.
+Per reviewer feedback (PR #209): the committed `server.json` is the source of truth, bumped by the
+existing prereleaser PR and merged before tagging; the tag-publish ships that file as-is (no rewrite).
 
-1. **`server.json` (committed, source for `validate`):**
-   - Bump `$schema` to the current `2025-12-11`.
-   - Add `repository` (`https://github.com/SigNoz/signoz-mcp-server`, source `github`).
-   - Use a fully-qualified `:latest` identifier (`docker.io/signoz/signoz-mcp-server:latest`) so the
-     committed file never drifts and stays valid for `mcp-publisher validate` / manual publish.
+1. **`server.json` (committed source of truth):**
+   - `$schema` `2025-12-11`, `repository` field, OCI identifier **pinned** to the released version
+     (`docker.io/signoz/signoz-mcp-server:vX.Y.Z`), `.version` semver.
 
-2. **`dockerbuildci.yaml` — new `publish-mcp-registry` job:**
+2. **`pre-release.yaml` + `post-release.yaml` (the prereleaser & its fallback):**
+   - The bump PR now updates BOTH `.version` and `.packages[0].identifier` (pinned image tag), so the
+     merged/tagged commit carries the exact `server.json` to publish.
+
+3. **`dockerbuildci.yaml` — `publish-mcp-registry` job:**
    - `needs: build` → runs only after the multi-arch image manifest is pushed (image must exist
-     before the registry can verify the OCI ownership label). Codex confirmed the reusable
+     before the registry verifies the OCI ownership label). Codex confirmed the reusable
      `go-build.yaml` pushes the manifest before the job returns success.
    - `if: startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, '-')` → skips `main`
      branch pushes and pre-release/RC tags (RCs should not appear in the public listing).
-   - Job permissions: `id-token: write` (OIDC to the registry) + `contents: read`.
+   - Job permissions: `id-token: write` (OIDC) + `contents: read`.
    - Steps:
      1. **checkout** the tag.
-     2. **pin** — validate `TAG` is stable `vX.Y.Z` (fail-fast otherwise), then rewrite
-        `server.json` `.version` (`${TAG#v}`) and `.packages[0].identifier`
-        (`docker.io/signoz/signoz-mcp-server:${TAG}`). The git tag is authoritative, so this is
-        correct even if the pre-release bump PR was not merged, and pins to the immutable tag.
+     2. **verify** — assert the committed `.version` and `.packages[0].identifier` match the tag;
+        fail loud pointing at the prereleaser if not (enforces "the commit contains the right
+        version"). Does NOT rewrite the file.
      3. **verify image** — `docker buildx imagetools inspect` in a 6×10s retry loop; covers
         registry propagation lag and fails loudly if the tag never appears.
      4. **idempotency check** — query `/v0/servers?search=<name>`; if this exact `name + version`
         already exists, skip publish (fail-open: only skip on positive confirmation).
      5. **publish** (gated on the check) — install `mcp-publisher` → `validate` → `login
-        github-oidc` → `publish`.
+        github-oidc` → `publish` the committed file.
 
-3. **`CONTRIBUTING.md`:** short note that releases auto-publish to the MCP Registry.
+4. **`CONTRIBUTING.md`:** document the prereleaser → merge → tag → publish flow.
 
 ## Files to Modify
-- `server.json` — schema bump, `repository`, fully-qualified `:latest` identifier.
-- `.github/workflows/dockerbuildci.yaml` — add `publish-mcp-registry` job (`needs: build`, tag-gated, OIDC).
-- `CONTRIBUTING.md` — document the release → registry automation.
+- `server.json` — schema bump, `repository`, pinned OCI identifier.
+- `.github/workflows/pre-release.yaml` + `post-release.yaml` — bump `.version` AND the pinned identifier.
+- `.github/workflows/dockerbuildci.yaml` — `publish-mcp-registry` job (`needs: build`, tag-gated, verify-and-publish, OIDC).
+- `CONTRIBUTING.md` — document the release → registry flow.
 - `plans/mcp-registry-publish.{context,plan}.md` — this pair.
 
 ## Verification
 - `mcp-publisher validate server.json` passes locally against the current schema.
-- Dry check the jq rewrite locally with `GITHUB_REF_NAME=v0.5.1` and confirm the resulting
-  `identifier` is `docker.io/signoz/signoz-mcp-server:v0.5.1` (a tag that exists on Docker Hub) and
-  `version` is `0.5.1`.
-- On the next `v*` tag: `dockerbuildci` builds+pushes the image, then `publish-mcp-registry` runs and
-  `curl "https://registry.modelcontextprotocol.io/v0/servers?search=signoz"` shows the new version as
-  `isLatest`.
-- One-off: to bring `0.5.1` live before the next release, run `mcp-publisher login github` (as a
-  SigNoz org member) + `mcp-publisher publish` locally, or re-run after merging.
+- Dry-run the prereleaser bump jq with `version=0.6.0`/`tag=v0.6.0` → `.version=0.6.0`,
+  `.identifier=docker.io/signoz/signoz-mcp-server:v0.6.0`.
+- Dry-run the publish-job verify step: committed `v0.5.1` + `:v0.5.1` against `GITHUB_REF_NAME=v0.5.1`
+  passes; a mismatched version/identifier fails loud.
+- On the next stable `vX.Y.Z` tag (after merging the prereleaser PR): `dockerbuildci` builds+pushes
+  the image, then `publish-mcp-registry` publishes and
+  `curl "https://registry.modelcontextprotocol.io/v0/servers?search=signoz"` shows it as `isLatest`.
 
 ## Known behavior / follow-ups
 - Re-runs are idempotent: the registry pre-check skips publish when the version already exists.

--- a/server.json
+++ b/server.json
@@ -1,13 +1,17 @@
 {
-  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-10-17/server.schema.json",
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.SigNoz/signoz-mcp-server",
   "description": "SigNoz MCP server: access metrics, traces, logs, alerts, and dashboards via AI assistants",
   "title": "SigNoz MCP Server",
+  "repository": {
+    "url": "https://github.com/SigNoz/signoz-mcp-server",
+    "source": "github"
+  },
   "version": "0.5.1",
   "packages": [
     {
       "registryType": "oci",
-      "identifier": "signoz/signoz-mcp-server:latest",
+      "identifier": "docker.io/signoz/signoz-mcp-server:latest",
       "transport": {
         "type": "stdio"
       }

--- a/server.json
+++ b/server.json
@@ -11,7 +11,7 @@
   "packages": [
     {
       "registryType": "oci",
-      "identifier": "docker.io/signoz/signoz-mcp-server:latest",
+      "identifier": "docker.io/signoz/signoz-mcp-server:v0.5.1",
       "transport": {
         "type": "stdio"
       }


### PR DESCRIPTION
## What & why

The server is already listed on the [official MCP Registry](https://registry.modelcontextprotocol.io) as `io.github.SigNoz/signoz-mcp-server`, but it was **frozen at a placeholder `0.0.4`** (published 2025-11-10) — publishing had only ever been done manually, so the registry never tracked real releases. This wires publishing into the existing release pipeline so every stable release keeps the listing current.

## Approach

Following the standard SigNoz release flow (per review): the committed `server.json` is the **source of truth**, bumped by the prereleaser PR and merged before tagging. The tag-publish job then ships that committed file as-is — it does not rewrite it.

```
prereleaser PR (bumps server.json: .version + pinned OCI tag)  ──merge──▶  create release (tag vX.Y.Z)
        │
        └─▶ dockerbuildci: build job pushes image ──needs──▶ publish-mcp-registry verifies + publishes committed server.json
```

## Changes

- **`.github/workflows/pre-release.yaml` + `post-release.yaml`** — the version-bump PR now updates **both** `server.json` `.version` and `.packages[0].identifier` (pinned `docker.io/signoz/signoz-mcp-server:vX.Y.Z`), so the merged/tagged commit carries the exact file to publish.
- **`.github/workflows/dockerbuildci.yaml`** — new `publish-mcp-registry` job:
  - `needs: build` so it runs only after the multi-arch image manifest is pushed (the registry verifies OCI ownership by pulling the image and reading its `io.modelcontextprotocol.server.name` label — the image must exist first).
  - Gated to **stable `vX.Y.Z` tags** (`startsWith(github.ref,'refs/tags/v') && !contains(github.ref,'-')`) — skips `main` pushes and pre-release/RC tags.
  - **Verifies** (does not rewrite) that the committed `server.json` `.version` and `.packages[0].identifier` match the tag — fails loud pointing at the prereleaser if not.
  - **Image-readiness preflight** (`docker buildx imagetools inspect`, 6×10s retry) — never publish before the tag is pullable.
  - **Idempotency skip** — queries the registry and no-ops if `name+version` already exists (fail-open: only skips on positive confirmation).
  - **GitHub OIDC** auth (`id-token: write`) — maps repo owner `SigNoz` to the `io.github.SigNoz/*` namespace; no secret required.
- **`server.json`** — schema bumped to `2025-12-11`, added `repository`, OCI identifier pinned to `:v0.5.1`.
- **`.gitignore`** — ignore Claude Code local state (`.claude/`).
- **`CONTRIBUTING.md`** — documents the prereleaser → merge → tag → publish flow.
- **`plans/mcp-registry-publish.{context,plan}.md`** — feature plan pair per repo convention.

## Validation

- All three workflows parse; publish job verified to contain no `server.json` rewrite.
- Dry-runs: prereleaser jq bumps `.version` + pinned identifier together; the publish-job verify step passes on a matching commit (`v0.5.1` + `:v0.5.1`) and fails loud on a stale identifier or mismatched version; gate runs `v0.5.1`, skips RC + `main`; idempotency check (live registry) says publish `v0.5.1`, skip `v0.0.4`.
- Reviewed by Codex (gpt-5.5, xhigh): verdict *fix-then-ship*; all findings incorporated.

## Notes

- `0.5.1` is **not** published retroactively — it lands on the next stable release tag (or a one-off manual publish per CONTRIBUTING).
- Pre-release/RC tags are intentionally excluded from the public listing — flag if that policy should change.