### PR TITLE
docs(plans): search_logs filter param handoff plan

### DIFF
--- a/plans/search-logs-filter-param.context.md
+++ b/plans/search-logs-filter-param.context.md
@@ -1,0 +1,48 @@
+# Feature: search_logs `filter` Param Handoff — Context & Discussion
+
+## Original Prompt
+> [Screenshot from a user/agent session] An agent repeatedly called `signoz_search_logs`
+> with `{"filter": "host LIKE 'storm%'", "start": ..., "end": ..., "limit": "50"}` and could
+> not find the expected logs. It kept second-guessing its *filter syntax* (LIKE, log IDs)
+> when the real problem was the argument was being dropped. User: "i think ur remote mcp tool
+> description is probably broken?" → asked for a handoff doc to the MCP dev owner.
+
+## Reference Links
+- Tool schema: `internal/handler/tools/logs.go:45-63` (`signoz_search_logs`)
+- Arg parser: `internal/handler/tools/logs_helper.go:28-59` (`parseSearchLogsArgs`)
+- Sibling tool using `filter`: `internal/handler/tools/logs.go:19-41` (`signoz_aggregate_logs`)
+
+## Key Decisions & Discussion Log
+### 2026-06-22 — root cause
+- The agent passed `filter` to `signoz_search_logs`, but that tool exposes **no `filter`
+  parameter**. Its free-form filter argument is named `query` (`logs.go:52`).
+- `parseSearchLogsArgs` only reads `args["query"]` (`logs_helper.go:29`). Any unknown key —
+  including `filter` — is **silently dropped**. MCP does not reject unknown properties, so
+  there is no error surfaced to the model.
+- Result: the search ran with an *empty* filter expression (time-window only) and returned
+  arbitrary logs. The agent then wasted turns "fixing" filter syntax that was never the
+  problem, because the entire argument had been discarded.
+
+### 2026-06-22 — why the model guessed wrong
+- Naming inconsistency between the two log tools is the trap:
+  - `signoz_aggregate_logs` → filter arg is **`filter`** (`logs.go:29`)
+  - `signoz_search_logs` → filter arg is **`query`** (`logs.go:52`)
+- `filter` is also the more natural term, so the model reaches for it. The two sibling tools
+  disagreeing on the name is the design smell to fix.
+
+### 2026-06-22 — recommended direction (for MCP owner to ratify)
+- Prefer **accepting `filter` as an alias** over a hard rename. A bare rename (`query`→`filter`)
+  would break any caller currently passing `query`. Aliasing tolerates both and converges the
+  two tools' vocabulary.
+- Check `signoz_search_traces` for the same `query` vs `filter` inconsistency while here.
+- Per CLAUDE.md doc-sync checklist: this DOES change a tool schema, so README.md tool tables
+  and manifest.json tool metadata must be updated in the same PR.
+
+## Open Questions
+- [ ] Alias (`filter` accepted, `query` still works) vs. rename with `query` kept as deprecated
+      alias — owner's call. Recommendation: alias, keep both documented.
+- [ ] Should unknown/unrecognized args produce a soft warning in the tool result instead of
+      being silently dropped? Broader fix that would have surfaced this class of bug
+      immediately. Out of scope for the immediate fix but worth a decision.
+- [ ] Does `signoz_search_traces` (and any other search-style tool) share the `query` vs
+      `filter` divergence? Audit before closing.

--- a/plans/search-logs-filter-param.plan.md
+++ b/plans/search-logs-filter-param.plan.md
@@ -1,0 +1,51 @@
+# Plan: search_logs `filter` Param Alias
+
+## Status
+Planning
+
+## Context
+`signoz_search_logs` exposes its free-form filter argument as `query`, while its sibling
+`signoz_aggregate_logs` calls the same thing `filter`. Models (and humans) naturally reach for
+`filter` on `search_logs`. Because `parseSearchLogsArgs` only reads `args["query"]`
+(`logs_helper.go:29`) and MCP silently ignores unknown properties, a `filter` argument is
+dropped with no error: the search runs with an empty filter (time-window only) and returns
+arbitrary logs. This produced a real failed session where an agent burned multiple turns
+debugging "filter syntax" that was actually being discarded wholesale.
+
+## Approach
+Make `signoz_search_logs` accept `filter` as an alias for `query`, and align the schema/docs
+with `signoz_aggregate_logs` so the two log tools share one vocabulary. No behavioral change
+for existing `query` callers.
+
+1. **Parser** (`logs_helper.go`): in `parseSearchLogsArgs`, read `filter` and fall back to it
+   when `query` is empty (e.g. `query := firstNonEmpty(args["query"], args["filter"])`). Keep
+   `query` working.
+2. **Schema** (`logs.go`): add a `filter` string param to `signoz_search_logs` whose
+   description matches the `aggregate_logs` `filter` wording, and note in the `query`
+   description that `filter` is an accepted alias (or vice-versa). Keep `searchContext` as a
+   top-level param per CLAUDE.md.
+3. **Audit sibling**: confirm whether `signoz_search_traces` has the same `query`/`filter`
+   divergence; if so, apply the same alias there (track as a follow-up if it widens scope).
+4. **Docs sync** (CLAUDE.md checklist — this IS a schema change):
+   - `README.md` — update the `signoz_search_logs` parameter table to list `filter`/`query`.
+   - `manifest.json` — update the `signoz_search_logs` tool metadata/param descriptions.
+   - Grep `docs/` for stale `signoz_search_logs` references.
+   - Call out the doc updates explicitly in the PR summary.
+
+## Files to Modify
+- `internal/handler/tools/logs_helper.go` — `parseSearchLogsArgs`: accept `filter` as alias for `query`
+- `internal/handler/tools/logs.go` — add/align `filter` param on `signoz_search_logs` schema
+- `internal/handler/tools/logs_test.go` — regression test: `filter` arg produces the same
+  filter expression as `query`; both-empty and both-set precedence covered
+- `README.md` — `signoz_search_logs` parameter table
+- `manifest.json` — `signoz_search_logs` tool metadata
+- (conditional) `internal/handler/tools/traces.go` — same alias if `search_traces` diverges
+
+## Verification
+- `go build ./...`, `gofmt -l`, `go vet ./internal/handler/tools/` clean.
+- `go test ./internal/handler/tools/` passes, including a new test asserting
+  `parseSearchLogsArgs({"filter": "host LIKE 'storm%'"})` yields filter expression
+  `host LIKE 'storm%'` (and that `query` still works and takes precedence when both set).
+- Manual: invoke `signoz_search_logs` with `filter` against a live instance and confirm the
+  filter is actually applied (reproduces the screenshot scenario, now returning scoped logs).
+- README.md / manifest.json reflect the new `filter` param.


### PR DESCRIPTION
## Summary

Adds a `plans/` context+plan pair documenting a bug in `signoz_search_logs` for the MCP dev owner to pick up. **Docs/plan only — no code or tool-schema changes.**

### The bug
`signoz_search_logs` names its free-form filter argument `query`, while the sibling `signoz_aggregate_logs` calls the same thing `filter`. The parser (`parseSearchLogsArgs`, `logs_helper.go:29`) only reads `args["query"]`, and MCP silently ignores unknown properties — so a caller passing `filter` to `search_logs` has the argument **silently dropped**. The search then runs with an empty filter expression (time-window only) and returns arbitrary logs, with no error surfaced. This produced a real failed session where an agent burned multiple turns debugging "filter syntax" that was actually being discarded.

### Proposed direction (for owner to ratify)
- Accept `filter` as an alias for `query` on `signoz_search_logs` (don't hard-rename — that breaks existing `query` callers).
- Align the two log tools' vocabulary and audit `signoz_search_traces` for the same divergence.
- This will be a schema change, so README.md + manifest.json need updating per the CLAUDE.md doc-sync checklist (tracked in the plan).

### Files
- `plans/search-logs-filter-param.context.md` — root cause, discussion log, open questions
- `plans/search-logs-filter-param.plan.md` — `Status: Planning`, alias approach, files to modify, verification

🤖 Generated with [Claude Code](https://claude.com/claude-code)