### PR TITLE
fix(tools): author typed-struct field descriptions in the native jsonschema tag

### DIFF
--- a/internal/handler/tools/schema_compat_test.go
+++ b/internal/handler/tools/schema_compat_test.go
@@ -164,3 +164,178 @@ func containsString(values []string, want string) bool {
 	}
 	return false
 }
+
+// TestTypedToolSchemasNeverEmitLiteralRequiredDescription guards
+// SigNoz/signoz-ai-assistant#359: google/jsonschema-go uses the `jsonschema`
+// tag value AS the field description, so a stray `jsonschema:"required"` would
+// surface the literal word "required" instead of authored prose. With
+// descriptions authored natively in the `jsonschema` tag, "required" must never
+// appear as a description at any depth of any typed-struct tool's input schema.
+func TestTypedToolSchemasNeverEmitLiteralRequiredDescription(t *testing.T) {
+	for _, tc := range typedToolSchemaCases(t) {
+		t.Run(tc.name, func(t *testing.T) {
+			var descriptions []string
+			collectDescriptions(tc.schema, &descriptions)
+			if len(descriptions) == 0 {
+				t.Fatalf("no descriptions found in %s schema", tc.name)
+			}
+			for _, d := range descriptions {
+				if d == "required" {
+					t.Fatalf("%s schema emits a description of %q (a stray jsonschema:\"required\" tag); descriptions=%d", tc.name, "required", len(descriptions))
+				}
+			}
+		})
+	}
+}
+
+// TestTypedToolSchemasExposeAuthoredDescriptions verifies the descriptions
+// authored in the native `jsonschema` tags reach the schema the model sees — at
+// the top level and through nested objects, slice element schemas (items), and
+// map value schemas (additionalProperties).
+func TestTypedToolSchemasExposeAuthoredDescriptions(t *testing.T) {
+	cases := typedToolSchemaCases(t)
+	schemaByName := map[string]map[string]any{}
+	for _, tc := range cases {
+		schemaByName[tc.name] = tc.schema
+	}
+
+	type check struct {
+		tool string
+		path []string
+		want string
+	}
+	checks := []check{
+		// top-level field (promoted from the embedded AlertRule)
+		{"create alert", []string{"alert"}, "Name of the alert rule. Must be unique and descriptive."},
+		// searchContext is authored natively in the jsonschema tag too
+		{"create alert", []string{"searchContext"}, "The user's original question or search text that triggered this tool call. Always include the user's raw query here for better results."},
+		// deep path through a slice element (queries -> items -> spec -> filter -> expression)
+		{"create alert", []string{"condition", "compositeQuery", "queries", "[]", "spec", "filter", "expression"}, "Filter expression using field operators. Example: service.name = frontend AND http.status_code >= 500. Use empty string for no filter."},
+		// direct named field on UpdateAlertInput
+		{"update alert", []string{"ruleId"}, "UUIDv7 of the alert rule to update. Obtain it from signoz_list_alert_rules or signoz_get_alert."},
+		// dashboard: slice element (widgets -> items -> id)
+		{"create dashboard", []string{"widgets", "[]", "id"}, "ID for the widget"},
+		// dashboard: map value schema (variables -> additionalProperties -> name)
+		{"create dashboard", []string{"variables", "{}", "name"}, "Name for the variable"},
+	}
+
+	for _, c := range checks {
+		t.Run(c.tool+":"+joinPath(c.path), func(t *testing.T) {
+			schema, ok := schemaByName[c.tool]
+			if !ok {
+				t.Fatalf("no schema for tool %q", c.tool)
+			}
+			node := descend(t, schema, c.path...)
+			got, _ := node["description"].(string)
+			if got != c.want {
+				t.Fatalf("description at %v = %q, want %q", c.path, got, c.want)
+			}
+		})
+	}
+}
+
+// TestTypedToolSchemasDescriptionCoverage guards against a *silent* loss of
+// field descriptions (a tag-dialect regression, a botched edit, or an upstream
+// generator change): each typed tool's schema must expose at least the number
+// of descriptions it has today. Adding described fields only raises the count;
+// dropping any drops below the floor and fails here. This closes the gap that
+// the "never emit a 'required' description" guards leave open — descriptions
+// vanishing entirely rather than turning into the word "required".
+func TestTypedToolSchemasDescriptionCoverage(t *testing.T) {
+	floors := map[string]int{
+		"create alert":     89,
+		"update alert":     90,
+		"create dashboard": 197,
+		"update dashboard": 199,
+	}
+	for _, tc := range typedToolSchemaCases(t) {
+		t.Run(tc.name, func(t *testing.T) {
+			var descriptions []string
+			collectDescriptions(tc.schema, &descriptions)
+			if floor := floors[tc.name]; len(descriptions) < floor {
+				t.Fatalf("%s exposes %d field descriptions, want >= %d (were descriptions silently dropped?)", tc.name, len(descriptions), floor)
+			}
+		})
+	}
+}
+
+type typedToolSchemaCase struct {
+	name   string
+	schema map[string]any
+}
+
+// typedToolSchemaCases builds each typed-struct tool's input schema the same way
+// registration does (mcp.WithInputSchema -> normalizeToolSchemas) and parses it.
+// Descriptions come natively from the `jsonschema` struct tags.
+func typedToolSchemaCases(t *testing.T) []typedToolSchemaCase {
+	t.Helper()
+	return []typedToolSchemaCase{
+		{"create alert", normalizedInputSchema(t, mcp.NewTool("signoz_create_alert", mcp.WithInputSchema[types.CreateAlertInput]()))},
+		{"update alert", normalizedInputSchema(t, mcp.NewTool("signoz_update_alert", mcp.WithInputSchema[types.UpdateAlertInput]()))},
+		{"create dashboard", normalizedInputSchema(t, mcp.NewTool("signoz_create_dashboard", mcp.WithInputSchema[types.CreateDashboardInput]()))},
+		{"update dashboard", normalizedInputSchema(t, mcp.NewTool("signoz_update_dashboard", mcp.WithInputSchema[types.UpdateDashboardInput]()))},
+	}
+}
+
+func normalizedInputSchema(t *testing.T, tool mcp.Tool) map[string]any {
+	t.Helper()
+	normalizeToolSchemas(&tool)
+	var schema map[string]any
+	if err := json.Unmarshal(tool.RawInputSchema, &schema); err != nil {
+		t.Fatalf("unmarshal input schema: %v", err)
+	}
+	return schema
+}
+
+// descend walks an object schema node. A step of "[]" descends into "items",
+// "{}" into "additionalProperties", and any other step into properties[step].
+func descend(t *testing.T, node map[string]any, steps ...string) map[string]any {
+	t.Helper()
+	cur := node
+	for i, step := range steps {
+		var next any
+		switch step {
+		case "[]":
+			next = cur["items"]
+		case "{}":
+			next = cur["additionalProperties"]
+		default:
+			props, _ := cur["properties"].(map[string]any)
+			next = props[step]
+		}
+		m, ok := next.(map[string]any)
+		if !ok {
+			t.Fatalf("descend step %d (%q) in %v: not an object node (got %T)", i, step, steps, next)
+		}
+		cur = m
+	}
+	return cur
+}
+
+// collectDescriptions gathers every "description" string anywhere in the schema.
+func collectDescriptions(node any, out *[]string) {
+	switch v := node.(type) {
+	case map[string]any:
+		if d, ok := v["description"].(string); ok {
+			*out = append(*out, d)
+		}
+		for _, val := range v {
+			collectDescriptions(val, out)
+		}
+	case []any:
+		for _, val := range v {
+			collectDescriptions(val, out)
+		}
+	}
+}
+
+func joinPath(steps []string) string {
+	out := ""
+	for i, s := range steps {
+		if i > 0 {
+			out += "."
+		}
+		out += s
+	}
+	return out
+}

--- a/internal/mcp-server/integration_test.go
+++ b/internal/mcp-server/integration_test.go
@@ -245,6 +245,87 @@ func TestIntegration_AllToolsExposeSearchContext(t *testing.T) {
 	}
 }
 
+// TestIntegration_ToolSchemasNeverExposeLiteralRequiredDescription guards
+// SigNoz/signoz-ai-assistant#359 at the real registration boundary: it lists
+// the registered tools (as a client would) and asserts that no field anywhere
+// in any tool's input schema has the literal description "required" — the
+// artifact google/jsonschema-go produces from a stray `jsonschema:"required"`
+// tag (it uses the `jsonschema` tag value as the field description).
+//
+// This complements the unit tests in internal/handler/tools: if a typed-struct
+// field ever regains a `jsonschema:"required"` tag, or a new field is added
+// without an authored `jsonschema` description, the leak surfaces here.
+func TestIntegration_ToolSchemasNeverExposeLiteralRequiredDescription(t *testing.T) {
+	s := buildTestServer(t)
+	ctx := context.Background()
+
+	c, err := mcpclient.NewInProcessClient(s)
+	if err != nil {
+		t.Fatalf("failed to create in-process client: %v", err)
+	}
+
+	if _, err := c.Initialize(ctx, mcp.InitializeRequest{
+		Params: mcp.InitializeParams{
+			ProtocolVersion: mcp.LATEST_PROTOCOL_VERSION,
+			ClientInfo: mcp.Implementation{
+				Name:    "test-client",
+				Version: version.Version,
+			},
+		},
+	}); err != nil {
+		t.Fatalf("Initialize failed: %v", err)
+	}
+
+	toolsResult, err := c.ListTools(ctx, mcp.ListToolsRequest{})
+	if err != nil {
+		t.Fatalf("ListTools failed: %v", err)
+	}
+
+	var sawCreateAlert bool
+	for _, tool := range toolsResult.Tools {
+		schema := inputSchema(t, tool)
+		for _, d := range collectSchemaDescriptions(schema) {
+			if d == "required" {
+				t.Errorf("%s inputSchema exposes a field description of %q (a stray jsonschema:\"required\" tag)", tool.Name, "required")
+			}
+		}
+		// End-to-end proof that authored descriptions reach the real
+		// registration output for at least one typed tool, not just in the
+		// unit harness.
+		if tool.Name == "signoz_create_alert" {
+			sawCreateAlert = true
+			props := schemaProperties(t, tool.Name, schema)
+			alert, _ := props["alert"].(map[string]any)
+			if alert == nil || alert["description"] != "Name of the alert rule. Must be unique and descriptive." {
+				t.Errorf("signoz_create_alert .alert description = %v, want authored prose", alert["description"])
+			}
+		}
+	}
+	if !sawCreateAlert {
+		t.Fatalf("signoz_create_alert was not registered; cannot verify descriptions")
+	}
+}
+
+// collectSchemaDescriptions returns every "description" string found anywhere in
+// a JSON-schema-shaped value.
+func collectSchemaDescriptions(node any) []string {
+	var out []string
+	switch v := node.(type) {
+	case map[string]any:
+		if d, ok := v["description"].(string); ok {
+			out = append(out, d)
+		}
+		for _, val := range v {
+			out = append(out, collectSchemaDescriptions(val)...)
+		}
+	case []any:
+		for _, val := range v {
+			out = append(out, collectSchemaDescriptions(val)...)
+		}
+	}
+	return out
+}
+
 func TestIntegration_FilterExpressionToolsAdvertiseCanonicalFilter(t *testing.T) {
 	s := buildTestServer(t)
 	ctx := context.Background()

--- a/pkg/types/alertrule.go
+++ b/pkg/types/alertrule.go
@@ -21,13 +21,13 @@ const (
 
 type CreateAlertInput struct {
 	AlertRule
-	SearchContext string `json:"searchContext,omitempty" jsonschema_extras:"description=The user's original question or search text that triggered this tool call. Always include the user's raw query here for better results."`
+	SearchContext string `json:"searchContext,omitempty" jsonschema:"The user's original question or search text that triggered this tool call. Always include the user's raw query here for better results."`
 }
 
 type UpdateAlertInput struct {
-	RuleID string `json:"ruleId" jsonschema:"required" jsonschema_extras:"description=UUIDv7 of the alert rule to update. Obtain it from signoz_list_alert_rules or signoz_get_alert."`
+	RuleID string `json:"ruleId" jsonschema:"UUIDv7 of the alert rule to update. Obtain it from signoz_list_alert_rules or signoz_get_alert."`
 	AlertRule
-	SearchContext string `json:"searchContext,omitempty" jsonschema_extras:"description=The user's original question or search text that triggered this tool call. Always include the user's raw query here for better results."`
+	SearchContext string `json:"searchContext,omitempty" jsonschema:"The user's original question or search text that triggered this tool call. Always include the user's raw query here for better results."`
 }
 
 // AlertRule is the payload for creating an alert rule via POST /api/v2/rules.
@@ -36,103 +36,103 @@ type UpdateAlertInput struct {
 // Anomaly rules use the v1 schema: top-level evalWindow/frequency with
 // condition.op/matchType/target/algorithm/seasonality (no thresholds block).
 type AlertRule struct {
-	Alert             string            `json:"alert" jsonschema:"required" jsonschema_extras:"description=Name of the alert rule. Must be unique and descriptive."`
-	AlertType         AlertType         `json:"alertType" jsonschema:"required" jsonschema_extras:"description=Signal type: METRIC_BASED_ALERT or LOGS_BASED_ALERT or TRACES_BASED_ALERT or EXCEPTIONS_BASED_ALERT."`
-	RuleType          RuleType          `json:"ruleType" jsonschema:"required" jsonschema_extras:"description=Evaluation type: threshold_rule (compare against value) or promql_rule (PromQL expression) or anomaly_rule (anomaly detection on metrics)."`
-	Description       string            `json:"description,omitempty" jsonschema_extras:"description=Human-readable description of what this alert monitors."`
-	Condition         AlertCondition    `json:"condition" jsonschema:"required" jsonschema_extras:"description=Alert condition containing the query and threshold configuration."`
-	Labels            map[string]string `json:"labels,omitempty" jsonschema_extras:"description=Labels for the alert rule. MUST include severity (one of critical, error, warning, info). When thresholds is used, threshold.name (e.g. critical) acts as the routing tier - set labels.severity to match the highest tier you want this rule to carry. Additional labels like team/service/environment enable routing policies."`
-	Annotations       map[string]string `json:"annotations,omitempty" jsonschema_extras:"description=Annotations like description and summary. Supports template variables: {{$value}} for current metric value and {{$threshold}} for the threshold and {{$labels.key}} for label values."`
-	Disabled          bool              `json:"disabled,omitempty" jsonschema_extras:"description=Whether the alert rule is disabled. Defaults to false (enabled)."`
-	Source            string            `json:"source,omitempty" jsonschema_extras:"description=Source URL for the alert. Set automatically."`
-	PreferredChannels []string          `json:"preferredChannels,omitempty" jsonschema_extras:"description=Notification channel names to send alerts to. Use signoz_list_notification_channels to discover available channel names."`
-	Version           string            `json:"version,omitempty" jsonschema_extras:"description=API version. Always v5. Set automatically if omitted."`
+	Alert             string            `json:"alert" jsonschema:"Name of the alert rule. Must be unique and descriptive."`
+	AlertType         AlertType         `json:"alertType" jsonschema:"Signal type: METRIC_BASED_ALERT or LOGS_BASED_ALERT or TRACES_BASED_ALERT or EXCEPTIONS_BASED_ALERT."`
+	RuleType          RuleType          `json:"ruleType" jsonschema:"Evaluation type: threshold_rule (compare against value) or promql_rule (PromQL expression) or anomaly_rule (anomaly detection on metrics)."`
+	Description       string            `json:"description,omitempty" jsonschema:"Human-readable description of what this alert monitors."`
+	Condition         AlertCondition    `json:"condition" jsonschema:"Alert condition containing the query and threshold configuration."`
+	Labels            map[string]string `json:"labels,omitempty" jsonschema:"Labels for the alert rule. MUST include severity (one of critical, error, warning, info). When thresholds is used, threshold.name (e.g. critical) acts as the routing tier - set labels.severity to match the highest tier you want this rule to carry. Additional labels like team/service/environment enable routing policies."`
+	Annotations       map[string]string `json:"annotations,omitempty" jsonschema:"Annotations like description and summary. Supports template variables: {{$value}} for current metric value and {{$threshold}} for the threshold and {{$labels.key}} for label values."`
+	Disabled          bool              `json:"disabled,omitempty" jsonschema:"Whether the alert rule is disabled. Defaults to false (enabled)."`
+	Source            string            `json:"source,omitempty" jsonschema:"Source URL for the alert. Set automatically."`
+	PreferredChannels []string          `json:"preferredChannels,omitempty" jsonschema:"Notification channel names to send alerts to. Use signoz_list_notification_channels to discover available channel names."`
+	Version           string            `json:"version,omitempty" jsonschema:"API version. Always v5. Set automatically if omitted."`
 
 	// v1-schema fields (used only when ruleType=anomaly_rule).
-	EvalWindow string `json:"evalWindow,omitempty" jsonschema_extras:"description=v1 schema only (anomaly_rule). Evaluation window as a Go duration string (e.g. 5m, 15m, 1h, 24h). For threshold/promql rules, use evaluation.spec.evalWindow instead."`
-	Frequency  string `json:"frequency,omitempty" jsonschema_extras:"description=v1 schema only (anomaly_rule). Evaluation frequency as a Go duration string (e.g. 1m, 5m, 3h). For threshold/promql rules, use evaluation.spec.frequency instead."`
+	EvalWindow string `json:"evalWindow,omitempty" jsonschema:"v1 schema only (anomaly_rule). Evaluation window as a Go duration string (e.g. 5m, 15m, 1h, 24h). For threshold/promql rules, use evaluation.spec.evalWindow instead."`
+	Frequency  string `json:"frequency,omitempty" jsonschema:"v1 schema only (anomaly_rule). Evaluation frequency as a Go duration string (e.g. 1m, 5m, 3h). For threshold/promql rules, use evaluation.spec.frequency instead."`
 
 	// v2alpha1 schema fields (used for threshold_rule and promql_rule).
-	Evaluation           *AlertEvaluation      `json:"evaluation,omitempty" jsonschema_extras:"description=v2alpha1 only. Evaluation configuration. kind=rolling (sliding window) auto-generated with defaults (5m/1m) if omitted; kind=cumulative (daily/monthly reset) for period-total alerts such as daily error counts or Cost Meter spend budgets. Skipped entirely for anomaly_rule which uses top-level evalWindow/frequency instead."`
-	SchemaVersion        string                `json:"schemaVersion,omitempty" jsonschema_extras:"description=Schema version. Set to v2alpha1 automatically for threshold_rule/promql_rule. Must be omitted (or empty) for anomaly_rule."`
-	NotificationSettings *NotificationSettings `json:"notificationSettings,omitempty" jsonschema_extras:"description=v2alpha1 only. Notification settings - controls grouping and re-notification behavior. Auto-generated with defaults if omitted."`
+	Evaluation           *AlertEvaluation      `json:"evaluation,omitempty" jsonschema:"v2alpha1 only. Evaluation configuration. kind=rolling (sliding window) auto-generated with defaults (5m/1m) if omitted; kind=cumulative (daily/monthly reset) for period-total alerts such as daily error counts or Cost Meter spend budgets. Skipped entirely for anomaly_rule which uses top-level evalWindow/frequency instead."`
+	SchemaVersion        string                `json:"schemaVersion,omitempty" jsonschema:"Schema version. Set to v2alpha1 automatically for threshold_rule/promql_rule. Must be omitted (or empty) for anomaly_rule."`
+	NotificationSettings *NotificationSettings `json:"notificationSettings,omitempty" jsonschema:"v2alpha1 only. Notification settings - controls grouping and re-notification behavior. Auto-generated with defaults if omitted."`
 }
 
 // AlertCondition defines when an alert should fire.
 type AlertCondition struct {
-	CompositeQuery AlertCompositeQuery `json:"compositeQuery" jsonschema:"required" jsonschema_extras:"description=The composite query defining what data to monitor."`
+	CompositeQuery AlertCompositeQuery `json:"compositeQuery" jsonschema:"The composite query defining what data to monitor."`
 
-	SelectedQuery string `json:"selectedQueryName,omitempty" jsonschema_extras:"description=Which query name triggers the alert (e.g. A or B or F1). Required when multiple queries exist. Defaults to the first query name."`
+	SelectedQuery string `json:"selectedQueryName,omitempty" jsonschema:"Which query name triggers the alert (e.g. A or B or F1). Required when multiple queries exist. Defaults to the first query name."`
 
 	// Absent data alerting
-	AlertOnAbsent     bool   `json:"alertOnAbsent,omitempty" jsonschema_extras:"description=Alert when no data is received within the evaluation window."`
-	AbsentFor         uint64 `json:"absentFor,omitempty" jsonschema_extras:"description=Minutes (equivalent to consecutive evaluation cycles when frequency is 1m) to wait with no data before firing an absent-data alert. Example: absentFor=15 with frequency=1m fires after 15 evaluations return no series."`
-	RequireMinPoints  bool   `json:"requireMinPoints,omitempty" jsonschema_extras:"description=Require a minimum number of data points before evaluating the condition."`
-	RequiredNumPoints int    `json:"requiredNumPoints,omitempty" jsonschema_extras:"description=Minimum number of data points required when requireMinPoints is true."`
+	AlertOnAbsent     bool   `json:"alertOnAbsent,omitempty" jsonschema:"Alert when no data is received within the evaluation window."`
+	AbsentFor         uint64 `json:"absentFor,omitempty" jsonschema:"Minutes (equivalent to consecutive evaluation cycles when frequency is 1m) to wait with no data before firing an absent-data alert. Example: absentFor=15 with frequency=1m fires after 15 evaluations return no series."`
+	RequireMinPoints  bool   `json:"requireMinPoints,omitempty" jsonschema:"Require a minimum number of data points before evaluating the condition."`
+	RequiredNumPoints int    `json:"requiredNumPoints,omitempty" jsonschema:"Minimum number of data points required when requireMinPoints is true."`
 
 	// v1-schema anomaly-rule fields. Used only when the parent AlertRule has
 	// ruleType=anomaly_rule. All six are required together in that case and
 	// replace the v2alpha1 thresholds block.
-	Op          string      `json:"op,omitempty" jsonschema_extras:"description=v1 (anomaly_rule) only. Comparison operator applied to the anomaly score - same accepted values as threshold.op (above, below, equal, not_equal, above_or_equal, below_or_equal, outside_bounds)."`
-	MatchType   string      `json:"matchType,omitempty" jsonschema_extras:"description=v1 (anomaly_rule) only. Match type - same accepted values as threshold.matchType (at_least_once, all_the_times, on_average/avg, in_total/sum, last)."`
-	Target      interface{} `json:"target,omitempty" jsonschema_extras:"description=v1 (anomaly_rule) only. Threshold value compared against the anomaly score."`
-	Algorithm   string      `json:"algorithm,omitempty" jsonschema_extras:"description=v1 (anomaly_rule) only. Anomaly detection algorithm. Accepted values include standard (z-score based). Used only when ruleType=anomaly_rule."`
-	Seasonality string      `json:"seasonality,omitempty" jsonschema_extras:"description=v1 (anomaly_rule) only. Seasonality pattern for anomaly detection: hourly, daily, or weekly."`
+	Op          string      `json:"op,omitempty" jsonschema:"v1 (anomaly_rule) only. Comparison operator applied to the anomaly score - same accepted values as threshold.op (above, below, equal, not_equal, above_or_equal, below_or_equal, outside_bounds)."`
+	MatchType   string      `json:"matchType,omitempty" jsonschema:"v1 (anomaly_rule) only. Match type - same accepted values as threshold.matchType (at_least_once, all_the_times, on_average/avg, in_total/sum, last)."`
+	Target      interface{} `json:"target,omitempty" jsonschema:"v1 (anomaly_rule) only. Threshold value compared against the anomaly score."`
+	Algorithm   string      `json:"algorithm,omitempty" jsonschema:"v1 (anomaly_rule) only. Anomaly detection algorithm. Accepted values include standard (z-score based). Used only when ruleType=anomaly_rule."`
+	Seasonality string      `json:"seasonality,omitempty" jsonschema:"v1 (anomaly_rule) only. Seasonality pattern for anomaly detection: hourly, daily, or weekly."`
 
 	// Threshold configuration (v2alpha1 schema). Required for threshold_rule
 	// and promql_rule unless alertOnAbsent is true. Omit for anomaly_rule.
-	Thresholds *AlertThresholds `json:"thresholds,omitempty" jsonschema_extras:"description=v2alpha1 only (threshold_rule, promql_rule). Each threshold level (critical, error, warning, info) can route to different notification channels. Required unless alertOnAbsent is true. Omit entirely for anomaly_rule - use condition.op/matchType/target there instead."`
+	Thresholds *AlertThresholds `json:"thresholds,omitempty" jsonschema:"v2alpha1 only (threshold_rule, promql_rule). Each threshold level (critical, error, warning, info) can route to different notification channels. Required unless alertOnAbsent is true. Omit entirely for anomaly_rule - use condition.op/matchType/target there instead."`
 }
 
 // AlertCompositeQuery contains the queries that define what data to monitor.
 type AlertCompositeQuery struct {
-	QueryType QueryType    `json:"queryType" jsonschema:"required" jsonschema_extras:"description=Query type: builder for Query Builder or promql for PromQL or clickhouse_sql for ClickHouse SQL."`
-	PanelType string       `json:"panelType,omitempty" jsonschema_extras:"description=Panel type. Use graph for alerts. Defaults to graph."`
-	Unit      string       `json:"unit,omitempty" jsonschema_extras:"description=Unit of the queried data (Y-axis unit). Used for value formatting in alert messages and for unit conversion with targetUnit in thresholds. Common values: percent, ms, s, bytes, ns, reqps, ops."`
-	Queries   []AlertQuery `json:"queries" jsonschema:"required" jsonschema_extras:"description=Array of queries. At least one query is required."`
+	QueryType QueryType    `json:"queryType" jsonschema:"Query type: builder for Query Builder or promql for PromQL or clickhouse_sql for ClickHouse SQL."`
+	PanelType string       `json:"panelType,omitempty" jsonschema:"Panel type. Use graph for alerts. Defaults to graph."`
+	Unit      string       `json:"unit,omitempty" jsonschema:"Unit of the queried data (Y-axis unit). Used for value formatting in alert messages and for unit conversion with targetUnit in thresholds. Common values: percent, ms, s, bytes, ns, reqps, ops."`
+	Queries   []AlertQuery `json:"queries" jsonschema:"Array of queries. At least one query is required."`
 }
 
 // AlertQuery wraps a single query within the composite query.
 type AlertQuery struct {
-	Type string         `json:"type" jsonschema:"required" jsonschema_extras:"description=Query envelope type. Must match compositeQuery.queryType: builder → builder_query or builder_formula; promql → promql; clickhouse_sql → clickhouse_sql. Also accepted: builder_trace_operator for trace operator queries."`
-	Spec AlertQuerySpec `json:"spec" jsonschema:"required" jsonschema_extras:"description=Query specification."`
+	Type string         `json:"type" jsonschema:"Query envelope type. Must match compositeQuery.queryType: builder → builder_query or builder_formula; promql → promql; clickhouse_sql → clickhouse_sql. Also accepted: builder_trace_operator for trace operator queries."`
+	Spec AlertQuerySpec `json:"spec" jsonschema:"Query specification."`
 }
 
 // AlertQuerySpec is the specification for a single query within an alert.
 // For builder_query type this uses the v5 query builder format.
 // For promql/clickhouse_sql types only name query legend and disabled are used.
 type AlertQuerySpec struct {
-	Name         string               `json:"name" jsonschema:"required" jsonschema_extras:"description=Query name (e.g. A or B or C). Used as reference in formulas and selectedQueryName."`
-	Signal       string               `json:"signal,omitempty" jsonschema_extras:"description=Signal type for builder queries: metrics or logs or traces. Required for builder_query type."`
-	StepInterval *int64               `json:"stepInterval,omitempty" jsonschema_extras:"description=Step interval in seconds for time aggregation. Use 60 for metrics alerts."`
-	Disabled     bool                 `json:"disabled,omitempty" jsonschema_extras:"description=Whether this query is disabled."`
-	Source       string               `json:"source,omitempty" jsonschema_extras:"description=Data-source filter for metrics builder_query only. Set to meter to alert on Cost Meter (usage/billing) metrics such as signoz.meter.log.size; omit otherwise."`
-	Aggregations []AlertAggregation   `json:"aggregations,omitempty" jsonschema_extras:"description=Aggregation expressions for builder queries. For metrics signal use the object shape: [{metricName: k8s.pod.cpu_request_utilization, timeAggregation: avg, spaceAggregation: max}]. For logs/traces use the expression shape: [{expression: count()}] or [{expression: p99(duration_nano)}]."`
-	Filter       *AlertQueryFilter    `json:"filter,omitempty" jsonschema_extras:"description=Filter expression for builder queries. Example: {expression: service.name = frontend AND http.status_code >= 500}."`
-	GroupBy      []AlertGroupByField  `json:"groupBy,omitempty" jsonschema_extras:"description=Fields to group by. Grouped dimensions appear as labels in alert notifications."`
-	Order        []AlertOrderField    `json:"order,omitempty" jsonschema_extras:"description=Order by specification."`
-	Having       *AlertQueryFilter    `json:"having,omitempty" jsonschema_extras:"description=Having clause to filter aggregation results."`
-	Functions    []AlertQueryFunction `json:"functions,omitempty" jsonschema_extras:"description=Post-query functions applied to the series. Required for anomaly_rule: wrap with {name: anomaly, args: [{name: z_score_threshold, value: 2}]}."`
+	Name         string               `json:"name" jsonschema:"Query name (e.g. A or B or C). Used as reference in formulas and selectedQueryName."`
+	Signal       string               `json:"signal,omitempty" jsonschema:"Signal type for builder queries: metrics or logs or traces. Required for builder_query type."`
+	StepInterval *int64               `json:"stepInterval,omitempty" jsonschema:"Step interval in seconds for time aggregation. Use 60 for metrics alerts."`
+	Disabled     bool                 `json:"disabled,omitempty" jsonschema:"Whether this query is disabled."`
+	Source       string               `json:"source,omitempty" jsonschema:"Data-source filter for metrics builder_query only. Set to meter to alert on Cost Meter (usage/billing) metrics such as signoz.meter.log.size; omit otherwise."`
+	Aggregations []AlertAggregation   `json:"aggregations,omitempty" jsonschema:"Aggregation expressions for builder queries. For metrics signal use the object shape: [{metricName: k8s.pod.cpu_request_utilization, timeAggregation: avg, spaceAggregation: max}]. For logs/traces use the expression shape: [{expression: count()}] or [{expression: p99(duration_nano)}]."`
+	Filter       *AlertQueryFilter    `json:"filter,omitempty" jsonschema:"Filter expression for builder queries. Example: {expression: service.name = frontend AND http.status_code >= 500}."`
+	GroupBy      []AlertGroupByField  `json:"groupBy,omitempty" jsonschema:"Fields to group by. Grouped dimensions appear as labels in alert notifications."`
+	Order        []AlertOrderField    `json:"order,omitempty" jsonschema:"Order by specification."`
+	Having       *AlertQueryFilter    `json:"having,omitempty" jsonschema:"Having clause to filter aggregation results."`
+	Functions    []AlertQueryFunction `json:"functions,omitempty" jsonschema:"Post-query functions applied to the series. Required for anomaly_rule: wrap with {name: anomaly, args: [{name: z_score_threshold, value: 2}]}."`
 
 	// For promql / clickhouse_sql query types
-	Query  string `json:"query,omitempty" jsonschema_extras:"description=PromQL or ClickHouse SQL query string. Used when queryType is promql or clickhouse_sql. PromQL with OTel dotted metric names MUST use the Prometheus 3.x UTF-8 quoted-selector form: {\"metric.name.with.dots\"}. Underscored / __name__ / bare-dotted forms return no data. Read signoz://promql/instructions for the full guide (histogram patterns dotted labels pre-flight checklist)."`
-	Legend string `json:"legend,omitempty" jsonschema_extras:"description=Legend template for the query."`
+	Query  string `json:"query,omitempty" jsonschema:"PromQL or ClickHouse SQL query string. Used when queryType is promql or clickhouse_sql. PromQL with OTel dotted metric names MUST use the Prometheus 3.x UTF-8 quoted-selector form: {\"metric.name.with.dots\"}. Underscored / __name__ / bare-dotted forms return no data. Read signoz://promql/instructions for the full guide (histogram patterns dotted labels pre-flight checklist)."`
+	Legend string `json:"legend,omitempty" jsonschema:"Legend template for the query."`
 
 	// For builder_formula type
-	Expression string `json:"expression,omitempty" jsonschema_extras:"description=Formula expression referencing other query names (e.g. A / B * 100). Used for builder_formula type."`
+	Expression string `json:"expression,omitempty" jsonschema:"Formula expression referencing other query names (e.g. A / B * 100). Used for builder_formula type."`
 }
 
 // AlertQueryFunction applies a post-query transform to a builder query series.
 // Most commonly used for anomaly detection on metrics.
 type AlertQueryFunction struct {
-	Name string                  `json:"name" jsonschema:"required" jsonschema_extras:"description=Function name (e.g. anomaly for ruleType=anomaly_rule)."`
-	Args []AlertQueryFunctionArg `json:"args,omitempty" jsonschema_extras:"description=Function arguments. Example for anomaly: [{name: z_score_threshold, value: 2}]."`
+	Name string                  `json:"name" jsonschema:"Function name (e.g. anomaly for ruleType=anomaly_rule)."`
+	Args []AlertQueryFunctionArg `json:"args,omitempty" jsonschema:"Function arguments. Example for anomaly: [{name: z_score_threshold, value: 2}]."`
 }
 
 // AlertQueryFunctionArg is a single argument to an AlertQueryFunction.
 type AlertQueryFunctionArg struct {
-	Name  string      `json:"name" jsonschema:"required" jsonschema_extras:"description=Argument name (e.g. z_score_threshold)."`
-	Value interface{} `json:"value,omitempty" jsonschema_extras:"description=Argument value. Can be number, string, or bool depending on the function."`
+	Name  string      `json:"name" jsonschema:"Argument name (e.g. z_score_threshold)."`
+	Value interface{} `json:"value,omitempty" jsonschema:"Argument value. Can be number, string, or bool depending on the function."`
 }
 
 // AlertAggregation represents an aggregation in a builder query.
@@ -141,87 +141,87 @@ type AlertQueryFunctionArg struct {
 //   - Logs/traces signal: set Expression (metric fields empty).
 type AlertAggregation struct {
 	// For metrics signal.
-	MetricName       string `json:"metricName,omitempty" jsonschema_extras:"description=Metric name (metrics signal only). Example: k8s.pod.cpu_request_utilization. Use alongside timeAggregation and spaceAggregation. Do not set expression when using this shape."`
-	TimeAggregation  string `json:"timeAggregation,omitempty" jsonschema_extras:"description=Per-series time aggregation (metrics signal only). Common values: avg, max, min, sum, rate, increase, count, count_distinct, latest. Default by metric type: gauge→avg, cumulative counter→rate, delta counter→sum."`
-	SpaceAggregation string `json:"spaceAggregation,omitempty" jsonschema_extras:"description=Cross-series space aggregation (metrics signal only). Common values: sum, avg, min, max, count. For histograms use percentiles: p50, p75, p90, p95, p99."`
+	MetricName       string `json:"metricName,omitempty" jsonschema:"Metric name (metrics signal only). Example: k8s.pod.cpu_request_utilization. Use alongside timeAggregation and spaceAggregation. Do not set expression when using this shape."`
+	TimeAggregation  string `json:"timeAggregation,omitempty" jsonschema:"Per-series time aggregation (metrics signal only). Common values: avg, max, min, sum, rate, increase, count, count_distinct, latest. Default by metric type: gauge→avg, cumulative counter→rate, delta counter→sum."`
+	SpaceAggregation string `json:"spaceAggregation,omitempty" jsonschema:"Cross-series space aggregation (metrics signal only). Common values: sum, avg, min, max, count. For histograms use percentiles: p50, p75, p90, p95, p99."`
 
 	// For logs/traces signal.
-	Expression string `json:"expression,omitempty" jsonschema_extras:"description=Aggregation expression (logs/traces signal). Examples: count(), avg(duration), p99(duration_nano), count_distinct(user_id), sum(bytes). Do not set metricName/timeAggregation/spaceAggregation when using this shape."`
+	Expression string `json:"expression,omitempty" jsonschema:"Aggregation expression (logs/traces signal). Examples: count(), avg(duration), p99(duration_nano), count_distinct(user_id), sum(bytes). Do not set metricName/timeAggregation/spaceAggregation when using this shape."`
 }
 
 // AlertQueryFilter holds a filter or having expression.
 type AlertQueryFilter struct {
-	Expression string `json:"expression" jsonschema_extras:"description=Filter expression using field operators. Example: service.name = frontend AND http.status_code >= 500. Use empty string for no filter."`
+	Expression string `json:"expression" jsonschema:"Filter expression using field operators. Example: service.name = frontend AND http.status_code >= 500. Use empty string for no filter."`
 }
 
 // AlertGroupByField identifies a field to group by.
 type AlertGroupByField struct {
-	Name          string `json:"name" jsonschema:"required" jsonschema_extras:"description=Field name to group by (e.g. service.name or http.method or severity_text)."`
-	FieldContext  string `json:"fieldContext,omitempty" jsonschema_extras:"description=Field context: resource for resource attributes or tag for span/log attributes. Required for non-top-level fields."`
-	FieldDataType string `json:"fieldDataType,omitempty" jsonschema_extras:"description=Data type of the field: string or int64 or float64 or bool."`
+	Name          string `json:"name" jsonschema:"Field name to group by (e.g. service.name or http.method or severity_text)."`
+	FieldContext  string `json:"fieldContext,omitempty" jsonschema:"Field context: resource for resource attributes or tag for span/log attributes. Required for non-top-level fields."`
+	FieldDataType string `json:"fieldDataType,omitempty" jsonschema:"Data type of the field: string or int64 or float64 or bool."`
 }
 
 // AlertOrderField specifies ordering for query results.
 type AlertOrderField struct {
-	Key       AlertOrderKey `json:"key" jsonschema:"required"`
-	Direction string        `json:"direction" jsonschema:"required" jsonschema_extras:"description=Sort direction: asc or desc."`
+	Key       AlertOrderKey `json:"key"`
+	Direction string        `json:"direction" jsonschema:"Sort direction: asc or desc."`
 }
 
 // AlertOrderKey identifies the field to order by.
 type AlertOrderKey struct {
-	Name string `json:"name" jsonschema:"required" jsonschema_extras:"description=Field or aggregation expression to order by (e.g. timestamp or count())."`
+	Name string `json:"name" jsonschema:"Field or aggregation expression to order by (e.g. timestamp or count())."`
 }
 
 // AlertThresholds holds multi-threshold configuration for v2 schema alerts.
 type AlertThresholds struct {
-	Kind string           `json:"kind" jsonschema:"required" jsonschema_extras:"description=Threshold kind. Currently only basic is supported."`
-	Spec []BasicThreshold `json:"spec" jsonschema:"required" jsonschema_extras:"description=Array of threshold specifications. Each threshold can route to different channels."`
+	Kind string           `json:"kind" jsonschema:"Threshold kind. Currently only basic is supported."`
+	Spec []BasicThreshold `json:"spec" jsonschema:"Array of threshold specifications. Each threshold can route to different channels."`
 }
 
 // BasicThreshold defines a single threshold level with routing.
 type BasicThreshold struct {
-	Name           string   `json:"name" jsonschema:"required" jsonschema_extras:"description=Threshold tier: critical, error, warning, or info. Also used as the routing label - alerts carry threshold_name equal to this value."`
-	Target         *float64 `json:"target" jsonschema:"required" jsonschema_extras:"description=Threshold value to compare against."`
-	TargetUnit     string   `json:"targetUnit,omitempty" jsonschema_extras:"description=Unit of the threshold target value. If different from compositeQuery.unit the backend converts between them during evaluation. Common values: percent, ms, s, bytes, ns."`
-	RecoveryTarget *float64 `json:"recoveryTarget" jsonschema_extras:"description=Hysteresis - value at which a firing alert is considered resolved. Useful to avoid flapping near the threshold (e.g. target=80 percent, recoveryTarget=75 percent). Use null to use the threshold target itself as the recovery point."`
-	MatchType      string   `json:"matchType" jsonschema:"required" jsonschema_extras:"description=How to evaluate the threshold. Canonical: at_least_once, all_the_times, on_average, in_total, last. Aliases accepted: avg (=on_average), sum (=in_total). Numeric 1-5 also accepted but discouraged."`
-	CompareOp      string   `json:"op" jsonschema:"required" jsonschema_extras:"description=Comparison operator. Canonical literals: above, below, equal, not_equal, above_or_equal, below_or_equal, outside_bounds. Short forms accepted: eq, not_eq, above_or_eq, below_or_eq. Symbolic accepted: >, <, =, !=, >=, <=. Numeric 1-7 also accepted but discouraged."`
-	Channels       []string `json:"channels,omitempty" jsonschema_extras:"description=Notification channel names for this threshold tier. Use signoz_list_notification_channels to discover available names. Ignored when notificationSettings.usePolicy is true."`
+	Name           string   `json:"name" jsonschema:"Threshold tier: critical, error, warning, or info. Also used as the routing label - alerts carry threshold_name equal to this value."`
+	Target         *float64 `json:"target" jsonschema:"Threshold value to compare against."`
+	TargetUnit     string   `json:"targetUnit,omitempty" jsonschema:"Unit of the threshold target value. If different from compositeQuery.unit the backend converts between them during evaluation. Common values: percent, ms, s, bytes, ns."`
+	RecoveryTarget *float64 `json:"recoveryTarget" jsonschema:"Hysteresis - value at which a firing alert is considered resolved. Useful to avoid flapping near the threshold (e.g. target=80 percent, recoveryTarget=75 percent). Use null to use the threshold target itself as the recovery point."`
+	MatchType      string   `json:"matchType" jsonschema:"How to evaluate the threshold. Canonical: at_least_once, all_the_times, on_average, in_total, last. Aliases accepted: avg (=on_average), sum (=in_total). Numeric 1-5 also accepted but discouraged."`
+	CompareOp      string   `json:"op" jsonschema:"Comparison operator. Canonical literals: above, below, equal, not_equal, above_or_equal, below_or_equal, outside_bounds. Short forms accepted: eq, not_eq, above_or_eq, below_or_eq. Symbolic accepted: >, <, =, !=, >=, <=. Numeric 1-7 also accepted but discouraged."`
+	Channels       []string `json:"channels,omitempty" jsonschema:"Notification channel names for this threshold tier. Use signoz_list_notification_channels to discover available names. Ignored when notificationSettings.usePolicy is true."`
 }
 
 // AlertEvaluation holds the evaluation schedule for v2 schema alerts.
 type AlertEvaluation struct {
-	Kind string              `json:"kind" jsonschema:"required" jsonschema_extras:"description=Evaluation kind: rolling (sliding lookback window) or cumulative (accumulates from a fixed daily/monthly reset boundary). Cumulative works for any period-total alert (e.g. daily error counts, monthly request budgets); Cost Meter spend budgets are one common use."`
-	Spec AlertEvaluationSpec `json:"spec" jsonschema:"required" jsonschema_extras:"description=Evaluation specification. For kind=rolling set evalWindow + frequency; for kind=cumulative set schedule + frequency + timezone."`
+	Kind string              `json:"kind" jsonschema:"Evaluation kind: rolling (sliding lookback window) or cumulative (accumulates from a fixed daily/monthly reset boundary). Cumulative works for any period-total alert (e.g. daily error counts, monthly request budgets); Cost Meter spend budgets are one common use."`
+	Spec AlertEvaluationSpec `json:"spec" jsonschema:"Evaluation specification. For kind=rolling set evalWindow + frequency; for kind=cumulative set schedule + frequency + timezone."`
 }
 
 // AlertEvaluationSpec defines the evaluation window. Rolling uses evalWindow+frequency;
 // cumulative uses schedule+frequency+timezone.
 type AlertEvaluationSpec struct {
-	EvalWindow string                   `json:"evalWindow,omitempty" jsonschema_extras:"description=Rolling kind only. Evaluation window as a Go duration string (e.g. 5m, 15m, 30m, 1h, 4h, 24h)."`
-	Frequency  string                   `json:"frequency" jsonschema:"required" jsonschema_extras:"description=Evaluation frequency as a Go duration string (e.g. 1m, 5m, 15m)."`
-	Schedule   *AlertEvaluationSchedule `json:"schedule,omitempty" jsonschema_extras:"description=Cumulative kind only. Fixed reset boundary the accumulation window starts from."`
-	Timezone   string                   `json:"timezone,omitempty" jsonschema_extras:"description=Cumulative kind only. IANA timezone for the schedule boundary (e.g. UTC)."`
+	EvalWindow string                   `json:"evalWindow,omitempty" jsonschema:"Rolling kind only. Evaluation window as a Go duration string (e.g. 5m, 15m, 30m, 1h, 4h, 24h)."`
+	Frequency  string                   `json:"frequency" jsonschema:"Evaluation frequency as a Go duration string (e.g. 1m, 5m, 15m)."`
+	Schedule   *AlertEvaluationSchedule `json:"schedule,omitempty" jsonschema:"Cumulative kind only. Fixed reset boundary the accumulation window starts from."`
+	Timezone   string                   `json:"timezone,omitempty" jsonschema:"Cumulative kind only. IANA timezone for the schedule boundary (e.g. UTC)."`
 }
 
 // AlertEvaluationSchedule is the reset schedule for a cumulative evaluation window.
 type AlertEvaluationSchedule struct {
-	Type   string `json:"type" jsonschema:"required" jsonschema_extras:"description=Reset cadence: daily or monthly."`
-	Minute int    `json:"minute" jsonschema_extras:"description=Minute of the reset boundary (0-59); e.g. 0 for the top of the hour."`
-	Hour   int    `json:"hour" jsonschema_extras:"description=Hour of the reset boundary (0-23); e.g. 0 for midnight."`
+	Type   string `json:"type" jsonschema:"Reset cadence: daily or monthly."`
+	Minute int    `json:"minute" jsonschema:"Minute of the reset boundary (0-59); e.g. 0 for the top of the hour."`
+	Hour   int    `json:"hour" jsonschema:"Hour of the reset boundary (0-23); e.g. 0 for midnight."`
 }
 
 // NotificationSettings controls alert notification behavior for v2alpha1 rules.
 type NotificationSettings struct {
-	GroupBy           []string  `json:"groupBy,omitempty" jsonschema_extras:"description=Fields to group alert notifications by (e.g. service.name, k8s.namespace.name). Reduces notification noise by batching alerts with the same group key."`
-	NewGroupEvalDelay string    `json:"newGroupEvalDelay,omitempty" jsonschema_extras:"description=Grace period (Go duration string, e.g. 2m) during which a newly-appearing label group is excluded from evaluation. Helps avoid flapping when new pods/services come online."`
-	Renotify          *Renotify `json:"renotify,omitempty" jsonschema_extras:"description=Re-notification configuration."`
-	UsePolicy         bool      `json:"usePolicy,omitempty" jsonschema_extras:"description=Routing mode. false (default) = deliver to channels listed in each threshold entry. true = ignore per-threshold channels and route via the org-level notification policy matching on labels."`
+	GroupBy           []string  `json:"groupBy,omitempty" jsonschema:"Fields to group alert notifications by (e.g. service.name, k8s.namespace.name). Reduces notification noise by batching alerts with the same group key."`
+	NewGroupEvalDelay string    `json:"newGroupEvalDelay,omitempty" jsonschema:"Grace period (Go duration string, e.g. 2m) during which a newly-appearing label group is excluded from evaluation. Helps avoid flapping when new pods/services come online."`
+	Renotify          *Renotify `json:"renotify,omitempty" jsonschema:"Re-notification configuration."`
+	UsePolicy         bool      `json:"usePolicy,omitempty" jsonschema:"Routing mode. false (default) = deliver to channels listed in each threshold entry. true = ignore per-threshold channels and route via the org-level notification policy matching on labels."`
 }
 
 // Renotify controls re-notification behavior.
 type Renotify struct {
-	Enabled     bool     `json:"enabled" jsonschema_extras:"description=Whether re-notification is enabled."`
-	Interval    string   `json:"interval,omitempty" jsonschema_extras:"description=Re-notification interval as a Go duration string (e.g. 15m, 30m, 1h, 4h)."`
-	AlertStates []string `json:"alertStates,omitempty" jsonschema_extras:"description=Alert states that trigger re-notification. Accepted values: firing, nodata. Other values are rejected."`
+	Enabled     bool     `json:"enabled" jsonschema:"Whether re-notification is enabled."`
+	Interval    string   `json:"interval,omitempty" jsonschema:"Re-notification interval as a Go duration string (e.g. 15m, 30m, 1h, 4h)."`
+	AlertStates []string `json:"alertStates,omitempty" jsonschema:"Alert states that trigger re-notification. Accepted values: firing, nodata. Other values are rejected."`
 }

--- a/pkg/types/dashboard.go
+++ b/pkg/types/dashboard.go
@@ -1,33 +1,33 @@
 package types
 
 type UpdateDashboardInput struct {
-	UUID          string    `json:"uuid" jsonschema:"required" jsonschema_extras:"description=Dashboard UUID to update."`
-	Dashboard     Dashboard `json:"dashboard" jsonschema:"required" jsonschema_extras:"description=Full dashboard configuration representing the complete post-update state."`
-	SearchContext string    `json:"searchContext,omitempty" jsonschema_extras:"description=The user's original question or search text that triggered this tool call. Always include the user's raw query here for better results."`
+	UUID          string    `json:"uuid" jsonschema:"Dashboard UUID to update."`
+	Dashboard     Dashboard `json:"dashboard" jsonschema:"Full dashboard configuration representing the complete post-update state."`
+	SearchContext string    `json:"searchContext,omitempty" jsonschema:"The user's original question or search text that triggered this tool call. Always include the user's raw query here for better results."`
 }
 
 type CreateDashboardInput struct {
 	Dashboard
-	SearchContext string `json:"searchContext,omitempty" jsonschema_extras:"description=The user's original question or search text that triggered this tool call. Always include the user's raw query here for better results."`
+	SearchContext string `json:"searchContext,omitempty" jsonschema:"The user's original question or search text that triggered this tool call. Always include the user's raw query here for better results."`
 }
 
 type Dashboard struct {
-	Title       string              `json:"title" jsonschema:"required" jsonschema_extras:"description=The display name of the dashboard."`
-	Description string              `json:"description,omitempty" jsonschema_extras:"description=A brief explanation of what the dashboard shows."`
-	Tags        []string            `json:"tags,omitempty" jsonschema_extras:"description=Keywords for categorization e.g performance latency."`
-	Layout      []LayoutItem        `json:"layout" jsonschema:"required" jsonschema_extras:"description=Defines the grid positioning and size for each widget."`
-	Variables   map[string]Variable `json:"variables,omitempty" jsonschema_extras:"description=Key-value map of template variables available for queries."`
-	Widgets     []Widget            `json:"widgets" jsonschema:"required" jsonschema_extras:"description=The list of all graphical components displayed on the dashboard."`
+	Title       string              `json:"title" jsonschema:"The display name of the dashboard."`
+	Description string              `json:"description,omitempty" jsonschema:"A brief explanation of what the dashboard shows."`
+	Tags        []string            `json:"tags,omitempty" jsonschema:"Keywords for categorization e.g performance latency."`
+	Layout      []LayoutItem        `json:"layout" jsonschema:"Defines the grid positioning and size for each widget."`
+	Variables   map[string]Variable `json:"variables,omitempty" jsonschema:"Key-value map of template variables available for queries."`
+	Widgets     []Widget            `json:"widgets" jsonschema:"The list of all graphical components displayed on the dashboard."`
 }
 
 type LayoutItem struct {
-	X           int    `json:"x" jsonschema:"required" jsonschema_extras:"description=X coordinate for the layout"`
-	Y           int    `json:"y" jsonschema:"required" jsonschema_extras:"description=Y coordinate for the layout"`
-	W           int    `json:"w" jsonschema:"required" jsonschema_extras:"description=Width for the layout"`
-	H           int    `json:"h" jsonschema:"required" jsonschema_extras:"description=Height for the layout"`
-	I           string `json:"i" jsonschema:"required" jsonschema_extras:"description=ID for the layout"`
-	Moved       bool   `json:"moved,omitempty" jsonschema_extras:"description=Whether the layout is moved or not"`
-	Static      bool   `json:"static,omitempty" jsonschema_extras:"description=Whether the layout is static or not"`
+	X           int    `json:"x" jsonschema:"X coordinate for the layout"`
+	Y           int    `json:"y" jsonschema:"Y coordinate for the layout"`
+	W           int    `json:"w" jsonschema:"Width for the layout"`
+	H           int    `json:"h" jsonschema:"Height for the layout"`
+	I           string `json:"i" jsonschema:"ID for the layout"`
+	Moved       bool   `json:"moved,omitempty" jsonschema:"Whether the layout is moved or not"`
+	Static      bool   `json:"static,omitempty" jsonschema:"Whether the layout is static or not"`
 	MaxH        int    `json:"maxH,omitempty"`
 	MinH        int    `json:"minH,omitempty"`
 	MinW        int    `json:"minW,omitempty"`
@@ -35,19 +35,19 @@ type LayoutItem struct {
 }
 
 type Variable struct {
-	ID                        string       `json:"id,omitempty" jsonschema_extras:"description=ID for the variable"`
-	Name                      string       `json:"name,omitempty" jsonschema_extras:"description=Name for the variable"`
-	Description               string       `json:"description,omitempty" jsonschema_extras:"description=Description for the variable"`
-	Key                       string       `json:"key,omitempty" jsonschema_extras:"description=Key for the variable, use same as name"`
-	Type                      VariableType `json:"type,omitempty" jsonschema_extras:"description=Type for the variable"`
-	QueryValue                string       `json:"queryValue,omitempty" jsonschema_extras:"description=Query for the variable"`
-	AllSelected               bool         `json:"allSelected,omitempty" jsonschema_extras:"description=Whether all the values are selected or not"`
-	CustomValue               string       `json:"customValue,omitempty" jsonschema_extras:"description=Custom value for the variable"`
-	MultiSelect               bool         `json:"multiSelect,omitempty" jsonschema_extras:"description=Whether the variable is multi select or not"`
-	Order                     int          `json:"order,omitempty" jsonschema_extras:"description=Order for the variable"`
-	ShowALLOption             bool         `json:"showALLOption,omitempty" jsonschema_extras:"description=Whether to show all option or not"`
-	Sort                      VariableSort `json:"sort,omitempty" jsonschema_extras:"description=Sort for the variable"`
-	TextboxValue              string       `json:"textboxValue,omitempty" jsonschema_extras:"description=Textbox value for the variable"`
+	ID                        string       `json:"id,omitempty" jsonschema:"ID for the variable"`
+	Name                      string       `json:"name,omitempty" jsonschema:"Name for the variable"`
+	Description               string       `json:"description,omitempty" jsonschema:"Description for the variable"`
+	Key                       string       `json:"key,omitempty" jsonschema:"Key for the variable, use same as name"`
+	Type                      VariableType `json:"type,omitempty" jsonschema:"Type for the variable"`
+	QueryValue                string       `json:"queryValue,omitempty" jsonschema:"Query for the variable"`
+	AllSelected               bool         `json:"allSelected,omitempty" jsonschema:"Whether all the values are selected or not"`
+	CustomValue               string       `json:"customValue,omitempty" jsonschema:"Custom value for the variable"`
+	MultiSelect               bool         `json:"multiSelect,omitempty" jsonschema:"Whether the variable is multi select or not"`
+	Order                     int          `json:"order,omitempty" jsonschema:"Order for the variable"`
+	ShowALLOption             bool         `json:"showALLOption,omitempty" jsonschema:"Whether to show all option or not"`
+	Sort                      VariableSort `json:"sort,omitempty" jsonschema:"Sort for the variable"`
+	TextboxValue              string       `json:"textboxValue,omitempty" jsonschema:"Textbox value for the variable"`
 	ModificationUUID          string       `json:"modificationUUID,omitempty"`
 	SelectedValue             interface{}  `json:"selectedValue,omitempty"`
 	DefaultValue              string       `json:"defaultValue,omitempty"`
@@ -57,16 +57,16 @@ type Variable struct {
 }
 
 type Widget struct {
-	ID                    string             `json:"id" jsonschema:"required" jsonschema_extras:"description=ID for the widget"`
-	Description           string             `json:"description,omitempty" jsonschema_extras:"description=Description for the widget"`
-	IsStacked             bool               `json:"isStacked,omitempty" jsonschema_extras:"description=Whether the widget is stacked or not"`
-	NullZeroValues        string             `json:"nullZeroValues,omitempty" jsonschema_extras:"description=Whether the widget has null zero values or not"`
-	Opacity               string             `json:"opacity,omitempty" jsonschema_extras:"description=Opacity for the widget"`
-	PanelTypes            PanelType          `json:"panelTypes" jsonschema:"required" jsonschema_extras:"description=Panel type for the widget."`
-	TimePreferance        TimePreferance     `json:"timePreferance,omitempty" jsonschema_extras:"description=Time preferance for the widget"`
-	Title                 string             `json:"title" jsonschema:"required" jsonschema_extras:"description=Title for the widget"`
-	YAxisUnit             string             `json:"yAxisUnit,omitempty" jsonschema_extras:"description=Y axis unit for the widget"`
-	Query                 WidgetQuery        `json:"query" jsonschema:"required" jsonschema_extras:"description=Query for the widget."`
+	ID                    string             `json:"id" jsonschema:"ID for the widget"`
+	Description           string             `json:"description,omitempty" jsonschema:"Description for the widget"`
+	IsStacked             bool               `json:"isStacked,omitempty" jsonschema:"Whether the widget is stacked or not"`
+	NullZeroValues        string             `json:"nullZeroValues,omitempty" jsonschema:"Whether the widget has null zero values or not"`
+	Opacity               string             `json:"opacity,omitempty" jsonschema:"Opacity for the widget"`
+	PanelTypes            PanelType          `json:"panelTypes" jsonschema:"Panel type for the widget."`
+	TimePreferance        TimePreferance     `json:"timePreferance,omitempty" jsonschema:"Time preferance for the widget"`
+	Title                 string             `json:"title" jsonschema:"Title for the widget"`
+	YAxisUnit             string             `json:"yAxisUnit,omitempty" jsonschema:"Y axis unit for the widget"`
+	Query                 WidgetQuery        `json:"query" jsonschema:"Query for the widget."`
 	BucketCount           int                `json:"bucketCount,omitempty"`
 	BucketWidth           int                `json:"bucketWidth,omitempty"`
 	ColumnUnits           map[string]string  `json:"columnUnits,omitempty"`
@@ -93,17 +93,17 @@ type ContextLinks struct {
 }
 
 type Threshold struct {
-	Index                 string      `json:"index,omitempty" jsonschema_extras:"description=Stable identifier for this threshold within the widget."`
+	Index                 string      `json:"index,omitempty" jsonschema:"Stable identifier for this threshold within the widget."`
 	IsEditEnabled         bool        `json:"isEditEnabled,omitempty"`
 	KeyIndex              int         `json:"keyIndex,omitempty"`
 	SelectedGraph         string      `json:"selectedGraph,omitempty"`
-	ThresholdColor        string      `json:"thresholdColor,omitempty" jsonschema_extras:"description=Hex color for the threshold (e.g. #FF0000)."`
-	ThresholdFormat       string      `json:"thresholdFormat,omitempty" jsonschema_extras:"description=How the threshold is rendered. Allowed values: 'Text' or 'Background'. SigNoz does NOT support a Grafana-style 'Line' marker; do not use 'Line'. 'Background' tints the panel area when the operator+value condition holds; 'Text' colors the threshold value label only."`
-	ThresholdLabel        string      `json:"thresholdLabel,omitempty" jsonschema_extras:"description=Optional display label for the threshold."`
-	ThresholdOperator     string      `json:"thresholdOperator,omitempty" jsonschema_extras:"description=Comparison operator. Allowed values: '>', '<', '>=', '<=', '='."`
+	ThresholdColor        string      `json:"thresholdColor,omitempty" jsonschema:"Hex color for the threshold (e.g. #FF0000)."`
+	ThresholdFormat       string      `json:"thresholdFormat,omitempty" jsonschema:"How the threshold is rendered. Allowed values: 'Text' or 'Background'. SigNoz does NOT support a Grafana-style 'Line' marker; do not use 'Line'. 'Background' tints the panel area when the operator+value condition holds; 'Text' colors the threshold value label only."`
+	ThresholdLabel        string      `json:"thresholdLabel,omitempty" jsonschema:"Optional display label for the threshold."`
+	ThresholdOperator     string      `json:"thresholdOperator,omitempty" jsonschema:"Comparison operator. Allowed values: '>', '<', '>=', '<=', '='."`
 	ThresholdTableOptions string      `json:"thresholdTableOptions,omitempty"`
-	ThresholdUnit         string      `json:"thresholdUnit,omitempty" jsonschema_extras:"description=Unit for the threshold value (should match the panel's yAxisUnit)."`
-	ThresholdValue        interface{} `json:"thresholdValue,omitempty" jsonschema_extras:"description=Numeric value the operator is compared against."`
+	ThresholdUnit         string      `json:"thresholdUnit,omitempty" jsonschema:"Unit for the threshold value (should match the panel's yAxisUnit)."`
+	ThresholdValue        interface{} `json:"thresholdValue,omitempty" jsonschema:"Numeric value the operator is compared against."`
 }
 
 type SelectedLogField struct {
@@ -119,56 +119,56 @@ type SelectedLogField struct {
 }
 
 type WidgetQuery struct {
-	QueryType     QueryType             `json:"queryType" jsonschema:"required" jsonschema_extras:"description=Query type for the widget"`
-	PromQL        []PromQL              `json:"promql" jsonschema_extras:"description=PromQL for the widget"`
-	ClickHouseSQL []ClickHouseSQL       `json:"clickhouse_sql" jsonschema_extras:"description=Clickhouse SQL for the widget"`
-	Builder       BuilderQueryDashboard `json:"builder" jsonschema_extras:"description=Builder query for the widget"`
+	QueryType     QueryType             `json:"queryType" jsonschema:"Query type for the widget"`
+	PromQL        []PromQL              `json:"promql" jsonschema:"PromQL for the widget"`
+	ClickHouseSQL []ClickHouseSQL       `json:"clickhouse_sql" jsonschema:"Clickhouse SQL for the widget"`
+	Builder       BuilderQueryDashboard `json:"builder" jsonschema:"Builder query for the widget"`
 	ID            string                `json:"id,omitempty"`
 }
 
 type PromQL struct {
-	Query    string `json:"query" jsonschema:"required" jsonschema_extras:"description=PromQL query expression. For OTel metrics with dots in the name use the Prometheus 3.x UTF-8 quoted-selector form: {\"metric.name.with.dots\"}. Underscored / __name__ / bare-dotted forms return no data in SigNoz. Read signoz://promql/instructions for the full guide."`
-	Name     string `json:"name" jsonschema:"required" jsonschema_extras:"description=Name for the query"`
-	Disabled bool   `json:"disabled" jsonschema:"required" jsonschema_extras:"description=Whether the PromQL query is disabled or not"`
-	Legend   string `json:"legend,omitempty" jsonschema_extras:"description=Legend template for naming PromQL series. Use {{label_name}} placeholders matching labels returned by the query. REQUIRED for grouped or multi-series charts. Example: {{service_name}} or {{service_name}} - {{instance}}. Without legend charts show generic series names."`
+	Query    string `json:"query" jsonschema:"PromQL query expression. For OTel metrics with dots in the name use the Prometheus 3.x UTF-8 quoted-selector form: {\"metric.name.with.dots\"}. Underscored / __name__ / bare-dotted forms return no data in SigNoz. Read signoz://promql/instructions for the full guide."`
+	Name     string `json:"name" jsonschema:"Name for the query"`
+	Disabled bool   `json:"disabled" jsonschema:"Whether the PromQL query is disabled or not"`
+	Legend   string `json:"legend,omitempty" jsonschema:"Legend template for naming PromQL series. Use {{label_name}} placeholders matching labels returned by the query. REQUIRED for grouped or multi-series charts. Example: {{service_name}} or {{service_name}} - {{instance}}. Without legend charts show generic series names."`
 }
 
 type ClickHouseSQL struct {
-	Query    string `json:"query" jsonschema:"required" jsonschema_extras:"description=Clickhouse SQL query for the widget"`
-	Name     string `json:"name" jsonschema:"required" jsonschema_extras:"description=Name for the query"`
-	Disabled bool   `json:"disabled" jsonschema:"required" jsonschema_extras:"description=Whether the Clickhouse SQL is disabled or not"`
-	Legend   string `json:"legend,omitempty" jsonschema_extras:"description=Legend template for naming ClickHouse query series. Use {{column_name}} placeholders for label columns returned by the query result. REQUIRED for grouped or multi-series charts. Example: {{service_name}} or {{service_name}} - {{http_method}}. Only columns present in the result can be used in the legend."`
+	Query    string `json:"query" jsonschema:"Clickhouse SQL query for the widget"`
+	Name     string `json:"name" jsonschema:"Name for the query"`
+	Disabled bool   `json:"disabled" jsonschema:"Whether the Clickhouse SQL is disabled or not"`
+	Legend   string `json:"legend,omitempty" jsonschema:"Legend template for naming ClickHouse query series. Use {{column_name}} placeholders for label columns returned by the query result. REQUIRED for grouped or multi-series charts. Example: {{service_name}} or {{service_name}} - {{http_method}}. Only columns present in the result can be used in the legend."`
 }
 
 type BuilderQueryDashboard struct {
-	QueryData          []BuilderQuery `json:"queryData" jsonschema_extras:"description=Query data for the widget. Populate with non-formula queries."`
-	QueryFormulas      []BuilderQuery `json:"queryFormulas" jsonschema_extras:"description=Query formulas for the widget. Populate with formula queries."`
+	QueryData          []BuilderQuery `json:"queryData" jsonschema:"Query data for the widget. Populate with non-formula queries."`
+	QueryFormulas      []BuilderQuery `json:"queryFormulas" jsonschema:"Query formulas for the widget. Populate with formula queries."`
 	QueryTraceOperator []interface{}  `json:"queryTraceOperator,omitempty"`
 }
 
 type BuilderQuery struct {
-	QueryName          string            `json:"queryName" jsonschema:"required" jsonschema_extras:"description=Name of the query"`
-	StepInterval       *int64            `json:"stepInterval" jsonschema:"required" jsonschema_extras:"description=Step/Aggregation interval for the query in seconds."`
-	DataSource         DataSource        `json:"dataSource" jsonschema:"required" jsonschema_extras:"description=Data source for the query"`
-	AggregateOperator  AggregateOperator `json:"aggregateOperator,omitempty" jsonschema_extras:"description=Aggregate operator for the query"`
+	QueryName          string            `json:"queryName" jsonschema:"Name of the query"`
+	StepInterval       *int64            `json:"stepInterval" jsonschema:"Step/Aggregation interval for the query in seconds."`
+	DataSource         DataSource        `json:"dataSource" jsonschema:"Data source for the query"`
+	AggregateOperator  AggregateOperator `json:"aggregateOperator,omitempty" jsonschema:"Aggregate operator for the query"`
 	AggregateAttribute AttributeKey      `json:"aggregateAttribute,omitempty"`
-	Temporality        Temporality       `json:"temporality,omitempty" jsonschema_extras:"description=Temporality for metrics data"`
+	Temporality        Temporality       `json:"temporality,omitempty" jsonschema:"Temporality for metrics data"`
 	Filters            FilterSet         `json:"filters,omitempty"`
-	GroupBy            []AttributeKey    `json:"groupBy" jsonschema_extras:"description=Group by attributes for the query"`
-	Expression         string            `json:"expression" jsonschema:"required" jsonschema_extras:"description=Expression for the query"`
-	Disabled           bool              `json:"disabled,omitempty" jsonschema_extras:"description=Whether the query is disabled"`
-	Having             interface{}       `json:"having,omitempty" jsonschema_extras:"description=Having clauses for the query"`
-	Legend             string            `json:"legend,omitempty" jsonschema_extras:"description=Legend template for labeling grouped chart series. Use {{attribute_name}} placeholders that exactly match groupBy keys. REQUIRED when this query uses groupBy and is rendered as a multi-series chart for timeseries/graph or bar or pie or histogram. Example: if groupBy includes service.name then set legend to {{service.name}}. For multiple keys use {{service.name}} - {{http.method}}. Without legend SigNoz shows raw query identifiers such as A."`
-	Limit              uint64            `json:"limit,omitempty" jsonschema_extras:"description=Limit for the query"`
-	Offset             uint64            `json:"offset,omitempty" jsonschema_extras:"description=Offset for the query"`
-	PageSize           uint64            `json:"pageSize,omitempty" jsonschema_extras:"description=Page size for the query"`
-	OrderBy            []OrderBy         `json:"orderBy" jsonschema_extras:"description=Order by for the query"`
-	ReduceTo           ReduceToOperator  `json:"reduceTo,omitempty" jsonschema_extras:"description=Reduce to operator for the query"`
-	SelectColumns      []AttributeKey    `json:"selectColumns" jsonschema_extras:"description=Select columns for the query. Required for list panel types."`
-	TimeAggregation    TimeAggregation   `json:"timeAggregation,omitempty" jsonschema_extras:"description=Time aggregation for metrics queries"`
-	SpaceAggregation   SpaceAggregation  `json:"spaceAggregation,omitempty" jsonschema_extras:"description=Space aggregation for metrics queries"`
-	SeriesAggregation  string            `json:"seriesAggregation,omitempty" jsonschema_extras:"description=Series aggregation for metrics queries with group by"`
-	Functions          []Function        `json:"functions" jsonschema_extras:"description=Functions to apply to the query result"`
+	GroupBy            []AttributeKey    `json:"groupBy" jsonschema:"Group by attributes for the query"`
+	Expression         string            `json:"expression" jsonschema:"Expression for the query"`
+	Disabled           bool              `json:"disabled,omitempty" jsonschema:"Whether the query is disabled"`
+	Having             interface{}       `json:"having,omitempty" jsonschema:"Having clauses for the query"`
+	Legend             string            `json:"legend,omitempty" jsonschema:"Legend template for labeling grouped chart series. Use {{attribute_name}} placeholders that exactly match groupBy keys. REQUIRED when this query uses groupBy and is rendered as a multi-series chart for timeseries/graph or bar or pie or histogram. Example: if groupBy includes service.name then set legend to {{service.name}}. For multiple keys use {{service.name}} - {{http.method}}. Without legend SigNoz shows raw query identifiers such as A."`
+	Limit              uint64            `json:"limit,omitempty" jsonschema:"Limit for the query"`
+	Offset             uint64            `json:"offset,omitempty" jsonschema:"Offset for the query"`
+	PageSize           uint64            `json:"pageSize,omitempty" jsonschema:"Page size for the query"`
+	OrderBy            []OrderBy         `json:"orderBy" jsonschema:"Order by for the query"`
+	ReduceTo           ReduceToOperator  `json:"reduceTo,omitempty" jsonschema:"Reduce to operator for the query"`
+	SelectColumns      []AttributeKey    `json:"selectColumns" jsonschema:"Select columns for the query. Required for list panel types."`
+	TimeAggregation    TimeAggregation   `json:"timeAggregation,omitempty" jsonschema:"Time aggregation for metrics queries"`
+	SpaceAggregation   SpaceAggregation  `json:"spaceAggregation,omitempty" jsonschema:"Space aggregation for metrics queries"`
+	SeriesAggregation  string            `json:"seriesAggregation,omitempty" jsonschema:"Series aggregation for metrics queries with group by"`
+	Functions          []Function        `json:"functions" jsonschema:"Functions to apply to the query result"`
 	Aggregations       []Aggregation     `json:"aggregations"`
 	Filter             *QueryFilter      `json:"filter,omitempty"`
 	Source             string            `json:"source,omitempty"`
@@ -188,46 +188,46 @@ type QueryFilter struct {
 }
 
 type AttributeKey struct {
-	Key           string `json:"key,omitempty" jsonschema_extras:"description=Key for the attribute"`
-	Name          string `json:"name,omitempty" jsonschema_extras:"description=Name for the attribute (alternative to key)"`
-	DataType      string `json:"dataType,omitempty" jsonschema_extras:"description=Data type of the attribute"`
-	Type          string `json:"type,omitempty" jsonschema_extras:"description=Type of the attribute (tag, resource, log, etc.)"`
-	IsColumn      bool   `json:"isColumn,omitempty" jsonschema_extras:"description=Whether the attribute is a materialized column or not"`
-	IsJSON        bool   `json:"isJSON,omitempty" jsonschema_extras:"description=Whether the attribute is a JSON or not"`
+	Key           string `json:"key,omitempty" jsonschema:"Key for the attribute"`
+	Name          string `json:"name,omitempty" jsonschema:"Name for the attribute (alternative to key)"`
+	DataType      string `json:"dataType,omitempty" jsonschema:"Data type of the attribute"`
+	Type          string `json:"type,omitempty" jsonschema:"Type of the attribute (tag, resource, log, etc.)"`
+	IsColumn      bool   `json:"isColumn,omitempty" jsonschema:"Whether the attribute is a materialized column or not"`
+	IsJSON        bool   `json:"isJSON,omitempty" jsonschema:"Whether the attribute is a JSON or not"`
 	ID            string `json:"id,omitempty"`
-	FieldContext  string `json:"fieldContext,omitempty" jsonschema_extras:"description=Field context (resource, span, log, etc.) - Required for selectColumns"`
-	FieldDataType string `json:"fieldDataType,omitempty" jsonschema_extras:"description=Field data type"`
-	Signal        string `json:"signal,omitempty" jsonschema_extras:"description=Signal type (traces, logs, metrics) - Required for selectColumns"`
+	FieldContext  string `json:"fieldContext,omitempty" jsonschema:"Field context (resource, span, log, etc.) - Required for selectColumns"`
+	FieldDataType string `json:"fieldDataType,omitempty" jsonschema:"Field data type"`
+	Signal        string `json:"signal,omitempty" jsonschema:"Signal type (traces, logs, metrics) - Required for selectColumns"`
 }
 
 type FilterSet struct {
-	Items []FilterItem `json:"items" jsonschema:"required"`
-	Op    string       `json:"op" jsonschema:"required" jsonschema_extras:"description=Operator for combining filter items."`
+	Items []FilterItem `json:"items"`
+	Op    string       `json:"op" jsonschema:"Operator for combining filter items."`
 }
 
 type FilterItem struct {
-	Key   AttributeKey `json:"key" jsonschema:"required" jsonschema_extras:"description=Key for the filter"`
-	Value interface{}  `json:"value" jsonschema:"required" jsonschema_extras:"description=Value for the filter"`
-	Op    string       `json:"op" jsonschema:"required" jsonschema_extras:"description=Filter operator"`
+	Key   AttributeKey `json:"key" jsonschema:"Key for the filter"`
+	Value interface{}  `json:"value" jsonschema:"Value for the filter"`
+	Op    string       `json:"op" jsonschema:"Filter operator"`
 	ID    string       `json:"id,omitempty"`
 }
 
 type HavingClause struct {
-	ColumnName string      `json:"columnName" jsonschema:"required" jsonschema_extras:"description=Column name for the having clause."`
-	Op         string      `json:"op" jsonschema:"required" jsonschema_extras:"description=Operator for the having clause"`
-	Value      interface{} `json:"value" jsonschema:"required" jsonschema_extras:"description=Value for the having clause."`
+	ColumnName string      `json:"columnName" jsonschema:"Column name for the having clause."`
+	Op         string      `json:"op" jsonschema:"Operator for the having clause"`
+	Value      interface{} `json:"value" jsonschema:"Value for the having clause."`
 	Expression string      `json:"expression,omitempty"`
 }
 
 type OrderBy struct {
-	ColumnName string `json:"columnName" jsonschema:"required" jsonschema_extras:"description=Column name for the order by."`
-	Order      string `json:"order" jsonschema:"required" jsonschema_extras:"description=Order direction"`
+	ColumnName string `json:"columnName" jsonschema:"Column name for the order by."`
+	Order      string `json:"order" jsonschema:"Order direction"`
 }
 
 type Function struct {
-	Name      string                 `json:"name" jsonschema:"required" jsonschema_extras:"description=Function name"`
-	Args      []interface{}          `json:"args" jsonschema_extras:"description=Function arguments"`
-	NamedArgs map[string]interface{} `json:"namedArgs,omitempty" jsonschema_extras:"description=Named arguments for the function"`
+	Name      string                 `json:"name" jsonschema:"Function name"`
+	Args      []interface{}          `json:"args" jsonschema:"Function arguments"`
+	NamedArgs map[string]interface{} `json:"namedArgs,omitempty" jsonschema:"Named arguments for the function"`
 }
 
 type VariableType string

--- a/plans/typed-struct-field-descriptions.context.md
+++ b/plans/typed-struct-field-descriptions.context.md
@@ -1,0 +1,53 @@
+# Feature: Typed-struct tool field descriptions — Context & Discussion
+
+## Original Prompt
+> Is this fixed? https://github.com/SigNoz/signoz-ai-assistant/issues/359
+> (follow-up) yes, implement the fix and then ask for codex xhigh 5.5 review
+
+## Reference Links
+- [Issue #359](https://github.com/SigNoz/signoz-ai-assistant/issues/359) — Typed-struct tools drop per-field descriptions: jsonschema-go ignores `jsonschema_extras` tags
+- [PR #213](https://github.com/SigNoz/signoz-mcp-server/pull/213) — filter/query work where #359 was discovered and spun off
+
+## Key Decisions & Discussion Log
+### 2026-06-24 — verified #359 still reproduces on main
+- Issue #359 is NOT the filter/`query` issue (that was #315, fixed by merged PR #213). #359 is a spun-off follow-up, still OPEN.
+- Ran the issue's own repro against `main` (b517f0d): generated `mcp.WithInputSchema[types.CreateAlertInput]()` schema, inspected `properties[*].description`. Result: 4 `jsonschema:"required"` fields (alert, alertType, condition, ruleType) emit the literal `"required"` as description; 13 fields empty; 0 fields carry the authored `jsonschema_extras` prose. Confirmed bug live.
+- Root cause confirmed: `google/jsonschema-go v0.4.2` (indirect, via `mcp-go v0.49.0` `mcp.WithInputSchema[T]`) reads only the `jsonschema` struct tag and uses its value as the field description; it never reads `jsonschema_extras`, and `jsonschema:"required"` is not a directive (requiredness comes from absence of `omitempty` in the `json` tag).
+
+### 2026-06-24 — schema shape investigation drove fix design
+- Dumped the generated schema: jsonschema-go **fully inlines** the nested struct tree — there are **no `$defs`/`$ref`** (confirmed grep count 0 for both alert and dashboard inputs). The types are non-recursive, so inlining is total.
+- Consequence: property names repeat across nested types (`name`, `expression`, `filter`, `query`, …) with different meanings, so a flat `name→description` map would inject the wrong text. Chosen approach must be **path-aware**.
+- Decision: implement **fix direction #2** from the issue (post-process the generated `RawInputSchema`), but make it a **reflection-guided parallel walk** of the Go type tree and the JSON schema tree rather than a flat map. For each struct field: resolve its JSON key (`json` tag), set `description` from the field's `jsonschema_extras:"description=…"`, and — when a field has no authored prose but jsonschema-go left `description:"required"` — delete that spurious description. Recurse into nested structs, slice/array element schemas (`items`), and map value schemas (`additionalProperties`). Anonymous embedded structs (e.g. `AlertRule` in `CreateAlertInput`, `Dashboard` in `CreateDashboardInput`) are promoted into the same object node, matching encoding/json + jsonschema-go behavior.
+- Why not fix direction #1 (move prose into the `jsonschema` tag): the `jsonschema` tag value is consumed wholesale as the description and the prose contains commas/`=`/quotes; it also collides with the existing `jsonschema:"required"` usage. The reflection post-process keeps the readable `jsonschema_extras` tags as the single source of truth and auto-neutralizes the `"required"` garbage.
+- Recursion is **JSON-gated** (we only descend where a matching JSON node exists), so it terminates even if a future type became recursive (jsonschema-go would emit `$ref`, which has no `properties`, halting descent). No visited-set needed.
+- `extrasDescription` parsing intentionally does NOT comma-split the `jsonschema_extras` value (descriptions contain commas); it takes everything after the single `description=` key, preserving commas/`=`/quotes verbatim.
+- Fail-open: parse/marshal errors return the schema unchanged (cross-boundary parsing per CLAUDE.md). Detectability: a unit test asserts the contract (authored prose present, `"required"` never appears as a description) so silent regression fails a test.
+- Out of scope (kept diff focused): leaving the now-ineffective `jsonschema:"required"` struct tags in place (the post-process neutralizes their bad description side-effect); requiredness itself already works correctly via `omitempty` and is unchanged.
+
+### 2026-06-24 — docs/metadata sync check
+- README.md / manifest.json / docs/ do NOT enumerate these per-field typed-struct descriptions (grep for a sample description string returned nothing). No doc/manifest change required; the only surface affected is the runtime-generated input schema.
+
+### 2026-06-24 — implemented + Codex (gpt-5.5/xhigh) review
+- Implemented the reflection-guided injection (`schema_descriptions.go`), switched the 4 sites to `addTypedTool`, added unit tests. Measured before→after across all 4 tools: literal-"required" descriptions 26/27/43/45 → **0/0/0/0**; authored descriptions 0/0/0/0 → **89/90/197/199**. `go build`, `go vet`, full `go test ./...` green.
+- Ran Codex gpt-5.5 xhigh read-only review of the diff. Verdict: 0 blockers. Two should-fix, two nice-to-have. Codex's area checks (reflection walk, jsonFieldName, extrasDescription, termination/safety, normalize-before-inject) all came back "OK for current structs".
+- **Acted on should-fix #1 (test the real registration path):** the unit tests exercised the helper pipeline but didn't assert the registration *sites* use `addTypedTool` — a revert to `addTool` would still pass. Added `TestIntegration_ToolSchemasNeverExposeLiteralRequiredDescription` in `internal/mcp-server/integration_test.go`: lists tools via the in-process client and asserts NO field description anywhere in ANY registered tool equals "required", plus that `signoz_create_alert .alert` carries its authored prose end-to-end. This also covers nice-to-have #4 (a future `WithInputSchema` tool registered via the wrong helper now fails this test).
+- **Acted on should-fix #2 (fail-open was fail-silent, violating CLAUDE.md):** `injectStructDescriptions` now returns `(json.RawMessage, error)`; `addTypedTool` takes the handler's `*slog.Logger` and logs a WARN ("…descriptions may be degraded", tool name + err) on failure while still registering the tool. Added `TestInjectStructDescriptionsFailsOpenLoudly` asserting the error is surfaced and the input is returned unchanged.
+- **Acted on nice-to-have #3 (document encoding/json subset):** added a doc comment on `describeStruct` noting it models only the field-selection subset these input structs use (exported fields + anonymous struct embeds), not full dominance/anonymous-non-struct semantics.
+- **Declined to act now:** removing the now-ineffective `jsonschema:"required"` struct tags (nice-to-have, ~60 fields, orthogonal churn; the post-process neutralizes their only bad effect and the new integration test guards against leakage). Noted as a possible follow-up cleanup.
+
+### 2026-06-24 — pivoted PR #214 to the NATIVE jsonschema-tag approach (the ideal)
+- Researched the stack from source (not memory). `mcp.WithInputSchema[T]` calls `jsonschema.For[T]` from `google/jsonschema-go`; confirmed latest mcp-go **v0.55.0** (we're on v0.49.0) STILL does this unchanged — upgrading mcp-go does not fix #359. jsonschema-go's `infer.go` documents the intended contract: **the `jsonschema` tag value IS the field description** (assigned whole, commas safe), and it rejects tag values matching `^[^ \t\n]*=` (a `WORD=` prefix reserved for future use). `jsonschema_extras` is a DIFFERENT library's convention (`invopop/jsonschema`) that google/jsonschema-go never reads — root cause is a tag-dialect mismatch.
+- Decision (user-directed): the **native** fix is ideal and consistent (mirrors option-style `mcp.Description`, no runtime reflection, no inlining coupling). Migrated all field tags in `pkg/types/alertrule.go` + `pkg/types/dashboard.go`: `jsonschema_extras:"description=X"` → `jsonschema:"X"`; dropped all `jsonschema:"required"` (63 of them — inert; requiredness is from `omitempty`). Verified all 192 descriptions pass the `WORD=` rule (none start with `token=`).
+- **Proof requiredness preserved:** dumped each of the 4 normalized schemas before vs after migration and compared with all `description` keys stripped — byte-identical structure (incl. every `required` array) for all 4. Only descriptions changed (89/90/197/199 added; 0 literal-"required" remain).
+- Reverted the 4 registration sites from `addTypedTool` back to `addTool`; **deleted `internal/handler/tools/schema_descriptions.go`** entirely (the post-process is unnecessary with native tags); dropped the inject-specific unit test/helpers; kept the description-presence + no-"required" unit tests (now reading the native normalized schema) and the registration-boundary integration test (now the sole guard, valid regardless of mechanism). `go build`, `go vet`, full `go test ./...` green.
+- Net vs the post-process version: simpler (no reflection walk, no `$defs`/inlining coupling, less code), and consistent with how the library is meant to be used. The `WORD=` constraint is the one caveat the integration test + future awareness cover.
+
+### 2026-06-24 — Codex (gpt-5.5/xhigh) review #2 of the native approach
+- Verdict: 0 blockers. Codex confirmed the migration is correct: authored text preserved exactly as `jsonschema:"…"`, no `json` tags changed, no empty/duplicate `jsonschema` tags, no remaining `jsonschema_extras`, no first-token `WORD=` violations, PromQL escaped quotes valid, and dropping `jsonschema:"required"` is safe (the two standalone ones — AlertOrderField.Key, FilterSet.Items — still infer required from their `json` tags; no former-required field carries `omitempty`).
+- should-fix (actioned): the registration-boundary guard "overclaims" — it only rejects the exact string "required" and spot-checks one field, so a *silently missing* description elsewhere would pass. Added `TestTypedToolSchemasDescriptionCoverage`: asserts each tool exposes ≥ its current description count (89/90/197/199), so wholesale/partial description loss fails CI. (Note: a brand-new field added with NO `jsonschema` tag is still a code-review matter — many fields legitimately have no description, so an "every field described" rule would false-positive.)
+- nice-to-have (actioned): fixed a stale `// …authored via jsonschema_extras` comment to say native `jsonschema`.
+
+## Open Questions
+- [x] Does jsonschema-go use `$defs`/`$ref` for these types? — No, fully inlined (non-recursive). Walk is positional/path-aware.
+- [x] Inject before or after `normalizeToolSchemas`? — After: normalize converts `interface{}` `true` schemas to `{}`, so `description` can be set on `any`-typed fields (Target, Value, ThresholdValue, …).
+- [x] Do README/manifest need updating? — No (descriptions not duplicated there).

--- a/plans/typed-struct-field-descriptions.plan.md
+++ b/plans/typed-struct-field-descriptions.plan.md
@@ -1,0 +1,33 @@
+# Plan: Typed-struct tool field descriptions (#359)
+
+## Status
+In Progress
+
+## Context
+The four typed-struct tools — `signoz_create_alert`, `signoz_update_alert`, `signoz_create_dashboard`, `signoz_update_dashboard` — register their input schema via `mcp.WithInputSchema[T]()`, which generates the schema with `google/jsonschema-go`. That library uses the **`jsonschema` tag value as the field description** and never reads the `jsonschema_extras` tags the structs were (mistakenly) authored with. It also treats `jsonschema:"required"` as description text, so those fields surfaced the literal word "required". Net: the model saw the most structurally complex tools with missing or garbage field docs. (SigNoz/signoz-ai-assistant#359 — a tag-dialect mismatch: the tags were written in `invopop/jsonschema`'s dialect but fed to `google/jsonschema-go`.)
+
+## Approach (native — final)
+Author the descriptions in the tag the generator actually reads, so descriptions flow natively with no post-process:
+
+- Migrate every field tag in `pkg/types/alertrule.go` and `pkg/types/dashboard.go`:
+  - `jsonschema:"required" jsonschema_extras:"description=X"` → `jsonschema:"X"`
+  - `jsonschema_extras:"description=X"` → `jsonschema:"X"`
+  - standalone `jsonschema:"required"` → removed (inert; requiredness comes from `omitempty`).
+- Constraint honored: a `jsonschema` tag value must not match `^[^ \t\n]*=` (a `WORD=` prefix). Verified all 192 descriptions comply.
+- No runtime code path: revert the 4 sites to plain `addTool`; the schema generator now emits descriptions directly.
+
+This is preferred over the post-process alternative (a reflection-guided injector, the first cut on this branch) because it removes runtime reflection, removes coupling to jsonschema-go's full-inlining behavior, and matches the option-style `mcp.Description` convention used by every other tool.
+
+## Files to Modify
+- `pkg/types/alertrule.go` — migrate all field tags to native `jsonschema` descriptions; drop `jsonschema:"required"`.
+- `pkg/types/dashboard.go` — same.
+- `internal/handler/tools/alerts.go` / `dashboards.go` — revert the 4 sites to `addTool`.
+- `internal/handler/tools/schema_descriptions.go` — **deleted** (post-process no longer needed).
+- `internal/handler/tools/schema_compat_test.go` — unit tests reading the native normalized schema: authored descriptions present (top-level + slice `items` + map `additionalProperties`); `"required"` never appears as a description in any of the 4 schemas.
+- `internal/mcp-server/integration_test.go` — registration-boundary guard (sole guard): lists tools via the in-process client and fails if any tool exposes a `"required"` description, plus an end-to-end authored-prose check on `signoz_create_alert`.
+
+## Verification
+- `go build ./...`, `go vet ./...`, full `go test ./...` pass.
+- Requiredness preserved: before/after schema dumps for all 4 tools are byte-identical once `description` keys are stripped (every `required` array unchanged). Descriptions added: 89 / 90 / 197 / 199; literal-`"required"` descriptions: 0.
+- Codex gpt-5.5/xhigh review of the native diff.
+- No live SigNoz calls needed. No README/manifest sync required (descriptions not duplicated there).


### PR DESCRIPTION
## Problem

The four **typed-struct tools** — `signoz_create_alert`, `signoz_update_alert`, `signoz_create_dashboard`, `signoz_update_dashboard` — register their input schema via `mcp.WithInputSchema[T]()`, which generates the schema with `google/jsonschema-go`. Verified from that library's source (`jsonschema/infer.go`):

- it uses the **`jsonschema` struct-tag value AS the field description**, and
- it never reads `jsonschema_extras`, and treats `jsonschema:"required"` as description text (requiredness is derived separately, from the absence of `omitempty` in the `json` tag).

These structs were authored with `jsonschema_extras:"description=…"` + `jsonschema:"required"` — the **`invopop/jsonschema` tag dialect**, fed to a generator that speaks a different one. So every authored field description was **dropped**, and `jsonschema:"required"` fields surfaced the **literal word `"required"`** as their description. The model was handed the most structurally complex tools with missing or garbage field docs → more malformed alert/dashboard payloads. **Fixes SigNoz/signoz-ai-assistant#359** (spun off from #213).

## Fix — author descriptions in the tag the generator actually reads

Migrate every field tag in `pkg/types/alertrule.go` and `pkg/types/dashboard.go`:

- `jsonschema:"required" jsonschema_extras:"description=X"` → `jsonschema:"X"`
- `jsonschema_extras:"description=X"` → `jsonschema:"X"`
- standalone `jsonschema:"required"` → removed (inert — requiredness is from `omitempty`)

Descriptions now flow **natively** from the generator with **no runtime post-processing**. This is consistent with the option-style tools (which already use `mcp.Description`), and avoids re-deriving field→description by reflection and any coupling to the generator's inlining behavior.

> An earlier revision of this PR added a reflection-guided runtime injector; it's been replaced with this native approach (no runtime code path; `internal/handler/tools/schema_descriptions.go` removed).

### Requiredness preserved (verified)

`google/jsonschema-go` never used `jsonschema:"required"` for requiredness, so dropping it changes nothing. Proven empirically: each tool's normalized schema **before vs after** the migration is byte-identical once all `description` keys are stripped — every `required` array is unchanged. The only differences are the descriptions themselves.

## Impact (measured)

| Tool | literal-`"required"` descriptions | authored descriptions |
|---|---|---|
| `signoz_create_alert` | 26 → **0** | 0 → **89** |
| `signoz_update_alert` | 27 → **0** | 0 → **90** |
| `signoz_create_dashboard` | 43 → **0** | 0 → **197** |
| `signoz_update_dashboard` | 45 → **0** | 0 → **199** |

## Tests

- **Unit** (`internal/handler/tools/schema_compat_test.go`): authored prose reaches the schema at the top level and through slice `items` + map `additionalProperties`; `"required"` never appears as a description in any of the four schemas; and a **coverage floor** per tool (≥ 89/90/197/199) so a *silent* wholesale/partial loss of descriptions fails CI.
- **Registration boundary** (`internal/mcp-server/integration_test.go`): lists tools via an in-process client and fails if **any** registered tool exposes a `"required"` description, with an end-to-end authored-prose check on `signoz_create_alert`.
- `go build ./...`, `go vet ./...`, full `go test ./...` pass.

## Review

Reviewed by Codex (gpt-5.5, xhigh) — 0 blockers. It confirmed the migration preserves every description exactly (incl. PromQL escaped quotes), changes no `json` tags, leaves no empty/duplicate/`WORD=` tags, and keeps requiredness intact. Its should-fix (the guard could miss a *silently missing* description) is addressed by the coverage-floor test above.

## Docs / metadata sync

No `README.md` / `manifest.json` / `docs/` change required — those don't enumerate the per-field typed-struct descriptions (only the runtime-generated input schema is affected). Planning pair under `plans/typed-struct-field-descriptions.*`.
