### PR TITLE
Redact reserved custom header values in logs

### DIFF
--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -362,7 +362,7 @@ func (s *SigNoz) doRequest(ctx context.Context, method, reqURL string, body io.R
 		for k, v := range s.customHeaders {
 			if strings.EqualFold(k, ContentType) || strings.EqualFold(k, s.authHeaderName) {
 				s.logger.WarnContext(ctx, "Custom header overrides a reserved header",
-					slog.String("header", k), slog.String("value", v))
+					slog.String("header", k))
 				continue
 			}
 			req.Header.Set(k, v)

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -1709,6 +1709,7 @@ func TestNewClient_EmptyHeaders(t *testing.T) {
 }
 
 func TestNewClient_ReservedHeadersSkipped(t *testing.T) {
+	var logs bytes.Buffer
 	customHeaders := map[string]string{
 		"Content-Type":        "text/plain",
 		"SIGNOZ-API-KEY":      "overridden-key",
@@ -1728,11 +1729,17 @@ func TestNewClient_ReservedHeadersSkipped(t *testing.T) {
 	}))
 	defer server.Close()
 
-	logger := logpkg.New("debug")
+	logger := newBufferedLogger(&logs, slog.LevelDebug)
 	client := NewClient(logger, server.URL, "test-api-key", "SIGNOZ-API-KEY", customHeaders)
 
 	_, err := client.ListAlerts(context.Background(), types.ListAlertsParams{})
 	assert.NoError(t, err)
+
+	logOutput := logs.String()
+	assert.Contains(t, logOutput, "Custom header overrides a reserved header")
+	assert.Contains(t, logOutput, "SIGNOZ-API-KEY")
+	assert.NotContains(t, logOutput, "overridden-key")
+	assert.NotContains(t, logOutput, "text/plain")
 }
 
 func TestCreateAlertRule_v2Returns201(t *testing.T) {

--- a/plans/reserved-header-log-redaction.context.md
+++ b/plans/reserved-header-log-redaction.context.md
@@ -1,0 +1,16 @@
+# Feature: Reserved Header Log Redaction — Context & Discussion
+
+## Original Prompt
+> [$improve](/Users/makeavish/.agents/skills/improve/SKILL.md) deep
+
+## Reference Links
+- None
+
+## Key Decisions & Discussion Log
+### 2026-06-24 — Deep improvement pass
+- The requested local `improve` skill file was not available in the container, so the pass proceeded using repository instructions.
+- During client request hardening review, `doRequest` was found to log the value of custom headers that attempt to override reserved headers such as `SIGNOZ-API-KEY` or `Authorization`. Those values can contain credentials and should not be emitted to logs.
+- Decision: keep the warning signal for misconfiguration, but log only the header name and remove the header value from structured attributes.
+
+## Open Questions
+- [x] Should reserved-header override warnings include the attempted value? — No; the value may be sensitive and the header name is enough to diagnose the misconfiguration.

--- a/plans/reserved-header-log-redaction.plan.md
+++ b/plans/reserved-header-log-redaction.plan.md
@@ -1,0 +1,21 @@
+# Plan: Reserved Header Log Redaction
+
+## Status
+Done
+
+## Context
+The SigNoz client allows tenant-specific custom headers, but prevents custom headers from overriding reserved headers such as `Content-Type` and the configured authentication header. The warning log for skipped reserved headers currently includes the attempted header value, which can leak credentials if a caller mistakenly supplies `SIGNOZ-API-KEY`, `Authorization`, or another secret-bearing reserved header in `customHeaders`.
+
+## Approach
+- Preserve the existing fail-open behavior: skip reserved custom header overrides and emit a warning.
+- Remove the header value from the warning attributes so logs do not contain potential credentials.
+- Add a regression test that exercises a reserved auth-header override and asserts the secret value is not present in captured logs while the warning still identifies the header name.
+
+## Files to Modify
+- `internal/client/client.go` — remove sensitive header value from the reserved-header warning log.
+- `internal/client/client_test.go` — add a regression test for reserved custom-header log redaction.
+- `plans/reserved-header-log-redaction.*` — record context and implementation plan.
+
+## Verification
+- `go test ./internal/client`
+- `go test ./...`


### PR DESCRIPTION
### Motivation
- Prevent accidental leakage of credential-like values when tenant-provided `customHeaders` attempt to override reserved headers such as `Content-Type` or the configured auth header.

### Description
- Remove the attempted header value from the reserved-header override warning in `internal/client/client.go` so the log now only emits the header name.  
- Add a regression test in `internal/client/client_test.go` that captures logs, asserts the warning still appears, and verifies the sensitive attempted values are not present in the logs.  
- Add plan and context files `plans/reserved-header-log-redaction.plan.md` and `plans/reserved-header-log-redaction.context.md` documenting the change.

### Testing
- Ran `go test ./internal/client` and `go test ./...`, and the test suite passed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3b5c8a9cf08326bc4fbd615addc190)