### PR TITLE
fix(tools): standardize filter-expression param on `filter` (accept legacy `query` alias)

### DIFF
--- a/README.md
+++ b/README.md
@@ -565,6 +565,14 @@ Fetch full markdown for one official SigNoz docs page from the local index. Acce
 
 Read-only MCP resource containing the indexed docs sitemap used by the docs search and fetch tools.
 
+#### `signoz://logs/query-builder-guide`
+
+Read-only MCP resource with logs Query Builder v5 filter syntax, field contexts, body text search, body JSON-path search, timestamp format, and complete raw/aggregation/time-series examples.
+
+#### `signoz://traces/query-builder-guide`
+
+Read-only MCP resource with traces Query Builder v5 filter syntax, field contexts, built-in span columns, timestamp format, and complete raw/aggregation/time-series examples.
+
 #### `signoz_create_view`
 
 Create a new saved Explorer view.
@@ -597,7 +605,7 @@ Aggregate logs with count, average, sum, min, max, or percentiles, optionally gr
   - `aggregation` (required) - Aggregation function: count, count_distinct, avg, sum, min, max, p50, p75, p90, p95, p99, rate
   - `aggregateOn` (optional) - Field to aggregate on (required for all except count and rate)
   - `groupBy` (optional) - Comma-separated fields to group by (e.g., 'service.name, severity_text')
-  - `filter` (optional) - Filter expression using SigNoz search syntax
+  - `filter` (optional) - Filter expression using SigNoz search syntax. Unknown keys hard-error; ambiguous keys default to resource context. See `signoz://logs/query-builder-guide`
   - `service` (optional) - Shortcut filter for service name
   - `severity` (optional) - Shortcut filter for severity (DEBUG, INFO, WARN, ERROR, FATAL)
   - `orderBy` (optional) - Order expression and direction (e.g., 'count() desc')
@@ -610,7 +618,7 @@ Aggregate logs with count, average, sum, min, max, or percentiles, optionally gr
 Search logs with flexible filtering across all services.
 
 - **Parameters**:
-  - `query` (optional) - Filter expression using SigNoz search syntax (e.g., "service.name = 'payment-svc' AND http.status_code >= 400")
+  - `filter` (optional) - Filter expression using SigNoz search syntax (e.g., "service.name = 'payment-svc' AND severity_text = 'ERROR'"). Legacy `query` is still accepted for backward compatibility, but `filter` is canonical. See `signoz://logs/query-builder-guide`
   - `service` (optional) - Service name to filter by
   - `severity` (optional) - Severity filter (DEBUG, INFO, WARN, ERROR, FATAL)
   - `searchText` (optional) - Text to search for in log body (uses CONTAINS matching)
@@ -648,7 +656,7 @@ Get possible values for a specific field key for a given signal.
 Search traces/spans with flexible filtering.
 
 - **Parameters**:
-  - `query` (optional) - Filter expression using SigNoz search syntax (e.g., "service.name = 'payment-svc' AND hasError = true")
+  - `filter` (optional) - Filter expression using SigNoz search syntax (e.g., "service.name = 'payment-svc' AND hasError = true"). Legacy `query` is still accepted for backward compatibility, but `filter` is canonical. See `signoz://traces/query-builder-guide`
   - `service` (optional) - Service name to filter by
   - `operation` (optional) - Operation/span name to filter by
   - `error` (optional) - Filter by error status ('true' or 'false')
@@ -666,7 +674,7 @@ Aggregate trace statistics like count, average, sum, min, max, or percentiles ov
   - `aggregation` (required) - Aggregation function: count, count_distinct, avg, sum, min, max, p50, p75, p90, p95, p99, rate
   - `aggregateOn` (optional) - Field to aggregate on (e.g., 'durationNano'). Required for all except count and rate
   - `groupBy` (optional) - Comma-separated fields to group by (e.g., 'service.name, name')
-  - `filter` (optional) - Filter expression using SigNoz search syntax
+  - `filter` (optional) - Filter expression using SigNoz search syntax. Unknown keys hard-error; ambiguous keys default to resource context. See `signoz://traces/query-builder-guide`
   - `service` (optional) - Shortcut filter for service name
   - `operation` (optional) - Shortcut filter for span/operation name
   - `error` (optional) - Shortcut filter for error spans ('true' or 'false')

--- a/README.md
+++ b/README.md
@@ -605,7 +605,7 @@ Aggregate logs with count, average, sum, min, max, or percentiles, optionally gr
   - `aggregation` (required) - Aggregation function: count, count_distinct, avg, sum, min, max, p50, p75, p90, p95, p99, rate
   - `aggregateOn` (optional) - Field to aggregate on (required for all except count and rate)
   - `groupBy` (optional) - Comma-separated fields to group by (e.g., 'service.name, severity_text')
-  - `filter` (optional) - Filter expression using SigNoz search syntax. Unknown keys hard-error; ambiguous keys default to resource context. See `signoz://logs/query-builder-guide`
+  - `filter` (optional) - Filter expression using SigNoz search syntax. Combine conditions with AND, OR, and parentheses. Unknown keys hard-error; ambiguous keys default to resource context. See `signoz://logs/query-builder-guide`
   - `service` (optional) - Shortcut filter for service name
   - `severity` (optional) - Shortcut filter for severity (DEBUG, INFO, WARN, ERROR, FATAL)
   - `orderBy` (optional) - Order expression and direction (e.g., 'count() desc')
@@ -618,7 +618,7 @@ Aggregate logs with count, average, sum, min, max, or percentiles, optionally gr
 Search logs with flexible filtering across all services.
 
 - **Parameters**:
-  - `filter` (optional) - Filter expression using SigNoz search syntax (e.g., "service.name = 'payment-svc' AND severity_text = 'ERROR'"). Legacy `query` is still accepted for backward compatibility, but `filter` is canonical. See `signoz://logs/query-builder-guide`
+  - `filter` (optional) - Filter expression using SigNoz search syntax. Combine conditions with AND, OR, and parentheses (e.g., "(severity_text = 'ERROR' OR body CONTAINS 'panic') AND service.name = 'payment-svc'"). Legacy `query` is still accepted for backward compatibility, but `filter` is canonical. See `signoz://logs/query-builder-guide`
   - `service` (optional) - Service name to filter by
   - `severity` (optional) - Severity filter (DEBUG, INFO, WARN, ERROR, FATAL)
   - `searchText` (optional) - Text to search for in log body (uses CONTAINS matching)
@@ -656,7 +656,7 @@ Get possible values for a specific field key for a given signal.
 Search traces/spans with flexible filtering.
 
 - **Parameters**:
-  - `filter` (optional) - Filter expression using SigNoz search syntax (e.g., "service.name = 'payment-svc' AND hasError = true"). Legacy `query` is still accepted for backward compatibility, but `filter` is canonical. See `signoz://traces/query-builder-guide`
+  - `filter` (optional) - Filter expression using SigNoz search syntax. Combine conditions with AND, OR, and parentheses (e.g., "service.name = 'payment-svc' AND (hasError = true OR responseStatusCode >= 500)"). Legacy `query` is still accepted for backward compatibility, but `filter` is canonical. See `signoz://traces/query-builder-guide`
   - `service` (optional) - Service name to filter by
   - `operation` (optional) - Operation/span name to filter by
   - `error` (optional) - Filter by error status ('true' or 'false')
@@ -674,7 +674,7 @@ Aggregate trace statistics like count, average, sum, min, max, or percentiles ov
   - `aggregation` (required) - Aggregation function: count, count_distinct, avg, sum, min, max, p50, p75, p90, p95, p99, rate
   - `aggregateOn` (optional) - Field to aggregate on (e.g., 'durationNano'). Required for all except count and rate
   - `groupBy` (optional) - Comma-separated fields to group by (e.g., 'service.name, name')
-  - `filter` (optional) - Filter expression using SigNoz search syntax. Unknown keys hard-error; ambiguous keys default to resource context. See `signoz://traces/query-builder-guide`
+  - `filter` (optional) - Filter expression using SigNoz search syntax. Combine conditions with AND, OR, and parentheses. Unknown keys hard-error; ambiguous keys default to resource context. See `signoz://traces/query-builder-guide`
   - `service` (optional) - Shortcut filter for service name
   - `operation` (optional) - Shortcut filter for span/operation name
   - `error` (optional) - Shortcut filter for error spans ('true' or 'false')

--- a/README.md
+++ b/README.md
@@ -635,8 +635,8 @@ Get available field keys for a given signal (metrics, traces, or logs).
   - `signal` (required) - Signal type: `metrics`, `traces`, or `logs`
   - `searchText` (optional) - Filter field keys by name substring
   - `metricName` (optional) - Filter by metric name (relevant for metrics signal)
-  - `fieldContext` (optional) - Filter by field context (e.g., `resource`, `span`)
-  - `fieldDataType` (optional) - Filter by data type (e.g., `string`, `int64`)
+  - `fieldContext` (optional) - Restrict to a field context: `resource`, `attribute` (alias `tag`), `scope`, `log`/`span`/`metric` (intrinsic/built-in columns), or `body` (JSON log body). Distinguishes intrinsic columns from user attributes.
+  - `fieldDataType` (optional) - Restrict to a data type: `string`, `bool`, `int64`, `float64`, `number`, or array forms like `[]string`
   - `source` (optional) - Filter by source
 
 #### `signoz_get_field_values`
@@ -648,6 +648,7 @@ Get possible values for a specific field key for a given signal.
   - `name` (required) - Field key name to get values for (e.g., `service.name`, `http.method`)
   - `searchText` (optional) - Filter values by substring
   - `metricName` (optional) - Filter by metric name (relevant for metrics signal)
+  - `fieldContext` (optional) - Restrict the lookup to a field context (`resource`, `attribute`/`tag`, `scope`, `log`/`span`/`metric`, `body`) when the same key name exists in more than one
   - `source` (optional) - Filter by source
 
 

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -703,7 +703,7 @@ func (s *SigNoz) GetFieldKeys(ctx context.Context, signal, metricName, searchTex
 	return s.doRequest(ctx, http.MethodGet, reqURL, nil, DefaultQueryTimeout)
 }
 
-func (s *SigNoz) GetFieldValues(ctx context.Context, signal, name, metricName, searchText, source string) (json.RawMessage, error) {
+func (s *SigNoz) GetFieldValues(ctx context.Context, signal, name, metricName, searchText, fieldContext, source string) (json.RawMessage, error) {
 	params := url.Values{}
 	params.Set("signal", signal)
 	params.Set("name", name)
@@ -712,6 +712,9 @@ func (s *SigNoz) GetFieldValues(ctx context.Context, signal, name, metricName, s
 	}
 	if searchText != "" {
 		params.Set("searchText", searchText)
+	}
+	if fieldContext != "" {
+		params.Set("fieldContext", fieldContext)
 	}
 	if source != "" {
 		params.Set("source", source)

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -1449,18 +1449,20 @@ func TestGetFieldValues(t *testing.T) {
 		fieldName     string
 		metricName    string
 		searchText    string
+		fieldContext  string
 		source        string
 		resp          map[string]interface{}
 		statusCode    int
 		expectedError bool
 	}{
 		{
-			name:       "successful retrieval with all params",
-			signal:     "metrics",
-			fieldName:  "host.name",
-			metricName: "container.cpu.usage",
-			searchText: "prod",
-			source:     "otel",
+			name:         "successful retrieval with all params",
+			signal:       "metrics",
+			fieldName:    "host.name",
+			metricName:   "container.cpu.usage",
+			searchText:   "prod",
+			fieldContext: "resource",
+			source:       "otel",
 			resp: map[string]interface{}{
 				"status": "success",
 				"data":   []string{"prod-host-1", "prod-host-2"},
@@ -1513,6 +1515,7 @@ func TestGetFieldValues(t *testing.T) {
 				assert.Equal(t, tt.fieldName, q.Get("name"))
 				assert.Equal(t, tt.metricName, q.Get("metricName"))
 				assert.Equal(t, tt.searchText, q.Get("searchText"))
+				assert.Equal(t, tt.fieldContext, q.Get("fieldContext"))
 				assert.Equal(t, tt.source, q.Get("source"))
 
 				w.WriteHeader(tt.statusCode)
@@ -1525,7 +1528,7 @@ func TestGetFieldValues(t *testing.T) {
 			client := NewClient(logger, server.URL, "test-api-key", "SIGNOZ-API-KEY", nil)
 
 			ctx := context.Background()
-			result, err := client.GetFieldValues(ctx, tt.signal, tt.fieldName, tt.metricName, tt.searchText, tt.source)
+			result, err := client.GetFieldValues(ctx, tt.signal, tt.fieldName, tt.metricName, tt.searchText, tt.fieldContext, tt.source)
 
 			if tt.expectedError {
 				assert.Error(t, err)

--- a/internal/client/interface.go
+++ b/internal/client/interface.go
@@ -32,7 +32,7 @@ type Client interface {
 	UpdateView(ctx context.Context, viewID string, body []byte) (json.RawMessage, error)
 	DeleteView(ctx context.Context, viewID string) (json.RawMessage, error)
 	GetFieldKeys(ctx context.Context, signal, metricName, searchText, fieldContext, fieldDataType, source string) (json.RawMessage, error)
-	GetFieldValues(ctx context.Context, signal, name, metricName, searchText, source string) (json.RawMessage, error)
+	GetFieldValues(ctx context.Context, signal, name, metricName, searchText, fieldContext, source string) (json.RawMessage, error)
 	GetTraceDetails(ctx context.Context, traceID string, includeSpans bool, startTime, endTime int64) (json.RawMessage, error)
 	CreateAlertRule(ctx context.Context, alertJSON []byte) (json.RawMessage, error)
 	UpdateAlertRule(ctx context.Context, ruleID string, alertJSON []byte) error

--- a/internal/client/mock.go
+++ b/internal/client/mock.go
@@ -33,7 +33,7 @@ type MockClient struct {
 	UpdateViewFn                func(ctx context.Context, viewID string, body []byte) (json.RawMessage, error)
 	DeleteViewFn                func(ctx context.Context, viewID string) (json.RawMessage, error)
 	GetFieldKeysFn              func(ctx context.Context, signal, metricName, searchText, fieldContext, fieldDataType, source string) (json.RawMessage, error)
-	GetFieldValuesFn            func(ctx context.Context, signal, name, metricName, searchText, source string) (json.RawMessage, error)
+	GetFieldValuesFn            func(ctx context.Context, signal, name, metricName, searchText, fieldContext, source string) (json.RawMessage, error)
 	GetTraceDetailsFn           func(ctx context.Context, traceID string, includeSpans bool, startTime, endTime int64) (json.RawMessage, error)
 	CreateAlertRuleFn           func(ctx context.Context, alertJSON []byte) (json.RawMessage, error)
 	UpdateAlertRuleFn           func(ctx context.Context, ruleID string, alertJSON []byte) error
@@ -203,9 +203,9 @@ func (m *MockClient) GetFieldKeys(ctx context.Context, signal, metricName, searc
 	return json.RawMessage(`{}`), nil
 }
 
-func (m *MockClient) GetFieldValues(ctx context.Context, signal, name, metricName, searchText, source string) (json.RawMessage, error) {
+func (m *MockClient) GetFieldValues(ctx context.Context, signal, name, metricName, searchText, fieldContext, source string) (json.RawMessage, error) {
 	if m.GetFieldValuesFn != nil {
-		return m.GetFieldValuesFn(ctx, signal, name, metricName, searchText, source)
+		return m.GetFieldValuesFn(ctx, signal, name, metricName, searchText, fieldContext, source)
 	}
 	return json.RawMessage(`{}`), nil
 }

--- a/internal/handler/tools/aggregate_helper.go
+++ b/internal/handler/tools/aggregate_helper.go
@@ -1,8 +1,11 @@
 package tools
 
 import (
+	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"log/slog"
 	"strconv"
 	"strings"
 
@@ -33,6 +36,35 @@ var aggregationsWithoutField = map[string]bool{
 }
 
 const allowedAggregations = "avg, count, count_distinct, max, min, p50, p75, p90, p95, p99, rate, sum"
+
+const conflictingFilterAliasError = "both 'filter' and 'query' were provided with different values; use only 'filter' (the 'query' alias is legacy)"
+
+// readFilterExpr returns the QB filter expression, accepting the canonical
+// "filter" key and the legacy "query" alias. TrimSpace is used only to decide
+// presence/equality; the returned expression preserves the caller's original
+// text. Never log filter expressions here because they can contain user data.
+func readFilterExpr(args map[string]any) (string, error) {
+	filterRaw := stringValue(args["filter"])
+	queryRaw := stringValue(args["query"])
+	filterTrimmed := strings.TrimSpace(filterRaw)
+	queryTrimmed := strings.TrimSpace(queryRaw)
+
+	if filterTrimmed != "" && queryTrimmed != "" && filterTrimmed != queryTrimmed {
+		return "", errors.New(conflictingFilterAliasError)
+	}
+	if filterTrimmed != "" {
+		return filterRaw, nil
+	}
+	if queryTrimmed != "" {
+		return queryRaw, nil
+	}
+	return "", nil
+}
+
+func stringValue(v any) string {
+	s, _ := v.(string)
+	return s
+}
 
 // AggregateRequest keeps parameters for any aggregation query.
 type AggregateRequest struct {
@@ -197,12 +229,67 @@ func clampLimit(n int) (int, bool) {
 	return n, false
 }
 
-// clampedResult wraps a raw JSON payload as a tool result. The JSON is always
-// the first (parseable) content block; when clamped, `note` is appended as a
-// separate block rather than prepended into the JSON.
-func clampedResult(payload []byte, limitClamped bool, note string) *mcp.CallToolResult {
+// extractBackendWarningMessages parses non-fatal QB v5 warning messages from a
+// success response. It fails open: malformed or unexpected response shapes
+// simply produce no notes and never block returning the raw backend payload.
+func extractBackendWarningMessages(response json.RawMessage) []string {
+	var resp struct {
+		Data struct {
+			Warning struct {
+				Warnings []struct {
+					Message string `json:"message"`
+				} `json:"warnings"`
+			} `json:"warning"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(response, &resp); err != nil {
+		return nil
+	}
+	var messages []string
+	for _, warning := range resp.Data.Warning.Warnings {
+		if strings.TrimSpace(warning.Message) != "" {
+			messages = append(messages, warning.Message)
+		}
+	}
+	return messages
+}
+
+func backendWarningsNote(messages []string) string {
+	var b strings.Builder
+	b.WriteString("note: SigNoz backend returned non-fatal warnings:")
+	for _, message := range messages {
+		b.WriteString("\n- ")
+		b.WriteString(message)
+	}
+	return b.String()
+}
+
+func warnBackendWarnings(ctx context.Context, logger *slog.Logger, toolName string, messages []string) {
+	if len(messages) == 0 {
+		return
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if logger == nil {
+		logger = slog.Default()
+	}
+	logger.WarnContext(ctx,
+		"SigNoz query builder returned non-fatal warnings",
+		slog.String("tool", toolName),
+		slog.Int("warningCount", len(messages)),
+	)
+}
+
+// resultWithNotes wraps a raw JSON payload as a tool result. The JSON is always
+// the first (parseable) content block; notes are appended as separate blocks
+// rather than prepended into the JSON.
+func resultWithNotes(payload []byte, notes ...string) *mcp.CallToolResult {
 	res := mcp.NewToolResultText(string(payload))
-	if limitClamped {
+	for _, note := range notes {
+		if strings.TrimSpace(note) == "" {
+			continue
+		}
 		res.Content = append(res.Content, mcp.NewTextContent(note))
 	}
 	return res
@@ -210,16 +297,34 @@ func clampedResult(payload []byte, limitClamped bool, note string) *mcp.CallTool
 
 // rawSearchResult is the result wrapper for raw row tools (search_logs /
 // search_traces), which support offset pagination.
-func rawSearchResult(payload []byte, limitClamped bool) *mcp.CallToolResult {
-	return clampedResult(payload, limitClamped, fmt.Sprintf(
-		"note: result limited to %d rows to bound server memory; paginate with \"offset\" (or narrow the time range/filters) for more.",
-		MaxRawResultLimit))
+func rawSearchResult(ctx context.Context, logger *slog.Logger, toolName string, payload []byte, limitClamped bool) *mcp.CallToolResult {
+	var notes []string
+	if limitClamped {
+		notes = append(notes, fmt.Sprintf(
+			"note: result limited to %d rows to bound server memory; paginate with \"offset\" (or narrow the time range/filters) for more.",
+			MaxRawResultLimit))
+	}
+	warnings := extractBackendWarningMessages(payload)
+	warnBackendWarnings(ctx, logger, toolName, warnings)
+	if len(warnings) > 0 {
+		notes = append(notes, backendWarningsNote(warnings))
+	}
+	return resultWithNotes(payload, notes...)
 }
 
 // aggregateResult is the result wrapper for aggregation tools. Aggregations
 // have no offset pagination, so the note advises narrowing the query instead.
-func aggregateResult(payload []byte, limitClamped bool) *mcp.CallToolResult {
-	return clampedResult(payload, limitClamped, fmt.Sprintf(
-		"note: result limited to %d groups to bound server memory; narrow the time range, filters, or groupBy cardinality for fewer, more-specific groups.",
-		MaxRawResultLimit))
+func aggregateResult(ctx context.Context, logger *slog.Logger, toolName string, payload []byte, limitClamped bool) *mcp.CallToolResult {
+	var notes []string
+	if limitClamped {
+		notes = append(notes, fmt.Sprintf(
+			"note: result limited to %d groups to bound server memory; narrow the time range, filters, or groupBy cardinality for fewer, more-specific groups.",
+			MaxRawResultLimit))
+	}
+	warnings := extractBackendWarningMessages(payload)
+	warnBackendWarnings(ctx, logger, toolName, warnings)
+	if len(warnings) > 0 {
+		notes = append(notes, backendWarningsNote(warnings))
+	}
+	return resultWithNotes(payload, notes...)
 }

--- a/internal/handler/tools/docs_test.go
+++ b/internal/handler/tools/docs_test.go
@@ -40,6 +40,16 @@ func TestDocsHandlers(t *testing.T) {
 		require.Contains(t, strings.ToLower(search.Results[0].Snippet), "docker")
 	})
 
+	t.Run("search docs still requires query not filter", func(t *testing.T) {
+		result, err := h.handleSearchDocs(ctx, makeToolRequest("signoz_search_docs", map[string]any{
+			"filter": "docker collector logs",
+			"limit":  5,
+		}))
+		require.NoError(t, err)
+		require.True(t, result.IsError)
+		require.Contains(t, textContent(t, result), `"query" is required`)
+	})
+
 	t.Run("fetch errors", func(t *testing.T) {
 		result, err := h.handleFetchDoc(ctx, makeToolRequest("signoz_fetch_doc", map[string]any{"url": "https://example.com/docs/logs/"}))
 		require.NoError(t, err)

--- a/internal/handler/tools/fields.go
+++ b/internal/handler/tools/fields.go
@@ -10,6 +10,16 @@ import (
 	logpkg "github.com/SigNoz/signoz-mcp-server/pkg/log"
 )
 
+const fieldContextParamDesc = "Restrict results to a single field context (optional). Valid values: " +
+	"'resource' (resource attributes, e.g. service.name, k8s.namespace.name), " +
+	"'attribute' (user-ingested attributes; 'tag' is accepted as an alias), " +
+	"'scope' (instrumentation scope), " +
+	"'log' / 'span' / 'metric' (intrinsic/built-in columns of the logs/traces/metrics signal), " +
+	"'body' (fields inside a JSON log body). Use this to tell intrinsic columns apart from user attributes."
+
+const fieldDataTypeParamDesc = "Restrict results to a single field data type (optional). " +
+	"Valid values: 'string', 'bool', 'int64', 'float64', 'number', or array forms like '[]string'."
+
 func (h *Handler) RegisterFieldsHandlers(s *server.MCPServer) {
 	h.logger.Debug("Registering fields handlers")
 
@@ -21,8 +31,8 @@ func (h *Handler) RegisterFieldsHandlers(s *server.MCPServer) {
 		mcp.WithString("signal", mcp.Required(), mcp.Description("Signal type: 'metrics', 'traces', or 'logs'.")),
 		mcp.WithString("searchText", mcp.Description("Filter field names by substring (optional).")),
 		mcp.WithString("metricName", mcp.Description("Metric name to scope field keys (optional, only relevant when signal=metrics).")),
-		mcp.WithString("fieldContext", mcp.Description("Field context filter (optional).")),
-		mcp.WithString("fieldDataType", mcp.Description("Field data type filter (optional).")),
+		mcp.WithString("fieldContext", mcp.Description(fieldContextParamDesc)),
+		mcp.WithString("fieldDataType", mcp.Description(fieldDataTypeParamDesc)),
 		mcp.WithString("source", mcp.Description("Source filter (optional).")),
 	)
 
@@ -37,6 +47,7 @@ func (h *Handler) RegisterFieldsHandlers(s *server.MCPServer) {
 		mcp.WithString("name", mcp.Required(), mcp.Description("Field name to get values for (e.g., 'service.name', 'http.status_code').")),
 		mcp.WithString("searchText", mcp.Description("Filter the returned values by substring (optional).")),
 		mcp.WithString("metricName", mcp.Description("Metric name to scope field values (optional, only relevant when signal=metrics).")),
+		mcp.WithString("fieldContext", mcp.Description(fieldContextParamDesc+" Set this when the same key name exists in more than one context to disambiguate which one to fetch values for.")),
 		mcp.WithString("source", mcp.Description("Source filter (optional).")),
 	)
 
@@ -97,6 +108,7 @@ func (h *Handler) handleGetFieldValues(ctx context.Context, req mcp.CallToolRequ
 
 	searchText, _ := args["searchText"].(string)
 	metricName, _ := args["metricName"].(string)
+	fieldContext, _ := args["fieldContext"].(string)
 	source, _ := args["source"].(string)
 
 	h.logger.DebugContext(ctx, "Tool called: signoz_get_field_values", slog.String("signal", signal), slog.String("name", name))
@@ -104,7 +116,7 @@ func (h *Handler) handleGetFieldValues(ctx context.Context, req mcp.CallToolRequ
 	if err != nil {
 		return mcp.NewToolResultError(err.Error()), nil
 	}
-	result, err := client.GetFieldValues(ctx, signal, name, metricName, searchText, source)
+	result, err := client.GetFieldValues(ctx, signal, name, metricName, searchText, fieldContext, source)
 	if err != nil {
 		h.logger.ErrorContext(ctx, "Failed to get field values", slog.String("signal", signal), slog.String("name", name), logpkg.ErrAttr(err))
 		return mcp.NewToolResultError(err.Error()), nil

--- a/internal/handler/tools/fields_test.go
+++ b/internal/handler/tools/fields_test.go
@@ -1,0 +1,69 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	signozclient "github.com/SigNoz/signoz-mcp-server/internal/client"
+)
+
+// TestHandleGetFieldValues_FieldContextPassedThrough guards against the silent-drop
+// class of bug: the fieldContext arg must reach the client (and thus the
+// /api/v1/fields/values?fieldContext=... query param), not be dropped by the handler.
+func TestHandleGetFieldValues_FieldContextPassedThrough(t *testing.T) {
+	var gotContext string
+	mock := &signozclient.MockClient{
+		GetFieldValuesFn: func(_ context.Context, _, _, _, _, fieldContext, _ string) (json.RawMessage, error) {
+			gotContext = fieldContext
+			return json.RawMessage(`{"status":"success","data":[]}`), nil
+		},
+	}
+	h := newTestHandler(mock)
+
+	req := makeToolRequest("signoz_get_field_values", map[string]any{
+		"signal":       "logs",
+		"name":         "service.name",
+		"fieldContext": "resource",
+	})
+	res, err := h.handleGetFieldValues(testCtx(), req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.IsError {
+		t.Fatalf("unexpected tool error: %s", textContent(t, res))
+	}
+	if gotContext != "resource" {
+		t.Fatalf("fieldContext not passed through: got %q, want %q", gotContext, "resource")
+	}
+}
+
+// TestHandleGetFieldKeys_FieldContextAndDataTypePassedThrough guards the same
+// contract for the field-keys tool.
+func TestHandleGetFieldKeys_FieldContextAndDataTypePassedThrough(t *testing.T) {
+	var gotContext, gotDataType string
+	mock := &signozclient.MockClient{
+		GetFieldKeysFn: func(_ context.Context, _, _, _, fieldContext, fieldDataType, _ string) (json.RawMessage, error) {
+			gotContext = fieldContext
+			gotDataType = fieldDataType
+			return json.RawMessage(`{"status":"success","data":{}}`), nil
+		},
+	}
+	h := newTestHandler(mock)
+
+	req := makeToolRequest("signoz_get_field_keys", map[string]any{
+		"signal":        "logs",
+		"fieldContext":  "attribute",
+		"fieldDataType": "string",
+	})
+	res, err := h.handleGetFieldKeys(testCtx(), req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.IsError {
+		t.Fatalf("unexpected tool error: %s", textContent(t, res))
+	}
+	if gotContext != "attribute" || gotDataType != "string" {
+		t.Fatalf("field filters not passed through: context=%q dataType=%q", gotContext, gotDataType)
+	}
+}

--- a/internal/handler/tools/filter_param_consistency_test.go
+++ b/internal/handler/tools/filter_param_consistency_test.go
@@ -1,0 +1,582 @@
+package tools
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"log/slog"
+	"strings"
+	"testing"
+
+	"github.com/mark3labs/mcp-go/mcp"
+
+	"github.com/SigNoz/signoz-mcp-server/internal/client"
+	"github.com/SigNoz/signoz-mcp-server/pkg/types"
+)
+
+func TestParseFilterExpressionParam_AcceptsFilterAndLegacyQuery(t *testing.T) {
+	type parserCase struct {
+		name  string
+		parse func(map[string]any) (string, error)
+		base  map[string]any
+	}
+
+	parsers := []parserCase{
+		{
+			name: "search_logs",
+			parse: func(args map[string]any) (string, error) {
+				req, err := parseSearchLogsArgs(args)
+				if err != nil {
+					return "", err
+				}
+				return req.FilterExpression, nil
+			},
+			base: map[string]any{"timeRange": "1h"},
+		},
+		{
+			name: "search_traces",
+			parse: func(args map[string]any) (string, error) {
+				req, err := parseSearchTracesArgs(args)
+				if err != nil {
+					return "", err
+				}
+				return req.FilterExpression, nil
+			},
+			base: map[string]any{"timeRange": "1h"},
+		},
+		{
+			name: "aggregate_logs",
+			parse: func(args map[string]any) (string, error) {
+				req, err := parseAggregateLogsArgs(args)
+				if err != nil {
+					return "", err
+				}
+				return req.FilterExpression, nil
+			},
+			base: map[string]any{"aggregation": "count", "timeRange": "1h"},
+		},
+		{
+			name: "aggregate_traces",
+			parse: func(args map[string]any) (string, error) {
+				req, err := parseAggregateTracesArgs(args)
+				if err != nil {
+					return "", err
+				}
+				return req.FilterExpression, nil
+			},
+			base: map[string]any{"aggregation": "count", "timeRange": "1h"},
+		},
+		{
+			name: "query_metrics",
+			parse: func(args map[string]any) (string, error) {
+				req, err := parseMetricsQueryArgs(args)
+				if err != nil {
+					return "", err
+				}
+				return req.Filter, nil
+			},
+			base: map[string]any{"metricName": "system.cpu.time"},
+		},
+	}
+
+	tests := []struct {
+		name    string
+		args    map[string]any
+		want    string
+		wantErr bool
+	}{
+		{
+			name: "filter only",
+			args: map[string]any{"filter": " service.name = 'checkout' "},
+			want: " service.name = 'checkout' ",
+		},
+		{
+			name: "legacy query only",
+			args: map[string]any{"query": "service.name = 'checkout'"},
+			want: "service.name = 'checkout'",
+		},
+		{
+			name: "both equal after trimming prefer raw filter",
+			args: map[string]any{
+				"filter": " service.name = 'checkout' ",
+				"query":  "service.name = 'checkout'",
+			},
+			want: " service.name = 'checkout' ",
+		},
+		{
+			name: "both differ",
+			args: map[string]any{
+				"filter": "service.name = 'checkout'",
+				"query":  "service.name = 'frontend'",
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, parser := range parsers {
+		for _, tt := range tests {
+			t.Run(parser.name+"/"+tt.name, func(t *testing.T) {
+				args := mergeArgs(parser.base, tt.args)
+				got, err := parser.parse(args)
+				if tt.wantErr {
+					if err == nil {
+						t.Fatal("expected error")
+					}
+					if err.Error() != conflictingFilterAliasError {
+						t.Fatalf("error = %q, want %q", err.Error(), conflictingFilterAliasError)
+					}
+					return
+				}
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				if got != tt.want {
+					t.Fatalf("filter expression = %q, want %q", got, tt.want)
+				}
+			})
+		}
+	}
+}
+
+func TestExtractBackendWarningMessages(t *testing.T) {
+	tests := []struct {
+		name string
+		body json.RawMessage
+		want []string
+	}{
+		{
+			name: "malformed body",
+			body: json.RawMessage(`{not json`),
+		},
+		{
+			name: "valid success without warning field",
+			body: json.RawMessage(`{"status":"success","data":{"data":{"results":[]}}}`),
+		},
+		{
+			name: "blank warning dropped",
+			body: json.RawMessage(`{"status":"success","data":{"warning":{"warnings":[{"message":"   "},{"message":"keep me"}]}}}`),
+			want: []string{"keep me"},
+		},
+		{
+			name: "multiple warnings preserve order",
+			body: json.RawMessage(`{"status":"success","data":{"warning":{"warnings":[{"message":"first"},{"message":"second"}]}}}`),
+			want: []string{"first", "second"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := extractBackendWarningMessages(tt.body)
+			if tt.want == nil && got != nil {
+				t.Fatalf("warnings = %#v, want nil", got)
+			}
+			if len(got) != len(tt.want) {
+				t.Fatalf("warning count = %d (%#v), want %d (%#v)", len(got), got, len(tt.want), tt.want)
+			}
+			for i := range got {
+				if got[i] != tt.want[i] {
+					t.Fatalf("warning[%d] = %q, want %q", i, got[i], tt.want[i])
+				}
+			}
+		})
+	}
+}
+
+func TestHandleSearchLogs_FilterParamReachesPayload(t *testing.T) {
+	var captured []byte
+	mock := &client.MockClient{
+		QueryBuilderV5Fn: func(ctx context.Context, body []byte) (json.RawMessage, error) {
+			captured = body
+			return json.RawMessage(`{"status":"success","data":[]}`), nil
+		},
+	}
+	h := newTestHandler(mock)
+	result, err := h.handleSearchLogs(testCtx(), makeToolRequest("signoz_search_logs", map[string]any{
+		"filter":    "service.name='x'",
+		"timeRange": "1h",
+	}))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("handler returned error result: %v", result.Content)
+	}
+	if got := payloadFilterExpression(t, captured); got != "service.name='x'" {
+		t.Fatalf("payload filter = %q, want service.name='x'", got)
+	}
+}
+
+func TestHandleAggregateLogs_LegacyQueryParamReachesPayload(t *testing.T) {
+	var captured []byte
+	mock := &client.MockClient{
+		QueryBuilderV5Fn: func(ctx context.Context, body []byte) (json.RawMessage, error) {
+			captured = body
+			return json.RawMessage(`{"status":"success","data":[]}`), nil
+		},
+	}
+	h := newTestHandler(mock)
+	result, err := h.handleAggregateLogs(testCtx(), makeToolRequest("signoz_aggregate_logs", map[string]any{
+		"aggregation": "count",
+		"query":       "service.name='x'",
+		"timeRange":   "1h",
+	}))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("handler returned error result: %v", result.Content)
+	}
+	if got := payloadFilterExpression(t, captured); got != "service.name='x'" {
+		t.Fatalf("payload filter = %q, want service.name='x'", got)
+	}
+}
+
+func TestFilterAliasConflict_HandlerErrorsAllFilterTools(t *testing.T) {
+	tests := []struct {
+		name    string
+		args    map[string]any
+		handler func(*Handler, context.Context, mcp.CallToolRequest) (*mcp.CallToolResult, error)
+	}{
+		{
+			name: "search_logs",
+			args: map[string]any{"timeRange": "1h"},
+			handler: func(h *Handler, ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+				return h.handleSearchLogs(ctx, req)
+			},
+		},
+		{
+			name: "search_traces",
+			args: map[string]any{"timeRange": "1h"},
+			handler: func(h *Handler, ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+				return h.handleSearchTraces(ctx, req)
+			},
+		},
+		{
+			name: "aggregate_logs",
+			args: map[string]any{"aggregation": "count", "timeRange": "1h"},
+			handler: func(h *Handler, ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+				return h.handleAggregateLogs(ctx, req)
+			},
+		},
+		{
+			name: "aggregate_traces",
+			args: map[string]any{"aggregation": "count", "timeRange": "1h"},
+			handler: func(h *Handler, ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+				return h.handleAggregateTraces(ctx, req)
+			},
+		},
+		{
+			name: "query_metrics",
+			args: map[string]any{"metricName": "system.cpu.time", "metricType": "gauge", "timeRange": "1h"},
+			handler: func(h *Handler, ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+				return h.handleQueryMetrics(ctx, req)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h := newTestHandler(&client.MockClient{})
+			args := mergeArgs(tt.args, map[string]any{
+				"filter": "service.name = 'checkout'",
+				"query":  "service.name = 'frontend'",
+			})
+			result, err := tt.handler(h, testCtx(), makeToolRequest("signoz_"+tt.name, args))
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if !result.IsError {
+				t.Fatal("expected error result")
+			}
+			body := noteText(t, result, 0)
+			if !strings.Contains(body, conflictingFilterAliasError) {
+				t.Fatalf("error body = %q, want conflict message", body)
+			}
+		})
+	}
+}
+
+func TestFilterAlias_FalseFriendHandlersUnaffected(t *testing.T) {
+	t.Run("list_alerts_filter_remains_alertmanager_matcher", func(t *testing.T) {
+		var captured types.ListAlertsParams
+		mock := &client.MockClient{
+			ListAlertsFn: func(ctx context.Context, params types.ListAlertsParams) (json.RawMessage, error) {
+				captured = params
+				return json.RawMessage(`{"status":"success","data":[]}`), nil
+			},
+		}
+		h := newTestHandler(mock)
+		result, err := h.handleListAlerts(testCtx(), makeToolRequest("signoz_list_alerts", map[string]any{
+			"filter": `alertname="HighCPU",severity="critical"`,
+			"query":  "service.name = 'checkout'",
+		}))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if result.IsError {
+			t.Fatalf("handler returned error result: %v", result.Content)
+		}
+		if len(captured.Filter) != 2 {
+			t.Fatalf("captured filters = %#v, want 2 matcher filters", captured.Filter)
+		}
+		if captured.Filter[0] != `alertname="HighCPU"` || captured.Filter[1] != `severity="critical"` {
+			t.Fatalf("captured filters = %#v, want Alertmanager matchers", captured.Filter)
+		}
+	})
+
+	t.Run("execute_builder_query_still_requires_query_object", func(t *testing.T) {
+		h := newTestHandler(&client.MockClient{})
+		result, err := h.handleExecuteBuilderQuery(testCtx(), makeToolRequest("signoz_execute_builder_query", map[string]any{
+			"filter": "service.name = 'checkout'",
+		}))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !result.IsError {
+			t.Fatal("expected error result")
+		}
+		body := noteText(t, result, 0)
+		if !strings.Contains(body, "query parameter must be a JSON object") {
+			t.Fatalf("error body = %q, want query-object validation", body)
+		}
+	})
+
+	t.Run("query_metrics_formula_query_filters_remain_nested", func(t *testing.T) {
+		var captured []byte
+		mock := &client.MockClient{
+			QueryBuilderV5Fn: func(ctx context.Context, body []byte) (json.RawMessage, error) {
+				captured = body
+				return json.RawMessage(`{"status":"success","data":{"data":{"results":[]}}}`), nil
+			},
+		}
+		h := newTestHandler(mock)
+		result, err := h.handleQueryMetrics(testCtx(), makeToolRequest("signoz_query_metrics", map[string]any{
+			"metricName":  "system.cpu.time",
+			"metricType":  "gauge",
+			"filter":      "service.name = 'frontend'",
+			"timeRange":   "1h",
+			"requestType": "time_series",
+			"formulaQueries": []any{map[string]any{
+				"name":       "B",
+				"metricName": "system.memory.usage",
+				"metricType": "gauge",
+				"filter":     "attribute.instance = 'i-123'",
+			}},
+		}))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if result.IsError {
+			t.Fatalf("handler returned error result: %v", result.Content)
+		}
+		filters := payloadFilterExpressionsByQueryName(t, captured)
+		if filters["A"] != "service.name = 'frontend'" {
+			t.Fatalf("primary query filter = %q, want top-level filter", filters["A"])
+		}
+		if filters["B"] != "attribute.instance = 'i-123'" {
+			t.Fatalf("formula sub-query filter = %q, want nested formulaQueries filter", filters["B"])
+		}
+		if filters["B"] == filters["A"] {
+			t.Fatalf("top-level filter leaked into formula sub-query: %#v", filters)
+		}
+	})
+
+	t.Run("create_view_filter_args_do_not_mutate_nested_composite_query", func(t *testing.T) {
+		var gotBody []byte
+		mock := &client.MockClient{
+			CreateViewFn: func(ctx context.Context, body []byte) (json.RawMessage, error) {
+				gotBody = body
+				return json.RawMessage(`{"status":"success","data":{"id":"v1"}}`), nil
+			},
+		}
+		h := newTestHandler(mock)
+		nestedFilter := "severity_text = 'ERROR'"
+		result, err := h.handleCreateView(testCtx(), makeToolRequest("signoz_create_view", map[string]any{
+			"name":       "logs errors",
+			"sourcePage": "logs",
+			"filter":     "service.name = 'frontend'",
+			"query":      "service.name = 'legacy'",
+			"compositeQuery": map[string]any{
+				"queryType": "builder",
+				"panelType": "list",
+				"queries": []any{map[string]any{
+					"type": "builder_query",
+					"spec": map[string]any{
+						"name":   "A",
+						"signal": "logs",
+						"filter": map[string]any{"expression": nestedFilter},
+					},
+				}},
+			},
+		}))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if result.IsError {
+			t.Fatalf("handler returned error result: %v", result.Content)
+		}
+		if got := savedViewNestedFilterExpression(t, gotBody); got != nestedFilter {
+			t.Fatalf("nested compositeQuery filter = %q, want %q", got, nestedFilter)
+		}
+	})
+}
+
+func TestBackendWarnings_SurfaceInToolResultAndWarnLog(t *testing.T) {
+	warningMessage := "Key http.status_code is ambiguous; using resource context"
+	response := json.RawMessage(`{"status":"success","data":{"warning":{"warnings":[{"message":"` + warningMessage + `"}]},"data":{"results":[]}}}`)
+	var logs bytes.Buffer
+	mock := &client.MockClient{
+		QueryBuilderV5Fn: func(ctx context.Context, body []byte) (json.RawMessage, error) {
+			return response, nil
+		},
+	}
+	h := newTestHandler(mock)
+	h.logger = slog.New(slog.NewTextHandler(&logs, &slog.HandlerOptions{Level: slog.LevelWarn}))
+
+	result, err := h.handleSearchLogs(testCtx(), makeToolRequest("signoz_search_logs", map[string]any{
+		"filter":    "service.name = 'checkout'",
+		"timeRange": "1h",
+	}))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("handler returned error result: %v", result.Content)
+	}
+	if len(result.Content) != 2 {
+		t.Fatalf("content block count = %d, want raw JSON + warning note", len(result.Content))
+	}
+	if block0 := noteText(t, result, 0); block0 != string(response) {
+		t.Fatalf("block 0 = %q, want raw response unchanged", block0)
+	}
+	if note := noteText(t, result, 1); !strings.Contains(note, warningMessage) {
+		t.Fatalf("warning note = %q, want backend warning message", note)
+	}
+	if gotLogs := logs.String(); !strings.Contains(gotLogs, "SigNoz query builder returned non-fatal warnings") || !strings.Contains(gotLogs, "warningCount=1") {
+		t.Fatalf("expected WARN log with warningCount, got %q", gotLogs)
+	}
+}
+
+func TestBackendWarnings_ComposeWithClampNote(t *testing.T) {
+	payload := []byte(`{"status":"success","data":{"warning":{"warnings":[{"message":"ambiguous key"}]},"data":{"results":[]}}}`)
+	var logs bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&logs, &slog.HandlerOptions{Level: slog.LevelWarn}))
+
+	result := rawSearchResult(testCtx(), logger, "signoz_search_logs", payload, true)
+	if len(result.Content) != 3 {
+		t.Fatalf("content block count = %d, want raw JSON + clamp note + warning note", len(result.Content))
+	}
+	if block0 := noteText(t, result, 0); block0 != string(payload) {
+		t.Fatalf("block 0 = %q, want raw response unchanged", block0)
+	}
+	if clampNote := noteText(t, result, 1); !strings.Contains(clampNote, "result limited to") {
+		t.Fatalf("block 1 = %q, want clamp note", clampNote)
+	}
+	if warningNote := noteText(t, result, 2); !strings.Contains(warningNote, "ambiguous key") {
+		t.Fatalf("block 2 = %q, want warning note", warningNote)
+	}
+}
+
+func mergeArgs(base, override map[string]any) map[string]any {
+	merged := make(map[string]any, len(base)+len(override))
+	for k, v := range base {
+		merged[k] = v
+	}
+	for k, v := range override {
+		merged[k] = v
+	}
+	return merged
+}
+
+func payloadFilterExpression(t *testing.T, payload []byte) string {
+	t.Helper()
+	if len(payload) == 0 {
+		t.Fatal("payload was not captured")
+	}
+	var decoded struct {
+		CompositeQuery struct {
+			Queries []struct {
+				Spec struct {
+					Filter struct {
+						Expression string `json:"expression"`
+					} `json:"filter"`
+				} `json:"spec"`
+			} `json:"queries"`
+		} `json:"compositeQuery"`
+	}
+	if err := json.Unmarshal(payload, &decoded); err != nil {
+		t.Fatalf("unmarshal payload: %v", err)
+	}
+	if len(decoded.CompositeQuery.Queries) != 1 {
+		t.Fatalf("query count = %d, want 1", len(decoded.CompositeQuery.Queries))
+	}
+	return decoded.CompositeQuery.Queries[0].Spec.Filter.Expression
+}
+
+func payloadFilterExpressionsByQueryName(t *testing.T, payload []byte) map[string]string {
+	t.Helper()
+	if len(payload) == 0 {
+		t.Fatal("payload was not captured")
+	}
+	var decoded struct {
+		CompositeQuery struct {
+			Queries []struct {
+				Type string `json:"type"`
+				Spec struct {
+					Name   string `json:"name"`
+					Filter *struct {
+						Expression string `json:"expression"`
+					} `json:"filter"`
+				} `json:"spec"`
+			} `json:"queries"`
+		} `json:"compositeQuery"`
+	}
+	if err := json.Unmarshal(payload, &decoded); err != nil {
+		t.Fatalf("unmarshal payload: %v", err)
+	}
+	filters := map[string]string{}
+	for _, q := range decoded.CompositeQuery.Queries {
+		if q.Type != "builder_query" || q.Spec.Filter == nil {
+			continue
+		}
+		filters[q.Spec.Name] = q.Spec.Filter.Expression
+	}
+	return filters
+}
+
+func savedViewNestedFilterExpression(t *testing.T, body []byte) string {
+	t.Helper()
+	if len(body) == 0 {
+		t.Fatal("view body was not captured")
+	}
+	var decoded struct {
+		CompositeQuery struct {
+			Queries []struct {
+				Spec struct {
+					Filter struct {
+						Expression string `json:"expression"`
+					} `json:"filter"`
+				} `json:"spec"`
+			} `json:"queries"`
+		} `json:"compositeQuery"`
+	}
+	if err := json.Unmarshal(body, &decoded); err != nil {
+		t.Fatalf("unmarshal view body: %v", err)
+	}
+	if len(decoded.CompositeQuery.Queries) != 1 {
+		t.Fatalf("view query count = %d, want 1", len(decoded.CompositeQuery.Queries))
+	}
+	return decoded.CompositeQuery.Queries[0].Spec.Filter.Expression
+}
+
+func noteText(t *testing.T, result *mcp.CallToolResult, index int) string {
+	t.Helper()
+	if len(result.Content) <= index {
+		t.Fatalf("result has %d content blocks, want index %d", len(result.Content), index)
+	}
+	text, ok := mcp.AsTextContent(result.Content[index])
+	if !ok {
+		t.Fatalf("content block %d is %T, want text", index, result.Content[index])
+	}
+	return text.Text
+}

--- a/internal/handler/tools/limit_clamp_test.go
+++ b/internal/handler/tools/limit_clamp_test.go
@@ -51,12 +51,12 @@ func TestParseSearchTracesArgs_LimitClamped(t *testing.T) {
 func TestRawSearchResult_NoteIsSeparateBlock(t *testing.T) {
 	payload := []byte(`{"status":"success","data":[]}`)
 
-	notClamped := rawSearchResult(payload, false)
+	notClamped := rawSearchResult(testCtx(), nil, "signoz_search_logs", payload, false)
 	if len(notClamped.Content) != 1 {
 		t.Fatalf("not-clamped: want 1 content block, got %d", len(notClamped.Content))
 	}
 
-	clamped := rawSearchResult(payload, true)
+	clamped := rawSearchResult(testCtx(), nil, "signoz_search_logs", payload, true)
 	if len(clamped.Content) != 2 {
 		t.Fatalf("clamped: want 2 content blocks, got %d", len(clamped.Content))
 	}
@@ -80,7 +80,7 @@ func TestRawSearchResult_NoteIsSeparateBlock(t *testing.T) {
 func TestAggregateResult_SurfaceSeparateNote(t *testing.T) {
 	payload := []byte(`{"status":"success","data":[]}`)
 
-	clamped := aggregateResult(payload, true)
+	clamped := aggregateResult(testCtx(), nil, "signoz_aggregate_logs", payload, true)
 	if len(clamped.Content) != 2 {
 		t.Fatalf("clamped: want 2 content blocks, got %d", len(clamped.Content))
 	}
@@ -97,7 +97,7 @@ func TestAggregateResult_SurfaceSeparateNote(t *testing.T) {
 		t.Fatalf("clamped: block 1 should be the groups note, got %#v", clamped.Content[1])
 	}
 
-	if n := len(aggregateResult(payload, false).Content); n != 1 {
+	if n := len(aggregateResult(testCtx(), nil, "signoz_aggregate_logs", payload, false).Content); n != 1 {
 		t.Fatalf("not-clamped aggregate: want 1 content block, got %d", n)
 	}
 }

--- a/internal/handler/tools/logs.go
+++ b/internal/handler/tools/logs.go
@@ -12,6 +12,8 @@ import (
 	"github.com/SigNoz/signoz-mcp-server/pkg/types"
 )
 
+const logsFilterParamDescription = "Filter expression using SigNoz search syntax (see signoz://logs/query-builder-guide). Unknown keys hard-error; keys present in multiple contexts default to resource context. Disambiguate with attribute.<key> or resource.<key>; discover real keys first with signoz_get_field_keys/signoz_get_field_values. Examples: \"service.name = 'payment-svc' AND severity_text = 'ERROR'\", \"body CONTAINS 'timeout'\", \"body.user.id = '123'\"."
+
 func (h *Handler) RegisterLogsHandlers(s *server.MCPServer) {
 	h.logger.Debug("Registering logs handlers")
 
@@ -26,7 +28,7 @@ func (h *Handler) RegisterLogsHandlers(s *server.MCPServer) {
 		mcp.WithString("aggregation", mcp.Required(), mcp.Description("Aggregation function to apply. One of: count, count_distinct, avg, sum, min, max, p50, p75, p90, p95, p99, rate")),
 		mcp.WithString("aggregateOn", mcp.Description("Field name to aggregate on (e.g., 'response_time', 'duration'). Required for all aggregations except count and rate.")),
 		mcp.WithString("groupBy", mcp.Description("Comma-separated list of field names to group results by (e.g., 'service.name' or 'service.name, severity_text'). Leave empty for a single aggregate value.")),
-		mcp.WithString("filter", mcp.Description("Filter expression using SigNoz search syntax (e.g., \"status_code >= 400 AND http.method = 'POST'\"). Combined with service/severity params using AND.")),
+		mcp.WithString("filter", mcp.Description(logsFilterParamDescription+" Combined with service/severity params using AND.")),
 		mcp.WithString("service", mcp.Description("Shortcut filter for service name. Equivalent to adding service.name = '<value>' to filter.")),
 		mcp.WithString("severity", mcp.Description("Shortcut filter for log severity (DEBUG, INFO, WARN, ERROR, FATAL). Equivalent to adding severity_text = '<value>' to filter.")),
 		mcp.WithString("orderBy", mcp.Description("How to order results. Format: '<expression> <direction>', e.g. 'count() desc' or 'avg(duration) asc'. Defaults to the aggregation expression descending.")),
@@ -46,10 +48,11 @@ func (h *Handler) RegisterLogsHandlers(s *server.MCPServer) {
 		mcp.WithReadOnlyHintAnnotation(true),
 		mcp.WithDestructiveHintAnnotation(false),
 		mcp.WithString("searchContext", mcp.Description("The user's original question or search text that triggered this tool call. Always include the user's raw query here for better results.")),
-		mcp.WithDescription("Search logs with flexible filtering. Supports free-form query expressions, optional service/severity filters, and body text search. "+
-			"Use service param to scope to a single service, severity param for error-only queries (e.g., severity='ERROR'), or query param for any filter expression. "+
+		mcp.WithDescription("Search logs with flexible filtering. Supports free-form filter expressions, optional service/severity filters, and body text search. "+
+			"Use service param to scope to a single service, severity param for error-only queries (e.g., severity='ERROR'), or filter param for any filter expression. "+
+			"For logs filter syntax, field contexts, and body JSON examples, read signoz://logs/query-builder-guide. "+
 			"Defaults to last 1 hour if no time specified."),
-		mcp.WithString("query", mcp.Description("Free-form filter expression using SigNoz search syntax. Examples: \"service.name = 'payment-svc' AND http.status_code >= 400\", \"workflow_run_id = 'wr_123'\", \"body CONTAINS 'timeout'\". Supports any log field/attribute.")),
+		mcp.WithString("filter", mcp.Description(logsFilterParamDescription)),
 		mcp.WithString("service", mcp.Description("Optional service name to filter by.")),
 		mcp.WithString("severity", mcp.Description("Optional severity filter (DEBUG, INFO, WARN, ERROR, FATAL).")),
 		mcp.WithString("searchText", mcp.Description("Text to search for in log body (uses CONTAINS matching).")),
@@ -101,7 +104,7 @@ func (h *Handler) handleAggregateLogs(ctx context.Context, req mcp.CallToolReque
 		return mcp.NewToolResultError(err.Error()), nil
 	}
 
-	return aggregateResult(result, reqData.LimitClamped), nil
+	return aggregateResult(ctx, h.logger, "signoz_aggregate_logs", result, reqData.LimitClamped), nil
 }
 
 func (h *Handler) handleSearchLogs(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
@@ -139,5 +142,5 @@ func (h *Handler) handleSearchLogs(ctx context.Context, req mcp.CallToolRequest)
 		return mcp.NewToolResultError(err.Error()), nil
 	}
 
-	return rawSearchResult(result, reqData.LimitClamped), nil
+	return rawSearchResult(ctx, h.logger, "signoz_search_logs", result, reqData.LimitClamped), nil
 }

--- a/internal/handler/tools/logs.go
+++ b/internal/handler/tools/logs.go
@@ -12,7 +12,7 @@ import (
 	"github.com/SigNoz/signoz-mcp-server/pkg/types"
 )
 
-const logsFilterParamDescription = "Filter expression using SigNoz search syntax (see signoz://logs/query-builder-guide). Unknown keys hard-error; keys present in multiple contexts default to resource context. Disambiguate with attribute.<key> or resource.<key>; discover real keys first with signoz_get_field_keys/signoz_get_field_values. Examples: \"service.name = 'payment-svc' AND severity_text = 'ERROR'\", \"body CONTAINS 'timeout'\", \"body.user.id = '123'\"."
+const logsFilterParamDescription = "Filter expression using SigNoz search syntax (see signoz://logs/query-builder-guide). Combine conditions with AND, OR, and parentheses for precedence. Unknown keys hard-error; keys present in multiple contexts default to resource context. Disambiguate with attribute.<key> or resource.<key>. Discover valid keys with signoz_get_field_keys, then confirm values with signoz_get_field_values, before filtering. Examples: \"service.name = 'payment-svc' AND severity_text = 'ERROR'\", \"(severity_text = 'ERROR' OR body CONTAINS 'panic') AND k8s.namespace.name = 'prod'\", \"body.user.id = '123'\"."
 
 func (h *Handler) RegisterLogsHandlers(s *server.MCPServer) {
 	h.logger.Debug("Registering logs handlers")

--- a/internal/handler/tools/logs_helper.go
+++ b/internal/handler/tools/logs_helper.go
@@ -9,7 +9,10 @@ import (
 func parseAggregateLogsArgs(args map[string]any) (*AggregateRequest, error) {
 	service, _ := args["service"].(string)
 	severity, _ := args["severity"].(string)
-	filter, _ := args["filter"].(string)
+	filter, err := readFilterExpr(args)
+	if err != nil {
+		return nil, err
+	}
 	filterExpr := buildLogFilterExpr(filter, service, severity, "")
 
 	return parseAggregateArgs(args, "logs", filterExpr)
@@ -26,11 +29,14 @@ type SearchLogsRequest struct {
 }
 
 func parseSearchLogsArgs(args map[string]any) (*SearchLogsRequest, error) {
-	query, _ := args["query"].(string)
+	filter, err := readFilterExpr(args)
+	if err != nil {
+		return nil, err
+	}
 	service, _ := args["service"].(string)
 	severity, _ := args["severity"].(string)
 	searchText, _ := args["searchText"].(string)
-	filterExpr := buildLogFilterExpr(query, service, severity, searchText)
+	filterExpr := buildLogFilterExpr(filter, service, severity, searchText)
 
 	limit, err := intArg(args, "limit", 100)
 	if err != nil {

--- a/internal/handler/tools/metrics_helper.go
+++ b/internal/handler/tools/metrics_helper.go
@@ -47,6 +47,10 @@ func parseMetricsQueryArgs(args map[string]any) (*metricsQueryRequest, error) {
 	if metricName == "" {
 		return nil, fmt.Errorf("\"metricName\" is required. Use signoz_list_metrics to find available metrics")
 	}
+	filter, err := readFilterExpr(args)
+	if err != nil {
+		return nil, err
+	}
 
 	req := &metricsQueryRequest{
 		MetricName:       metricName,
@@ -55,7 +59,7 @@ func parseMetricsQueryArgs(args map[string]any) (*metricsQueryRequest, error) {
 		TimeAggregation:  stringArg(args, "timeAggregation"),
 		SpaceAggregation: stringArg(args, "spaceAggregation"),
 		ReduceTo:         stringArg(args, "reduceTo"),
-		Filter:           stringArg(args, "filter"),
+		Filter:           filter,
 		TimeRange:        stringArg(args, "timeRange"),
 		RequestType:      stringArg(args, "requestType"),
 		Formula:          stringArg(args, "formula"),

--- a/internal/handler/tools/metrics_query.go
+++ b/internal/handler/tools/metrics_query.go
@@ -180,6 +180,8 @@ func (h *Handler) handleQueryMetrics(ctx context.Context, req mcp.CallToolReques
 			decisions = append(decisions, fmt.Sprintf("stepInterval: %ds (backend-determined)", si))
 		}
 	}
+	backendWarnings := extractBackendWarningMessages(result)
+	warnBackendWarnings(ctx, h.logger, "signoz_query_metrics", backendWarnings)
 
 	// Build response with decisions block
 	var response strings.Builder
@@ -189,6 +191,9 @@ func (h *Handler) handleQueryMetrics(ctx context.Context, req mcp.CallToolReques
 	}
 	for _, w := range resolved.Warnings {
 		response.WriteString(fmt.Sprintf("  WARNING: %s\n", w))
+	}
+	for _, w := range backendWarnings {
+		response.WriteString(fmt.Sprintf("  WARNING: backend: %s\n", w))
 	}
 	response.WriteString("---\n")
 	response.WriteString(string(result))

--- a/internal/handler/tools/metrics_query_test.go
+++ b/internal/handler/tools/metrics_query_test.go
@@ -1,8 +1,11 @@
 package tools
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
+	"log/slog"
+	"strings"
 	"testing"
 
 	"github.com/SigNoz/signoz-mcp-server/internal/client"
@@ -46,5 +49,42 @@ func TestHandleQueryMetrics_ExplicitStartEndOverrideTimeRange(t *testing.T) {
 	}
 	if payload.End != 1711130400000 {
 		t.Fatalf("end = %d, want explicit end", payload.End)
+	}
+}
+
+func TestHandleQueryMetrics_BackendWarningsInDecisionsBlockAndWarnLog(t *testing.T) {
+	const warningMessage = "Key http.status_code is ambiguous"
+	var logs bytes.Buffer
+	mock := &client.MockClient{
+		QueryBuilderV5Fn: func(ctx context.Context, body []byte) (json.RawMessage, error) {
+			return json.RawMessage(`{"status":"success","data":{"meta":{"stepIntervals":{"A":60}},"warning":{"warnings":[{"message":"` + warningMessage + `"}]}}}`), nil
+		},
+	}
+	h := newTestHandler(mock)
+	h.logger = slog.New(slog.NewTextHandler(&logs, &slog.HandlerOptions{Level: slog.LevelWarn}))
+	req := makeToolRequest("signoz_query_metrics", map[string]any{
+		"metricName":  "system.cpu.time",
+		"metricType":  "gauge",
+		"timeRange":   "1h",
+		"requestType": "time_series",
+	})
+
+	result, err := h.handleQueryMetrics(testCtx(), req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("handler returned error result: %v", result.Content)
+	}
+	body := textContent(t, result)
+	wantLine := "WARNING: backend: " + warningMessage
+	if !strings.Contains(body, "[Decisions applied]\n") || !strings.Contains(body, wantLine) {
+		t.Fatalf("metrics result missing backend warning in decisions block; want %q in:\n%s", wantLine, body)
+	}
+	if strings.Index(body, wantLine) > strings.Index(body, "---\n") {
+		t.Fatalf("backend warning appears after decisions block delimiter; body:\n%s", body)
+	}
+	if gotLogs := logs.String(); !strings.Contains(gotLogs, "level=WARN") || !strings.Contains(gotLogs, "SigNoz query builder returned non-fatal warnings") || !strings.Contains(gotLogs, "warningCount=1") {
+		t.Fatalf("expected WARN log with warningCount, got %q", gotLogs)
 	}
 }

--- a/internal/handler/tools/query_builder.go
+++ b/internal/handler/tools/query_builder.go
@@ -52,6 +52,23 @@ func (h *Handler) RegisterQueryBuilderV5Handlers(s *server.MCPServer) {
 			},
 		}, nil
 	})
+
+	logsQueryBuilderGuide := mcp.NewResource(
+		"signoz://logs/query-builder-guide",
+		"Logs Query Builder Guide",
+		mcp.WithResourceDescription("SigNoz Query Builder v5 logs guide: filter expression syntax (string, not structured object), log built-in columns, resource/log attribute naming, body text search, body JSON-path search, and complete working examples for raw, aggregation, and time series queries."),
+		mcp.WithMIMEType("text/plain"),
+	)
+
+	s.AddResource(logsQueryBuilderGuide, func(ctx context.Context, req mcp.ReadResourceRequest) ([]mcp.ResourceContents, error) {
+		return []mcp.ResourceContents{
+			mcp.TextResourceContents{
+				URI:      req.Params.URI,
+				MIMEType: "text/plain",
+				Text:     querybuilder.LogsQueryBuilderGuide,
+			},
+		}, nil
+	})
 }
 
 func (h *Handler) handleExecuteBuilderQuery(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {

--- a/internal/handler/tools/traces.go
+++ b/internal/handler/tools/traces.go
@@ -15,7 +15,7 @@ import (
 	"github.com/SigNoz/signoz-mcp-server/pkg/util"
 )
 
-const tracesFilterParamDescription = "Filter expression using SigNoz search syntax (see signoz://traces/query-builder-guide). Unknown keys hard-error; keys present in multiple contexts default to resource context. Disambiguate with attribute.<key> or resource.<key>; discover real keys first with signoz_get_field_keys/signoz_get_field_values. Examples: \"service.name = 'payment-svc' AND hasError = true\", \"httpMethod = 'POST' AND responseStatusCode >= 500\"."
+const tracesFilterParamDescription = "Filter expression using SigNoz search syntax (see signoz://traces/query-builder-guide). Combine conditions with AND, OR, and parentheses for precedence. Unknown keys hard-error; keys present in multiple contexts default to resource context. Disambiguate with attribute.<key> or resource.<key>. Discover valid keys with signoz_get_field_keys, then confirm values with signoz_get_field_values, before filtering. Examples: \"service.name = 'payment-svc' AND hasError = true\", \"httpMethod = 'POST' AND (responseStatusCode >= 500 OR durationNano > 1000000000)\"."
 
 func (h *Handler) RegisterTracesHandlers(s *server.MCPServer) {
 	h.logger.Debug("Registering traces handlers")

--- a/internal/handler/tools/traces.go
+++ b/internal/handler/tools/traces.go
@@ -15,6 +15,8 @@ import (
 	"github.com/SigNoz/signoz-mcp-server/pkg/util"
 )
 
+const tracesFilterParamDescription = "Filter expression using SigNoz search syntax (see signoz://traces/query-builder-guide). Unknown keys hard-error; keys present in multiple contexts default to resource context. Disambiguate with attribute.<key> or resource.<key>; discover real keys first with signoz_get_field_keys/signoz_get_field_values. Examples: \"service.name = 'payment-svc' AND hasError = true\", \"httpMethod = 'POST' AND responseStatusCode >= 500\"."
+
 func (h *Handler) RegisterTracesHandlers(s *server.MCPServer) {
 	h.logger.Debug("Registering traces handlers")
 
@@ -30,7 +32,7 @@ func (h *Handler) RegisterTracesHandlers(s *server.MCPServer) {
 		mcp.WithString("aggregation", mcp.Required(), mcp.Description("Aggregation function to apply. One of: count, count_distinct, avg, sum, min, max, p50, p75, p90, p95, p99, rate")),
 		mcp.WithString("aggregateOn", mcp.Description("Field name to aggregate on (e.g., 'durationNano'). Required for all aggregations except count and rate.")),
 		mcp.WithString("groupBy", mcp.Description("Comma-separated list of field names to group results by (e.g., 'service.name' or 'service.name, name'). Leave empty for a single aggregate value.")),
-		mcp.WithString("filter", mcp.Description("Filter expression using SigNoz search syntax (e.g., \"hasError = true AND httpMethod = 'GET'\"). Combined with service/operation/error/duration params using AND.")),
+		mcp.WithString("filter", mcp.Description(tracesFilterParamDescription+" Combined with service/operation/error/duration params using AND.")),
 		mcp.WithString("service", mcp.Description("Shortcut filter for service name. Equivalent to adding service.name = '<value>' to filter.")),
 		mcp.WithString("operation", mcp.Description("Shortcut filter for span/operation name. Equivalent to adding name = '<value>' to filter.")),
 		mcp.WithString("error", mcp.Description("Shortcut filter for error spans ('true' or 'false'). Equivalent to adding hasError = true/false to filter.")),
@@ -51,10 +53,11 @@ func (h *Handler) RegisterTracesHandlers(s *server.MCPServer) {
 		mcp.WithReadOnlyHintAnnotation(true),
 		mcp.WithDestructiveHintAnnotation(false),
 		mcp.WithString("searchContext", mcp.Description("The user's original question or search text that triggered this tool call. Always include the user's raw query here for better results.")),
-		mcp.WithDescription("Search traces with flexible filtering. Supports free-form query expressions, optional service/operation/error filters, and duration filtering. "+
-			"Use service param to scope to a single service, or query param for any filter expression. "+
+		mcp.WithDescription("Search traces with flexible filtering. Supports free-form filter expressions, optional service/operation/error filters, and duration filtering. "+
+			"Use service param to scope to a single service, or filter param for any filter expression. "+
+			"For traces filter syntax and field contexts, read signoz://traces/query-builder-guide. "+
 			"Defaults to last 1 hour if no time specified."),
-		mcp.WithString("query", mcp.Description("Free-form filter expression using SigNoz search syntax. Examples: \"service.name = 'payment-svc' AND hasError = true\", \"httpMethod = 'POST' AND responseStatusCode >= 500\". Combined with shortcut params using AND.")),
+		mcp.WithString("filter", mcp.Description(tracesFilterParamDescription+" Combined with shortcut params using AND.")),
 		mcp.WithString("service", mcp.Description("Optional service name to filter by.")),
 		mcp.WithString("operation", mcp.Description("Operation/span name to filter by.")),
 		mcp.WithString("error", mcp.Description("Filter by error status ('true' or 'false').")),
@@ -122,7 +125,7 @@ func (h *Handler) handleAggregateTraces(ctx context.Context, req mcp.CallToolReq
 		return mcp.NewToolResultError(err.Error()), nil
 	}
 
-	return aggregateResult(result, reqData.LimitClamped), nil
+	return aggregateResult(ctx, h.logger, "signoz_aggregate_traces", result, reqData.LimitClamped), nil
 }
 
 func (h *Handler) handleSearchTraces(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
@@ -158,7 +161,7 @@ func (h *Handler) handleSearchTraces(ctx context.Context, req mcp.CallToolReques
 	}
 
 	result = h.enrichSearchTracesWebURL(ctx, result)
-	return rawSearchResult(result, reqData.LimitClamped), nil
+	return rawSearchResult(ctx, h.logger, "signoz_search_traces", result, reqData.LimitClamped), nil
 }
 
 func (h *Handler) handleGetTraceDetails(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {

--- a/internal/handler/tools/traces_helper.go
+++ b/internal/handler/tools/traces_helper.go
@@ -16,13 +16,16 @@ type SearchTracesRequest struct {
 }
 
 func parseSearchTracesArgs(args map[string]any) (*SearchTracesRequest, error) {
-	query, _ := args["query"].(string)
+	filter, err := readFilterExpr(args)
+	if err != nil {
+		return nil, err
+	}
 	service, _ := args["service"].(string)
 	operation, _ := args["operation"].(string)
 	errorFilter, _ := args["error"].(string)
 	minDuration, _ := args["minDuration"].(string)
 	maxDuration, _ := args["maxDuration"].(string)
-	filterExpr := buildTraceFilterExpr(query, service, operation, errorFilter, minDuration, maxDuration)
+	filterExpr := buildTraceFilterExpr(filter, service, operation, errorFilter, minDuration, maxDuration)
 
 	limit, err := intArg(args, "limit", 100)
 	if err != nil {
@@ -57,7 +60,10 @@ func parseAggregateTracesArgs(args map[string]any) (*AggregateRequest, error) {
 	errorFilter, _ := args["error"].(string)
 	minDuration, _ := args["minDuration"].(string)
 	maxDuration, _ := args["maxDuration"].(string)
-	filter, _ := args["filter"].(string)
+	filter, err := readFilterExpr(args)
+	if err != nil {
+		return nil, err
+	}
 	filterExpr := buildTraceFilterExpr(filter, service, operation, errorFilter, minDuration, maxDuration)
 
 	return parseAggregateArgs(args, "traces", filterExpr)

--- a/internal/mcp-server/integration_test.go
+++ b/internal/mcp-server/integration_test.go
@@ -244,6 +244,73 @@ func TestIntegration_AllToolsExposeSearchContext(t *testing.T) {
 	}
 }
 
+func TestIntegration_FilterExpressionToolsAdvertiseCanonicalFilter(t *testing.T) {
+	s := buildTestServer(t)
+	ctx := context.Background()
+
+	c, err := mcpclient.NewInProcessClient(s)
+	if err != nil {
+		t.Fatalf("failed to create in-process client: %v", err)
+	}
+
+	if _, err := c.Initialize(ctx, mcp.InitializeRequest{
+		Params: mcp.InitializeParams{
+			ProtocolVersion: mcp.LATEST_PROTOCOL_VERSION,
+			ClientInfo: mcp.Implementation{
+				Name:    "test-client",
+				Version: version.Version,
+			},
+		},
+	}); err != nil {
+		t.Fatalf("Initialize failed: %v", err)
+	}
+
+	toolsResult, err := c.ListTools(ctx, mcp.ListToolsRequest{})
+	if err != nil {
+		t.Fatalf("ListTools failed: %v", err)
+	}
+	toolsByName := make(map[string]mcp.Tool, len(toolsResult.Tools))
+	for _, tool := range toolsResult.Tools {
+		toolsByName[tool.Name] = tool
+	}
+
+	for _, name := range []string{
+		"signoz_search_logs",
+		"signoz_search_traces",
+		"signoz_aggregate_logs",
+		"signoz_aggregate_traces",
+		"signoz_query_metrics",
+	} {
+		tool, ok := toolsByName[name]
+		if !ok {
+			t.Fatalf("tool %s not registered", name)
+		}
+		props := schemaProperties(t, name, inputSchema(t, tool))
+		if _, ok := props["filter"]; !ok {
+			t.Errorf("%s should advertise canonical filter param", name)
+		}
+		if _, ok := props["query"]; ok {
+			t.Errorf("%s should not advertise legacy query alias", name)
+		}
+	}
+
+	falseFriends := map[string]string{
+		"signoz_list_alerts":           "filter",
+		"signoz_search_docs":           "query",
+		"signoz_execute_builder_query": "query",
+	}
+	for name, param := range falseFriends {
+		tool, ok := toolsByName[name]
+		if !ok {
+			t.Fatalf("tool %s not registered", name)
+		}
+		props := schemaProperties(t, name, inputSchema(t, tool))
+		if _, ok := props[param]; !ok {
+			t.Errorf("%s should keep %q param", name, param)
+		}
+	}
+}
+
 func TestIntegration_PromqlInstructionsResourceRegistered(t *testing.T) {
 	s := buildTestServer(t)
 	ctx := context.Background()

--- a/manifest.json
+++ b/manifest.json
@@ -135,19 +135,19 @@
     },
     {
       "name": "signoz_aggregate_logs",
-      "description": "Aggregate logs to compute statistics (count, avg, sum, min, max, percentiles)"
+      "description": "Aggregate logs to compute statistics (count, avg, sum, min, max, percentiles) with canonical filter expressions; see signoz://logs/query-builder-guide"
     },
     {
       "name": "signoz_search_logs",
-      "description": "Search logs with flexible filtering by service, severity, and body text"
+      "description": "Search logs with flexible filtering by service, severity, body text, and canonical filter expressions; see signoz://logs/query-builder-guide"
     },
     {
       "name": "signoz_aggregate_traces",
-      "description": "Aggregate traces to compute statistics over spans, optionally grouped by fields"
+      "description": "Aggregate traces to compute statistics over spans, optionally grouped by fields, with canonical filter expressions; see signoz://traces/query-builder-guide"
     },
     {
       "name": "signoz_search_traces",
-      "description": "Search traces with flexible filtering by service, operation, error, and duration"
+      "description": "Search traces with flexible filtering by service, operation, error, duration, and canonical filter expressions; see signoz://traces/query-builder-guide"
     },
     {
       "name": "signoz_get_trace_details",
@@ -184,6 +184,18 @@
       "name": "SigNoz Docs Sitemap",
       "description": "Indexed sitemap used by signoz_search_docs and signoz_fetch_doc",
       "mimeType": "text/markdown"
+    },
+    {
+      "uri": "signoz://logs/query-builder-guide",
+      "name": "Logs Query Builder Guide",
+      "description": "SigNoz Query Builder v5 logs guide with filter expression syntax, field contexts, body search, and complete examples",
+      "mimeType": "text/plain"
+    },
+    {
+      "uri": "signoz://traces/query-builder-guide",
+      "name": "Traces Query Builder Guide",
+      "description": "SigNoz Query Builder v5 traces guide with filter expression syntax, field contexts, built-in span columns, and complete examples",
+      "mimeType": "text/plain"
     }
   ],
   "compatibility": {

--- a/pkg/querybuilder/logs_guide.go
+++ b/pkg/querybuilder/logs_guide.go
@@ -102,7 +102,9 @@ Use body for full rendered-message text search:
   body CONTAINS 'timeout'
   body ILIKE '%connection refused%'
 
-Use body.<json path> only when the log body is JSON and you need a nested field:
+Use body.<json path> only when the log body is JSON and you need a nested field. If a record's body is not
+valid JSON, body.<path> (and has(...)) match nothing for that row — prefer body CONTAINS / ILIKE when you
+are unsure the body is JSON:
   body.user.id = '12345'
   body.error.code = 'E_CONN_RESET'
   body.request.method = 'POST'

--- a/pkg/querybuilder/logs_guide.go
+++ b/pkg/querybuilder/logs_guide.go
@@ -10,7 +10,7 @@ Filters are a STRING expression in filter.expression - NOT a structured {op, ite
 CORRECT:   "filter": {"expression": "severity_text = 'ERROR' AND service.name = 'checkout'"}
 INCORRECT: "filter": {"op": "AND", "items": [...]}
 
-Operators: =  !=  >  >=  <  <=  IN  NOT IN  LIKE  NOT LIKE  ILIKE  CONTAINS  NOT CONTAINS  EXISTS  NOT EXISTS
+Operators: =  !=  >  >=  <  <=  IN  NOT IN  LIKE  NOT LIKE  ILIKE  NOT ILIKE  CONTAINS  NOT CONTAINS  REGEXP  NOT REGEXP  BETWEEN  NOT BETWEEN  EXISTS  NOT EXISTS
 Combine:   AND  OR  (use parentheses for precedence)
 
 Examples:
@@ -29,24 +29,28 @@ Unknown keys hard-error. Do not guess field names. If unsure, call:
   signoz_get_field_keys(signal="logs", fieldContext="attribute")
   signoz_get_field_values(signal="logs", name="<field>")
 
-If the same key exists in more than one context, SigNoz defaults to the resource context.
-Disambiguate explicitly in filter expressions with resource.<key> or attribute.<key>.
+If a key matches BOTH the resource and attribute contexts, SigNoz defaults to the resource context (and warns). For other multi-context matches, every matching context is ORed together.
+Disambiguate explicitly in filter expressions with resource.<key> or attribute.<key> (scope.<key> also exists).
 
 --- 1. Built-in log columns ---
 
 Use these directly by name in filter expressions:
 
-  timestamp       datetime  - log timestamp
+  timestamp       datetime  - log timestamp (stored as Unix NANOSECONDS; see TIMESTAMP FORMAT)
   body            string    - rendered log body
   severity_text   string    - DEBUG, INFO, WARN, ERROR, FATAL, etc.
-  severity_number int64     - numeric severity when present
+  severity_number number    - numeric severity when present
   trace_id        string    - linked trace identifier
   span_id         string    - linked span identifier
+  trace_flags     number    - W3C trace flags
+  id              string    - unique log record id (also the default secondary sort key)
+  scope_name      string    - instrumentation scope / logger name (fieldContext: "scope")
+  scope_version   string    - instrumentation scope version (fieldContext: "scope")
 
 Examples:
   severity_text = 'ERROR'
   trace_id = '4bf92f3577b34da6a3ce929d0e0e4736'
-  timestamp >= 1756386047000
+  trace_flags = 1
 
 --- 2. Resource attributes (dot notation, fieldContext: "resource") ---
 
@@ -104,8 +108,8 @@ Use body.<json path> only when the log body is JSON and you need a nested field:
   body.request.method = 'POST'
   body.latency_ms >= 1000
 
-For arrays inside JSON bodies, use the backend's body-array helpers when available:
-  has(body.tags, 'production')
+For arrays inside JSON bodies, mark the path as an array with the [*] suffix and use has():
+  has(body.tags[*], 'production')
 
 == COMPLETE WORKING EXAMPLES ==
 
@@ -230,17 +234,19 @@ For arrays inside JSON bodies, use the backend's body-array helpers when availab
 
 == TIMESTAMP FORMAT ==
 
-"start" and "end" are Unix milliseconds (13-digit). Example: 1756386047000
-The built-in timestamp field also uses Unix milliseconds in numeric comparisons.
+The top-level "start" and "end" request fields are Unix milliseconds (13-digit), e.g. 1756386047000;
+the backend auto-scales them to nanoseconds. Prefer start/end to bound the time window.
+The built-in "timestamp" COLUMN stores Unix NANOSECONDS, so an inline filter like "timestamp >= ..." must
+use a nanosecond value (e.g. 1756386047000000000), not milliseconds — otherwise it silently matches everything.
 
 == QUICK REFERENCE ==
 
 | Need                         | Field example            | Context in select/groupBy |
 |------------------------------|--------------------------|---------------------------|
-| Log severity                 | severity_text            | log/built-in              |
-| Rendered message text        | body                     | log/built-in              |
-| JSON field inside body       | body.error.code          | body JSON path            |
-| Trace correlation            | trace_id                 | log/built-in              |
+| Log severity                 | severity_text            | log (built-in)            |
+| Rendered message text        | body                     | log (built-in)            |
+| JSON field inside body       | body.error.code          | body                      |
+| Trace correlation            | trace_id                 | log (built-in)            |
 | Service name                 | service.name             | resource                  |
 | Kubernetes namespace         | k8s.namespace.name       | resource                  |
 | Application log attribute    | workflow_run_id          | attribute                 |

--- a/pkg/querybuilder/logs_guide.go
+++ b/pkg/querybuilder/logs_guide.go
@@ -1,0 +1,247 @@
+package querybuilder
+
+const LogsQueryBuilderGuide = `
+=== SIGNOZ QUERY BUILDER V5 - LOGS GUIDE ===
+
+== FILTER EXPRESSION FORMAT ==
+
+Filters are a STRING expression in filter.expression - NOT a structured {op, items} object.
+
+CORRECT:   "filter": {"expression": "severity_text = 'ERROR' AND service.name = 'checkout'"}
+INCORRECT: "filter": {"op": "AND", "items": [...]}
+
+Operators: =  !=  >  >=  <  <=  IN  NOT IN  LIKE  NOT LIKE  ILIKE  CONTAINS  NOT CONTAINS  EXISTS  NOT EXISTS
+Combine:   AND  OR  (use parentheses for precedence)
+
+Examples:
+  severity_text = 'ERROR'
+  body CONTAINS 'timeout'
+  service.name = 'checkout' AND severity_text IN ('ERROR', 'FATAL')
+  body.user.id = '12345'
+  body.error.message ILIKE '%connection refused%'
+  trace_id = 'abc123def456'
+  (severity_text = 'ERROR' OR body CONTAINS 'panic') AND k8s.namespace.name = 'prod'
+
+== FIELD NAMES AND CONTEXTS ==
+
+Unknown keys hard-error. Do not guess field names. If unsure, call:
+  signoz_get_field_keys(signal="logs", fieldContext="resource")
+  signoz_get_field_keys(signal="logs", fieldContext="attribute")
+  signoz_get_field_values(signal="logs", name="<field>")
+
+If the same key exists in more than one context, SigNoz defaults to the resource context.
+Disambiguate explicitly in filter expressions with resource.<key> or attribute.<key>.
+
+--- 1. Built-in log columns ---
+
+Use these directly by name in filter expressions:
+
+  timestamp       datetime  - log timestamp
+  body            string    - rendered log body
+  severity_text   string    - DEBUG, INFO, WARN, ERROR, FATAL, etc.
+  severity_number int64     - numeric severity when present
+  trace_id        string    - linked trace identifier
+  span_id         string    - linked span identifier
+
+Examples:
+  severity_text = 'ERROR'
+  trace_id = '4bf92f3577b34da6a3ce929d0e0e4736'
+  timestamp >= 1756386047000
+
+--- 2. Resource attributes (dot notation, fieldContext: "resource") ---
+
+OTel resource attributes describe the emitting service, host, pod, or deployment.
+Discover real keys first with signoz_get_field_keys(signal="logs", fieldContext="resource").
+
+Common examples:
+  service.name
+  k8s.namespace.name
+  k8s.pod.name
+  k8s.cluster.name
+  host.name
+  deployment.environment
+
+Filter examples:
+  service.name = 'checkout'
+  k8s.namespace.name = 'prod'
+  resource.service.name = 'checkout'
+
+groupBy/selectFields entry:
+  {"name": "service.name", "fieldDataType": "string", "signal": "logs", "fieldContext": "resource"}
+
+--- 3. Log attributes (fieldContext: "attribute") ---
+
+Log attributes are key-value fields attached to individual log records.
+They vary by application and collector pipeline, so discover them before use:
+  signoz_get_field_keys(signal="logs", fieldContext="attribute")
+
+Common examples when instrumented:
+  http.method
+  http.status_code
+  exception.type
+  exception.message
+  workflow_run_id
+  user.id
+
+Filter examples:
+  http.status_code >= 500
+  attribute.http.status_code >= 500
+  workflow_run_id = 'wr_123'
+  attribute.workflow_run_id = 'wr_123'
+
+groupBy/selectFields entry:
+  {"name": "workflow_run_id", "fieldDataType": "string", "signal": "logs", "fieldContext": "attribute"}
+
+--- 4. Body text and body JSON path search ---
+
+Use body for full rendered-message text search:
+  body CONTAINS 'timeout'
+  body ILIKE '%connection refused%'
+
+Use body.<json path> only when the log body is JSON and you need a nested field:
+  body.user.id = '12345'
+  body.error.code = 'E_CONN_RESET'
+  body.request.method = 'POST'
+  body.latency_ms >= 1000
+
+For arrays inside JSON bodies, use the backend's body-array helpers when available:
+  has(body.tags, 'production')
+
+== COMPLETE WORKING EXAMPLES ==
+
+--- Example 1: Raw error logs for a service (requestType: "raw") ---
+
+{
+  "schemaVersion": "v1",
+  "start": 1756386047000,
+  "end": 1756387847000,
+  "requestType": "raw",
+  "compositeQuery": {
+    "queries": [
+      {
+        "type": "builder_query",
+        "spec": {
+          "name": "A",
+          "signal": "logs",
+          "disabled": false,
+          "limit": 100,
+          "offset": 0,
+          "order": [{"key": {"name": "timestamp"}, "direction": "desc"}],
+          "having": {"expression": ""},
+          "filter": {"expression": "service.name = 'checkout' AND severity_text = 'ERROR' AND body CONTAINS 'timeout'"}
+        }
+      }
+    ]
+  },
+  "formatOptions": {"formatTableResultForUI": false, "fillGaps": false},
+  "variables": {}
+}
+
+--- Example 2: Raw logs matching JSON body fields (requestType: "raw") ---
+
+{
+  "schemaVersion": "v1",
+  "start": 1756386047000,
+  "end": 1756387847000,
+  "requestType": "raw",
+  "compositeQuery": {
+    "queries": [
+      {
+        "type": "builder_query",
+        "spec": {
+          "name": "A",
+          "signal": "logs",
+          "disabled": false,
+          "limit": 50,
+          "offset": 0,
+          "order": [{"key": {"name": "timestamp"}, "direction": "desc"}],
+          "having": {"expression": ""},
+          "filter": {"expression": "body.user.id = '12345' AND body.request.method = 'POST'"}
+        }
+      }
+    ]
+  },
+  "formatOptions": {"formatTableResultForUI": false, "fillGaps": false},
+  "variables": {}
+}
+
+--- Example 3: Aggregation - error count grouped by service (requestType: "scalar") ---
+
+{
+  "schemaVersion": "v1",
+  "start": 1756386047000,
+  "end": 1756387847000,
+  "requestType": "scalar",
+  "compositeQuery": {
+    "queries": [
+      {
+        "type": "builder_query",
+        "spec": {
+          "name": "A",
+          "signal": "logs",
+          "disabled": false,
+          "limit": 20,
+          "offset": 0,
+          "having": {"expression": ""},
+          "filter": {"expression": "severity_text IN ('ERROR', 'FATAL')"},
+          "aggregations": [
+            {"expression": "count()"}
+          ],
+          "groupBy": [
+            {"name": "service.name", "fieldDataType": "string", "signal": "logs", "fieldContext": "resource"}
+          ],
+          "order": [{"key": {"name": "count()"}, "direction": "desc"}]
+        }
+      }
+    ]
+  },
+  "formatOptions": {"formatTableResultForUI": false, "fillGaps": false},
+  "variables": {}
+}
+
+--- Example 4: Time series - error logs per minute (requestType: "time_series") ---
+
+{
+  "schemaVersion": "v1",
+  "start": 1756386047000,
+  "end": 1756387847000,
+  "requestType": "time_series",
+  "compositeQuery": {
+    "queries": [
+      {
+        "type": "builder_query",
+        "spec": {
+          "name": "A",
+          "signal": "logs",
+          "disabled": false,
+          "stepInterval": 60,
+          "having": {"expression": ""},
+          "filter": {"expression": "service.name = 'checkout' AND severity_text = 'ERROR'"},
+          "aggregations": [
+            {"expression": "count()"}
+          ]
+        }
+      }
+    ]
+  },
+  "formatOptions": {"formatTableResultForUI": false, "fillGaps": false},
+  "variables": {}
+}
+
+== TIMESTAMP FORMAT ==
+
+"start" and "end" are Unix milliseconds (13-digit). Example: 1756386047000
+The built-in timestamp field also uses Unix milliseconds in numeric comparisons.
+
+== QUICK REFERENCE ==
+
+| Need                         | Field example            | Context in select/groupBy |
+|------------------------------|--------------------------|---------------------------|
+| Log severity                 | severity_text            | log/built-in              |
+| Rendered message text        | body                     | log/built-in              |
+| JSON field inside body       | body.error.code          | body JSON path            |
+| Trace correlation            | trace_id                 | log/built-in              |
+| Service name                 | service.name             | resource                  |
+| Kubernetes namespace         | k8s.namespace.name       | resource                  |
+| Application log attribute    | workflow_run_id          | attribute                 |
+`

--- a/pkg/querybuilder/traces_guide.go
+++ b/pkg/querybuilder/traces_guide.go
@@ -10,13 +10,13 @@ Filters are a STRING expression in filter.expression — NOT a structured {op, i
 CORRECT:   "filter": {"expression": "hasError = true AND k8s.namespace.name = 'my-ns'"}
 INCORRECT: "filter": {"op": "AND", "items": [...]}
 
-Operators: =  !=  >  >=  <  <=  IN  NOT IN  LIKE  NOT LIKE  EXISTS  NOT EXISTS
+Operators: =  !=  >  >=  <  <=  IN  NOT IN  LIKE  NOT LIKE  ILIKE  NOT ILIKE  CONTAINS  NOT CONTAINS  REGEXP  NOT REGEXP  BETWEEN  NOT BETWEEN  EXISTS  NOT EXISTS
 Combine:   AND  OR  (use parentheses for precedence)
 
 Examples:
   hasError = true
   durationNano > 500000000
-  statusCodeString = 'STATUS_CODE_ERROR'
+  statusCodeString = 'Error'
   name LIKE '%payment%'
   hasError = true AND k8s.namespace.name = 'prod'
   (hasError = true OR durationNano > 1000000000) AND service.name = 'checkout'
@@ -29,7 +29,7 @@ Use these directly by name in filter expressions and selectFields without fieldC
 
   hasError           bool      — whether the span has an error
   statusMessage      string    — OTel status message
-  statusCodeString   string    — e.g. "STATUS_CODE_ERROR", "STATUS_CODE_OK"
+  statusCodeString   string    — span status: 'Ok', 'Error', or 'Unset' (prefer hasError = true for errors)
   statusCode         int64     — numeric status code
   durationNano       int64     — span duration in nanoseconds
   traceID            string    — trace identifier
@@ -38,7 +38,7 @@ Use these directly by name in filter expressions and selectFields without fieldC
   timestamp          datetime  — span start timestamp
   httpMethod         string    — HTTP method
   httpUrl            string    — HTTP URL
-  spanKind           string    — SPAN_KIND_SERVER, SPAN_KIND_CLIENT, etc.
+  spanKind           string    — 'Server', 'Client', 'Internal', 'Producer', 'Consumer'
   responseStatusCode string    — HTTP response status as string
 
 selectFields entry (no fieldContext needed):
@@ -114,13 +114,13 @@ selectFields entry (fieldContext: "tag" required):
   "variables": {}
 }
 
---- Example 2: Aggregation query — error count grouped by service (requestType: "aggregate") ---
+--- Example 2: Aggregation query — error count grouped by service (requestType: "scalar") ---
 
 {
   "schemaVersion": "v1",
   "start": 1756386047000,
   "end": 1756387847000,
-  "requestType": "aggregate",
+  "requestType": "scalar",
   "compositeQuery": {
     "queries": [
       {
@@ -179,7 +179,9 @@ selectFields entry (fieldContext: "tag" required):
 
 == TIMESTAMP FORMAT ==
 
-"start" and "end" are Unix milliseconds (13-digit). Example: 1756386047000
+The top-level "start" and "end" request fields are Unix milliseconds (13-digit), e.g. 1756386047000.
+Prefer start/end to bound the time window. The built-in "timestamp" COLUMN is nanosecond-scale
+(DateTime64(9)), so do NOT put a millisecond value in an inline "timestamp" filter — use start/end instead.
 
 == QUICK REFERENCE ==
 

--- a/plans/filter-param-consistency.context.md
+++ b/plans/filter-param-consistency.context.md
@@ -161,6 +161,27 @@ body-JSON section; did NOT add a version string.
   desync it from shipping code. Tracked as a follow-up (migrate guide + MCP traces payloads to snake_case).
 Build + tests green. Committed on PR #213.
 
+### 2026-06-23 — Completed signoz-ai-assistant#332 fix #2 (field-discovery context legend), folded into PR #213
+#332 (logs intrinsic-vs-attribute) had 3 suggested fixes. #1 (logs guide) already shipped in #213. Verified
+#2 against the backend BEFORE implementing (to avoid the silent-drop class): the `/api/v1/fields/values`
+endpoint DOES accept & honor `fieldContext` (PostableFieldValueParams embeds PostableFieldKeysParams which has
+`FieldContext query:"fieldContext"`, field.go:306; constructor copies it to FieldKeySelector.FieldContext,
+:337; scopes getLogFieldValues/getSpanFieldValues). So adding it is genuinely helpful, not advisory.
+Implemented (all behind the existing client interface):
+- Enumerated the bare `fieldContext`/`fieldDataType` descriptions on get_field_keys with the real valid
+  values (fieldContext: resource/attribute[alias tag]/scope/log|span|metric[intrinsic]/body, from
+  telemetrytypes/field_context.go:47-78; fieldDataType: string/bool/int64/float64/number/[]…, from
+  field_datatype.go:18-35). Framed to teach intrinsic-column vs user-attribute.
+- Added a `fieldContext` param to get_field_values + plumbed it through interface.go, client.go (sets the
+  query param), mock.go, and the handler. README rows synced. Manifest unchanged (no per-param schema; tool
+  descriptions unchanged).
+- Tests: TestGetFieldValues asserts the fieldContext query param; new fields_test.go asserts the handler
+  passes fieldContext (values) and fieldContext/fieldDataType (keys) through to the client (silent-drop guard).
+- Did NOT do #332 fix #3 (surface isColumn/fieldContext in field-discovery OUTPUT): the get_field_keys
+  response already passes `fieldContext` per key through verbatim, and the legend is now documented — so #3's
+  intent is largely subsumed; the `isColumn` enrichment is low marginal value. Left as optional follow-up.
+Build + full `go test ./...` green. Committed on PR #213.
+
 ## Open Questions
 - [x] Canonical name `filter` vs `query`? → **`filter`** (matches QB `filter.expression`; majority; `query`
       overloaded). Agreed by Claude + Codex.

--- a/plans/filter-param-consistency.context.md
+++ b/plans/filter-param-consistency.context.md
@@ -112,6 +112,28 @@ source of truth… read the `signoz://*` resources rather than transcribing sche
   pre-existing "Combined with service/... params using AND" suffix on the aggregate tools is correct (it
   describes shortcut-param attachment, always AND) and was left unchanged. No test pins description strings.
 
+### 2026-06-23 — Deep verification of logs_guide.go against real backend (~/signoz/signoz @ b8567664)
+Ran a 12-agent workflow (6 dimensions × adversarial double-check) verifying every claim in
+`pkg/querybuilder/logs_guide.go` against the authoritative backend source (filterquery grammar,
+querybuildertypesv5, telemetrylogs). Payload shape, `count()`, IN-lists, `body CONTAINS/ILIKE`, `body.<path>`,
+and `resource.`/`attribute.` prefixes all verified CORRECT. Found + fixed:
+- **BLOCKER:** the guide taught inline `timestamp >= <ms>` and "timestamp uses Unix ms". The `timestamp`
+  COLUMN is UInt64 **nanoseconds** (telemetrylogs/field_mapper.go:26); a user NUMBER literal is passed raw with
+  no ms→ns scaling (where_clause_visitor.go:884-890 → condition_builder.go:96-103), so a 13-digit ms value
+  matches essentially every row → silent unfiltered data. Fix: steer to top-level `start`/`end` (ms,
+  auto-scaled to ns); inline `timestamp` must use ns. Rewrote the TIMESTAMP FORMAT section + removed the bad
+  example.
+- **MAJOR:** `has(body.tags, 'production')` needs the `[*]` array suffix — `has(body.tags[*], 'production')`
+  (json_string.go:94-99; bare form errors in the new path / does scalar has() in the old). Fixed.
+- **MAJOR:** operator list omitted `REGEXP`/`NOT REGEXP` (real: builder_elements.go:109-110,
+  where_clause_visitor.go:620-624) — also added `NOT ILIKE`, `BETWEEN`/`NOT BETWEEN` for completeness.
+- **MINOR:** "ambiguous key → resource context" is only the resource↔attribute tiebreaker (and warns); other
+  multi-context matches are ORed (where_clause_visitor.go:982-994). Tightened the wording.
+- **MINOR:** added omitted built-ins `id`, `trace_flags`, `scope_name`/`scope_version` (const.go IntrinsicFields;
+  field_mapper.go logsV2Columns); softened `severity_number int64` → `number`; quick-ref context column now
+  uses literal `fieldContext` enum values (`log`/`body`) instead of prose labels.
+Build + tests green. Committed on PR #213.
+
 ## Open Questions
 - [x] Canonical name `filter` vs `query`? → **`filter`** (matches QB `filter.expression`; majority; `query`
       overloaded). Agreed by Claude + Codex.

--- a/plans/filter-param-consistency.context.md
+++ b/plans/filter-param-consistency.context.md
@@ -1,0 +1,111 @@
+# Feature: Filter/Query Param Consistency — Context & Discussion
+
+## Original Prompt
+> I want to fix this issue: https://github.com/SigNoz/signoz-ai-assistant/issues/315
+> Suggest an ideal solution. Also get review from codex xhigh 5.5 fast
+
+## Reference Links
+- [signoz-ai-assistant#315](https://github.com/SigNoz/signoz-ai-assistant/issues/315) — "Claude gets confused filtering logs via MCP: `filter` vs `query` param inconsistency silently drops the filter"
+- Project memory: `project_filter_param_inconsistency` (known issue, fix previously deferred 2026-06-09)
+
+## Key Decisions & Discussion Log
+
+### 2026-06-23 — Codebase analysis (5-reader workflow) confirmed and extended the issue
+- The issue's 6-tool table is correct; full inventory is 42 tools. The filter-expression param has THREE
+  names: `query` (search_logs, search_traces), `filter` (aggregate_logs, aggregate_traces, query_metrics),
+  and nested-in-object (execute_builder_query, create/update view). So only the **2 search tools** are the
+  outliers — `filter` is already the majority (3/5) name.
+- Confirmed false friends (same word, different language, must NOT be aliased): `list_alerts.filter`
+  (Alertmanager matcher), `search_docs.query` (BM25 text), `execute_builder_query.query` (whole QB object).
+- mcp-go performs NO arg validation; unknown keys are silently passed through, never rejected/stripped
+  (mcp-go@v0.49.0 server.go, mcp/tools.go GetArguments). An alias is therefore a pure handler-read concern.
+- Empty filter is sent verbatim as `{"expression":""}` for logs/traces (match-all) — that is the silent
+  broadening. For metrics, an empty filter is omitted entirely (querybuilder.go:429/506) — same net effect,
+  different JSON shape.
+- Backend warnings live at `data.warning.warnings[].message` and are NEVER surfaced (pure 2xx passthrough,
+  client.go:410). Insertion point = shared result wrappers in aggregate_helper.go (+ metrics decisions block).
+- LATENT BONUS BUG: `mcp.WithInputSchema[T]` uses google/jsonschema-go v0.4.2, which reads only the
+  `jsonschema` tag (as description) and IGNORES `jsonschema_extras:"description=..."`. So rich field docs on
+  create/update alert/dashboard never reach the model, and `jsonschema:"required"` emits the literal word
+  "required" as the description. Out of scope here — file separately.
+
+### 2026-06-23 — Codex review (gpt-5.5, xhigh, fast, read-only)
+Codex independently verified the claims against the code (and cross-checked the SigNoz backend repo for the
+warning envelope). It agreed with the core design and tightened four points:
+- **Canonical = `filter`: confirmed.** QB v5 shape is `filter.expression` (querybuilder.go:125/148); `query`
+  is overloaded across docs/QB-object/PromQL/ClickHouse. No reason to prefer `query`.
+- **Hidden alias: confirmed.** Do not advertise both names — advertising both would preserve the confusion.
+- **Conflict handling — TIGHTEN:** a log-only WARN is "too invisible." If both `filter` and `query` are
+  non-empty AND differ (after `strings.TrimSpace`), prefer a **hard error** with an actionable message
+  (or at minimum an in-band note in the tool result, never log-only). Never log the raw expression values.
+  Otherwise: `filter` then legacy `query`. → **Decision: hard error on differing non-empty values.**
+- **New false friend caught:** `query_metrics` has a top-level `filter` (alias this) AND nested
+  `formulaQueries[].filter` (metrics.go:59, metrics_query.go:147). Alias ONLY the top-level one; do not recurse.
+  Same for nested `compositeQuery` filters in views — leave untouched.
+- **Layer 2 plumbing — TIGHTEN:** the aggregate_helper.go wrapper currently has only one optional note path
+  (clamp note, :203); warning-surfacing must preserve raw JSON first and compose MULTIPLE notes.
+- **Layer 3 — caution:** write an honest, logs-specific guide; do NOT copy the traces guide wholesale (logs
+  syntax differs — body/JSON search, severity_text, logs field contexts).
+- **Latent jsonschema bug: confirmed** independently (infer.go:330; alertrule.go:24/28/39/111).
+- Codex verdict: 🟢 main fix sound; conflict handling + warning-surfacing are the two places to tighten.
+
+### 2026-06-23 — agent-skills cross-repo audit (read-only agent)
+Audited `~/signoz/agent-skills` for drift under the `filter` standardization. Blast radius is tiny because
+the repo's own rule (CONTRIBUTING.md:31-32) forbids transcribing MCP input schemas into skills ("MCP is the
+source of truth… read the `signoz://*` resources rather than transcribing schema — duplicated schema rots").
+- **Only ONE skill needs updating:** `plugins/signoz/skills/signoz-generating-queries/SKILL.md` — it is the
+  single place that violated the no-transcribe rule by naming the `query` param literally:
+  - L104 (`signoz_search_logs` row): "Use `searchText` for body text, `query` for field filters…" → `filter`.
+  - L105 (`signoz_search_traces` row): "…plus `query` for field filters." → `filter`.
+  - L124: "less error-prone than building `query` expressions." → `filter`.
+  - L125: "Combine shortcut params with `query`/`filter`…" → collapse to just `filter`.
+- **No "Supports any log field/attribute" phrase exists in agent-skills** (that wording lives only in
+  signoz-mcp-server). Change-item C is MCP-repo-only.
+- **No explicit filter-vs-query gotcha/workaround** to remove anywhere.
+- **False friends correctly present and must be left alone:** `signoz_search_docs.query` (BM25,
+  signoz-searching-docs/SKILL.md:23), `execute_builder_query.query` + traces-guide ref
+  (signoz-generating-queries/SKILL.md:108), dashboard widget `query` object, alert/QB `filter`, nested
+  `compositeQuery`/`formulaQueries[].filter`, and generic "with filter:" prose in signoz-investigating-alerts
+  (already canonical-aligned).
+- **Optional (item D):** once `signoz://logs/query-builder-guide` exists, 3 traces-guide references could gain
+  a logs sibling (signoz-creating-dashboards/SKILL.md:331, signoz-modifying-dashboards/SKILL.md:123,
+  signoz-generating-queries/SKILL.md:108) — optional per the convention, not required.
+- Plugin manifests need touching only if skills are added/removed (CONTRIBUTING.md:35) — not triggered here.
+
+### 2026-06-23 — Implementation (Codex gpt-5.5/xhigh/fast) + adversarial multi-agent review
+- Codex implemented all THREE layers on branch `fix/filter-param-consistency` (uncommitted). `go build ./...`
+  and full `go test ./...` pass (verified independently). Decision: **all three layers ship in ONE PR** (not
+  Layer 1 first) — resolves the scope open question below. The latent jsonschema bug was filed separately as
+  signoz-ai-assistant#359 (and param-inconsistency cleanup as #360) — resolves that open question below.
+- Ran a 6-dimension adversarial review workflow (17 agents): each finding refuted-or-confirmed by a 2nd agent.
+  Result: **0 blockers, 0 majors** (both claimed-major test-coverage findings downgraded to minor on
+  verification). Highest-risk dimensions — readFilterExpr correctness and FALSE-FRIEND safety — came back
+  fully CLEAN (false friends list_alerts/search_docs/execute_builder_query/views/formulaQueries[].filter
+  confirmed untouched; readFilterExpr confined to the 5 intended tools). Warning JSON path
+  `data.warning.warnings[].message` verified against the real SigNoz backend types.
+- Verified minor/nit findings being addressed before commit: (a) add unit test for
+  extractBackendWarningMessages (fail-open on malformed body / blank-message skip / multi-message order);
+  (b) add query_metrics backend-warning handler test (unique [Decisions applied] composition path);
+  (c) extend conflict-error HANDLER assertion from search_logs-only to all 5 handlers; (d) add false-friend
+  guard tests for formulaQueries[].filter and view create/update; (e) document the pre-existing
+  signoz://traces/query-builder-guide symmetrically in manifest.json + README (the PR added only the logs
+  sibling). Plan Status bumped to In Progress.
+- Deferred follow-up (needs a live SigNoz instance): a recorded-real / live warning-envelope contract test so
+  an upstream field rename (warning→warnings, message→msg) fails a test rather than silently returning nil.
+  Mitigation already in place: the WARN log fires when warnings are found (detectable, not fail-silent).
+- The "ambiguous keys default to `resource` context" wording in the filter descriptions/logs guide is
+  grounded in the backend's own warning text quoted in #315 ("Using `resource` context by default…"), so it
+  is accurate; the live/recorded test above is what would pin it long-term.
+- Companion skills change shipped as draft agent-skills#51 (blocked until this MCP change is released).
+
+## Open Questions
+- [x] Canonical name `filter` vs `query`? → **`filter`** (matches QB `filter.expression`; majority; `query`
+      overloaded). Agreed by Claude + Codex.
+- [x] Old `query` name visibility? → **Hidden back-compat alias** (advertise only `filter`; handler still
+      reads `query`). Agreed by Claude + Codex.
+- [x] Conflict resolution when both keys differ? → **Hard error** (actionable message), not log-only WARN.
+- [x] Surface backend warnings in-band? → **Yes**, as a composed note block in the shared wrapper + WARN log.
+- [x] Scope: ship Layer 1 first or all layers together? → **All three layers in ONE PR** (2026-06-23).
+- [x] File the latent jsonschema_extras description-drop bug separately? → **Yes**, filed as
+      signoz-ai-assistant#359 (param-inconsistency cleanup as #360). Issues go in signoz-ai-assistant, not
+      signoz-mcp-server (owner direction 2026-06-23).

--- a/plans/filter-param-consistency.context.md
+++ b/plans/filter-param-consistency.context.md
@@ -98,6 +98,20 @@ source of truth… read the `signoz://*` resources rather than transcribing sche
   is accurate; the live/recorded test above is what would pin it long-term.
 - Companion skills change shipped as draft agent-skills#51 (blocked until this MCP change is released).
 
+### 2026-06-23 — Post-review wording refinements (commit 4d05f59 on PR #213)
+- Owner flagged that the discovery nudge said "discover real **keys** first with
+  signoz_get_field_keys/**signoz_get_field_values**" — but get_field_values finds VALUES for a known key,
+  not keys (it requires name=<key>). Reworded both filter param descriptions (logs.go:15, traces.go:18) to
+  a two-step: "Discover valid keys with signoz_get_field_keys, then confirm values with
+  signoz_get_field_values, before filtering." Rationale: keys-discovery avoids `key not found` + resolves
+  resource/attribute ambiguity; value-discovery avoids the right-key/wrong-value → empty-results spiral.
+- Owner also noted logs (and traces) filter expressions support OR, but the TOOL DESCRIPTIONS only showed
+  AND examples (the param description is what most clients read; the guide is a passive resource). Confirmed
+  OR + parentheses are supported (logs_guide.go:14,23 already document them). Added "Combine conditions with
+  AND, OR, and parentheses" + an OR example to both param descriptions and the 4 README filter rows. The
+  pre-existing "Combined with service/... params using AND" suffix on the aggregate tools is correct (it
+  describes shortcut-param attachment, always AND) and was left unchanged. No test pins description strings.
+
 ## Open Questions
 - [x] Canonical name `filter` vs `query`? → **`filter`** (matches QB `filter.expression`; majority; `query`
       overloaded). Agreed by Claude + Codex.

--- a/plans/filter-param-consistency.context.md
+++ b/plans/filter-param-consistency.context.md
@@ -134,6 +134,33 @@ and `resource.`/`attribute.` prefixes all verified CORRECT. Found + fixed:
   uses literal `fieldContext` enum values (`log`/`body`) instead of prose labels.
 Build + tests green. Committed on PR #213.
 
+### 2026-06-23 — Body-JSON version-compat check + deep verification of traces_guide.go
+**Body-JSON version compatibility (logs guide):** agent traced ~/signoz/signoz git history. `body.<path>` AND
+`has(body.tags[*], …)` both shipped in v0.80.0 (commit b0d19035a4, 2025-04-17) — BEFORE the `/api/v5/query_range`
+route itself (v0.91.1). The `use_json_body` flag (registry.go:12, default OFF) only switches implementation
+(raw-body JSON funcs vs materialized columns); the default-off path supports the full syntax and is the tested
+one (filter_expr_logs_body_json_test.go with flag unset). So NO version gate is warranted beyond "a backend new
+enough to serve QB v5", which every logs query already requires. The genuinely-newer "new JSON QB" materialized
+work (PR #10050, v0.110+) is a flag-gated optimization, not a prerequisite. Real risk is DATA-SHAPE not version:
+body must be valid JSON or body.<path>/has() match nothing. → Added a data-shape caution to the logs guide
+body-JSON section; did NOT add a version string.
+
+**Traces guide deep verification (33-agent workflow vs backend):** fixed —
+- BLOCKER: `requestType: "aggregate"` is invalid (enum = scalar/time_series/raw/raw_stream/trace/distribution,
+  request_type.go:21-27); errors on unmarshal. → "scalar" (matches BuildAggregateQueryPayload default).
+- BLOCKER: `statusCodeString = 'STATUS_CODE_ERROR'` matches nothing on traces — values are 'Ok'/'Error'/'Unset'
+  (the STATUS_CODE_* form is a metrics label). → 'Error'; prefer hasError = true.
+- MAJOR: spanKind values are 'Server'/'Client'/'Internal'/'Producer'/'Consumer' (const.go:48), NOT SPAN_KIND_*.
+- MAJOR: operator list extended (ILIKE/NOT ILIKE, REGEXP/NOT REGEXP, CONTAINS/NOT CONTAINS, BETWEEN/NOT BETWEEN)
+  — all implemented for traces (telemetrytraces/condition_builder.go:96-135).
+- Hardening: timestamp column is DateTime64(9) ns — added the start/end warning (latent ms/ns hazard).
+- NOT changed: the camelCase intrinsic names (traceID/spanID/durationNano/httpMethod/httpUrl/spanKind/
+  statusCodeString/responseStatusCode) are DEPRECATED ALIASES (canonical is snake_case: trace_id/span_id/
+  duration_nano/kind_string/…), but they still resolve via the oldToNew map AND the MCP server's own
+  BuildTracesQueryPayload + buildTraceFilterExpr emit the SAME camelCase — so changing the guide alone would
+  desync it from shipping code. Tracked as a follow-up (migrate guide + MCP traces payloads to snake_case).
+Build + tests green. Committed on PR #213.
+
 ## Open Questions
 - [x] Canonical name `filter` vs `query`? → **`filter`** (matches QB `filter.expression`; majority; `query`
       overloaded). Agreed by Claude + Codex.

--- a/plans/filter-param-consistency.plan.md
+++ b/plans/filter-param-consistency.plan.md
@@ -1,0 +1,120 @@
+# Plan: Filter/Query Param Consistency
+
+## Status
+In Progress
+
+## Context
+The QB filter-expression parameter is named inconsistently across sibling MCP tools — `query` on
+`signoz_search_logs`/`signoz_search_traces`, but `filter` on `signoz_aggregate_logs`/`signoz_aggregate_traces`/
+`signoz_query_metrics`. Each handler reads only its one key, so when the model generalizes to the majority
+name (`filter`, 4 visible occurrences vs 2) and sends it to a search tool, the key is silently dropped, the
+filter expression resolves to `""`, and the backend returns the most recent N rows across the whole instance
+unfiltered. The model then "gets confused filtering logs" (signoz-ai-assistant#315). Reviewed with Codex
+(gpt-5.5/xhigh); see `.context.md`.
+
+## Approach (layered)
+
+### Layer 1 — Standardize on `filter`, alias legacy `query` (the bug fix)
+Canonical name = **`filter`** (matches QB v5 `filter.expression`; already the majority; `query` is overloaded
+by docs-search / full-QB-object / PromQL).
+
+- Add one shared reader in `aggregate_helper.go` (or a small shared helper file):
+  ```go
+  // readFilterExpr returns the QB filter expression, accepting the canonical "filter" key and the
+  // legacy "query" alias. If both are non-empty and differ (after TrimSpace), it returns an error so
+  // the caller can fail loud (the silent-broadening bug we are fixing). Never logs the expression text.
+  func readFilterExpr(args map[string]any) (string, error) {
+      f := strings.TrimSpace(asString(args["filter"]))
+      q := strings.TrimSpace(asString(args["query"]))
+      if f != "" && q != "" && f != q {
+          return "", fmt.Errorf("both 'filter' and 'query' were provided with different values; " +
+              "use only 'filter' (the 'query' alias is legacy)")
+      }
+      if f != "" { return f, nil }
+      return q, nil
+  }
+  ```
+  (Return the raw, non-trimmed winner if trimming risks altering valid expressions — TBD during impl; trim
+  only for the comparison. Decide in code review.)
+- Route all 5 filter-expression parsers through `readFilterExpr`:
+  - `parseSearchLogsArgs` (logs_helper.go:29) — currently reads `args["query"]`.
+  - `parseSearchTracesArgs` (traces_helper.go:19) — currently reads `args["query"]`.
+  - `parseAggregateLogsArgs` (logs_helper.go:12) — currently reads `args["filter"]`.
+  - `parseAggregateTracesArgs` (traces_helper.go:60) — currently reads `args["filter"]`.
+  - `parseMetricsQueryArgs` (metrics_helper.go:58) — currently reads `args["filter"]` (top-level only;
+    do NOT touch nested `formulaQueries[].filter`).
+- Schema changes: rename the advertised param `query` → `filter` on `search_logs` (logs.go:52) and
+  `search_traces` (traces.go:57). Do NOT advertise `query` — it remains a silent, undocumented back-compat
+  alias read by the handler. The other 3 tools already advertise `filter` (no schema change).
+- **Do NOT alias / touch the false friends:** `list_alerts.filter` (alerts.go:152, Alertmanager matcher),
+  `search_docs.query` (docs.go:60, BM25), `execute_builder_query.query` (query_builder.go:66, whole QB
+  object), nested `compositeQuery` filters in create/update views, nested `formulaQueries[].filter`.
+
+### Layer 2 — Never fail silent (guardrail)
+- Conflict hard-error above is the primary loud signal.
+- Surface backend warnings. Add an extractor (mirror `extractStepInterval`, metrics_helper.go:167) that
+  decodes `data.warning.warnings[].message` from the QB v5 response (confirmed path via SigNoz backend
+  `QueryRangeResponse.Warning` rendered under the success envelope). Then:
+  - In the shared result wrappers (`rawSearchResult`/`aggregateResult`/`clampedResult`,
+    aggregate_helper.go:203-225) compose the warning messages as an ADDITIONAL note block — preserve the raw
+    JSON first and support multiple notes (clamp note + warnings), do not overwrite the existing clamp path.
+  - Emit a `WarnContext` log when warnings are present (idiom: enrichSearchTracesWebURL, traces.go:230).
+  - `query_metrics` already has a `[Decisions applied]` block (metrics_query.go:184/190) — merge backend
+    warnings there.
+
+### Layer 3 — Guidance so the model writes correct filters
+- Replace the misleading "Supports any log field/attribute" wording (logs.go:52) with honest guidance:
+  unknown keys hard-error; ambiguous keys default to `resource` context; disambiguate with `attribute.x` /
+  `resource.x`; discover real keys first with `signoz_get_field_keys` / `signoz_get_field_values`. Apply to
+  the logs + traces filter param descriptions.
+- Add `pkg/querybuilder/logs_guide.go` — an HONEST, logs-specific guide (do not copy the traces guide
+  wholesale): filter expression format, field contexts (resource vs attribute vs body), `body.` JSON-path
+  search, `severity_text`, complete verified examples. Expose as resource `signoz://logs/query-builder-guide`
+  and reference it by URI from the logs tool descriptions (same pattern as traces).
+- Add a key-discovery nudge to the filter param description.
+
+## Files to Modify
+- `internal/handler/tools/aggregate_helper.go` — `readFilterExpr`, warning extractor, multi-note wrapper.
+- `internal/handler/tools/logs_helper.go` — route search/aggregate logs filter reads through `readFilterExpr`.
+- `internal/handler/tools/traces_helper.go` — route search/aggregate traces filter reads through it.
+- `internal/handler/tools/metrics_helper.go` — route top-level metrics `filter` read through it.
+- `internal/handler/tools/logs.go` — rename `query`→`filter` param (search), honest descriptions, logs-guide ref.
+- `internal/handler/tools/traces.go` — rename `query`→`filter` param (search), honest description.
+- `internal/handler/tools/metrics_query.go` — merge backend warnings into the decisions block.
+- `pkg/querybuilder/logs_guide.go` — NEW logs query-builder guide.
+- `internal/handler/tools/query_builder.go` (or wherever resources register) — register the logs guide resource.
+- `README.md` — rows 613/651 (`query`→`filter`, note legacy alias); verify 600/669/415; document new resource.
+- `manifest.json` — update tool descriptions only if wording changes (no per-param schema there).
+- Tests — see Verification.
+
+## Verification
+- Parser unit tests (aggregate_helper_test.go style), table-driven over the 5 tools:
+  `filter` only / legacy `query` only / both equal / both differ → assert `FilterExpression` and that
+  both-differ returns an error.
+- Regression handler tests: `search_logs` with `filter:` now filters (the exact reported call);
+  `aggregate_logs` with `query:` now filters.
+- False-friend guard tests: assert `list_alerts`, `search_docs`, `execute_builder_query`, view create/update,
+  and `formulaQueries[].filter` are unaffected by the alias.
+- Warning-surfacing test: fixture QB response containing `data.warning.warnings[].message`; assert it appears
+  in the tool result note block + a WARN is logged.
+- Live/integration (CLAUDE.md cross-contract mandate): via a subagent, run the reported call
+  (`filter: "orgId = '…' AND testName = 'radio-group'"`) against a real instance and confirm the filter
+  round-trips server-side; clean up nothing (read-only).
+
+## Cross-repo: agent-skills (`~/signoz/agent-skills`)
+Audited read-only (2026-06-23). The repo deliberately does NOT transcribe MCP schemas (CONTRIBUTING.md:31-32),
+so only ONE skill drifts:
+- `plugins/signoz/skills/signoz-generating-queries/SKILL.md` — rename the literal `query` param to `filter`
+  at L104, L105, L124, L125 (the only place that names the param). Optionally add the honest field-context
+  guidance there too.
+- Optional: add a `signoz://logs/query-builder-guide` sibling next to the traces-guide references at
+  signoz-creating-dashboards/SKILL.md:331, signoz-modifying-dashboards/SKILL.md:123,
+  signoz-generating-queries/SKILL.md:108 (only after Layer 3 ships the resource).
+- Everything else (false friends, generic "with filter:" prose) is correct as-is — do not touch.
+- This is a SEPARATE PR in the agent-skills repo, coordinated with the MCP change.
+
+## Out of Scope (file separately)
+- jsonschema-go v0.4.2 ignoring `jsonschema_extras:"description=…"` on typed-struct tools (create/update
+  alert/dashboard) — field docs silently dropped; `jsonschema:"required"` emits literal "required".
+- Broader consistency: time-unit (ms vs ns), default-window (1h vs 6h), `search_docs.limit` being the only
+  `WithNumber` limit, resource-id naming (`ruleId`/`uuid`/`viewId`/`id`).


### PR DESCRIPTION
## Problem

The QB filter-expression parameter was named inconsistently across sibling tools — `query` on
`signoz_search_logs` / `signoz_search_traces`, but `filter` on `signoz_aggregate_logs` /
`signoz_aggregate_traces` / `signoz_query_metrics`. Each handler read only its one key, so when a model
generalized to the majority name (`filter`) and sent it to a search tool, the key was **silently dropped**,
the filter resolved to `""`, and the backend returned the most recent N rows unfiltered — the reported
"Claude gets confused filtering logs" symptom. **Fixes SigNoz/signoz-ai-assistant#315.**

While in here, the two query-builder guides and the field-discovery tools were deep-verified against the
SigNoz backend source, which surfaced (and this PR fixes) three further **blocker-class** correctness bugs in
the guides plus the logs intrinsic-vs-attribute gap. See the sections below.

---

## 1. Filter param standardization + alias (the #315 fix)

- A shared `readFilterExpr` is routed through all five filter-expression parsers. Canonical name is **`filter`**
  (matches QB v5 `filter.expression`; already the majority). The two search tools now advertise `filter`;
  **legacy `query` is still accepted as a silent back-compat alias.** `readFilterExpr` prefers `filter`,
  returns the untrimmed winner, and **errors if `filter` and `query` are both non-empty and differ** (fail
  loud instead of silently broadening).
- False friends are deliberately untouched: `signoz_list_alerts.filter` (Alertmanager matcher),
  `signoz_search_docs.query` (BM25), `signoz_execute_builder_query.query` (whole QB object), nested view
  `compositeQuery`, and nested `query_metrics` `formulaQueries[].filter`.
- **Never fail silent:** backend `data.warning.warnings[].message` is now extracted and surfaced as result
  notes (composed alongside the existing limit-clamp note) plus a `WARN` log; fail-open if unparseable.
- **Honest guidance:** the misleading *"Supports any log field/attribute"* wording is replaced with
  field-context guidance, and the filter descriptions now state conditions combine with **AND / OR /
  parentheses** (the grammar always supported OR; only AND was advertised) and steer key→value discovery via
  `signoz_get_field_keys` then `signoz_get_field_values`.

## 2. Logs query-builder guide — new resource + backend-verified

- New `pkg/querybuilder/logs_guide.go`, exposed as resource `signoz://logs/query-builder-guide` (the logs
  analog of the traces guide). Directly addresses the "no logs guide" half of
  **SigNoz/signoz-ai-assistant#332.**
- Deep-verified against `~/signoz/signoz`; fixed:
  - 🔴 **timestamp units** — the `timestamp` column is Unix **nanoseconds**, and inline numeric literals are
    passed through unscaled, so the original `timestamp >= <ms>` guidance silently matched every row. Now
    steers time-bounding to top-level `start`/`end` (ms, auto-scaled); inline `timestamp` uses ns.
  - `has(body.tags[*], …)` now carries the required `[*]` array-path suffix (bare form errors / does scalar).
  - operator list completed (`REGEXP`/`NOT REGEXP`, `NOT ILIKE`, `BETWEEN`/`NOT BETWEEN`).
  - ambiguity rule tightened (resource default is the resource↔attribute tiebreaker only).
  - added omitted built-ins (`id`, `trace_flags`, `scope_name`/`scope_version`); body-JSON section gained a
    data-shape caution (body must be valid JSON, else prefer `body CONTAINS`/`ILIKE`).

## 3. Traces query-builder guide — backend-verified

Deep-verified against `~/signoz/signoz`; fixed:
- 🔴 **`requestType: "aggregate"`** is not a valid enum value (only `scalar`/`time_series`/`raw`/…) and errors
  on unmarshal → `"scalar"`.
- 🔴 **`statusCodeString = 'STATUS_CODE_ERROR'`** matches nothing on traces (values are `'Ok'`/`'Error'`/
  `'Unset'`; the `STATUS_CODE_*` form is a metrics label) → `'Error'`; prefer `hasError = true`.
- 🟠 `spanKind` values are `'Server'`/`'Client'`/`'Internal'`/`'Producer'`/`'Consumer'`, not `SPAN_KIND_*`.
- operator list completed (same as logs); added the nanosecond `timestamp`-column note.
- *Not changed:* the camelCase intrinsic names (`traceID`, `durationNano`, …) are deprecated aliases that
  still resolve and match the MCP server's own `BuildTracesQueryPayload` — migrating both together is tracked
  in **SigNoz/signoz-ai-assistant#361**.

## 4. Field discovery — intrinsic vs attribute (#332 fix 2)

- `signoz_get_field_keys`: the bare `fieldContext`/`fieldDataType` descriptions now enumerate the real valid
  values (`fieldContext`: `resource` / `attribute` [alias `tag`] / `scope` / `log`·`span`·`metric` [intrinsic]
  / `body`; `fieldDataType`: `string`/`bool`/`int64`/`float64`/`number`/`[]…`), so the model can tell
  intrinsic columns from user-ingested attributes.
- `signoz_get_field_values`: added a `fieldContext` param, plumbed through to
  `/api/v1/fields/values?fieldContext=…`. Verified backend-honored (the endpoint binds `fieldContext` and
  scopes the value lookup) — not a silently-dropped param.

---

## Tests
- Alias matrix across all 5 tools (`filter`-only / legacy-`query`-only / both-equal / both-differ→error);
  conflict error asserted across **all five handlers**; false-friend guards (incl. `formulaQueries[].filter`
  and view `compositeQuery`); backend-warning surfacing + fail-open unit test.
- `fieldContext` query-param + handler pass-through guards for the field-discovery tools.
- `go build ./...` and full `go test ./...` pass locally.
- Each guide change was verified against `~/signoz/signoz` backend source via adversarial multi-agent review
  (each finding independently refuted-or-confirmed).

## Docs / metadata sync
- `README.md` param rows updated (filter `query`→`filter` + legacy note; AND/OR; field-discovery contexts);
  both query-builder guides documented symmetrically; `manifest.json` resources + descriptions synced.
- Planning pair under `plans/filter-param-consistency.*` (append-only context log of every decision + review).

## Related
- **Fixes** SigNoz/signoz-ai-assistant#315 (filter/query silent-drop).
- **Closes** SigNoz/signoz-ai-assistant#332 (logs intrinsic-vs-attribute — guide + field-discovery
  contexts; optional output-enrichment fix 3 left as follow-up).
- Companion skills PR: SigNoz/agent-skills#51 (draft) — **merge only after this ships.**
- Spun-off follow-ups: SigNoz/signoz-ai-assistant#359 (typed-struct field descriptions dropped via
  `jsonschema_extras`), #360 (param inconsistencies), #361 (migrate traces camelCase → snake_case names).
- **Deferred:** a recorded-real / live warning-envelope contract test (needs a live instance; the WARN log
  already prevents fail-silent meanwhile).
