### PR TITLE
refactor(tools): converge error/validation strings onto shared helpers (Family B, #364)

### DIFF
--- a/internal/handler/tools/aggregate_helper.go
+++ b/internal/handler/tools/aggregate_helper.go
@@ -87,23 +87,23 @@ func parseAggregateArgs(args map[string]any, signal string, filterExpr string) (
 	aggregation, _ := args["aggregation"].(string)
 	if aggregation == "" {
 		return nil, fmt.Errorf(
-			"\"aggregation\" is required. Supported values: %s. "+
+			"%s \"aggregation\" is required. Supported values: %s. "+
 				"Tip: for simple totals use {\"aggregation\": \"count\", \"groupBy\": \"service.name\"}",
-			allowedAggregations)
+			validationErrorPrefix, allowedAggregations)
 	}
 	if !validAggregations[aggregation] {
 		return nil, fmt.Errorf(
-			"invalid aggregation %q. Supported values: %s. "+
+			"%s \"aggregation\" is invalid (%q). Supported values: %s. "+
 				"Tip: for counting use \"count\", for averages use \"avg\"",
-			aggregation, allowedAggregations)
+			validationErrorPrefix, aggregation, allowedAggregations)
 	}
 
 	aggregateOn, _ := args["aggregateOn"].(string)
 	if !aggregationsWithoutField[aggregation] && aggregateOn == "" {
 		return nil, fmt.Errorf(
-			"\"aggregateOn\" is required for %q aggregation. Specify the field to aggregate, "+
+			"%s \"aggregateOn\" is required for %q aggregation. Specify the field to aggregate, "+
 				"e.g. {\"aggregation\": \"%s\", \"aggregateOn\": \"duration\"}",
-			aggregation, aggregation)
+			validationErrorPrefix, aggregation, aggregation)
 	}
 
 	var aggregationExpr string

--- a/internal/handler/tools/alerts.go
+++ b/internal/handler/tools/alerts.go
@@ -271,14 +271,10 @@ func (h *Handler) handleListAlertRules(ctx context.Context, req mcp.CallToolRequ
 }
 
 func (h *Handler) handleGetAlert(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-	ruleID, ok := req.GetArguments()["ruleId"].(string)
-	if !ok {
-		h.logger.WarnContext(ctx, "Invalid ruleId parameter type", slog.Any("type", req.Params.Arguments))
-		return mcp.NewToolResultError(`Parameter validation failed: "ruleId" must be a string. Example: {"ruleId": "0196634d-5d66-75c4-b778-e317f49dab7a"}`), nil
-	}
-	if ruleID == "" {
-		h.logger.WarnContext(ctx, "Empty ruleId parameter")
-		return mcp.NewToolResultError(`Parameter validation failed: "ruleId" cannot be empty. Provide a valid alert rule ID (UUID format)`), nil
+	ruleID, errResult := requireStringArg(req.GetArguments(), "ruleId")
+	if errResult != nil {
+		h.logger.WarnContext(ctx, "Invalid or empty ruleId parameter", slog.Any("type", req.Params.Arguments))
+		return errResult, nil
 	}
 
 	h.logger.DebugContext(ctx, "Tool called: signoz_get_alert", slog.String("ruleId", ruleID))
@@ -307,10 +303,10 @@ func enrichAlertWebURL(ctx context.Context, data []byte, ruleID string) []byte {
 func (h *Handler) handleGetAlertHistory(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	args := req.GetArguments()
 
-	ruleID, ok := args["ruleId"].(string)
-	if !ok || ruleID == "" {
+	ruleID, errResult := requireStringArg(args, "ruleId")
+	if errResult != nil {
 		h.logger.WarnContext(ctx, "Invalid or empty ruleId parameter", slog.Any("ruleId", args["ruleId"]))
-		return mcp.NewToolResultError(`Parameter validation failed: "ruleId" must be a non-empty string. Example: {"ruleId": "0196634d-5d66-75c4-b778-e317f49dab7a", "timeRange": "24h"}`), nil
+		return errResult, nil
 	}
 
 	startStr, endStr := timeutil.GetTimestampsWithDefaults(args, "ms")
@@ -396,7 +392,7 @@ func (h *Handler) handleCreateAlert(ctx context.Context, req mcp.CallToolRequest
 
 	if !ok || len(rawConfig) == 0 {
 		h.logger.WarnContext(ctx, "Received empty or invalid arguments map for create alert.")
-		return mcp.NewToolResultError(`Parameter validation failed: The alert configuration object is empty or improperly formatted.`), nil
+		return notAConfigObjectError(), nil
 	}
 
 	cleanJSON, errResult := h.validateAlertPayload(ctx, rawConfig)
@@ -413,7 +409,7 @@ func (h *Handler) handleCreateAlert(ctx context.Context, req mcp.CallToolRequest
 	data, err := client.CreateAlertRule(ctx, cleanJSON)
 	if err != nil {
 		h.logger.ErrorContext(ctx, "Failed to create alert rule in SigNoz", logpkg.ErrAttr(err))
-		return mcp.NewToolResultError(fmt.Sprintf("SigNoz API Error: %s", err.Error())), nil
+		return upstreamError(err), nil
 	}
 
 	return mcp.NewToolResultText(string(data)), nil
@@ -423,12 +419,12 @@ func (h *Handler) handleUpdateAlert(ctx context.Context, req mcp.CallToolRequest
 	rawConfig, ok := req.Params.Arguments.(map[string]any)
 	if !ok || len(rawConfig) == 0 {
 		h.logger.WarnContext(ctx, "Received empty or invalid arguments map for update alert.")
-		return mcp.NewToolResultError(`Parameter validation failed: The alert configuration object is empty or improperly formatted.`), nil
+		return notAConfigObjectError(), nil
 	}
 
-	ruleID, _ := rawConfig["ruleId"].(string)
-	if ruleID == "" {
-		return mcp.NewToolResultError(`Parameter validation failed: "ruleId" is required. Provide the UUIDv7 of the rule to update.`), nil
+	ruleID, errResult := requireStringArg(rawConfig, "ruleId")
+	if errResult != nil {
+		return errResult, nil
 	}
 	if !util.IsUUIDv7(ruleID) {
 		return mcp.NewToolResultError(fmt.Sprintf(`Invalid "ruleId": %q is not a UUIDv7. Obtain the rule ID from signoz_list_alert_rules or signoz_get_alert.`, ruleID)), nil
@@ -448,20 +444,17 @@ func (h *Handler) handleUpdateAlert(ctx context.Context, req mcp.CallToolRequest
 
 	if err := client.UpdateAlertRule(ctx, ruleID, cleanJSON); err != nil {
 		h.logger.ErrorContext(ctx, "Failed to update alert rule in SigNoz", slog.String("ruleId", ruleID), logpkg.ErrAttr(err))
-		return mcp.NewToolResultError(fmt.Sprintf("SigNoz API Error: %s", err.Error())), nil
+		return upstreamError(err), nil
 	}
 
 	return mcp.NewToolResultText(fmt.Sprintf(`{"status":"success","ruleId":%q}`, ruleID)), nil
 }
 
 func (h *Handler) handleDeleteAlert(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-	args, ok := req.Params.Arguments.(map[string]any)
-	if !ok {
-		return mcp.NewToolResultError(`Parameter validation failed: expected an arguments object with "ruleId".`), nil
-	}
-	ruleID, _ := args["ruleId"].(string)
-	if ruleID == "" {
-		return mcp.NewToolResultError(`Parameter validation failed: "ruleId" is required.`), nil
+	args, _ := req.Params.Arguments.(map[string]any)
+	ruleID, errResult := requireStringArg(args, "ruleId")
+	if errResult != nil {
+		return errResult, nil
 	}
 	if !util.IsUUIDv7(ruleID) {
 		return mcp.NewToolResultError(fmt.Sprintf(`Invalid "ruleId": %q is not a UUIDv7. The SigNoz API will reject this with invalid_input.`, ruleID)), nil
@@ -475,7 +468,7 @@ func (h *Handler) handleDeleteAlert(ctx context.Context, req mcp.CallToolRequest
 
 	if err := client.DeleteAlertRule(ctx, ruleID); err != nil {
 		h.logger.ErrorContext(ctx, "Failed to delete alert rule in SigNoz", slog.String("ruleId", ruleID), logpkg.ErrAttr(err))
-		return mcp.NewToolResultError(fmt.Sprintf("SigNoz API Error: %s", err.Error())), nil
+		return upstreamError(err), nil
 	}
 
 	return mcp.NewToolResultText(fmt.Sprintf(`{"status":"success","ruleId":%q}`, ruleID)), nil

--- a/internal/handler/tools/alerts.go
+++ b/internal/handler/tools/alerts.go
@@ -305,7 +305,10 @@ func enrichAlertWebURL(ctx context.Context, data []byte, ruleID string) []byte {
 }
 
 func (h *Handler) handleGetAlertHistory(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-	args := req.GetArguments()
+	args, errResult := requireArgsMap(req.Params.Arguments)
+	if errResult != nil {
+		return errResult, nil
+	}
 
 	ruleID, errResult := requireStringArg(args, "ruleId")
 	if errResult != nil {

--- a/internal/handler/tools/alerts.go
+++ b/internal/handler/tools/alerts.go
@@ -164,7 +164,7 @@ func (h *Handler) handleListAlerts(ctx context.Context, req mcp.CallToolRequest)
 	alerts, err := client.ListAlerts(ctx, params)
 	if err != nil {
 		h.logger.ErrorContext(ctx, "Failed to list alerts", logpkg.ErrAttr(err))
-		return mcp.NewToolResultError(err.Error()), nil
+		return upstreamError(err), nil
 	}
 
 	var apiResponse types.APIAlertsResponse
@@ -216,7 +216,7 @@ func (h *Handler) handleListAlertRules(ctx context.Context, req mcp.CallToolRequ
 	rules, err := client.ListAlertRules(ctx)
 	if err != nil {
 		h.logger.ErrorContext(ctx, "Failed to list alert rules", logpkg.ErrAttr(err))
-		return mcp.NewToolResultError(err.Error()), nil
+		return upstreamError(err), nil
 	}
 
 	var apiResponse types.APIAlertRulesResponse
@@ -271,7 +271,11 @@ func (h *Handler) handleListAlertRules(ctx context.Context, req mcp.CallToolRequ
 }
 
 func (h *Handler) handleGetAlert(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-	ruleID, errResult := requireStringArg(req.GetArguments(), "ruleId")
+	args, errResult := requireArgsMap(req.Params.Arguments)
+	if errResult != nil {
+		return errResult, nil
+	}
+	ruleID, errResult := requireStringArg(args, "ruleId")
 	if errResult != nil {
 		h.logger.WarnContext(ctx, "Invalid or empty ruleId parameter", slog.Any("type", req.Params.Arguments))
 		return errResult, nil
@@ -285,7 +289,7 @@ func (h *Handler) handleGetAlert(ctx context.Context, req mcp.CallToolRequest) (
 	respJSON, err := client.GetAlertByRuleID(ctx, ruleID)
 	if err != nil {
 		h.logger.ErrorContext(ctx, "Failed to get alert", slog.String("ruleId", ruleID), logpkg.ErrAttr(err))
-		return mcp.NewToolResultError(err.Error()), nil
+		return upstreamError(err), nil
 	}
 
 	respJSON = enrichAlertWebURL(ctx, respJSON, ruleID)
@@ -382,7 +386,7 @@ func (h *Handler) handleGetAlertHistory(ctx context.Context, req mcp.CallToolReq
 		h.logger.ErrorContext(ctx, "Failed to get alert history",
 			slog.String("ruleId", ruleID),
 			logpkg.ErrAttr(err))
-		return mcp.NewToolResultError(err.Error()), nil
+		return upstreamError(err), nil
 	}
 	return mcp.NewToolResultText(string(respJSON)), nil
 }
@@ -451,7 +455,10 @@ func (h *Handler) handleUpdateAlert(ctx context.Context, req mcp.CallToolRequest
 }
 
 func (h *Handler) handleDeleteAlert(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-	args, _ := req.Params.Arguments.(map[string]any)
+	args, errResult := requireArgsMap(req.Params.Arguments)
+	if errResult != nil {
+		return errResult, nil
+	}
 	ruleID, errResult := requireStringArg(args, "ruleId")
 	if errResult != nil {
 		return errResult, nil
@@ -495,7 +502,7 @@ func (h *Handler) validateAlertPayload(ctx context.Context, rawConfig map[string
 	availableChannels, err := fetchChannelNames(ctx, client)
 	if err != nil {
 		h.logger.WarnContext(ctx, "Failed to fetch notification channels for validation", logpkg.ErrAttr(err))
-		return nil, mcp.NewToolResultError(fmt.Sprintf("Failed to fetch notification channels: %s", err.Error()))
+		return nil, upstreamError(fmt.Errorf("could not fetch notification channels for alert validation: %w", err))
 	}
 
 	referencedChannels := extractReferencedChannels(rawConfig)

--- a/internal/handler/tools/dashboards.go
+++ b/internal/handler/tools/dashboards.go
@@ -206,14 +206,10 @@ func (h *Handler) handleListDashboards(ctx context.Context, req mcp.CallToolRequ
 }
 
 func (h *Handler) handleGetDashboard(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-	uuid, ok := req.GetArguments()["uuid"].(string)
-	if !ok {
-		h.logger.WarnContext(ctx, "Invalid uuid parameter type", slog.Any("type", req.Params.Arguments))
-		return mcp.NewToolResultError(`Parameter validation failed: "uuid" must be a string. Example: {"uuid": "a1b2c3d4-e5f6-7890-abcd-ef1234567890"}`), nil
-	}
-	if uuid == "" {
-		h.logger.WarnContext(ctx, "Empty uuid parameter")
-		return mcp.NewToolResultError(`Parameter validation failed: "uuid" cannot be empty. Provide a valid dashboard UUID. Use signoz_list_dashboards tool to see available dashboards.`), nil
+	uuid, errResult := requireStringArg(req.GetArguments(), "uuid")
+	if errResult != nil {
+		h.logger.WarnContext(ctx, "Invalid or empty uuid parameter", slog.Any("type", req.Params.Arguments))
+		return errResult, nil
 	}
 
 	h.logger.DebugContext(ctx, "Tool called: signoz_get_dashboard", slog.String("uuid", uuid))
@@ -243,7 +239,7 @@ func (h *Handler) handleCreateDashboard(ctx context.Context, req mcp.CallToolReq
 
 	if !ok || len(rawConfig) == 0 {
 		h.logger.WarnContext(ctx, "Received empty or invalid arguments map.")
-		return mcp.NewToolResultError(`Parameter validation failed: The dashboard configuration object is empty or improperly formatted.`), nil
+		return notAConfigObjectError(), nil
 	}
 	delete(rawConfig, "searchContext")
 
@@ -263,7 +259,7 @@ func (h *Handler) handleCreateDashboard(ctx context.Context, req mcp.CallToolReq
 
 	if err != nil {
 		h.logger.ErrorContext(ctx, "Failed to create dashboard in SigNoz", logpkg.ErrAttr(err))
-		return mcp.NewToolResultError(fmt.Sprintf("SigNoz API Error: %s", err.Error())), nil
+		return upstreamError(err), nil
 	}
 
 	return mcp.NewToolResultText(string(data)), nil
@@ -272,15 +268,15 @@ func (h *Handler) handleCreateDashboard(ctx context.Context, req mcp.CallToolReq
 func (h *Handler) handleImportDashboard(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	args, ok := req.Params.Arguments.(map[string]any)
 	if !ok {
-		return mcp.NewToolResultError(`Parameter validation failed: arguments must be an object with a "path" string field.`), nil
+		return notAJSONObjectError(), nil
 	}
 	path, ok := args["path"].(string)
 	if !ok || strings.TrimSpace(path) == "" {
-		return mcp.NewToolResultError(`Parameter validation failed: "path" must be a non-empty string, e.g. "hostmetrics/hostmetrics.json". Use signoz_list_dashboard_templates to discover available paths.`), nil
+		return validationError("path", `must be a non-empty string, e.g. "hostmetrics/hostmetrics.json". Use signoz_list_dashboard_templates to discover available paths.`), nil
 	}
 	path = strings.TrimSpace(path)
 	if strings.Contains(path, "..") || strings.HasPrefix(path, "/") || strings.HasPrefix(path, "http://") || strings.HasPrefix(path, "https://") {
-		return mcp.NewToolResultError(`Parameter validation failed: "path" must be a relative template path within the SigNoz/dashboards repo (e.g. "hostmetrics/hostmetrics.json"), not an absolute path or URL.`), nil
+		return validationError("path", `must be a relative template path within the SigNoz/dashboards repo (e.g. "hostmetrics/hostmetrics.json"), not an absolute path or URL.`), nil
 	}
 
 	h.logger.DebugContext(ctx, "Tool called: signoz_import_dashboard", slog.String("path", path))
@@ -313,7 +309,7 @@ func (h *Handler) handleImportDashboard(ctx context.Context, req mcp.CallToolReq
 	data, err := client.CreateDashboardRaw(ctx, cleanJSON)
 	if err != nil {
 		h.logger.ErrorContext(ctx, "Failed to create dashboard from template", slog.String("path", path), logpkg.ErrAttr(err))
-		return mcp.NewToolResultError(fmt.Sprintf("SigNoz API Error: %s", err.Error())), nil
+		return upstreamError(err), nil
 	}
 
 	return mcp.NewToolResultText(string(data)), nil
@@ -366,20 +362,20 @@ func (h *Handler) handleUpdateDashboard(ctx context.Context, req mcp.CallToolReq
 
 	if !ok || len(rawConfig) == 0 {
 		h.logger.WarnContext(ctx, "Received empty or invalid arguments map from Claude.")
-		return mcp.NewToolResultError(`Parameter validation failed: The dashboard configuration object is empty or improperly formatted.`), nil
+		return notAConfigObjectError(), nil
 	}
 
 	// Extract UUID before validation (it's at the top level, not inside dashboard data).
-	uuid, _ := rawConfig["uuid"].(string)
-	if uuid == "" {
-		h.logger.WarnContext(ctx, "Empty uuid parameter")
-		return mcp.NewToolResultError(`Parameter validation failed: "uuid" cannot be empty. Provide a valid dashboard UUID. Use list_dashboards tool to see available dashboards.`), nil
+	uuid, errResult := requireStringArg(rawConfig, "uuid")
+	if errResult != nil {
+		h.logger.WarnContext(ctx, "Invalid or empty uuid parameter")
+		return errResult, nil
 	}
 
 	// Extract the dashboard sub-object for validation.
 	dashboardRaw, ok := rawConfig["dashboard"].(map[string]any)
 	if !ok || len(dashboardRaw) == 0 {
-		return mcp.NewToolResultError(`Parameter validation failed: "dashboard" field is required and must be a valid object.`), nil
+		return validationError("dashboard", "is required and must be a valid object."), nil
 	}
 
 	// Validate and normalize via the dashboardbuilder + panelbuilder pipeline.
@@ -398,21 +394,17 @@ func (h *Handler) handleUpdateDashboard(ctx context.Context, req mcp.CallToolReq
 
 	if err != nil {
 		h.logger.ErrorContext(ctx, "Failed to update dashboard in SigNoz", logpkg.ErrAttr(err))
-		return mcp.NewToolResultError(fmt.Sprintf("SigNoz API Error: %s", err.Error())), nil
+		return upstreamError(err), nil
 	}
 
 	return mcp.NewToolResultText("dashboard updated"), nil
 }
 
 func (h *Handler) handleDeleteDashboard(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-	uuid, ok := req.GetArguments()["uuid"].(string)
-	if !ok {
-		h.logger.WarnContext(ctx, "Invalid uuid parameter type", slog.Any("type", req.Params.Arguments))
-		return mcp.NewToolResultError(`Parameter validation failed: "uuid" must be a string. Example: {"uuid": "a1b2c3d4-e5f6-7890-abcd-ef1234567890"}`), nil
-	}
-	if uuid == "" {
-		h.logger.WarnContext(ctx, "Empty uuid parameter")
-		return mcp.NewToolResultError(`Parameter validation failed: "uuid" cannot be empty. Provide a valid dashboard UUID. Use signoz_list_dashboards tool to see available dashboards.`), nil
+	uuid, errResult := requireStringArg(req.GetArguments(), "uuid")
+	if errResult != nil {
+		h.logger.WarnContext(ctx, "Invalid or empty uuid parameter", slog.Any("type", req.Params.Arguments))
+		return errResult, nil
 	}
 
 	h.logger.DebugContext(ctx, "Tool called: signoz_delete_dashboard", slog.String("uuid", uuid))
@@ -423,7 +415,7 @@ func (h *Handler) handleDeleteDashboard(ctx context.Context, req mcp.CallToolReq
 	err = client.DeleteDashboard(ctx, uuid)
 	if err != nil {
 		h.logger.ErrorContext(ctx, "Failed to delete dashboard", slog.String("uuid", uuid), logpkg.ErrAttr(err))
-		return mcp.NewToolResultError(fmt.Sprintf("SigNoz API Error: %s", err.Error())), nil
+		return upstreamError(err), nil
 	}
 	return mcp.NewToolResultText("dashboard deleted"), nil
 }

--- a/internal/handler/tools/dashboards.go
+++ b/internal/handler/tools/dashboards.go
@@ -165,7 +165,7 @@ func (h *Handler) handleListDashboards(ctx context.Context, req mcp.CallToolRequ
 	result, err := client.ListDashboards(ctx)
 	if err != nil {
 		h.logger.ErrorContext(ctx, "Failed to list dashboards", logpkg.ErrAttr(err))
-		return mcp.NewToolResultError(err.Error()), nil
+		return upstreamError(err), nil
 	}
 
 	var dashboards map[string]any
@@ -206,7 +206,11 @@ func (h *Handler) handleListDashboards(ctx context.Context, req mcp.CallToolRequ
 }
 
 func (h *Handler) handleGetDashboard(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-	uuid, errResult := requireStringArg(req.GetArguments(), "uuid")
+	args, errResult := requireArgsMap(req.Params.Arguments)
+	if errResult != nil {
+		return errResult, nil
+	}
+	uuid, errResult := requireStringArg(args, "uuid")
 	if errResult != nil {
 		h.logger.WarnContext(ctx, "Invalid or empty uuid parameter", slog.Any("type", req.Params.Arguments))
 		return errResult, nil
@@ -220,7 +224,7 @@ func (h *Handler) handleGetDashboard(ctx context.Context, req mcp.CallToolReques
 	data, err := client.GetDashboard(ctx, uuid)
 	if err != nil {
 		h.logger.ErrorContext(ctx, "Failed to get dashboard", slog.String("uuid", uuid), logpkg.ErrAttr(err))
-		return mcp.NewToolResultError(err.Error()), nil
+		return upstreamError(err), nil
 	}
 	data = enrichDashboardWebURL(ctx, data, uuid)
 	return mcp.NewToolResultText(string(data)), nil
@@ -401,7 +405,11 @@ func (h *Handler) handleUpdateDashboard(ctx context.Context, req mcp.CallToolReq
 }
 
 func (h *Handler) handleDeleteDashboard(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-	uuid, errResult := requireStringArg(req.GetArguments(), "uuid")
+	args, errResult := requireArgsMap(req.Params.Arguments)
+	if errResult != nil {
+		return errResult, nil
+	}
+	uuid, errResult := requireStringArg(args, "uuid")
 	if errResult != nil {
 		h.logger.WarnContext(ctx, "Invalid or empty uuid parameter", slog.Any("type", req.Params.Arguments))
 		return errResult, nil

--- a/internal/handler/tools/docs.go
+++ b/internal/handler/tools/docs.go
@@ -55,11 +55,11 @@ func (h *Handler) handleSearchDocs(ctx context.Context, req mcp.CallToolRequest)
 	}
 	args, ok := req.Params.Arguments.(map[string]any)
 	if !ok {
-		return mcp.NewToolResultError("invalid arguments format: expected JSON object"), nil
+		return notAJSONObjectError(), nil
 	}
 	query, _ := args["query"].(string)
 	if query == "" {
-		return mcp.NewToolResultError(`parameter validation failed: "query" is required`), nil
+		return validationError("query", "is required"), nil
 	}
 	sectionSlug, _ := args["section_slug"].(string)
 	limit := parseLimit(args["limit"], 10)
@@ -98,11 +98,11 @@ func (h *Handler) handleFetchDoc(ctx context.Context, req mcp.CallToolRequest) (
 	}
 	args, ok := req.Params.Arguments.(map[string]any)
 	if !ok {
-		return mcp.NewToolResultError("invalid arguments format: expected JSON object"), nil
+		return notAJSONObjectError(), nil
 	}
 	rawURL, _ := args["url"].(string)
 	if rawURL == "" {
-		return mcp.NewToolResultError(`parameter validation failed: "url" is required`), nil
+		return validationError("url", "is required"), nil
 	}
 	heading, _ := args["heading"].(string)
 	h.logger.DebugContext(ctx, "Tool called: signoz_fetch_doc",

--- a/internal/handler/tools/e2e_familyb_test.go
+++ b/internal/handler/tools/e2e_familyb_test.go
@@ -1,0 +1,268 @@
+//go:build e2e
+
+// Package tools — Family B (#364) live end-to-end verification.
+//
+// This file exercises the error/validation flows converged onto the shared
+// helpers in errs.go (validationError, requireStringArg, notAJSONObjectError,
+// notAConfigObjectError, upstreamError) against a REAL SigNoz instance, so that
+// upstream contract drift (a renamed field, a changed error envelope) fails a
+// test rather than a user — per CLAUDE.md's cross-contract testing mandate.
+//
+// CREDENTIAL HYGIENE: this test reads the instance URL and a session token
+// ONLY from the environment and SKIPS when either is absent. It NEVER hardcodes
+// a secret, NEVER logs the token, and NEVER persists it. Run it like:
+//
+//	SIGNOZ_E2E_URL="https://<your-instance>" \
+//	SIGNOZ_E2E_TOKEN="<your-session-jwt-or-api-key>" \
+//	go test -tags=e2e -run TestE2EFamilyB ./internal/handler/tools/...
+//
+// By default SIGNOZ_E2E_AUTH_HEADER is "Authorization" and the token is sent as
+// a "Bearer <token>" value (session JWT). Set SIGNOZ_E2E_AUTH_HEADER to
+// "SIGNOZ-API-KEY" and SIGNOZ_E2E_RAW_TOKEN=1 to use a raw API key instead.
+package tools
+
+import (
+	"context"
+	"os"
+	"strings"
+	"testing"
+
+	signozclient "github.com/SigNoz/signoz-mcp-server/internal/client"
+	logpkg "github.com/SigNoz/signoz-mcp-server/pkg/log"
+)
+
+// e2eHandler builds a Handler backed by a real SigNoz client, or skips the test
+// when the required env vars are absent. The token is read from the environment
+// only and never logged.
+func e2eHandler(t *testing.T) (*Handler, context.Context) {
+	t.Helper()
+
+	baseURL := strings.TrimRight(os.Getenv("SIGNOZ_E2E_URL"), "/")
+	token := os.Getenv("SIGNOZ_E2E_TOKEN")
+	if baseURL == "" || token == "" {
+		t.Skip("SIGNOZ_E2E_URL and SIGNOZ_E2E_TOKEN must be set to run Family B e2e tests")
+	}
+
+	authHeader := os.Getenv("SIGNOZ_E2E_AUTH_HEADER")
+	if authHeader == "" {
+		authHeader = "Authorization"
+	}
+
+	// A session JWT is sent as "Bearer <token>" on the Authorization header.
+	// A raw API key (SIGNOZ_E2E_RAW_TOKEN=1) is sent verbatim.
+	apiKey := token
+	if os.Getenv("SIGNOZ_E2E_RAW_TOKEN") != "1" && strings.EqualFold(authHeader, "Authorization") {
+		apiKey = "Bearer " + token
+	}
+
+	client := signozclient.NewClient(logpkg.New("error"), baseURL, apiKey, authHeader, nil)
+	h := &Handler{logger: logpkg.New("error"), clientOverride: client}
+	return h, context.Background()
+}
+
+// errResultText asserts the result is an error and returns its first text block.
+func errResultText(t *testing.T, body string, isErr bool) string {
+	t.Helper()
+	if !isErr {
+		t.Fatalf("expected an error result, got success: %s", body)
+	}
+	return body
+}
+
+// --- Pure validation flows (no upstream call; the helper rejects before the
+// client is ever reached). These pin the canonical capital-P strings. ---
+
+func TestE2EFamilyB_ValidationStrings(t *testing.T) {
+	h, ctx := e2eHandler(t)
+
+	cases := []struct {
+		name     string
+		run      func() (string, bool)
+		wantSub  string
+		wantNoIn string // substring that must NOT appear
+	}{
+		{
+			name: "get_alert missing ruleId -> cannot be empty",
+			run: func() (string, bool) {
+				r, _ := h.handleGetAlert(ctx, makeToolRequest("signoz_get_alert", map[string]any{}))
+				return textContent(t, r), r.IsError
+			},
+			wantSub: `Parameter validation failed: "ruleId" cannot be empty`,
+		},
+		{
+			name: "get_alert wrong-typed ruleId -> must be a string",
+			run: func() (string, bool) {
+				r, _ := h.handleGetAlert(ctx, makeToolRequest("signoz_get_alert", map[string]any{"ruleId": 12345}))
+				return textContent(t, r), r.IsError
+			},
+			wantSub: `Parameter validation failed: "ruleId" must be a string`,
+		},
+		{
+			name: "get_dashboard missing uuid -> cannot be empty",
+			run: func() (string, bool) {
+				r, _ := h.handleGetDashboard(ctx, makeToolRequest("signoz_get_dashboard", map[string]any{}))
+				return textContent(t, r), r.IsError
+			},
+			wantSub: `Parameter validation failed: "uuid" cannot be empty`,
+		},
+		{
+			name: "get_dashboard wrong-typed uuid -> must be a string",
+			run: func() (string, bool) {
+				r, _ := h.handleGetDashboard(ctx, makeToolRequest("signoz_get_dashboard", map[string]any{"uuid": true}))
+				return textContent(t, r), r.IsError
+			},
+			wantSub: `Parameter validation failed: "uuid" must be a string`,
+		},
+		{
+			name: "get_view missing viewId -> cannot be empty",
+			run: func() (string, bool) {
+				r, _ := h.handleGetView(ctx, makeToolRequest("signoz_get_view", map[string]any{}))
+				return textContent(t, r), r.IsError
+			},
+			wantSub: `Parameter validation failed: "viewId" cannot be empty`,
+		},
+		{
+			name: "get_notification_channel missing id -> cannot be empty",
+			run: func() (string, bool) {
+				r, _ := h.handleGetNotificationChannel(ctx, makeToolRequest("signoz_get_notification_channel", map[string]any{}))
+				return textContent(t, r), r.IsError
+			},
+			wantSub: `Parameter validation failed: "id" cannot be empty`,
+		},
+		{
+			name: "execute_builder_query missing query -> must be a JSON object",
+			run: func() (string, bool) {
+				r, _ := h.handleExecuteBuilderQuery(ctx, makeToolRequest("signoz_execute_builder_query", map[string]any{}))
+				return textContent(t, r), r.IsError
+			},
+			wantSub: `Parameter validation failed: "query" must be a JSON object`,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			body, isErr := tc.run()
+			errResultText(t, body, isErr)
+			if !strings.Contains(body, tc.wantSub) {
+				t.Fatalf("error text = %q, want substring %q", body, tc.wantSub)
+			}
+			if !strings.HasPrefix(body, "Parameter validation failed:") {
+				t.Fatalf("error text = %q, want canonical capital-P prefix", body)
+			}
+		})
+	}
+}
+
+// N23: get_trace_details with a malformed start/end must be reframed as a
+// user/parameter error — NOT the old "Internal error:" prefix.
+func TestE2EFamilyB_TraceTimestampIsParameterError(t *testing.T) {
+	h, ctx := e2eHandler(t)
+	r, _ := h.handleGetTraceDetails(ctx, makeToolRequest("signoz_get_trace_details", map[string]any{
+		"traceId": "deadbeefdeadbeefdeadbeefdeadbeef",
+		"start":   "not-a-timestamp",
+		"end":     "also-bad",
+	}))
+	body := textContent(t, r)
+	if !r.IsError {
+		t.Fatalf("expected an error result, got success: %s", body)
+	}
+	if strings.Contains(body, "Internal error:") {
+		t.Fatalf("trace timestamp parse must not be labeled Internal error; got %q", body)
+	}
+	if !strings.HasPrefix(body, "Parameter validation failed:") {
+		t.Fatalf("trace timestamp parse should be a parameter error; got %q", body)
+	}
+}
+
+// --- Upstream-error flow: a well-formed-but-nonexistent id reaches the backend,
+// which rejects it; the result must carry the uniform "SigNoz API error:"
+// prefix. This is the flow that detects upstream contract drift. ---
+
+func TestE2EFamilyB_UpstreamErrorPrefix(t *testing.T) {
+	h, ctx := e2eHandler(t)
+
+	// A syntactically-valid UUIDv7 that (almost certainly) does not exist.
+	const ghostRuleID = "01900000-0000-7000-8000-000000000000"
+
+	r, transportErr := h.handleGetAlert(ctx, makeToolRequest("signoz_get_alert", map[string]any{"ruleId": ghostRuleID}))
+	if transportErr != nil {
+		t.Fatalf("unexpected transport error: %v", transportErr)
+	}
+	body := textContent(t, r)
+	if !r.IsError {
+		// Some deployments return an empty 200 rather than a 4xx for an unknown
+		// rule. That's a backend behavior, not a Family B regression — log and
+		// skip the prefix assertion rather than fail spuriously.
+		t.Skipf("backend returned success for a nonexistent ruleId (no upstream error to assert); body=%s", body)
+	}
+	if !strings.HasPrefix(body, "SigNoz API error:") {
+		t.Fatalf("upstream error should carry the uniform prefix; got %q", body)
+	}
+}
+
+// --- Happy-path sanity: confirm the refactor did not break successful
+// get/list calls. Uses read-only list endpoints so nothing is created. ---
+
+func TestE2EFamilyB_HappyPathStillSucceeds(t *testing.T) {
+	h, ctx := e2eHandler(t)
+
+	cases := []struct {
+		name string
+		args map[string]any
+		run  func(map[string]any) (isErr bool, body string)
+	}{
+		{
+			name: "list_dashboards",
+			args: map[string]any{},
+			run: func(a map[string]any) (bool, string) {
+				r, err := h.handleListDashboards(ctx, makeToolRequest("signoz_list_dashboards", a))
+				if err != nil {
+					t.Fatalf("transport error: %v", err)
+				}
+				return r.IsError, textContent(t, r)
+			},
+		},
+		{
+			name: "list_alert_rules",
+			args: map[string]any{},
+			run: func(a map[string]any) (bool, string) {
+				r, err := h.handleListAlertRules(ctx, makeToolRequest("signoz_list_alert_rules", a))
+				if err != nil {
+					t.Fatalf("transport error: %v", err)
+				}
+				return r.IsError, textContent(t, r)
+			},
+		},
+		{
+			name: "list_views_traces",
+			args: map[string]any{"sourcePage": "traces"},
+			run: func(a map[string]any) (bool, string) {
+				r, err := h.handleListViews(ctx, makeToolRequest("signoz_list_views", a))
+				if err != nil {
+					t.Fatalf("transport error: %v", err)
+				}
+				return r.IsError, textContent(t, r)
+			},
+		},
+		{
+			name: "list_notification_channels",
+			args: map[string]any{},
+			run: func(a map[string]any) (bool, string) {
+				r, err := h.handleListNotificationChannels(ctx, makeToolRequest("signoz_list_notification_channels", a))
+				if err != nil {
+					t.Fatalf("transport error: %v", err)
+				}
+				return r.IsError, textContent(t, r)
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			isErr, body := tc.run(tc.args)
+			if isErr {
+				t.Fatalf("happy-path %s returned an error result: %s", tc.name, body)
+			}
+		})
+	}
+}

--- a/internal/handler/tools/errs.go
+++ b/internal/handler/tools/errs.go
@@ -88,16 +88,35 @@ func notAJSONObjectError() *mcp.CallToolResult {
 	return mcp.NewToolResultError(notAJSONObjectMessage)
 }
 
-// requireArgsMap asserts that the raw MCP arguments payload is a JSON object and
-// returns it. On a non-object payload (including an untyped nil, which is what
-// the framework delivers when a tool is called with no "arguments" at all) it
-// returns the shared JSON-object guard result. Use this before requireStringArg
-// so a non-object payload yields the JSON-object guard rather than a misleading
-// "<field> cannot be empty".
+// requireArgsMap normalizes the raw MCP arguments payload into a JSON object map.
+//
+// A nil payload is NOT an error: the framework delivers an untyped nil when a
+// tool is called with no "arguments" object at all, which is the common case of
+// an omitted required parameter (or a legitimate no-args call to an all-optional
+// tool). Treating nil as an EMPTY map lets the downstream per-field checks own
+// the diagnosis — requireStringArg then emits the specific, actionable
+// `"<field>" cannot be empty` (e.g. naming the missing ruleId/id), and a tool
+// whose params are all optional simply proceeds with its defaults. Mapping nil
+// to the generic "expected JSON object" guard instead would both mis-describe an
+// omitted-arg call as malformed JSON and wrongly reject valid no-args list calls.
+//
+// A genuinely malformed payload — a non-nil value that is NOT an object (a JSON
+// array, string, or scalar) — still returns the shared JSON-object guard, since
+// no per-field check can run against it.
 func requireArgsMap(raw any) (map[string]any, *mcp.CallToolResult) {
+	if raw == nil {
+		return map[string]any{}, nil
+	}
 	args, ok := raw.(map[string]any)
 	if !ok {
 		return nil, notAJSONObjectError()
+	}
+	if args == nil {
+		// A typed nil map (e.g. JSON "arguments": null decoded into a
+		// map[string]any) is not the untyped-nil case above; normalize it to a
+		// non-nil empty map so the helper's success contract is uniform and
+		// callers never have to special-case a nil map.
+		return map[string]any{}, nil
 	}
 	return args, nil
 }

--- a/internal/handler/tools/errs.go
+++ b/internal/handler/tools/errs.go
@@ -1,6 +1,7 @@
 package tools
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/mark3labs/mcp-go/mcp"
@@ -131,4 +132,36 @@ func notAConfigObjectError() *mcp.CallToolResult {
 // can distinguish a backend problem (retry) from a parameter problem (fix).
 func upstreamError(err error) *mcp.CallToolResult {
 	return mcp.NewToolResultError(fmt.Sprintf("%s %s", upstreamErrorPrefix, err.Error()))
+}
+
+// upstreamFetchError tags an error as originating from an upstream SigNoz client
+// call inside a helper that otherwise returns a plain error mixing upstream and
+// local-validation failures (e.g. resolveFormulaSubQuery, whose metadata
+// auto-fetch hits the backend but whose "metric not found"/"validation error"
+// paths are local). Wrapping only the upstream path lets the caller route it
+// through upstreamError() for the uniform prefix while leaving the local
+// validation errors raw.
+type upstreamFetchError struct{ err error }
+
+func (e *upstreamFetchError) Error() string { return e.err.Error() }
+func (e *upstreamFetchError) Unwrap() error { return e.err }
+
+// markUpstream tags err as an upstream-client failure so a caller can detect it
+// via asUpstreamResult. Returns nil when err is nil.
+func markUpstream(err error) error {
+	if err == nil {
+		return nil
+	}
+	return &upstreamFetchError{err: err}
+}
+
+// asUpstreamResult returns a uniform upstreamError result (and true) when err's
+// chain contains an upstreamFetchError; otherwise (nil, false) so the caller can
+// surface the error as a plain/local validation message.
+func asUpstreamResult(err error) (*mcp.CallToolResult, bool) {
+	var ufe *upstreamFetchError
+	if errors.As(err, &ufe) {
+		return upstreamError(err), true
+	}
+	return nil, false
 }

--- a/internal/handler/tools/errs.go
+++ b/internal/handler/tools/errs.go
@@ -7,63 +7,43 @@ import (
 	"github.com/mark3labs/mcp-go/mcp"
 )
 
-// This file holds the shared error/validation string helpers used across all
-// MCP tool handlers. Converging on these helpers keeps the strings the AI
-// assistant sees uniform, so it can reliably tell a user/parameter mistake
-// (fixable by re-calling with corrected args) apart from an upstream SigNoz
+// Shared error/validation string helpers used across the MCP tool handlers.
+// Converging on these keeps the strings uniform so the AI assistant can tell a
+// user/parameter mistake (fix and re-call) apart from an upstream SigNoz
 // failure (retryable).
-//
-// Design note for Family C (#365): these helpers are intentionally shaped so a
-// structured `code` taxonomy (e.g. VALIDATION_FAILED, UPSTREAM_ERROR) can be
-// layered on later without changing call sites — the code would be derived from
-// the helper that produced the result. Do NOT add codes here yet.
 
 const (
-	// validationErrorPrefix is the canonical capital-P prefix for all
-	// parameter/validation failures. The historical lowercase "parameter
-	// validation failed:" variants are converged onto this.
+	// validationErrorPrefix is the canonical prefix for all parameter/validation failures.
 	validationErrorPrefix = "Parameter validation failed:"
 
-	// upstreamErrorPrefix is the uniform prefix for every failure that
-	// originates from the SigNoz backend (any client API call). It gives the
-	// LLM a machine-detectable marker to distinguish an upstream failure from a
-	// local parameter mistake.
+	// upstreamErrorPrefix marks failures originating from the SigNoz backend
+	// (any client API call), giving the LLM a detectable signal to distinguish
+	// them from a local parameter mistake.
 	upstreamErrorPrefix = "SigNoz API error:"
 
-	// notAJSONObjectMessage is the shared guard message for read-only tools
-	// whose entire arguments payload failed to decode as a JSON object.
+	// notAJSONObjectMessage guards read-only tools whose arguments payload is not a JSON object.
 	notAJSONObjectMessage = "invalid arguments format: expected JSON object"
 
-	// notAConfigObjectMessage is the body-carrying-tool variant of the
-	// arguments guard, used by create/update tools whose payload IS the
-	// resource body (alerts/dashboards/views).
+	// notAConfigObjectMessage is the body-carrying-tool variant (create/update tools whose payload is the resource body).
 	notAConfigObjectMessage = `Parameter validation failed: the configuration object is empty or improperly formatted.`
 )
 
-// validationError builds a canonical parameter-validation error result of the
-// form: Parameter validation failed: "<field>" <reason>
-//
-// reason should read as a clause that follows the quoted field name, e.g.
-// "must be a string" or "is required. Use signoz_list_metrics to find metrics".
+// validationError builds a canonical result of the form:
+// Parameter validation failed: "<field>" <reason>
+// reason is a clause that follows the quoted field, e.g. "must be a string".
 func validationError(field, reason string) *mcp.CallToolResult {
 	return mcp.NewToolResultError(fmt.Sprintf(`%s %q %s`, validationErrorPrefix, field, reason))
 }
 
-// validationErrorf is a convenience wrapper for validationError whose reason is
-// built from a format string. It exists so call sites that interpolate values
-// into the reason (e.g. an index or a "got %q") stay on the canonical prefix.
+// validationErrorf is validationError with a printf-style reason, for call
+// sites that interpolate values into the reason.
 func validationErrorf(field, reasonFormat string, args ...any) *mcp.CallToolResult {
 	return validationError(field, fmt.Sprintf(reasonFormat, args...))
 }
 
-// requireStringArg reads a required string argument from args. It returns the
-// value and a nil result on success. On failure it returns "" and a two-tier
-// canonical validation error:
-//   - "must be a string" when the key is present but not a string (wrong type),
-//   - "cannot be empty" when the key is missing or an empty string.
-//
-// This replaces the ad-hoc one- and two-tier id/name readers that previously
-// mislabeled a wrong-typed value as "empty".
+// requireStringArg reads a required string argument, returning a two-tier
+// canonical error: "must be a string" for a wrong-typed value, "cannot be
+// empty" for a missing or empty one (so wrong-type and absence are not conflated).
 func requireStringArg(args map[string]any, key string) (string, *mcp.CallToolResult) {
 	if args == nil {
 		return "", validationError(key, "cannot be empty")
@@ -82,27 +62,17 @@ func requireStringArg(args map[string]any, key string) (string, *mcp.CallToolRes
 	return s, nil
 }
 
-// notAJSONObjectError is the shared guard result for read-only tools whose
-// arguments payload is not a JSON object.
+// notAJSONObjectError is the shared guard result for a non-object arguments payload.
 func notAJSONObjectError() *mcp.CallToolResult {
 	return mcp.NewToolResultError(notAJSONObjectMessage)
 }
 
 // requireArgsMap normalizes the raw MCP arguments payload into a JSON object map.
-//
-// A nil payload is NOT an error: the framework delivers an untyped nil when a
-// tool is called with no "arguments" object at all, which is the common case of
-// an omitted required parameter (or a legitimate no-args call to an all-optional
-// tool). Treating nil as an EMPTY map lets the downstream per-field checks own
-// the diagnosis — requireStringArg then emits the specific, actionable
-// `"<field>" cannot be empty` (e.g. naming the missing ruleId/id), and a tool
-// whose params are all optional simply proceeds with its defaults. Mapping nil
-// to the generic "expected JSON object" guard instead would both mis-describe an
-// omitted-arg call as malformed JSON and wrongly reject valid no-args list calls.
-//
-// A genuinely malformed payload — a non-nil value that is NOT an object (a JSON
-// array, string, or scalar) — still returns the shared JSON-object guard, since
-// no per-field check can run against it.
+// A nil payload is treated as an empty map (the common omitted-args / no-args
+// call) so the per-field checks own the diagnosis — emitting a specific
+// `"<field>" cannot be empty` rather than mislabeling it as malformed JSON and
+// rejecting valid no-args list calls. A non-nil, non-object payload (array,
+// string, scalar) returns the shared JSON-object guard.
 func requireArgsMap(raw any) (map[string]any, *mcp.CallToolResult) {
 	if raw == nil {
 		return map[string]any{}, nil
@@ -112,10 +82,7 @@ func requireArgsMap(raw any) (map[string]any, *mcp.CallToolResult) {
 		return nil, notAJSONObjectError()
 	}
 	if args == nil {
-		// A typed nil map (e.g. JSON "arguments": null decoded into a
-		// map[string]any) is not the untyped-nil case above; normalize it to a
-		// non-nil empty map so the helper's success contract is uniform and
-		// callers never have to special-case a nil map.
+		// Typed-nil map (JSON "arguments": null): normalize to a non-nil empty map.
 		return map[string]any{}, nil
 	}
 	return args, nil
@@ -123,10 +90,8 @@ func requireArgsMap(raw any) (map[string]any, *mcp.CallToolResult) {
 
 // requireStringField is the error-returning sibling of requireStringArg, for
 // helpers that propagate a plain error (e.g. notification-channel receiver
-// builders) rather than a tool result. It applies the same two-tier rule —
-// "must be a string" for a wrong-typed value, "is required" for a missing or
-// empty one — so wrong-type and absence are not conflated. reason is appended
-// after the "is required" clause to carry per-field guidance.
+// builders). Same two-tier rule; requiredReason is appended after the
+// "is required" clause to carry per-field guidance.
 func requireStringField(args map[string]any, key, requiredReason string) (string, error) {
 	if raw, present := args[key]; present {
 		s, ok := raw.(string)
@@ -140,33 +105,29 @@ func requireStringField(args map[string]any, key, requiredReason string) (string
 	return "", fmt.Errorf(`%s %q is required%s`, validationErrorPrefix, key, requiredReason)
 }
 
-// notAConfigObjectError is the body-carrying-tool variant of the arguments
-// guard (create/update tools whose payload is the resource body).
+// notAConfigObjectError is the body-carrying-tool variant of the arguments guard.
 func notAConfigObjectError() *mcp.CallToolResult {
 	return mcp.NewToolResultError(notAConfigObjectMessage)
 }
 
-// upstreamError wraps an error returned by a SigNoz backend client call in the
-// uniform upstream prefix. Use this for every upstream API failure so the LLM
-// can distinguish a backend problem (retry) from a parameter problem (fix).
+// upstreamError wraps a SigNoz backend client error in the uniform upstream
+// prefix, so the LLM can distinguish a backend problem (retry) from a parameter
+// problem (fix).
 func upstreamError(err error) *mcp.CallToolResult {
 	return mcp.NewToolResultError(fmt.Sprintf("%s %s", upstreamErrorPrefix, err.Error()))
 }
 
-// upstreamFetchError tags an error as originating from an upstream SigNoz client
-// call inside a helper that otherwise returns a plain error mixing upstream and
-// local-validation failures (e.g. resolveFormulaSubQuery, whose metadata
-// auto-fetch hits the backend but whose "metric not found"/"validation error"
-// paths are local). Wrapping only the upstream path lets the caller route it
-// through upstreamError() for the uniform prefix while leaving the local
-// validation errors raw.
+// upstreamFetchError tags an error as upstream-originated inside a helper that
+// otherwise mixes upstream and local-validation failures (e.g.
+// resolveFormulaSubQuery), so the caller can route only the upstream path
+// through upstreamError() and leave the local validation errors raw.
 type upstreamFetchError struct{ err error }
 
 func (e *upstreamFetchError) Error() string { return e.err.Error() }
 func (e *upstreamFetchError) Unwrap() error { return e.err }
 
-// markUpstream tags err as an upstream-client failure so a caller can detect it
-// via asUpstreamResult. Returns nil when err is nil.
+// markUpstream tags err as an upstream-client failure (detectable via
+// asUpstreamResult). Returns nil when err is nil.
 func markUpstream(err error) error {
 	if err == nil {
 		return nil
@@ -175,8 +136,7 @@ func markUpstream(err error) error {
 }
 
 // asUpstreamResult returns a uniform upstreamError result (and true) when err's
-// chain contains an upstreamFetchError; otherwise (nil, false) so the caller can
-// surface the error as a plain/local validation message.
+// chain contains an upstreamFetchError; otherwise (nil, false).
 func asUpstreamResult(err error) (*mcp.CallToolResult, bool) {
 	var ufe *upstreamFetchError
 	if errors.As(err, &ufe) {

--- a/internal/handler/tools/errs.go
+++ b/internal/handler/tools/errs.go
@@ -87,6 +87,39 @@ func notAJSONObjectError() *mcp.CallToolResult {
 	return mcp.NewToolResultError(notAJSONObjectMessage)
 }
 
+// requireArgsMap asserts that the raw MCP arguments payload is a JSON object and
+// returns it. On a non-object payload (including an untyped nil, which is what
+// the framework delivers when a tool is called with no "arguments" at all) it
+// returns the shared JSON-object guard result. Use this before requireStringArg
+// so a non-object payload yields the JSON-object guard rather than a misleading
+// "<field> cannot be empty".
+func requireArgsMap(raw any) (map[string]any, *mcp.CallToolResult) {
+	args, ok := raw.(map[string]any)
+	if !ok {
+		return nil, notAJSONObjectError()
+	}
+	return args, nil
+}
+
+// requireStringField is the error-returning sibling of requireStringArg, for
+// helpers that propagate a plain error (e.g. notification-channel receiver
+// builders) rather than a tool result. It applies the same two-tier rule —
+// "must be a string" for a wrong-typed value, "is required" for a missing or
+// empty one — so wrong-type and absence are not conflated. reason is appended
+// after the "is required" clause to carry per-field guidance.
+func requireStringField(args map[string]any, key, requiredReason string) (string, error) {
+	if raw, present := args[key]; present {
+		s, ok := raw.(string)
+		if !ok {
+			return "", fmt.Errorf(`%s %q must be a string`, validationErrorPrefix, key)
+		}
+		if s != "" {
+			return s, nil
+		}
+	}
+	return "", fmt.Errorf(`%s %q is required%s`, validationErrorPrefix, key, requiredReason)
+}
+
 // notAConfigObjectError is the body-carrying-tool variant of the arguments
 // guard (create/update tools whose payload is the resource body).
 func notAConfigObjectError() *mcp.CallToolResult {

--- a/internal/handler/tools/errs.go
+++ b/internal/handler/tools/errs.go
@@ -1,0 +1,101 @@
+package tools
+
+import (
+	"fmt"
+
+	"github.com/mark3labs/mcp-go/mcp"
+)
+
+// This file holds the shared error/validation string helpers used across all
+// MCP tool handlers. Converging on these helpers keeps the strings the AI
+// assistant sees uniform, so it can reliably tell a user/parameter mistake
+// (fixable by re-calling with corrected args) apart from an upstream SigNoz
+// failure (retryable).
+//
+// Design note for Family C (#365): these helpers are intentionally shaped so a
+// structured `code` taxonomy (e.g. VALIDATION_FAILED, UPSTREAM_ERROR) can be
+// layered on later without changing call sites — the code would be derived from
+// the helper that produced the result. Do NOT add codes here yet.
+
+const (
+	// validationErrorPrefix is the canonical capital-P prefix for all
+	// parameter/validation failures. The historical lowercase "parameter
+	// validation failed:" variants are converged onto this.
+	validationErrorPrefix = "Parameter validation failed:"
+
+	// upstreamErrorPrefix is the uniform prefix for every failure that
+	// originates from the SigNoz backend (any client API call). It gives the
+	// LLM a machine-detectable marker to distinguish an upstream failure from a
+	// local parameter mistake.
+	upstreamErrorPrefix = "SigNoz API error:"
+
+	// notAJSONObjectMessage is the shared guard message for read-only tools
+	// whose entire arguments payload failed to decode as a JSON object.
+	notAJSONObjectMessage = "invalid arguments format: expected JSON object"
+
+	// notAConfigObjectMessage is the body-carrying-tool variant of the
+	// arguments guard, used by create/update tools whose payload IS the
+	// resource body (alerts/dashboards/views).
+	notAConfigObjectMessage = `Parameter validation failed: the configuration object is empty or improperly formatted.`
+)
+
+// validationError builds a canonical parameter-validation error result of the
+// form: Parameter validation failed: "<field>" <reason>
+//
+// reason should read as a clause that follows the quoted field name, e.g.
+// "must be a string" or "is required. Use signoz_list_metrics to find metrics".
+func validationError(field, reason string) *mcp.CallToolResult {
+	return mcp.NewToolResultError(fmt.Sprintf(`%s %q %s`, validationErrorPrefix, field, reason))
+}
+
+// validationErrorf is a convenience wrapper for validationError whose reason is
+// built from a format string. It exists so call sites that interpolate values
+// into the reason (e.g. an index or a "got %q") stay on the canonical prefix.
+func validationErrorf(field, reasonFormat string, args ...any) *mcp.CallToolResult {
+	return validationError(field, fmt.Sprintf(reasonFormat, args...))
+}
+
+// requireStringArg reads a required string argument from args. It returns the
+// value and a nil result on success. On failure it returns "" and a two-tier
+// canonical validation error:
+//   - "must be a string" when the key is present but not a string (wrong type),
+//   - "cannot be empty" when the key is missing or an empty string.
+//
+// This replaces the ad-hoc one- and two-tier id/name readers that previously
+// mislabeled a wrong-typed value as "empty".
+func requireStringArg(args map[string]any, key string) (string, *mcp.CallToolResult) {
+	if args == nil {
+		return "", validationError(key, "cannot be empty")
+	}
+	raw, present := args[key]
+	if !present {
+		return "", validationError(key, "cannot be empty")
+	}
+	s, ok := raw.(string)
+	if !ok {
+		return "", validationError(key, "must be a string")
+	}
+	if s == "" {
+		return "", validationError(key, "cannot be empty")
+	}
+	return s, nil
+}
+
+// notAJSONObjectError is the shared guard result for read-only tools whose
+// arguments payload is not a JSON object.
+func notAJSONObjectError() *mcp.CallToolResult {
+	return mcp.NewToolResultError(notAJSONObjectMessage)
+}
+
+// notAConfigObjectError is the body-carrying-tool variant of the arguments
+// guard (create/update tools whose payload is the resource body).
+func notAConfigObjectError() *mcp.CallToolResult {
+	return mcp.NewToolResultError(notAConfigObjectMessage)
+}
+
+// upstreamError wraps an error returned by a SigNoz backend client call in the
+// uniform upstream prefix. Use this for every upstream API failure so the LLM
+// can distinguish a backend problem (retry) from a parameter problem (fix).
+func upstreamError(err error) *mcp.CallToolResult {
+	return mcp.NewToolResultError(fmt.Sprintf("%s %s", upstreamErrorPrefix, err.Error()))
+}

--- a/internal/handler/tools/errs_test.go
+++ b/internal/handler/tools/errs_test.go
@@ -121,7 +121,22 @@ func TestRequireArgsMap(t *testing.T) {
 			t.Fatalf("got = %#v, want passthrough of input map", got)
 		}
 	})
-	for _, raw := range []any{nil, "string-not-object", 42, []any{"x"}} {
+	t.Run("nil payload becomes an empty map (no error)", func(t *testing.T) {
+		// A nil/untyped-nil payload means "no arguments object" — the common
+		// case of an omitted required param or a no-args call to an all-optional
+		// tool. It must NOT be the JSON-object guard: downstream per-field checks
+		// own the specific diagnosis (e.g. `"ruleId" cannot be empty`).
+		got, errResult := requireArgsMap(nil)
+		if errResult != nil {
+			t.Fatalf("requireArgsMap(nil) = error %v, want empty map + no error", errResult.Content)
+		}
+		if got == nil || len(got) != 0 {
+			t.Fatalf("requireArgsMap(nil) = %#v, want empty non-nil map", got)
+		}
+	})
+	// A genuinely malformed payload — non-nil and not an object — still returns
+	// the shared JSON-object guard, since no per-field check can run against it.
+	for _, raw := range []any{"string-not-object", 42, []any{"x"}} {
 		_, errResult := requireArgsMap(raw)
 		if errResult == nil {
 			t.Fatalf("requireArgsMap(%#v) = no error, want JSON-object guard", raw)

--- a/internal/handler/tools/errs_test.go
+++ b/internal/handler/tools/errs_test.go
@@ -110,6 +110,76 @@ func TestRequireStringArg(t *testing.T) {
 	}
 }
 
+func TestRequireArgsMap(t *testing.T) {
+	t.Run("object passes through", func(t *testing.T) {
+		in := map[string]any{"a": 1}
+		got, errResult := requireArgsMap(in)
+		if errResult != nil {
+			t.Fatalf("unexpected error result: %v", errResult.Content)
+		}
+		if got == nil || got["a"] != 1 {
+			t.Fatalf("got = %#v, want passthrough of input map", got)
+		}
+	})
+	for _, raw := range []any{nil, "string-not-object", 42, []any{"x"}} {
+		_, errResult := requireArgsMap(raw)
+		if errResult == nil {
+			t.Fatalf("requireArgsMap(%#v) = no error, want JSON-object guard", raw)
+		}
+		if got := resultText(t, errResult); got != "invalid arguments format: expected JSON object" {
+			t.Fatalf("requireArgsMap(%#v) text = %q, want JSON-object guard", raw, got)
+		}
+	}
+}
+
+func TestRequireStringField(t *testing.T) {
+	cases := []struct {
+		name      string
+		args      map[string]any
+		reason    string
+		wantVal   string
+		wantErrIs string
+	}{
+		{name: "valid", args: map[string]any{"type": "slack"}, wantVal: "slack"},
+		{
+			name:      "wrong type -> must be a string",
+			args:      map[string]any{"type": 7},
+			wantErrIs: `Parameter validation failed: "type" must be a string`,
+		},
+		{
+			name:      "empty -> is required with reason",
+			args:      map[string]any{"type": ""},
+			reason:    ". Must be one of: slack, webhook",
+			wantErrIs: `Parameter validation failed: "type" is required. Must be one of: slack, webhook`,
+		},
+		{
+			name:      "missing -> is required",
+			args:      map[string]any{},
+			wantErrIs: `Parameter validation failed: "type" is required`,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			val, err := requireStringField(tc.args, "type", tc.reason)
+			if tc.wantErrIs != "" {
+				if err == nil {
+					t.Fatalf("expected error, got val=%q", val)
+				}
+				if err.Error() != tc.wantErrIs {
+					t.Fatalf("err = %q, want %q", err.Error(), tc.wantErrIs)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if val != tc.wantVal {
+				t.Fatalf("val = %q, want %q", val, tc.wantVal)
+			}
+		})
+	}
+}
+
 func TestNotAJSONObjectError_CanonicalForm(t *testing.T) {
 	got := resultText(t, notAJSONObjectError())
 	want := "invalid arguments format: expected JSON object"

--- a/internal/handler/tools/errs_test.go
+++ b/internal/handler/tools/errs_test.go
@@ -1,0 +1,135 @@
+package tools
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/mark3labs/mcp-go/mcp"
+)
+
+// resultText extracts the first text content block of a tool result, asserting
+// it is an error result. Used to pin the canonical strings the shared helpers
+// produce — the AI assistant branches on these, so they are a contract.
+func resultText(t *testing.T, r *mcp.CallToolResult) string {
+	t.Helper()
+	if r == nil {
+		t.Fatal("nil result")
+	}
+	if !r.IsError {
+		t.Fatalf("expected an error result, got success: %+v", r.Content)
+	}
+	if len(r.Content) == 0 {
+		t.Fatal("result has no content")
+	}
+	tc, ok := mcp.AsTextContent(r.Content[0])
+	if !ok {
+		t.Fatal("first content block is not text")
+	}
+	return tc.Text
+}
+
+func TestValidationError_CanonicalForm(t *testing.T) {
+	got := resultText(t, validationError("ruleId", "must be a string"))
+	want := `Parameter validation failed: "ruleId" must be a string`
+	if got != want {
+		t.Fatalf("validationError = %q, want %q", got, want)
+	}
+}
+
+func TestValidationErrorf_InterpolatesReason(t *testing.T) {
+	got := resultText(t, validationErrorf("sourcePage", "got %q", "bogus"))
+	want := `Parameter validation failed: "sourcePage" got "bogus"`
+	if got != want {
+		t.Fatalf("validationErrorf = %q, want %q", got, want)
+	}
+}
+
+func TestRequireStringArg(t *testing.T) {
+	cases := []struct {
+		name     string
+		args     map[string]any
+		key      string
+		wantVal  string
+		wantErr  bool
+		wantText string
+	}{
+		{
+			name:    "valid string",
+			args:    map[string]any{"id": "abc"},
+			key:     "id",
+			wantVal: "abc",
+		},
+		{
+			name:     "wrong type",
+			args:     map[string]any{"id": 123},
+			key:      "id",
+			wantErr:  true,
+			wantText: `Parameter validation failed: "id" must be a string`,
+		},
+		{
+			name:     "empty string",
+			args:     map[string]any{"id": ""},
+			key:      "id",
+			wantErr:  true,
+			wantText: `Parameter validation failed: "id" cannot be empty`,
+		},
+		{
+			name:     "missing key",
+			args:     map[string]any{},
+			key:      "id",
+			wantErr:  true,
+			wantText: `Parameter validation failed: "id" cannot be empty`,
+		},
+		{
+			name:     "nil args",
+			args:     nil,
+			key:      "id",
+			wantErr:  true,
+			wantText: `Parameter validation failed: "id" cannot be empty`,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			val, errResult := requireStringArg(tc.args, tc.key)
+			if tc.wantErr {
+				if errResult == nil {
+					t.Fatalf("expected an error result, got val=%q", val)
+				}
+				if got := resultText(t, errResult); got != tc.wantText {
+					t.Fatalf("error text = %q, want %q", got, tc.wantText)
+				}
+				return
+			}
+			if errResult != nil {
+				t.Fatalf("unexpected error result: %v", errResult.Content)
+			}
+			if val != tc.wantVal {
+				t.Fatalf("val = %q, want %q", val, tc.wantVal)
+			}
+		})
+	}
+}
+
+func TestNotAJSONObjectError_CanonicalForm(t *testing.T) {
+	got := resultText(t, notAJSONObjectError())
+	want := "invalid arguments format: expected JSON object"
+	if got != want {
+		t.Fatalf("notAJSONObjectError = %q, want %q", got, want)
+	}
+}
+
+func TestNotAConfigObjectError_CanonicalForm(t *testing.T) {
+	got := resultText(t, notAConfigObjectError())
+	want := `Parameter validation failed: the configuration object is empty or improperly formatted.`
+	if got != want {
+		t.Fatalf("notAConfigObjectError = %q, want %q", got, want)
+	}
+}
+
+func TestUpstreamError_UniformPrefix(t *testing.T) {
+	got := resultText(t, upstreamError(errors.New("connection refused")))
+	want := "SigNoz API error: connection refused"
+	if got != want {
+		t.Fatalf("upstreamError = %q, want %q", got, want)
+	}
+}

--- a/internal/handler/tools/fields.go
+++ b/internal/handler/tools/fields.go
@@ -79,7 +79,7 @@ func (h *Handler) handleGetFieldKeys(ctx context.Context, req mcp.CallToolReques
 	result, err := client.GetFieldKeys(ctx, signal, metricName, searchText, fieldContext, fieldDataType, source)
 	if err != nil {
 		h.logger.ErrorContext(ctx, "Failed to get field keys", slog.String("signal", signal), logpkg.ErrAttr(err))
-		return mcp.NewToolResultError(err.Error()), nil
+		return upstreamError(err), nil
 	}
 	return mcp.NewToolResultText(string(result)), nil
 }
@@ -113,7 +113,7 @@ func (h *Handler) handleGetFieldValues(ctx context.Context, req mcp.CallToolRequ
 	result, err := client.GetFieldValues(ctx, signal, name, metricName, searchText, fieldContext, source)
 	if err != nil {
 		h.logger.ErrorContext(ctx, "Failed to get field values", slog.String("signal", signal), slog.String("name", name), logpkg.ErrAttr(err))
-		return mcp.NewToolResultError(err.Error()), nil
+		return upstreamError(err), nil
 	}
 	return mcp.NewToolResultText(string(result)), nil
 }

--- a/internal/handler/tools/fields.go
+++ b/internal/handler/tools/fields.go
@@ -57,15 +57,12 @@ func (h *Handler) RegisterFieldsHandlers(s *server.MCPServer) {
 func (h *Handler) handleGetFieldKeys(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	args, ok := req.Params.Arguments.(map[string]any)
 	if !ok {
-		return mcp.NewToolResultError("invalid arguments format"), nil
+		return notAJSONObjectError(), nil
 	}
 
 	signal, ok := args["signal"].(string)
-	if !ok || signal == "" {
-		return mcp.NewToolResultError(`Parameter validation failed: "signal" must be one of: "metrics", "traces", "logs"`), nil
-	}
-	if signal != "metrics" && signal != "traces" && signal != "logs" {
-		return mcp.NewToolResultError(`Parameter validation failed: "signal" must be one of: "metrics", "traces", "logs"`), nil
+	if !ok || signal == "" || (signal != "metrics" && signal != "traces" && signal != "logs") {
+		return validationError("signal", `must be one of: "metrics", "traces", "logs"`), nil
 	}
 
 	searchText, _ := args["searchText"].(string)
@@ -90,20 +87,17 @@ func (h *Handler) handleGetFieldKeys(ctx context.Context, req mcp.CallToolReques
 func (h *Handler) handleGetFieldValues(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	args, ok := req.Params.Arguments.(map[string]any)
 	if !ok {
-		return mcp.NewToolResultError("invalid arguments format"), nil
+		return notAJSONObjectError(), nil
 	}
 
 	signal, ok := args["signal"].(string)
-	if !ok || signal == "" {
-		return mcp.NewToolResultError(`Parameter validation failed: "signal" must be one of: "metrics", "traces", "logs"`), nil
-	}
-	if signal != "metrics" && signal != "traces" && signal != "logs" {
-		return mcp.NewToolResultError(`Parameter validation failed: "signal" must be one of: "metrics", "traces", "logs"`), nil
+	if !ok || signal == "" || (signal != "metrics" && signal != "traces" && signal != "logs") {
+		return validationError("signal", `must be one of: "metrics", "traces", "logs"`), nil
 	}
 
 	name, ok := args["name"].(string)
 	if !ok || name == "" {
-		return mcp.NewToolResultError(`Parameter validation failed: "name" must be a non-empty string. Example: "service.name", "http.status_code"`), nil
+		return validationError("name", `must be a non-empty string. Example: "service.name", "http.status_code"`), nil
 	}
 
 	searchText, _ := args["searchText"].(string)

--- a/internal/handler/tools/filter_param_consistency_test.go
+++ b/internal/handler/tools/filter_param_consistency_test.go
@@ -336,7 +336,7 @@ func TestFilterAlias_FalseFriendHandlersUnaffected(t *testing.T) {
 			t.Fatal("expected error result")
 		}
 		body := noteText(t, result, 0)
-		if !strings.Contains(body, "query parameter must be a JSON object") {
+		if !strings.Contains(body, `Parameter validation failed: "query" must be a JSON object`) {
 			t.Fatalf("error body = %q, want query-object validation", body)
 		}
 	})

--- a/internal/handler/tools/logs.go
+++ b/internal/handler/tools/logs.go
@@ -69,7 +69,7 @@ func (h *Handler) RegisterLogsHandlers(s *server.MCPServer) {
 func (h *Handler) handleAggregateLogs(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	args, ok := req.Params.Arguments.(map[string]any)
 	if !ok {
-		return mcp.NewToolResultError("invalid arguments format: expected JSON object"), nil
+		return notAJSONObjectError(), nil
 	}
 
 	reqData, err := parseAggregateLogsArgs(args)
@@ -101,7 +101,7 @@ func (h *Handler) handleAggregateLogs(ctx context.Context, req mcp.CallToolReque
 	result, err := client.QueryBuilderV5(ctx, queryJSON)
 	if err != nil {
 		h.logger.ErrorContext(ctx, "Failed to aggregate logs", logpkg.ErrAttr(err))
-		return mcp.NewToolResultError(err.Error()), nil
+		return upstreamError(err), nil
 	}
 
 	return aggregateResult(ctx, h.logger, "signoz_aggregate_logs", result, reqData.LimitClamped), nil
@@ -110,7 +110,7 @@ func (h *Handler) handleAggregateLogs(ctx context.Context, req mcp.CallToolReque
 func (h *Handler) handleSearchLogs(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	args, ok := req.Params.Arguments.(map[string]any)
 	if !ok {
-		return mcp.NewToolResultError("invalid arguments format: expected JSON object"), nil
+		return notAJSONObjectError(), nil
 	}
 
 	reqData, err := parseSearchLogsArgs(args)
@@ -139,7 +139,7 @@ func (h *Handler) handleSearchLogs(ctx context.Context, req mcp.CallToolRequest)
 	result, err := client.QueryBuilderV5(ctx, queryJSON)
 	if err != nil {
 		h.logger.ErrorContext(ctx, "Failed to search logs", logpkg.ErrAttr(err))
-		return mcp.NewToolResultError(err.Error()), nil
+		return upstreamError(err), nil
 	}
 
 	return rawSearchResult(ctx, h.logger, "signoz_search_logs", result, reqData.LimitClamped), nil

--- a/internal/handler/tools/metrics.go
+++ b/internal/handler/tools/metrics.go
@@ -119,7 +119,7 @@ func (h *Handler) handleListMetrics(ctx context.Context, req mcp.CallToolRequest
 	result, err := client.ListMetrics(ctx, start, end, limit, searchText, source)
 	if err != nil {
 		h.logger.ErrorContext(ctx, "Failed to list metrics", slog.String("searchText", searchText), logpkg.ErrAttr(err))
-		return mcp.NewToolResultError(err.Error()), nil
+		return upstreamError(err), nil
 	}
 	return mcp.NewToolResultText(string(result)), nil
 }

--- a/internal/handler/tools/metrics_helper.go
+++ b/internal/handler/tools/metrics_helper.go
@@ -45,7 +45,7 @@ type formulaSubQuery struct {
 func parseMetricsQueryArgs(args map[string]any) (*metricsQueryRequest, error) {
 	metricName, _ := args["metricName"].(string)
 	if metricName == "" {
-		return nil, fmt.Errorf("\"metricName\" is required. Use signoz_list_metrics to find available metrics")
+		return nil, fmt.Errorf(`%s "metricName" is required. Use signoz_list_metrics to find available metrics`, validationErrorPrefix)
 	}
 	filter, err := readFilterExpr(args)
 	if err != nil {

--- a/internal/handler/tools/metrics_query.go
+++ b/internal/handler/tools/metrics_query.go
@@ -171,7 +171,7 @@ func (h *Handler) handleQueryMetrics(ctx context.Context, req mcp.CallToolReques
 	result, err := client.QueryBuilderV5(ctx, queryJSON)
 	if err != nil {
 		h.logger.ErrorContext(ctx, "Metrics query failed", logpkg.ErrAttr(err))
-		return mcp.NewToolResultError(fmt.Sprintf("Query execution failed: %s", err.Error())), nil
+		return upstreamError(err), nil
 	}
 
 	// Extract backend-determined stepInterval from response if caller didn't provide one

--- a/internal/handler/tools/metrics_query.go
+++ b/internal/handler/tools/metrics_query.go
@@ -46,11 +46,11 @@ func (h *Handler) handleQueryMetrics(ctx context.Context, req mcp.CallToolReques
 	if mqr.MetricType == "" {
 		meta, fetchErr := h.fetchMetricMetadata(ctx, client, mqr.MetricName, mqr.Source)
 		if fetchErr != nil {
-			return mcp.NewToolResultError(fmt.Sprintf(
-				"Failed to auto-fetch metric metadata for %q: %s\n"+
-					"Please provide metricType, temporality, and isMonotonic manually "+
-					"(get them from signoz_list_metrics).",
-				mqr.MetricName, fetchErr.Error())), nil
+			return upstreamError(fmt.Errorf(
+				"could not auto-fetch metric metadata for %q: %w. "+
+					"Provide metricType, temporality, and isMonotonic manually "+
+					"(get them from signoz_list_metrics)",
+				mqr.MetricName, fetchErr)), nil
 		}
 		if meta != nil {
 			mqr.MetricType = meta.MetricType

--- a/internal/handler/tools/metrics_query.go
+++ b/internal/handler/tools/metrics_query.go
@@ -22,7 +22,10 @@ type metricMetadata struct {
 }
 
 func (h *Handler) handleQueryMetrics(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-	args := req.GetArguments()
+	args, errResult := requireArgsMap(req.Params.Arguments)
+	if errResult != nil {
+		return errResult, nil
+	}
 
 	mqr, err := parseMetricsQueryArgs(args)
 	if err != nil {
@@ -131,6 +134,11 @@ func (h *Handler) handleQueryMetrics(ctx context.Context, req mcp.CallToolReques
 	for _, fq := range mqr.FormulaQueries {
 		subResolved, subErr := resolveFormulaSubQuery(ctx, h, client, fq, mqr.RequestType, mqr.Source, &decisions)
 		if subErr != nil {
+			// Upstream metadata-fetch failures get the uniform prefix; local
+			// validation errors ("metric not found"/"validation error") stay raw.
+			if res, ok := asUpstreamResult(subErr); ok {
+				return res, nil
+			}
 			return mcp.NewToolResultError(subErr.Error()), nil
 		}
 
@@ -308,7 +316,10 @@ func resolveFormulaSubQuery(ctx context.Context, h *Handler, client interface {
 	if metricType == "" {
 		meta, err := h.fetchMetricMetadata(ctx, client, fq.MetricName, source)
 		if err != nil {
-			return nil, fmt.Errorf("failed to auto-fetch metadata for formula query %q (%s): %w", fq.Name, fq.MetricName, err)
+			// Upstream (ListMetrics) failure — tag it so the caller surfaces the
+			// uniform "SigNoz API error:" prefix. The "metric not found" and
+			// "validation error" paths below are local and stay untagged.
+			return nil, markUpstream(fmt.Errorf("failed to auto-fetch metadata for formula query %q (%s): %w", fq.Name, fq.MetricName, err))
 		}
 		if meta != nil {
 			metricType = meta.MetricType

--- a/internal/handler/tools/metrics_top.go
+++ b/internal/handler/tools/metrics_top.go
@@ -52,7 +52,7 @@ func (h *Handler) handleGetTopMetrics(ctx context.Context, req mcp.CallToolReque
 	result, err := client.GetTopMetrics(ctx, startTime, endTime, 100)
 	if err != nil {
 		h.logger.ErrorContext(ctx, "Failed to get top metrics", logpkg.ErrAttr(err))
-		return mcp.NewToolResultError(err.Error()), nil
+		return upstreamError(err), nil
 	}
 
 	return mcp.NewToolResultText(string(result)), nil

--- a/internal/handler/tools/nil_arguments_test.go
+++ b/internal/handler/tools/nil_arguments_test.go
@@ -36,13 +36,16 @@ func TestHandlers_NilArguments_NoPanic(t *testing.T) {
 	}{
 		{"signoz_get_alert", h.handleGetAlert},
 		{"signoz_get_alert_history", h.handleGetAlertHistory},
+		{"signoz_delete_alert", h.handleDeleteAlert},
 		{"signoz_get_dashboard", h.handleGetDashboard},
 		{"signoz_delete_dashboard", h.handleDeleteDashboard},
 		{"signoz_get_trace_details", h.handleGetTraceDetails},
 		{"signoz_get_service_top_operations", h.handleGetServiceTopOperations},
 		{"signoz_query_metrics", h.handleQueryMetrics},
 		{"signoz_create_notification_channel", h.handleCreateNotificationChannel},
+		{"signoz_get_notification_channel", h.handleGetNotificationChannel},
 		{"signoz_update_notification_channel", h.handleUpdateNotificationChannel},
+		{"signoz_delete_notification_channel", h.handleDeleteNotificationChannel},
 	}
 
 	for _, tc := range cases {
@@ -57,6 +60,16 @@ func TestHandlers_NilArguments_NoPanic(t *testing.T) {
 			}
 			if !result.IsError {
 				t.Fatalf("expected a validation error result for missing arguments, got a success result")
+			}
+			// These tools all require at least one argument, so a no-arguments
+			// call must surface the SPECIFIC missing-parameter message (e.g.
+			// `"ruleId" cannot be empty`), NOT the generic JSON-object guard.
+			// requireArgsMap maps the untyped-nil payload to an empty map so the
+			// per-field check owns the diagnosis; this assertion locks that in
+			// (a bare IsError check passes for the generic guard too, which is
+			// why the production regression slipped past it).
+			if msg := resultText(t, result); msg == notAJSONObjectMessage {
+				t.Fatalf("no-arguments call returned the generic JSON-object guard %q; want a specific per-field validation message", msg)
 			}
 		})
 	}

--- a/internal/handler/tools/notification_channels.go
+++ b/internal/handler/tools/notification_channels.go
@@ -180,7 +180,10 @@ func (h *Handler) RegisterNotificationChannelHandlers(s *server.MCPServer) {
 }
 
 func (h *Handler) handleGetNotificationChannel(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-	args, _ := req.Params.Arguments.(map[string]any)
+	args, errResult := requireArgsMap(req.Params.Arguments)
+	if errResult != nil {
+		return errResult, nil
+	}
 	id, errResult := requireStringArg(args, "id")
 	if errResult != nil {
 		return errResult, nil
@@ -195,13 +198,16 @@ func (h *Handler) handleGetNotificationChannel(ctx context.Context, req mcp.Call
 	resp, err := client.GetNotificationChannel(ctx, id)
 	if err != nil {
 		h.logger.ErrorContext(ctx, "Failed to get notification channel", slog.String("id", id), logpkg.ErrAttr(err))
-		return mcp.NewToolResultError(err.Error()), nil
+		return upstreamError(err), nil
 	}
 	return mcp.NewToolResultText(string(resp)), nil
 }
 
 func (h *Handler) handleDeleteNotificationChannel(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-	args, _ := req.Params.Arguments.(map[string]any)
+	args, errResult := requireArgsMap(req.Params.Arguments)
+	if errResult != nil {
+		return errResult, nil
+	}
 	id, errResult := requireStringArg(args, "id")
 	if errResult != nil {
 		return errResult, nil
@@ -215,7 +221,7 @@ func (h *Handler) handleDeleteNotificationChannel(ctx context.Context, req mcp.C
 
 	if err := client.DeleteNotificationChannel(ctx, id); err != nil {
 		h.logger.ErrorContext(ctx, "Failed to delete notification channel", slog.String("id", id), logpkg.ErrAttr(err))
-		return mcp.NewToolResultError(err.Error()), nil
+		return upstreamError(err), nil
 	}
 	return mcp.NewToolResultText(fmt.Sprintf(`{"status":"success","id":%q}`, id)), nil
 }
@@ -232,7 +238,7 @@ func (h *Handler) handleListNotificationChannels(ctx context.Context, req mcp.Ca
 	result, err := client.ListNotificationChannels(ctx)
 	if err != nil {
 		h.logger.ErrorContext(ctx, "Failed to list notification channels", logpkg.ErrAttr(err))
-		return mcp.NewToolResultError(err.Error()), nil
+		return upstreamError(err), nil
 	}
 
 	var response map[string]any
@@ -289,20 +295,23 @@ func (h *Handler) handleListNotificationChannels(ctx context.Context, req mcp.Ca
 func (h *Handler) handleCreateNotificationChannel(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	h.logger.DebugContext(ctx, "Tool called: signoz_create_notification_channel")
 
-	args := req.GetArguments()
+	args, errResult := requireArgsMap(req.Params.Arguments)
+	if errResult != nil {
+		return errResult, nil
+	}
 
 	// Validate required fields
-	channelType, _ := args["type"].(string)
-	if channelType == "" {
-		return mcp.NewToolResultError(`Parameter validation failed: "type" is required. Must be one of: slack, webhook, pagerduty, email, opsgenie, msteams`), nil
+	channelType, err := requireStringField(args, "type", ". Must be one of: slack, webhook, pagerduty, email, opsgenie, msteams")
+	if err != nil {
+		return mcp.NewToolResultError(err.Error()), nil
 	}
 	if !validChannelTypes[channelType] {
 		return mcp.NewToolResultError(fmt.Sprintf(`Invalid channel type: "%s". Must be one of: slack, webhook, pagerduty, email, opsgenie, msteams`, channelType)), nil
 	}
 
-	name, _ := args["name"].(string)
-	if name == "" {
-		return mcp.NewToolResultError(`Parameter validation failed: "name" is required. Provide a unique name for the notification channel.`), nil
+	name, err := requireStringField(args, "name", ". Provide a unique name for the notification channel")
+	if err != nil {
+		return mcp.NewToolResultError(err.Error()), nil
 	}
 
 	sendResolved := true
@@ -369,26 +378,29 @@ func (h *Handler) handleCreateNotificationChannel(ctx context.Context, req mcp.C
 func (h *Handler) handleUpdateNotificationChannel(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	h.logger.DebugContext(ctx, "Tool called: signoz_update_notification_channel")
 
-	args := req.GetArguments()
+	args, errResult := requireArgsMap(req.Params.Arguments)
+	if errResult != nil {
+		return errResult, nil
+	}
 
 	// Validate id
-	id, _ := args["id"].(string)
-	if id == "" {
-		return mcp.NewToolResultError(`Parameter validation failed: "id" is required. Provide the UUID of the notification channel to update.`), nil
+	id, err := requireStringField(args, "id", ". Provide the UUID of the notification channel to update")
+	if err != nil {
+		return mcp.NewToolResultError(err.Error()), nil
 	}
 
 	// Validate required fields
-	channelType, _ := args["type"].(string)
-	if channelType == "" {
-		return mcp.NewToolResultError(`Parameter validation failed: "type" is required. Must be one of: slack, webhook, pagerduty, email, opsgenie, msteams`), nil
+	channelType, err := requireStringField(args, "type", ". Must be one of: slack, webhook, pagerduty, email, opsgenie, msteams")
+	if err != nil {
+		return mcp.NewToolResultError(err.Error()), nil
 	}
 	if !validChannelTypes[channelType] {
 		return mcp.NewToolResultError(fmt.Sprintf(`Invalid channel type: "%s". Must be one of: slack, webhook, pagerduty, email, opsgenie, msteams`, channelType)), nil
 	}
 
-	name, _ := args["name"].(string)
-	if name == "" {
-		return mcp.NewToolResultError(`Parameter validation failed: "name" is required. Provide a unique name for the notification channel.`), nil
+	name, err := requireStringField(args, "name", ". Provide a unique name for the notification channel")
+	if err != nil {
+		return mcp.NewToolResultError(err.Error()), nil
 	}
 
 	sendResolved := true
@@ -471,9 +483,9 @@ func buildReceiverJSON(channelType, name string, sendResolved bool, args map[str
 
 	switch channelType {
 	case "slack":
-		apiURL := getStringParam(args, "slack_api_url")
-		if apiURL == "" {
-			return nil, fmt.Errorf(`Parameter validation failed: "slack_api_url" is required when type=slack. Provide the Slack incoming webhook URL`)
+		apiURL, err := requireStringField(args, "slack_api_url", " when type=slack. Provide the Slack incoming webhook URL")
+		if err != nil {
+			return nil, err
 		}
 		cfg := types.SlackConfig{
 			SendResolved: sendResolved,
@@ -485,9 +497,9 @@ func buildReceiverJSON(channelType, name string, sendResolved bool, args map[str
 		receiver.SlackConfigs = []types.SlackConfig{cfg}
 
 	case "webhook":
-		webhookURL := getStringParam(args, "webhook_url")
-		if webhookURL == "" {
-			return nil, fmt.Errorf(`Parameter validation failed: "webhook_url" is required when type=webhook. Provide the webhook endpoint URL`)
+		webhookURL, err := requireStringField(args, "webhook_url", " when type=webhook. Provide the webhook endpoint URL")
+		if err != nil {
+			return nil, err
 		}
 		cfg := types.WebhookConfig{
 			SendResolved: sendResolved,
@@ -506,9 +518,9 @@ func buildReceiverJSON(channelType, name string, sendResolved bool, args map[str
 		receiver.WebhookConfigs = []types.WebhookConfig{cfg}
 
 	case "pagerduty":
-		routingKey := getStringParam(args, "pagerduty_routing_key")
-		if routingKey == "" {
-			return nil, fmt.Errorf(`Parameter validation failed: "pagerduty_routing_key" is required when type=pagerduty. Provide the PagerDuty integration/routing key`)
+		routingKey, err := requireStringField(args, "pagerduty_routing_key", " when type=pagerduty. Provide the PagerDuty integration/routing key")
+		if err != nil {
+			return nil, err
 		}
 		cfg := types.PagerdutyConfig{
 			SendResolved: sendResolved,
@@ -519,9 +531,9 @@ func buildReceiverJSON(channelType, name string, sendResolved bool, args map[str
 		receiver.PagerdutyConfigs = []types.PagerdutyConfig{cfg}
 
 	case "email":
-		to := getStringParam(args, "email_to")
-		if to == "" {
-			return nil, fmt.Errorf(`Parameter validation failed: "email_to" is required when type=email. Provide comma-separated email addresses`)
+		to, err := requireStringField(args, "email_to", " when type=email. Provide comma-separated email addresses")
+		if err != nil {
+			return nil, err
 		}
 		cfg := types.EmailConfig{
 			SendResolved: sendResolved,
@@ -531,9 +543,9 @@ func buildReceiverJSON(channelType, name string, sendResolved bool, args map[str
 		receiver.EmailConfigs = []types.EmailConfig{cfg}
 
 	case "opsgenie":
-		apiKey := getStringParam(args, "opsgenie_api_key")
-		if apiKey == "" {
-			return nil, fmt.Errorf(`Parameter validation failed: "opsgenie_api_key" is required when type=opsgenie. Provide the OpsGenie API key`)
+		apiKey, err := requireStringField(args, "opsgenie_api_key", " when type=opsgenie. Provide the OpsGenie API key")
+		if err != nil {
+			return nil, err
 		}
 		cfg := types.OpsgenieConfig{
 			SendResolved: sendResolved,
@@ -545,9 +557,9 @@ func buildReceiverJSON(channelType, name string, sendResolved bool, args map[str
 		receiver.OpsgenieConfigs = []types.OpsgenieConfig{cfg}
 
 	case "msteams":
-		webhookURL := getStringParam(args, "msteams_webhook_url")
-		if webhookURL == "" {
-			return nil, fmt.Errorf(`Parameter validation failed: "msteams_webhook_url" is required when type=msteams. Provide the MS Teams incoming webhook URL`)
+		webhookURL, err := requireStringField(args, "msteams_webhook_url", " when type=msteams. Provide the MS Teams incoming webhook URL")
+		if err != nil {
+			return nil, err
 		}
 		cfg := types.MSTeamsV2Config{
 			SendResolved: sendResolved,

--- a/internal/handler/tools/notification_channels.go
+++ b/internal/handler/tools/notification_channels.go
@@ -181,9 +181,9 @@ func (h *Handler) RegisterNotificationChannelHandlers(s *server.MCPServer) {
 
 func (h *Handler) handleGetNotificationChannel(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	args, _ := req.Params.Arguments.(map[string]any)
-	id, _ := args["id"].(string)
-	if id == "" {
-		return mcp.NewToolResultError(`Parameter validation failed: "id" is required.`), nil
+	id, errResult := requireStringArg(args, "id")
+	if errResult != nil {
+		return errResult, nil
 	}
 
 	h.logger.DebugContext(ctx, "Tool called: signoz_get_notification_channel", slog.String("id", id))
@@ -202,9 +202,9 @@ func (h *Handler) handleGetNotificationChannel(ctx context.Context, req mcp.Call
 
 func (h *Handler) handleDeleteNotificationChannel(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	args, _ := req.Params.Arguments.(map[string]any)
-	id, _ := args["id"].(string)
-	if id == "" {
-		return mcp.NewToolResultError(`Parameter validation failed: "id" is required.`), nil
+	id, errResult := requireStringArg(args, "id")
+	if errResult != nil {
+		return errResult, nil
 	}
 
 	h.logger.DebugContext(ctx, "Tool called: signoz_delete_notification_channel", slog.String("id", id))
@@ -330,7 +330,7 @@ func (h *Handler) handleCreateNotificationChannel(ctx context.Context, req mcp.C
 	createResp, err := client.CreateNotificationChannel(ctx, receiverJSON)
 	if err != nil {
 		h.logger.ErrorContext(ctx, "Failed to create notification channel", slog.String("type", channelType), slog.String("name", name), logpkg.ErrAttr(err))
-		return mcp.NewToolResultError(fmt.Sprintf("Failed to create notification channel: %s", err.Error())), nil
+		return upstreamError(err), nil
 	}
 
 	h.logger.InfoContext(ctx, "Notification channel created", slog.String("type", channelType), slog.String("name", name))
@@ -415,7 +415,7 @@ func (h *Handler) handleUpdateNotificationChannel(ctx context.Context, req mcp.C
 	// Step 1: Update the channel (204 No Content on success)
 	if err := client.UpdateNotificationChannel(ctx, id, receiverJSON); err != nil {
 		h.logger.ErrorContext(ctx, "Failed to update notification channel", slog.String("type", channelType), slog.String("name", name), slog.String("id", id), logpkg.ErrAttr(err))
-		return mcp.NewToolResultError(fmt.Sprintf("Failed to update notification channel: %s", err.Error())), nil
+		return upstreamError(err), nil
 	}
 
 	h.logger.InfoContext(ctx, "Notification channel updated", slog.String("type", channelType), slog.String("name", name), slog.String("id", id))
@@ -473,7 +473,7 @@ func buildReceiverJSON(channelType, name string, sendResolved bool, args map[str
 	case "slack":
 		apiURL := getStringParam(args, "slack_api_url")
 		if apiURL == "" {
-			return nil, fmt.Errorf(`parameter validation failed: "slack_api_url" is required when type=slack. Provide the Slack incoming webhook URL`)
+			return nil, fmt.Errorf(`Parameter validation failed: "slack_api_url" is required when type=slack. Provide the Slack incoming webhook URL`)
 		}
 		cfg := types.SlackConfig{
 			SendResolved: sendResolved,
@@ -487,7 +487,7 @@ func buildReceiverJSON(channelType, name string, sendResolved bool, args map[str
 	case "webhook":
 		webhookURL := getStringParam(args, "webhook_url")
 		if webhookURL == "" {
-			return nil, fmt.Errorf(`parameter validation failed: "webhook_url" is required when type=webhook. Provide the webhook endpoint URL`)
+			return nil, fmt.Errorf(`Parameter validation failed: "webhook_url" is required when type=webhook. Provide the webhook endpoint URL`)
 		}
 		cfg := types.WebhookConfig{
 			SendResolved: sendResolved,
@@ -508,7 +508,7 @@ func buildReceiverJSON(channelType, name string, sendResolved bool, args map[str
 	case "pagerduty":
 		routingKey := getStringParam(args, "pagerduty_routing_key")
 		if routingKey == "" {
-			return nil, fmt.Errorf(`parameter validation failed: "pagerduty_routing_key" is required when type=pagerduty. Provide the PagerDuty integration/routing key`)
+			return nil, fmt.Errorf(`Parameter validation failed: "pagerduty_routing_key" is required when type=pagerduty. Provide the PagerDuty integration/routing key`)
 		}
 		cfg := types.PagerdutyConfig{
 			SendResolved: sendResolved,
@@ -521,7 +521,7 @@ func buildReceiverJSON(channelType, name string, sendResolved bool, args map[str
 	case "email":
 		to := getStringParam(args, "email_to")
 		if to == "" {
-			return nil, fmt.Errorf(`parameter validation failed: "email_to" is required when type=email. Provide comma-separated email addresses`)
+			return nil, fmt.Errorf(`Parameter validation failed: "email_to" is required when type=email. Provide comma-separated email addresses`)
 		}
 		cfg := types.EmailConfig{
 			SendResolved: sendResolved,
@@ -533,7 +533,7 @@ func buildReceiverJSON(channelType, name string, sendResolved bool, args map[str
 	case "opsgenie":
 		apiKey := getStringParam(args, "opsgenie_api_key")
 		if apiKey == "" {
-			return nil, fmt.Errorf(`parameter validation failed: "opsgenie_api_key" is required when type=opsgenie. Provide the OpsGenie API key`)
+			return nil, fmt.Errorf(`Parameter validation failed: "opsgenie_api_key" is required when type=opsgenie. Provide the OpsGenie API key`)
 		}
 		cfg := types.OpsgenieConfig{
 			SendResolved: sendResolved,
@@ -547,7 +547,7 @@ func buildReceiverJSON(channelType, name string, sendResolved bool, args map[str
 	case "msteams":
 		webhookURL := getStringParam(args, "msteams_webhook_url")
 		if webhookURL == "" {
-			return nil, fmt.Errorf(`parameter validation failed: "msteams_webhook_url" is required when type=msteams. Provide the MS Teams incoming webhook URL`)
+			return nil, fmt.Errorf(`Parameter validation failed: "msteams_webhook_url" is required when type=msteams. Provide the MS Teams incoming webhook URL`)
 		}
 		cfg := types.MSTeamsV2Config{
 			SendResolved: sendResolved,

--- a/internal/handler/tools/query_builder.go
+++ b/internal/handler/tools/query_builder.go
@@ -77,13 +77,13 @@ func (h *Handler) handleExecuteBuilderQuery(ctx context.Context, req mcp.CallToo
 	args, ok := req.Params.Arguments.(map[string]any)
 	if !ok {
 		h.logger.WarnContext(ctx, "Invalid arguments payload type", slog.Any("type", req.Params.Arguments))
-		return mcp.NewToolResultError("invalid arguments payload"), nil
+		return notAJSONObjectError(), nil
 	}
 
 	queryObj, ok := args["query"].(map[string]any)
 	if !ok {
 		h.logger.WarnContext(ctx, "Invalid query parameter type", slog.Any("type", args["query"]))
-		return mcp.NewToolResultError("query parameter must be a JSON object"), nil
+		return validationError("query", "must be a JSON object"), nil
 	}
 
 	queryJSON, err := json.Marshal(queryObj)
@@ -116,7 +116,7 @@ func (h *Handler) handleExecuteBuilderQuery(ctx context.Context, req mcp.CallToo
 	data, err := client.QueryBuilderV5(ctx, finalQueryJSON)
 	if err != nil {
 		h.logger.ErrorContext(ctx, "Failed to execute query builder v5", logpkg.ErrAttr(err))
-		return mcp.NewToolResultError(err.Error()), nil
+		return upstreamError(err), nil
 	}
 
 	h.logger.DebugContext(ctx, "Successfully executed query builder v5")

--- a/internal/handler/tools/services.go
+++ b/internal/handler/tools/services.go
@@ -97,14 +97,10 @@ func (h *Handler) handleListServices(ctx context.Context, req mcp.CallToolReques
 func (h *Handler) handleGetServiceTopOperations(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	args := req.GetArguments()
 
-	service, ok := args["service"].(string)
-	if !ok {
-		h.logger.WarnContext(ctx, "Invalid service parameter type", slog.Any("type", args["service"]))
-		return mcp.NewToolResultError(`Parameter validation failed: "service" must be a string. Example: {"service": "frontend-api", "timeRange": "1h"}`), nil
-	}
-	if service == "" {
-		h.logger.WarnContext(ctx, "Empty service parameter")
-		return mcp.NewToolResultError(`Parameter validation failed: "service" cannot be empty. Provide a valid service name. Use signoz_list_services tool to see available services.`), nil
+	service, errResult := requireStringArg(args, "service")
+	if errResult != nil {
+		h.logger.WarnContext(ctx, "Invalid service parameter", slog.Any("type", args["service"]))
+		return errResult, nil
 	}
 
 	start, end := timeutil.GetTimestampsWithDefaults(args, "ns")

--- a/internal/handler/tools/services.go
+++ b/internal/handler/tools/services.go
@@ -60,7 +60,7 @@ func (h *Handler) handleListServices(ctx context.Context, req mcp.CallToolReques
 	result, err := client.ListServices(ctx, start, end)
 	if err != nil {
 		h.logger.ErrorContext(ctx, "Failed to list services", slog.String("start", start), slog.String("end", end), logpkg.ErrAttr(err))
-		return mcp.NewToolResultError(err.Error()), nil
+		return upstreamError(err), nil
 	}
 
 	var services []any
@@ -95,7 +95,10 @@ func (h *Handler) handleListServices(ctx context.Context, req mcp.CallToolReques
 }
 
 func (h *Handler) handleGetServiceTopOperations(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-	args := req.GetArguments()
+	args, errResult := requireArgsMap(req.Params.Arguments)
+	if errResult != nil {
+		return errResult, nil
+	}
 
 	service, errResult := requireStringArg(args, "service")
 	if errResult != nil {
@@ -128,7 +131,7 @@ func (h *Handler) handleGetServiceTopOperations(ctx context.Context, req mcp.Cal
 			slog.String("end", end),
 			slog.String("service", service),
 			logpkg.ErrAttr(err))
-		return mcp.NewToolResultError(err.Error()), nil
+		return upstreamError(err), nil
 	}
 	return mcp.NewToolResultText(string(result)), nil
 }

--- a/internal/handler/tools/traces.go
+++ b/internal/handler/tools/traces.go
@@ -3,7 +3,6 @@ package tools
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"log/slog"
 
 	"github.com/mark3labs/mcp-go/mcp"
@@ -90,7 +89,7 @@ func (h *Handler) RegisterTracesHandlers(s *server.MCPServer) {
 func (h *Handler) handleAggregateTraces(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	args, ok := req.Params.Arguments.(map[string]any)
 	if !ok {
-		return mcp.NewToolResultError("invalid arguments format: expected JSON object"), nil
+		return notAJSONObjectError(), nil
 	}
 
 	reqData, err := parseAggregateTracesArgs(args)
@@ -122,7 +121,7 @@ func (h *Handler) handleAggregateTraces(ctx context.Context, req mcp.CallToolReq
 	result, err := client.QueryBuilderV5(ctx, queryJSON)
 	if err != nil {
 		h.logger.ErrorContext(ctx, "Failed to aggregate traces", logpkg.ErrAttr(err))
-		return mcp.NewToolResultError(err.Error()), nil
+		return upstreamError(err), nil
 	}
 
 	return aggregateResult(ctx, h.logger, "signoz_aggregate_traces", result, reqData.LimitClamped), nil
@@ -131,7 +130,7 @@ func (h *Handler) handleAggregateTraces(ctx context.Context, req mcp.CallToolReq
 func (h *Handler) handleSearchTraces(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	args, ok := req.Params.Arguments.(map[string]any)
 	if !ok {
-		return mcp.NewToolResultError("invalid arguments format: expected JSON object"), nil
+		return notAJSONObjectError(), nil
 	}
 
 	reqData, err := parseSearchTracesArgs(args)
@@ -157,7 +156,7 @@ func (h *Handler) handleSearchTraces(ctx context.Context, req mcp.CallToolReques
 	result, err := client.QueryBuilderV5(ctx, queryJSON)
 	if err != nil {
 		h.logger.ErrorContext(ctx, "Failed to search traces", logpkg.ErrAttr(err))
-		return mcp.NewToolResultError(err.Error()), nil
+		return upstreamError(err), nil
 	}
 
 	result = h.enrichSearchTracesWebURL(ctx, result)
@@ -167,9 +166,9 @@ func (h *Handler) handleSearchTraces(ctx context.Context, req mcp.CallToolReques
 func (h *Handler) handleGetTraceDetails(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	args := req.GetArguments()
 
-	traceID, ok := args["traceId"].(string)
-	if !ok || traceID == "" {
-		return mcp.NewToolResultError(`Parameter validation failed: "traceId" must be a non-empty string. Example: {"traceId": "abc123def456", "includeSpans": "true", "timeRange": "1h"}`), nil
+	traceID, errResult := requireStringArg(args, "traceId")
+	if errResult != nil {
+		return errResult, nil
 	}
 
 	start, end := timeutil.GetTimestampsWithDefaults(args, "ms")
@@ -181,10 +180,10 @@ func (h *Handler) handleGetTraceDetails(ctx context.Context, req mcp.CallToolReq
 
 	var startTime, endTime int64
 	if err := json.Unmarshal([]byte(start), &startTime); err != nil {
-		return mcp.NewToolResultError(fmt.Sprintf(`Internal error: Invalid "start" timestamp format: %s. Use "timeRange" parameter instead (e.g., "1h", "24h")`, start)), nil
+		return validationErrorf("start", `invalid timestamp format: %s. Use "timeRange" instead (e.g., "1h", "24h")`, start), nil
 	}
 	if err := json.Unmarshal([]byte(end), &endTime); err != nil {
-		return mcp.NewToolResultError(fmt.Sprintf(`Internal error: Invalid "end" timestamp format: %s. Use "timeRange" parameter instead (e.g., "1h", "24h")`, end)), nil
+		return validationErrorf("end", `invalid timestamp format: %s. Use "timeRange" instead (e.g., "1h", "24h")`, end), nil
 	}
 
 	h.logger.DebugContext(ctx, "Tool called: signoz_get_trace_details", slog.String("traceId", traceID), slog.Bool("includeSpans", includeSpans), slog.String("start", start), slog.String("end", end))

--- a/internal/handler/tools/traces.go
+++ b/internal/handler/tools/traces.go
@@ -164,7 +164,10 @@ func (h *Handler) handleSearchTraces(ctx context.Context, req mcp.CallToolReques
 }
 
 func (h *Handler) handleGetTraceDetails(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-	args := req.GetArguments()
+	args, errResult := requireArgsMap(req.Params.Arguments)
+	if errResult != nil {
+		return errResult, nil
+	}
 
 	traceID, errResult := requireStringArg(args, "traceId")
 	if errResult != nil {
@@ -194,7 +197,7 @@ func (h *Handler) handleGetTraceDetails(ctx context.Context, req mcp.CallToolReq
 	result, err := client.GetTraceDetails(ctx, traceID, includeSpans, startTime, endTime)
 	if err != nil {
 		h.logger.ErrorContext(ctx, "Failed to get trace details", slog.String("traceId", traceID), logpkg.ErrAttr(err))
-		return mcp.NewToolResultError(err.Error()), nil
+		return upstreamError(err), nil
 	}
 	result = enrichTraceWebURL(ctx, result, traceID)
 	return mcp.NewToolResultText(string(result)), nil

--- a/internal/handler/tools/traces.go
+++ b/internal/handler/tools/traces.go
@@ -3,6 +3,7 @@ package tools
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"log/slog"
 
 	"github.com/mark3labs/mcp-go/mcp"

--- a/internal/handler/tools/upstream_error_test.go
+++ b/internal/handler/tools/upstream_error_test.go
@@ -105,6 +105,95 @@ func TestUpstreamErrorPrefix_NonQueryBuilderHandlers(t *testing.T) {
 	}
 }
 
+// TestUpstreamErrorPrefix_FormulaMetadataFetchFailure pins the round-2 fix:
+// resolveFormulaSubQuery's metadata auto-fetch (client.ListMetrics) is an
+// upstream call, so when it fails the tool result must carry the uniform
+// "SigNoz API error:" prefix — even though sibling error paths in the same
+// function ("metric not found"/"validation error") are local and stay raw.
+//
+// The primary metric "A" provides metricType so it does NOT auto-fetch; only
+// the formula sub-query "B" triggers the ListMetrics call, which we fail.
+func TestUpstreamErrorPrefix_FormulaMetadataFetchFailure(t *testing.T) {
+	mock := &client.MockClient{
+		ListMetricsFn: func(ctx context.Context, start, end int64, limit int, searchText, source string) (json.RawMessage, error) {
+			return nil, fmt.Errorf("connection refused")
+		},
+		// QueryBuilderV5 must never be reached — the sub-query resolution fails first.
+		QueryBuilderV5Fn: func(ctx context.Context, body []byte) (json.RawMessage, error) {
+			t.Fatal("QueryBuilderV5 should not be called when formula metadata fetch fails")
+			return nil, nil
+		},
+	}
+	h := newTestHandler(mock)
+	req := makeToolRequest("signoz_query_metrics", map[string]any{
+		"metricName":  "system.cpu.time",
+		"metricType":  "gauge", // primary "A" provided -> no auto-fetch
+		"timeRange":   "1h",
+		"requestType": "time_series",
+		"formula":     "A / B",
+		"formulaQueries": []any{map[string]any{
+			"name":       "B",
+			"metricName": "system.memory.usage",
+			// metricType omitted -> triggers the auto-fetch (ListMetrics) that fails
+		}},
+	})
+
+	result, err := h.handleQueryMetrics(testCtx(), req)
+	if err != nil {
+		t.Fatalf("unexpected transport error: %v", err)
+	}
+	text := textContent(t, result)
+	if !result.IsError {
+		t.Fatalf("expected an error result, got success: %s", text)
+	}
+	if !strings.HasPrefix(text, "SigNoz API error:") {
+		t.Fatalf("formula metadata-fetch failure should carry the upstream prefix; got %q", text)
+	}
+	if !strings.Contains(text, "connection refused") {
+		t.Fatalf("error should preserve the underlying upstream message; got %q", text)
+	}
+}
+
+// TestQueryMetrics_FormulaMetricNotFoundStaysLocal is the inverse guard: when
+// the metadata fetch SUCCEEDS but the metric is absent from the response, that
+// is a local "metric not found" validation error and must NOT be relabeled as
+// an upstream failure.
+func TestQueryMetrics_FormulaMetricNotFoundStaysLocal(t *testing.T) {
+	mock := &client.MockClient{
+		ListMetricsFn: func(ctx context.Context, start, end int64, limit int, searchText, source string) (json.RawMessage, error) {
+			// Successful upstream response, but no metrics -> meta == nil -> local error.
+			return json.RawMessage(`{"status":"success","data":{"metrics":[]}}`), nil
+		},
+	}
+	h := newTestHandler(mock)
+	req := makeToolRequest("signoz_query_metrics", map[string]any{
+		"metricName":  "system.cpu.time",
+		"metricType":  "gauge",
+		"timeRange":   "1h",
+		"requestType": "time_series",
+		"formula":     "A / B",
+		"formulaQueries": []any{map[string]any{
+			"name":       "B",
+			"metricName": "does.not.exist",
+		}},
+	})
+
+	result, err := h.handleQueryMetrics(testCtx(), req)
+	if err != nil {
+		t.Fatalf("unexpected transport error: %v", err)
+	}
+	text := textContent(t, result)
+	if !result.IsError {
+		t.Fatalf("expected an error result, got success: %s", text)
+	}
+	if strings.HasPrefix(text, "SigNoz API error:") {
+		t.Fatalf("a local 'metric not found' error must NOT carry the upstream prefix; got %q", text)
+	}
+	if !strings.Contains(text, "not found") {
+		t.Fatalf("expected a 'metric not found' local error; got %q", text)
+	}
+}
+
 // TestUpstreamErrorPrefix_NotForLocalErrors confirms the inverse: a local
 // validation failure (missing required arg) does NOT get the upstream prefix —
 // it stays on the "Parameter validation failed:" prefix so the LLM can tell a

--- a/internal/handler/tools/upstream_error_test.go
+++ b/internal/handler/tools/upstream_error_test.go
@@ -1,0 +1,125 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/SigNoz/signoz-mcp-server/internal/client"
+	"github.com/SigNoz/signoz-mcp-server/pkg/types"
+)
+
+// TestUpstreamErrorPrefix_NonQueryBuilderHandlers locks in N9 (#364): every
+// user-visible upstream client-call failure must surface the uniform
+// "SigNoz API error:" prefix, not a bare or bespoke message. The e2e-tagged
+// suite covers this against a live backend; this mock-driven test pins the
+// contract per-PR for a representative spread of non-QueryBuilder handlers
+// (list + single-get across alerts, dashboards, services, fields, channels).
+func TestUpstreamErrorPrefix_NonQueryBuilderHandlers(t *testing.T) {
+	const upstreamMsg = "connection refused"
+	wantPrefix := "SigNoz API error:"
+
+	cases := []struct {
+		name    string
+		mock    *client.MockClient
+		invoke  func(*Handler) (isErr bool, text string)
+	}{
+		{
+			name: "list_dashboards",
+			mock: &client.MockClient{ListDashboardsFn: func(ctx context.Context) (json.RawMessage, error) {
+				return nil, fmt.Errorf(upstreamMsg)
+			}},
+			invoke: func(h *Handler) (bool, string) {
+				r, _ := h.handleListDashboards(testCtx(), makeToolRequest("signoz_list_dashboards", map[string]any{}))
+				return r.IsError, textContent(t, r)
+			},
+		},
+		{
+			name: "get_alert",
+			mock: &client.MockClient{GetAlertByRuleIDFn: func(ctx context.Context, ruleID string) (json.RawMessage, error) {
+				return nil, fmt.Errorf(upstreamMsg)
+			}},
+			invoke: func(h *Handler) (bool, string) {
+				r, _ := h.handleGetAlert(testCtx(), makeToolRequest("signoz_get_alert", map[string]any{"ruleId": "01900000-0000-7000-8000-000000000000"}))
+				return r.IsError, textContent(t, r)
+			},
+		},
+		{
+			name: "list_services",
+			mock: &client.MockClient{ListServicesFn: func(ctx context.Context, start, end string) (json.RawMessage, error) {
+				return nil, fmt.Errorf(upstreamMsg)
+			}},
+			invoke: func(h *Handler) (bool, string) {
+				r, _ := h.handleListServices(testCtx(), makeToolRequest("signoz_list_services", map[string]any{}))
+				return r.IsError, textContent(t, r)
+			},
+		},
+		{
+			name: "get_field_keys",
+			mock: &client.MockClient{GetFieldKeysFn: func(ctx context.Context, signal, metricName, searchText, fieldContext, fieldDataType, source string) (json.RawMessage, error) {
+				return nil, fmt.Errorf(upstreamMsg)
+			}},
+			invoke: func(h *Handler) (bool, string) {
+				r, _ := h.handleGetFieldKeys(testCtx(), makeToolRequest("signoz_get_field_keys", map[string]any{"signal": "logs"}))
+				return r.IsError, textContent(t, r)
+			},
+		},
+		{
+			name: "get_notification_channel",
+			mock: &client.MockClient{GetNotificationChannelFn: func(ctx context.Context, id string) (json.RawMessage, error) {
+				return nil, fmt.Errorf(upstreamMsg)
+			}},
+			invoke: func(h *Handler) (bool, string) {
+				r, _ := h.handleGetNotificationChannel(testCtx(), makeToolRequest("signoz_get_notification_channel", map[string]any{"id": "abc"}))
+				return r.IsError, textContent(t, r)
+			},
+		},
+		{
+			name: "list_alerts",
+			mock: &client.MockClient{ListAlertsFn: func(ctx context.Context, params types.ListAlertsParams) (json.RawMessage, error) {
+				return nil, fmt.Errorf(upstreamMsg)
+			}},
+			invoke: func(h *Handler) (bool, string) {
+				r, _ := h.handleListAlerts(testCtx(), makeToolRequest("signoz_list_alerts", map[string]any{}))
+				return r.IsError, textContent(t, r)
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			h := newTestHandler(tc.mock)
+			isErr, text := tc.invoke(h)
+			if !isErr {
+				t.Fatalf("%s: expected an error result, got success: %s", tc.name, text)
+			}
+			if !strings.HasPrefix(text, wantPrefix) {
+				t.Fatalf("%s: error text = %q, want %q prefix", tc.name, text, wantPrefix)
+			}
+			if !strings.Contains(text, upstreamMsg) {
+				t.Fatalf("%s: error text = %q, want it to preserve the underlying message %q", tc.name, text, upstreamMsg)
+			}
+		})
+	}
+}
+
+// TestUpstreamErrorPrefix_NotForLocalErrors confirms the inverse: a local
+// validation failure (missing required arg) does NOT get the upstream prefix —
+// it stays on the "Parameter validation failed:" prefix so the LLM can tell a
+// fixable parameter mistake apart from a retryable backend failure.
+func TestUpstreamErrorPrefix_NotForLocalErrors(t *testing.T) {
+	h := newTestHandler(&client.MockClient{})
+	r, _ := h.handleGetAlert(testCtx(), makeToolRequest("signoz_get_alert", map[string]any{}))
+	text := textContent(t, r)
+	if !r.IsError {
+		t.Fatalf("expected an error result, got success: %s", text)
+	}
+	if strings.HasPrefix(text, "SigNoz API error:") {
+		t.Fatalf("local validation error must NOT carry the upstream prefix; got %q", text)
+	}
+	if !strings.HasPrefix(text, "Parameter validation failed:") {
+		t.Fatalf("local validation error should keep the validation prefix; got %q", text)
+	}
+}

--- a/internal/handler/tools/upstream_error_test.go
+++ b/internal/handler/tools/upstream_error_test.go
@@ -3,7 +3,7 @@ package tools
 import (
 	"context"
 	"encoding/json"
-	"fmt"
+	"errors"
 	"strings"
 	"testing"
 
@@ -29,7 +29,7 @@ func TestUpstreamErrorPrefix_NonQueryBuilderHandlers(t *testing.T) {
 		{
 			name: "list_dashboards",
 			mock: &client.MockClient{ListDashboardsFn: func(ctx context.Context) (json.RawMessage, error) {
-				return nil, fmt.Errorf(upstreamMsg)
+				return nil, errors.New(upstreamMsg)
 			}},
 			invoke: func(h *Handler) (bool, string) {
 				r, _ := h.handleListDashboards(testCtx(), makeToolRequest("signoz_list_dashboards", map[string]any{}))
@@ -39,7 +39,7 @@ func TestUpstreamErrorPrefix_NonQueryBuilderHandlers(t *testing.T) {
 		{
 			name: "get_alert",
 			mock: &client.MockClient{GetAlertByRuleIDFn: func(ctx context.Context, ruleID string) (json.RawMessage, error) {
-				return nil, fmt.Errorf(upstreamMsg)
+				return nil, errors.New(upstreamMsg)
 			}},
 			invoke: func(h *Handler) (bool, string) {
 				r, _ := h.handleGetAlert(testCtx(), makeToolRequest("signoz_get_alert", map[string]any{"ruleId": "01900000-0000-7000-8000-000000000000"}))
@@ -49,7 +49,7 @@ func TestUpstreamErrorPrefix_NonQueryBuilderHandlers(t *testing.T) {
 		{
 			name: "list_services",
 			mock: &client.MockClient{ListServicesFn: func(ctx context.Context, start, end string) (json.RawMessage, error) {
-				return nil, fmt.Errorf(upstreamMsg)
+				return nil, errors.New(upstreamMsg)
 			}},
 			invoke: func(h *Handler) (bool, string) {
 				r, _ := h.handleListServices(testCtx(), makeToolRequest("signoz_list_services", map[string]any{}))
@@ -59,7 +59,7 @@ func TestUpstreamErrorPrefix_NonQueryBuilderHandlers(t *testing.T) {
 		{
 			name: "get_field_keys",
 			mock: &client.MockClient{GetFieldKeysFn: func(ctx context.Context, signal, metricName, searchText, fieldContext, fieldDataType, source string) (json.RawMessage, error) {
-				return nil, fmt.Errorf(upstreamMsg)
+				return nil, errors.New(upstreamMsg)
 			}},
 			invoke: func(h *Handler) (bool, string) {
 				r, _ := h.handleGetFieldKeys(testCtx(), makeToolRequest("signoz_get_field_keys", map[string]any{"signal": "logs"}))
@@ -69,7 +69,7 @@ func TestUpstreamErrorPrefix_NonQueryBuilderHandlers(t *testing.T) {
 		{
 			name: "get_notification_channel",
 			mock: &client.MockClient{GetNotificationChannelFn: func(ctx context.Context, id string) (json.RawMessage, error) {
-				return nil, fmt.Errorf(upstreamMsg)
+				return nil, errors.New(upstreamMsg)
 			}},
 			invoke: func(h *Handler) (bool, string) {
 				r, _ := h.handleGetNotificationChannel(testCtx(), makeToolRequest("signoz_get_notification_channel", map[string]any{"id": "abc"}))
@@ -79,7 +79,7 @@ func TestUpstreamErrorPrefix_NonQueryBuilderHandlers(t *testing.T) {
 		{
 			name: "list_alerts",
 			mock: &client.MockClient{ListAlertsFn: func(ctx context.Context, params types.ListAlertsParams) (json.RawMessage, error) {
-				return nil, fmt.Errorf(upstreamMsg)
+				return nil, errors.New(upstreamMsg)
 			}},
 			invoke: func(h *Handler) (bool, string) {
 				r, _ := h.handleListAlerts(testCtx(), makeToolRequest("signoz_list_alerts", map[string]any{}))
@@ -116,7 +116,7 @@ func TestUpstreamErrorPrefix_NonQueryBuilderHandlers(t *testing.T) {
 func TestUpstreamErrorPrefix_FormulaMetadataFetchFailure(t *testing.T) {
 	mock := &client.MockClient{
 		ListMetricsFn: func(ctx context.Context, start, end int64, limit int, searchText, source string) (json.RawMessage, error) {
-			return nil, fmt.Errorf("connection refused")
+			return nil, errors.New("connection refused")
 		},
 		// QueryBuilderV5 must never be reached — the sub-query resolution fails first.
 		QueryBuilderV5Fn: func(ctx context.Context, body []byte) (json.RawMessage, error) {

--- a/internal/handler/tools/views.go
+++ b/internal/handler/tools/views.go
@@ -242,19 +242,19 @@ func validateBuilderSignal(compositeQuery any, sourcePage string) error {
 			// Cost Meter views are queried as metrics against the meter store.
 			if signal == "" {
 				return fmt.Errorf(
-					`Parameter validation failed: compositeQuery.queries[%d].spec.signal is required for a "meter" view and must be "metrics"`,
+					`parameter validation failed: compositeQuery.queries[%d].spec.signal is required for a "meter" view and must be "metrics"`,
 					i,
 				)
 			}
 			if signal != "metrics" {
 				return fmt.Errorf(
-					`Parameter validation failed: compositeQuery.queries[%d].spec.signal = %q but a "meter" (Cost Meter) view must use signal "metrics"`,
+					`parameter validation failed: compositeQuery.queries[%d].spec.signal = %q but a "meter" (Cost Meter) view must use signal "metrics"`,
 					i, signal,
 				)
 			}
 			if source != "meter" {
 				return fmt.Errorf(
-					`Parameter validation failed: compositeQuery.queries[%d].spec.source = %q but a "meter" (Cost Meter) view must set source "meter"`,
+					`parameter validation failed: compositeQuery.queries[%d].spec.source = %q but a "meter" (Cost Meter) view must set source "meter"`,
 					i, source,
 				)
 			}
@@ -263,20 +263,20 @@ func validateBuilderSignal(compositeQuery any, sourcePage string) error {
 
 		if signal == "" {
 			return fmt.Errorf(
-				`Parameter validation failed: compositeQuery.queries[%d].spec.signal is required and must equal sourcePage (%q)`,
+				`parameter validation failed: compositeQuery.queries[%d].spec.signal is required and must equal sourcePage (%q)`,
 				i, sourcePage,
 			)
 		}
 		if signal != sourcePage {
 			return fmt.Errorf(
-				`Parameter validation failed: compositeQuery.queries[%d].spec.signal = %q but sourcePage = %q, they must match`,
+				`parameter validation failed: compositeQuery.queries[%d].spec.signal = %q but sourcePage = %q, they must match`,
 				i, signal, sourcePage,
 			)
 		}
 		// A Cost Meter query (source="meter") must live on the "meter" page.
 		if source == "meter" {
 			return fmt.Errorf(
-				`Parameter validation failed: compositeQuery.queries[%d].spec.source = "meter" requires sourcePage "meter" (a Cost Meter view), but sourcePage = %q`,
+				`parameter validation failed: compositeQuery.queries[%d].spec.source = "meter" requires sourcePage "meter" (a Cost Meter view), but sourcePage = %q`,
 				i, sourcePage,
 			)
 		}

--- a/internal/handler/tools/views.go
+++ b/internal/handler/tools/views.go
@@ -27,10 +27,10 @@ var validSourcePages = map[string]struct{}{
 
 func validateSourcePage(sp string) error {
 	if sp == "" {
-		return fmt.Errorf(`parameter validation failed: "sourcePage" is required. Must be one of: "traces", "logs", "metrics", "meter"`)
+		return fmt.Errorf(`%s "sourcePage" is required. Must be one of: "traces", "logs", "metrics", "meter"`, validationErrorPrefix)
 	}
 	if _, ok := validSourcePages[sp]; !ok {
-		return fmt.Errorf(`parameter validation failed: "sourcePage" must be one of: "traces", "logs", "metrics", "meter" (got %q)`, sp)
+		return fmt.Errorf(`%s "sourcePage" must be one of: "traces", "logs", "metrics", "meter" (got %q)`, validationErrorPrefix, sp)
 	}
 	return nil
 }
@@ -242,19 +242,19 @@ func validateBuilderSignal(compositeQuery any, sourcePage string) error {
 			// Cost Meter views are queried as metrics against the meter store.
 			if signal == "" {
 				return fmt.Errorf(
-					`parameter validation failed: compositeQuery.queries[%d].spec.signal is required for a "meter" view and must be "metrics"`,
+					`Parameter validation failed: compositeQuery.queries[%d].spec.signal is required for a "meter" view and must be "metrics"`,
 					i,
 				)
 			}
 			if signal != "metrics" {
 				return fmt.Errorf(
-					`parameter validation failed: compositeQuery.queries[%d].spec.signal = %q but a "meter" (Cost Meter) view must use signal "metrics"`,
+					`Parameter validation failed: compositeQuery.queries[%d].spec.signal = %q but a "meter" (Cost Meter) view must use signal "metrics"`,
 					i, signal,
 				)
 			}
 			if source != "meter" {
 				return fmt.Errorf(
-					`parameter validation failed: compositeQuery.queries[%d].spec.source = %q but a "meter" (Cost Meter) view must set source "meter"`,
+					`Parameter validation failed: compositeQuery.queries[%d].spec.source = %q but a "meter" (Cost Meter) view must set source "meter"`,
 					i, source,
 				)
 			}
@@ -263,20 +263,20 @@ func validateBuilderSignal(compositeQuery any, sourcePage string) error {
 
 		if signal == "" {
 			return fmt.Errorf(
-				`parameter validation failed: compositeQuery.queries[%d].spec.signal is required and must equal sourcePage (%q)`,
+				`Parameter validation failed: compositeQuery.queries[%d].spec.signal is required and must equal sourcePage (%q)`,
 				i, sourcePage,
 			)
 		}
 		if signal != sourcePage {
 			return fmt.Errorf(
-				`parameter validation failed: compositeQuery.queries[%d].spec.signal = %q but sourcePage = %q, they must match`,
+				`Parameter validation failed: compositeQuery.queries[%d].spec.signal = %q but sourcePage = %q, they must match`,
 				i, signal, sourcePage,
 			)
 		}
 		// A Cost Meter query (source="meter") must live on the "meter" page.
 		if source == "meter" {
 			return fmt.Errorf(
-				`parameter validation failed: compositeQuery.queries[%d].spec.source = "meter" requires sourcePage "meter" (a Cost Meter view), but sourcePage = %q`,
+				`Parameter validation failed: compositeQuery.queries[%d].spec.source = "meter" requires sourcePage "meter" (a Cost Meter view), but sourcePage = %q`,
 				i, sourcePage,
 			)
 		}
@@ -345,7 +345,7 @@ func unwrapViewEnvelope(args map[string]any) {
 func (h *Handler) handleListViews(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	args, ok := req.Params.Arguments.(map[string]any)
 	if !ok {
-		return mcp.NewToolResultError("invalid arguments format: expected JSON object"), nil
+		return notAJSONObjectError(), nil
 	}
 	sourcePage, _ := args["sourcePage"].(string)
 	if err := validateSourcePage(sourcePage); err != nil {
@@ -402,12 +402,12 @@ func (h *Handler) handleListViews(ctx context.Context, req mcp.CallToolRequest) 
 func (h *Handler) handleGetView(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	args, ok := req.Params.Arguments.(map[string]any)
 	if !ok {
-		return mcp.NewToolResultError("invalid arguments format: expected JSON object"), nil
+		return notAJSONObjectError(), nil
 	}
-	viewID, _ := args["viewId"].(string)
-	if viewID == "" {
-		h.logger.WarnContext(ctx, "get_view missing viewId")
-		return mcp.NewToolResultError(`Parameter validation failed: "viewId" cannot be empty. Provide a valid saved view UUID. Use signoz_list_views to see available views.`), nil
+	viewID, errResult := requireStringArg(args, "viewId")
+	if errResult != nil {
+		h.logger.WarnContext(ctx, "get_view invalid or missing viewId")
+		return errResult, nil
 	}
 	h.logger.DebugContext(ctx, "Tool called: signoz_get_view", slog.String("viewId", viewID))
 
@@ -426,13 +426,13 @@ func (h *Handler) handleGetView(ctx context.Context, req mcp.CallToolRequest) (*
 func (h *Handler) handleCreateView(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	args, ok := req.Params.Arguments.(map[string]any)
 	if !ok || len(args) == 0 {
-		return mcp.NewToolResultError("parameter validation failed: request body is empty or not an object"), nil
+		return notAConfigObjectError(), nil
 	}
 	unwrapViewEnvelope(args)
 
-	name, _ := args["name"].(string)
-	if name == "" {
-		return mcp.NewToolResultError(`Parameter validation failed: "name" is required and cannot be empty.`), nil
+	name, errResult := requireStringArg(args, "name")
+	if errResult != nil {
+		return errResult, nil
 	}
 	sourcePage, _ := args["sourcePage"].(string)
 	if err := validateSourcePage(sourcePage); err != nil {
@@ -460,7 +460,7 @@ func (h *Handler) handleCreateView(ctx context.Context, req mcp.CallToolRequest)
 	data, err := client.CreateView(ctx, body)
 	if err != nil {
 		h.logger.ErrorContext(ctx, "Failed to create view", logpkg.ErrAttr(err))
-		return mcp.NewToolResultError(err.Error()), nil
+		return upstreamError(err), nil
 	}
 	return mcp.NewToolResultText(string(data)), nil
 }
@@ -468,12 +468,12 @@ func (h *Handler) handleCreateView(ctx context.Context, req mcp.CallToolRequest)
 func (h *Handler) handleUpdateView(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	args, ok := req.Params.Arguments.(map[string]any)
 	if !ok || len(args) == 0 {
-		return mcp.NewToolResultError("parameter validation failed: request body is empty or not an object"), nil
+		return notAConfigObjectError(), nil
 	}
 
-	viewID, _ := args["viewId"].(string)
-	if viewID == "" {
-		return mcp.NewToolResultError(`Parameter validation failed: "viewId" cannot be empty. Use signoz_list_views to find the UUID.`), nil
+	viewID, errResult := requireStringArg(args, "viewId")
+	if errResult != nil {
+		return errResult, nil
 	}
 
 	// The canonical shape (per input schema) wraps the body under "view".
@@ -545,7 +545,7 @@ func (h *Handler) handleUpdateView(ctx context.Context, req mcp.CallToolRequest)
 	data, err := client.UpdateView(ctx, viewID, body)
 	if err != nil {
 		h.logger.ErrorContext(ctx, "Failed to update view", slog.String("viewId", viewID), logpkg.ErrAttr(err))
-		return mcp.NewToolResultError(err.Error()), nil
+		return upstreamError(err), nil
 	}
 	return mcp.NewToolResultText(string(data)), nil
 }
@@ -553,11 +553,11 @@ func (h *Handler) handleUpdateView(ctx context.Context, req mcp.CallToolRequest)
 func (h *Handler) handleDeleteView(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	args, ok := req.Params.Arguments.(map[string]any)
 	if !ok {
-		return mcp.NewToolResultError("invalid arguments format: expected JSON object"), nil
+		return notAJSONObjectError(), nil
 	}
-	viewID, _ := args["viewId"].(string)
-	if viewID == "" {
-		return mcp.NewToolResultError(`Parameter validation failed: "viewId" cannot be empty. Use signoz_list_views to find the UUID.`), nil
+	viewID, errResult := requireStringArg(args, "viewId")
+	if errResult != nil {
+		return errResult, nil
 	}
 	h.logger.DebugContext(ctx, "Tool called: signoz_delete_view", slog.String("viewId", viewID))
 
@@ -568,7 +568,7 @@ func (h *Handler) handleDeleteView(ctx context.Context, req mcp.CallToolRequest)
 	data, err := client.DeleteView(ctx, viewID)
 	if err != nil {
 		h.logger.ErrorContext(ctx, "Failed to delete view", slog.String("viewId", viewID), logpkg.ErrAttr(err))
-		return mcp.NewToolResultError(err.Error()), nil
+		return upstreamError(err), nil
 	}
 	return mcp.NewToolResultText(string(data)), nil
 }

--- a/internal/handler/tools/views.go
+++ b/internal/handler/tools/views.go
@@ -369,7 +369,7 @@ func (h *Handler) handleListViews(ctx context.Context, req mcp.CallToolRequest) 
 	result, err := client.ListViews(ctx, sourcePage, name, category)
 	if err != nil {
 		h.logger.ErrorContext(ctx, "Failed to list views", logpkg.ErrAttr(err))
-		return mcp.NewToolResultError(err.Error()), nil
+		return upstreamError(err), nil
 	}
 
 	var parsed map[string]any
@@ -418,7 +418,7 @@ func (h *Handler) handleGetView(ctx context.Context, req mcp.CallToolRequest) (*
 	data, err := client.GetView(ctx, viewID)
 	if err != nil {
 		h.logger.ErrorContext(ctx, "Failed to get view", slog.String("viewId", viewID), logpkg.ErrAttr(err))
-		return mcp.NewToolResultError(err.Error()), nil
+		return upstreamError(err), nil
 	}
 	return mcp.NewToolResultText(string(data)), nil
 }


### PR DESCRIPTION
Closes #364. Part of the #360 read-tool parameter-consistency batch.

## Converges error & validation strings onto shared helpers (`errs.go`)
- **N21/N25** `validationError(field, reason)` → canonical `Parameter validation failed: "<field>" <reason>` (capital P); all bespoke/lowercase sites routed onto it.
- **N24** `requireStringArg` → two-tier (`must be a string` / `cannot be empty`), replacing the 3+ ad-hoc variants that mislabeled a wrong-typed id as "empty".
- **N22** shared "arguments is not a JSON object" guard (+ a body-tool "configuration object" variant); `requireArgsMap` so non-object args hit the guard, not "cannot be empty".
- **N23** dropped the misleading `Internal error:` prefix on the get_trace_details timestamp parse (it's a user/parameter error).
- **N27** fixed the stale `list_dashboards` → `signoz_list_dashboards` reference.
- **N9** `upstreamError(err)` → uniform `SigNoz API error: <msg>` on **every** user-visible upstream `client.*` failure (~20 sites, package-swept). `GetClient`/local-validation errors deliberately left unwrapped.

## Verification
- **Codex** (gpt-5.5 / xhigh): 1 blocker — N9 was initially incomplete (~20 upstream sites still raw) — **fixed** (all wrapped + a non-e2e mock-client test asserting the prefix, plus an inverse test proving validation errors are *not* wrapped).
- Unit tests green; env-guarded **live E2E against staging green** (validation strings, upstream prefix, happy-path lists, N23) — read-only/negative-path, no resources created.

Suggested batch merge order: **A → B → C → E → D**. (#365 / Family C is stacked on this branch.)