### PR TITLE
fix(auth): honor ingress header for user/session tokens

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -41,8 +41,8 @@ subgraph HTTPPath["HTTP Transport — Multi Tenant"]
     APIKEY -->|Yes + OAuth enabled| TRYDECRYPT["Try decrypt as OAuth token"]
     TRYDECRYPT -->|Success| OAUTHCTX["Extract apiKey + signozURL<br/>from encrypted token"]
     TRYDECRYPT -->|Expired| EXPIRED["401 + WWW-Authenticate challenge"]
-    TRYDECRYPT -->|Not OAuth format| RAWKEY["Treat as raw API key<br/>(backward compatible)"]
-    APIKEY -->|Yes + OAuth disabled| PARSE["Extract apiKey<br/>(Bearer or raw token)"]
+    TRYDECRYPT -->|Not OAuth format| RAWKEY["Forward token upstream<br/>as Authorization: Bearer"]
+    APIKEY -->|Yes + OAuth disabled| PARSE["Forward token upstream<br/>as Authorization: Bearer"]
     APIKEY -->|No + OAuth enabled| CHALLENGE["401 + WWW-Authenticate<br/>resource_metadata URL"]
     APIKEY -->|No + env set| ENVKEY["Use config.APIKey"]
     APIKEY -->|No + no env| DENY["401 Unauthorized"]
@@ -167,6 +167,13 @@ Each blob is prefixed with a type byte to prevent cross-type confusion:
 
 Since tokens are self-contained encrypted blobs, any server instance with the same `OAUTH_TOKEN_SECRET` can validate any token. No sticky sessions or shared state needed. The only requirement is that all instances share the same encryption key.
 
-### Backward Compatibility
+### Credential header routing
 
-The auth middleware tries OAuth token decryption first. If decryption fails (e.g., the Bearer token is a plain SigNoz API key), it falls back to the legacy `Authorization` header + `X-SigNoz-URL` header approach. Existing integrations continue to work without changes.
+The auth middleware forwards each credential upstream on the **header the client used** — SigNoz classifies credentials by header name, not token shape:
+
+- `SIGNOZ-API-KEY: <key>` → forwarded as `SIGNOZ-API-KEY` (service-account API keys).
+- `Authorization: [Bearer] <token>` → forwarded as `Authorization: Bearer <token>` (user/session tokens, JWT **or** opaque).
+
+When OAuth is enabled, the middleware first tries to decrypt an `Authorization` Bearer token as a server-issued OAuth access token; a valid one unwraps to a stored API key forwarded via `SIGNOZ-API-KEY`. Only if decryption fails (and a SigNoz URL is available) is the token treated as a direct credential and forwarded on `Authorization`.
+
+> **Removed (breaking):** earlier versions used a shape heuristic (`isJWTToken`) to reroute non-JWT `Authorization` tokens to `SIGNOZ-API-KEY`. That heuristic misrouted opaque user/session tokens (which SigNoz only accepts on `Authorization`) and has been removed. Clients sending a service-account API key must use the `SIGNOZ-API-KEY` header, not `Authorization`.

--- a/internal/handler/tools/handler.go
+++ b/internal/handler/tools/handler.go
@@ -78,7 +78,7 @@ func (h *Handler) GetClient(ctx context.Context) (signozclient.Client, error) {
 		authHeader = "SIGNOZ-API-KEY"
 	}
 
-	cacheKey := util.HashTenantKey(apiKey, signozURL)
+	cacheKey := util.HashTenantKey(authHeader, apiKey, signozURL)
 
 	if cachedClient, ok := h.clientCache.Get(cacheKey); ok {
 		return cachedClient, nil

--- a/internal/mcp-server/server.go
+++ b/internal/mcp-server/server.go
@@ -1121,16 +1121,21 @@ func (m *MCPServer) runStdio(ctx context.Context, s *server.MCPServer) error {
 	return nil
 }
 
-func isJWTToken(token string) bool {
-	return strings.Count(token, ".") == 2 && strings.HasPrefix(token, "eyJ")
+// stripBearerPrefix removes a leading "Bearer " scheme token (case-insensitive,
+// per RFC 7235 — SigNoz parses the scheme the same way) and trims surrounding
+// whitespace, returning the bare token value.
+func stripBearerPrefix(authValue string) string {
+	const prefix = "Bearer "
+	if len(authValue) >= len(prefix) && strings.EqualFold(authValue[:len(prefix)], prefix) {
+		return strings.TrimSpace(authValue[len(prefix):])
+	}
+	return strings.TrimSpace(authValue)
 }
 
 const (
 	authModeNone                = "none"
 	authModeSignozAPIKeyHeader  = "signoz-api-key-header"
-	authModeAuthorizationAPIKey = "authorization-api-key"
 	authModeAuthorizationBearer = "authorization-bearer"
-	authModeAuthorizationJWT    = "authorization-jwt"
 	authModeOAuthAccessToken    = "oauth-access-token"
 	authModeConfigAPIKey        = "config-api-key"
 
@@ -1258,11 +1263,10 @@ func (m *MCPServer) authMiddleware(next http.Handler) http.Handler {
 		// Extract X-SigNoz-URL custom header (takes precedence over JWT audience)
 		customURL := r.Header.Get("X-SigNoz-URL")
 
-		// Check for auth credentials from headers.
-		// Clients can provide either:
-		//   - SIGNOZ-API-KEY: <pat-token>
-		//   - Authorization: Bearer <token>  (JWT, PAT)
-		//   - Authorization: <token>         (legacy)
+		// SigNoz classifies credentials by header name, not token shape, so
+		// each is forwarded on the header the client used: SIGNOZ-API-KEY
+		// as-is, Authorization bearer tokens as Authorization (unless the
+		// bearer is a server-issued OAuth access token, handled below).
 		signozAPIKey := r.Header.Get("SIGNOZ-API-KEY")
 		authHeader := r.Header.Get("Authorization")
 
@@ -1273,27 +1277,21 @@ func (m *MCPServer) authMiddleware(next http.Handler) http.Handler {
 
 		if signozAPIKey != "" {
 			// Explicit PAT via SIGNOZ-API-KEY header — forward as-is.
-			apiKey = strings.TrimPrefix(signozAPIKey, "Bearer ")
+			apiKey = stripBearerPrefix(signozAPIKey)
 			authMode = authModeSignozAPIKeyHeader
 
 			ctx = util.SetAPIKey(ctx, apiKey)
 			ctx = util.SetAuthHeader(ctx, "SIGNOZ-API-KEY")
 		} else if authHeader != "" {
-			token := strings.TrimSpace(strings.TrimPrefix(authHeader, "Bearer "))
+			token := stripBearerPrefix(authHeader)
 			if customURL != "" {
-				if isJWTToken(token) {
-					// JWT token — forward via Authorization: Bearer <token>
-					apiKey = "Bearer " + token
-					authMode = authModeAuthorizationJWT
-					ctx = util.SetAPIKey(ctx, apiKey)
-					ctx = util.SetAuthHeader(ctx, "Authorization")
-				} else {
-					// PAT token — forward via SIGNOZ-API-KEY
-					apiKey = token
-					authMode = authModeAuthorizationAPIKey
-					ctx = util.SetAPIKey(ctx, apiKey)
-					ctx = util.SetAuthHeader(ctx, "SIGNOZ-API-KEY")
-				}
+				// Direct (non-OAuth) credential: honor the ingress header and
+				// forward as Authorization: Bearer regardless of token shape.
+				// Service-account API keys must use the SIGNOZ-API-KEY header.
+				apiKey = "Bearer " + token
+				authMode = authModeAuthorizationBearer
+				ctx = util.SetAPIKey(ctx, apiKey)
+				ctx = util.SetAuthHeader(ctx, "Authorization")
 			} else if m.config.OAuthEnabled {
 				decryptedAPIKey, decryptedURL, _, _, err := oauth.DecryptToken(token, []byte(m.config.OAuthTokenSecret))
 				switch {
@@ -1320,26 +1318,27 @@ func (m *MCPServer) authMiddleware(next http.Handler) http.Handler {
 					http.Error(w, "OAuth access token expired", http.StatusUnauthorized)
 					return
 				default:
-					// Only fall back to legacy raw API key mode when the request also
-					// carries an explicit SigNoz URL (header or config). Otherwise a
-					// stale bearer token can mask the OAuth challenge flow.
+					// Not an OAuth token. Forward as a direct credential only
+					// when a SigNoz URL is available; otherwise a stale bearer
+					// token would mask the OAuth challenge flow.
 					if customURL == "" && m.config.URL == "" {
 						m.logAuthFailure(ctx, r, http.StatusUnauthorized, authFailureInvalidOAuthToken, authModeAuthorizationBearer, "Bearer token did not match OAuth token format and no SigNoz URL is available for legacy fallback")
 						m.setOAuthChallenge(w, `error="invalid_token", error_description="access token is invalid"`)
 						http.Error(w, "OAuth access token is invalid", http.StatusUnauthorized)
 						return
 					}
-					apiKey = token
-					authMode = authModeAuthorizationAPIKey
+					apiKey = "Bearer " + token
+					authMode = authModeAuthorizationBearer
 					ctx = util.SetAPIKey(ctx, apiKey)
-					ctx = util.SetAuthHeader(ctx, "SIGNOZ-API-KEY")
-					m.logger.DebugContext(ctx, "Bearer token did not match OAuth token format, falling back to raw API key")
+					ctx = util.SetAuthHeader(ctx, "Authorization")
+					m.logger.DebugContext(ctx, "Bearer token did not match OAuth token format, forwarding as Authorization")
 				}
 			} else {
-				apiKey = token
-				authMode = authModeAuthorizationAPIKey
+				// OAuth disabled: honor the ingress header (Authorization).
+				apiKey = "Bearer " + token
+				authMode = authModeAuthorizationBearer
 				ctx = util.SetAPIKey(ctx, apiKey)
-				ctx = util.SetAuthHeader(ctx, "SIGNOZ-API-KEY")
+				ctx = util.SetAuthHeader(ctx, "Authorization")
 			}
 
 		} else if m.config.APIKey != "" {

--- a/internal/mcp-server/server_test.go
+++ b/internal/mcp-server/server_test.go
@@ -374,35 +374,117 @@ func TestAuthMiddlewareAcceptsOAuthBearerToken(t *testing.T) {
 	}
 }
 
-func TestAuthMiddlewareFallsBackToRawAPIKey(t *testing.T) {
+// TestAuthMiddlewareHonorsAuthorizationIngress verifies an Authorization token
+// is forwarded upstream as Authorization: Bearer regardless of shape — opaque
+// and JWT-shaped tokens must behave identically.
+func TestAuthMiddlewareHonorsAuthorizationIngress(t *testing.T) {
 	cfg := &config.Config{
 		OAuthEnabled:     true,
 		OAuthTokenSecret: "0123456789abcdef0123456789abcdef",
 		OAuthIssuerURL:   "https://mcp.example.com",
 	}
 
-	server := &MCPServer{logger: logpkg.New("error"), config: cfg, analytics: noopanalytics.New()}
-	req := httptest.NewRequest(http.MethodPost, "/mcp", nil)
-	req.Header.Set("Authorization", "Bearer raw-api-key")
-	req.Header.Set("X-SigNoz-URL", "https://1.1.1.1")
-
-	rr := httptest.NewRecorder()
-	server.authMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		apiKey, _ := util.GetAPIKey(r.Context())
-		signozURL, _ := util.GetSigNozURL(r.Context())
-		w.Header().Set("X-API-Key", apiKey)
-		w.Header().Set("X-SigNoz-URL", signozURL)
-		w.WriteHeader(http.StatusOK)
-	})).ServeHTTP(rr, req)
-
-	if rr.Code != http.StatusOK {
-		t.Fatalf("status = %d, want %d", rr.Code, http.StatusOK)
+	// authHeader is the raw Authorization value; wantAPIKey is what must be
+	// forwarded upstream. The "Bearer " scheme is stripped case-insensitively
+	// and always re-added, so opaque, JWT-shaped, prefix-less, and lowercase
+	// inputs all converge on a single canonical "Bearer <token>" form.
+	cases := []struct {
+		name       string
+		authHeader string
+		wantAPIKey string
+	}{
+		{name: "opaque token", authHeader: "Bearer opaque-session-token", wantAPIKey: "Bearer opaque-session-token"},
+		{name: "jwt-shaped token", authHeader: "Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxIn0.sig", wantAPIKey: "Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxIn0.sig"},
+		{name: "opaque token starting with eyJ", authHeader: "Bearer eyJ-not-a-jwt", wantAPIKey: "Bearer eyJ-not-a-jwt"},
+		{name: "no Bearer prefix", authHeader: "opaque-session-token", wantAPIKey: "Bearer opaque-session-token"},
+		{name: "lowercase bearer scheme", authHeader: "bearer opaque-session-token", wantAPIKey: "Bearer opaque-session-token"},
 	}
-	if rr.Header().Get("X-API-Key") != "raw-api-key" {
-		t.Fatalf("api key = %q, want %q", rr.Header().Get("X-API-Key"), "raw-api-key")
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			server := &MCPServer{logger: logpkg.New("error"), config: cfg, analytics: noopanalytics.New()}
+			req := httptest.NewRequest(http.MethodPost, "/mcp", nil)
+			req.Header.Set("Authorization", tc.authHeader)
+			req.Header.Set("X-SigNoz-URL", "https://1.1.1.1")
+
+			rr := httptest.NewRecorder()
+			server.authMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				apiKey, _ := util.GetAPIKey(r.Context())
+				authHeader, _ := util.GetAuthHeader(r.Context())
+				signozURL, _ := util.GetSigNozURL(r.Context())
+				w.Header().Set("X-API-Key", apiKey)
+				w.Header().Set("X-Auth-Header", authHeader)
+				w.Header().Set("X-SigNoz-URL", signozURL)
+				w.WriteHeader(http.StatusOK)
+			})).ServeHTTP(rr, req)
+
+			if rr.Code != http.StatusOK {
+				t.Fatalf("status = %d, want %d", rr.Code, http.StatusOK)
+			}
+			if got := rr.Header().Get("X-API-Key"); got != tc.wantAPIKey {
+				t.Fatalf("api key = %q, want %q", got, tc.wantAPIKey)
+			}
+			if got := rr.Header().Get("X-Auth-Header"); got != "Authorization" {
+				t.Fatalf("auth header = %q, want %q", got, "Authorization")
+			}
+			if got := rr.Header().Get("X-SigNoz-URL"); got != "https://1.1.1.1" {
+				t.Fatalf("signoz URL = %q, want %q", got, "https://1.1.1.1")
+			}
+		})
 	}
-	if rr.Header().Get("X-SigNoz-URL") != "https://1.1.1.1" {
-		t.Fatalf("signoz URL = %q, want %q", rr.Header().Get("X-SigNoz-URL"), "https://1.1.1.1")
+}
+
+// TestAuthMiddlewareHonorsAuthorizationWithConfigURL pins the two non-customURL
+// Authorization branches: a bearer token that is not a server-issued OAuth
+// token is honored as Authorization when a SigNoz URL comes from config,
+// whether OAuth is enabled (decrypt-fail path) or disabled.
+func TestAuthMiddlewareHonorsAuthorizationWithConfigURL(t *testing.T) {
+	cases := []struct {
+		name string
+		cfg  config.Config
+	}{
+		{
+			name: "oauth disabled",
+			cfg:  config.Config{URL: "https://signoz.example.com"},
+		},
+		{
+			name: "oauth enabled, non-oauth bearer token",
+			cfg: config.Config{
+				OAuthEnabled:     true,
+				OAuthTokenSecret: "0123456789abcdef0123456789abcdef",
+				OAuthIssuerURL:   "https://mcp.example.com",
+				URL:              "https://signoz.example.com",
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := tc.cfg
+			server := &MCPServer{logger: logpkg.New("error"), config: &cfg, analytics: noopanalytics.New()}
+			req := httptest.NewRequest(http.MethodPost, "/mcp", nil)
+			req.Header.Set("Authorization", "Bearer opaque-session-token")
+			// No X-SigNoz-URL: forces the config-URL branches.
+
+			rr := httptest.NewRecorder()
+			server.authMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				apiKey, _ := util.GetAPIKey(r.Context())
+				authHeader, _ := util.GetAuthHeader(r.Context())
+				w.Header().Set("X-API-Key", apiKey)
+				w.Header().Set("X-Auth-Header", authHeader)
+				w.WriteHeader(http.StatusOK)
+			})).ServeHTTP(rr, req)
+
+			if rr.Code != http.StatusOK {
+				t.Fatalf("status = %d, want %d", rr.Code, http.StatusOK)
+			}
+			if got := rr.Header().Get("X-API-Key"); got != "Bearer opaque-session-token" {
+				t.Fatalf("api key = %q, want %q", got, "Bearer opaque-session-token")
+			}
+			if got := rr.Header().Get("X-Auth-Header"); got != "Authorization" {
+				t.Fatalf("auth header = %q, want %q", got, "Authorization")
+			}
+		})
 	}
 }
 
@@ -753,7 +835,7 @@ func TestAuthMiddlewareAuthFailureTelemetryBranches(t *testing.T) {
 			},
 			wantStatus: http.StatusBadRequest,
 			wantReason: authFailureInvalidSignozURL,
-			wantMode:   authModeAuthorizationAPIKey,
+			wantMode:   authModeAuthorizationBearer,
 		},
 		{
 			name: "missing SigNoz URL",

--- a/pkg/util/context.go
+++ b/pkg/util/context.go
@@ -147,11 +147,13 @@ func GetAssistantExecutionID(ctx context.Context) (string, bool) {
 	return id, ok
 }
 
-// HashTenantKey returns a SHA-256 hash of apiKey and signozURL, suitable for
-// use as a cache/map key without exposing the raw API key in memory.
-// A null-byte separator is used to prevent collisions between different
-// (apiKey, signozURL) pairs that contain colons.
-func HashTenantKey(apiKey, signozURL string) string {
-	h := sha256.Sum256([]byte(apiKey + "\x00" + signozURL))
+// HashTenantKey returns a SHA-256 hash of authHeader, apiKey and signozURL,
+// suitable for use as a cache/map key without exposing the raw API key in
+// memory. The auth-header name is included so two requests carrying the same
+// raw token in different upstream modes (Authorization vs SIGNOZ-API-KEY)
+// never share a cached client. Null-byte separators prevent collisions
+// between different tuples whose fields contain colons.
+func HashTenantKey(authHeader, apiKey, signozURL string) string {
+	h := sha256.Sum256([]byte(authHeader + "\x00" + apiKey + "\x00" + signozURL))
 	return hex.EncodeToString(h[:])
 }

--- a/plans/opaque-user-token-auth.context.md
+++ b/plans/opaque-user-token-auth.context.md
@@ -1,0 +1,63 @@
+# Feature: Opaque User-Token Auth — Context & Discussion
+
+## Original Prompt
+> Suggest a solution for the opaque-user-token auth bug, and confirm whether the JWT-detection-deprecation issue is related. (Both tracked in the internal issue tracker.)
+
+## Reference Links
+- Internal issue — bug: MCP rejects opaque user tokens by forwarding them as `SIGNOZ-API-KEY`.
+- Internal issue — cleanup: deprecate the JWT token-detection logic.
+- [signoz-mcp-server#86 — feat: add JWT token support and refactor authentication header handling](https://github.com/SigNoz/signoz-mcp-server/pull/86) (the PR that introduced `isJWTToken` + the 9-row behavior table)
+- SigNoz backend auth pipeline: `pkg/identn/{resolver,config}.go`, `pkg/identn/{tokenizeridentn,apikeyidentn}/provider.go`, `pkg/tokenizer/{jwttokenizer,opaquetokenizer}`, `pkg/modules/serviceaccount/implserviceaccount/module.go`, `tests/integration/tests/serviceaccount/03_auth.py` (github.com/SigNoz/signoz)
+
+## Key Decisions & Discussion Log
+
+### 2026-06-25 — #10 and #12 are the same root cause
+- `isJWTToken()` (`internal/mcp-server/server.go:1124`, sole caller at `:1284`) is a **backward-compat shim**: its only job is to route legacy clients that put a service-account PAT in the `Authorization` header (diagram rows #5/#6) over to `SIGNOZ-API-KEY`.
+- That same shim causes #10: an **opaque (non-JWT) user/session token** sent as `Authorization: Bearer <token>` fails the JWT shape test, is rerouted to `SIGNOZ-API-KEY`, and SigNoz returns 401. Shape alone cannot distinguish an opaque user token from an opaque PAT.
+- **#12 ("deprecate jwt token detection") is the planned removal of that shim.** Removing it *is* the fix for #10. Resolve them together.
+
+### 2026-06-25 — Verified the pivotal backend contract (two independent investigations, high confidence)
+Question: does the SigNoz backend accept a service-account PAT presented as `Authorization: Bearer <pat>`?
+- **Answer: NO (rejected).** SigNoz classifies credentials **purely by header name**, not token shape:
+  - `Authorization` (and `Sec-WebSocket-Protocol`) → **tokenizer** provider → JWT signature verify OR opaque token-store DB lookup. Accepts user/session tokens (JWT *and* opaque). Rejects PATs (a PAT is neither a signed JWT nor a token-store row).
+  - `SIGNOZ-API-KEY` → **service-account** module → api-key-table lookup. Accepts PATs only. Rejects user tokens.
+  - There is **no shape-sniffing and no cross-header fallback** upstream — `isJWTToken` has no counterpart in the backend.
+- Sources: `pkg/identn/config.go` (header→provider map), `pkg/identn/resolver.go` (first-Test()-wins), `apikeyidentn/provider.go` (`extractToken` reads only SIGNOZ-API-KEY), `implserviceaccount/module.go` (`GetFactorAPIKeyByKey`), `opaquetokenizer/provider.go` (`GetByAccessToken`), `tests/integration/tests/serviceaccount/03_auth.py` (`test_service_account_key_forbidden_on_user_me`), signoz.io service-accounts doc (PAT only via `SIGNOZ-API-KEY`), `pkg/signoz/openapi.go` (two separate security schemes).
+- **Consequence:** opaque user tokens via `Authorization` already work upstream → #10's fix (stop rerouting them) is correct and safe. BUT honoring the header is **not zero-breakage**: legacy rows #5/#6 (PAT via `Authorization`) currently work *only because* MCP reroutes them to `SIGNOZ-API-KEY`; removing the reroute sends them upstream as `Authorization: Bearer <pat>` where SigNoz rejects them. So #12's removal needs a migration bridge.
+
+### 2026-06-25 — Adversarial design review findings (must address regardless of chosen bridge)
+1. Honoring the header also flips the **identity-validation endpoint** (`client.go:200-205`: `Authorization`→`/api/v2/users/me`, principal=user; `SIGNOZ-API-KEY`→`/api/v1/service_accounts/me`, principal=service_account). Correct for real user tokens; a deprecated Bearer-PAT would be mislabeled `principal=user` — acceptable since that path is being removed.
+2. **Latent cache-key bug:** `HashTenantKey(apiKey, signozURL)` (`handler.go:81`, `context.go:154`) omits the auth-header name. Today modes don't collide only because the stored `apiKey` differs by the literal `"Bearer "` prefix. Any future normalization would silently serve a wrong-mode client. **Include `authHeader` in the cache key regardless of bridge chosen.**
+3. **Scope:** the bug repro is the `customURL != ""` branch (`:1283-1296`), but two other `Authorization` branches also force `SIGNOZ-API-KEY` — the OAuth-disabled no-customURL `else` (`:1338-1342`) and the OAuth-decrypt-fail legacy fallback (`:1326-1336`). #10 persists for config-`SIGNOZ_URL` clients unless the fix is applied consistently across all three (or the contract explicitly documents "honoring only applies with X-SigNoz-URL").
+4. **OAuth path is orthogonal** — the OAuth setup form validates and stores a service-account API key; keep the decrypted-token path on `SIGNOZ-API-KEY`. Do **not** thread an auth-mode into the encrypted OAuth payload (wrong scope; would force a token-format migration).
+5. **Observability (CLAUDE.md cross-contract rule):** fixtures cannot catch backend drift on Bearer-PAT acceptance; the failure is a silent 401. Emit a distinct `mcp.auth.mode` for "Authorization-ingress, non-JWT" and a WARN/metric on "Authorization-ingress request got upstream 401" so the deprecation window is observable.
+
+## Key Decisions & Discussion Log (cont.)
+
+### 2026-06-25 — Bridge decision: clean fix (Option A, no telemetry gate, no fallback)
+- Owner: "We already gave deprecation notice 3 months back so let's do clean fix." The #12 deprecation notice predates today by ~3 months (issue filed 2026-03-24) — well past the stated 1-month window.
+- **Decision: do the clean honor-the-header cutover now.** No Phase-0 measurement gate and no try-both fallback (Option B) — the deprecation window has already elapsed, so legacy rows #5/#6 (PAT via `Authorization`) are intentionally broken and must use `SIGNOZ-API-KEY`. Option C remains rejected.
+- Apply honoring to **all three** `Authorization` raw-token branches (consistent contract; fixes #10 for config-`SIGNOZ_URL` clients too). Collapse the JWT/APIKey auth-modes into a single `authModeAuthorizationBearer`. Delete `isJWTToken` (completes #12).
+- Keep the cache-key hardening (`HashTenantKey` to include the auth-header name) — cheap, makes the mode-isolation invariant explicit rather than accidental.
+- OAuth-decrypted path stays on `SIGNOZ-API-KEY` (orthogonal, unchanged).
+- Owner added: "no cloud users are using that route anyway" — legacy PAT-via-`Authorization` (rows #5/#6) has effectively zero real traffic, so the cutover carries no practical breakage risk for Cloud.
+
+### 2026-06-25 — Implemented + Codex review
+- Implemented the clean cutover: honor the ingress header across all three Authorization branches; deleted `isJWTToken` and the unused `authorization-jwt`/`authorization-api-key` auth-modes (consolidated on `authorization-bearer`); `HashTenantKey` now includes the auth-header name; OAuth-decrypted path unchanged. All unit tests pass.
+- Codex (gpt-5.5, xhigh, read-only) review: **no blocker/high findings**; confirmed no regression to OAuth success / expired-challenge / invalid-OAuth-no-URL / SIGNOZ-API-KEY / env-fallback / missing-credential paths. Two mediums, both addressed:
+  1. `Bearer ` prefix stripping was case-sensitive → added `stripBearerPrefix` (case-insensitive per RFC 7235, matching SigNoz's own parser); fixes lowercase `bearer` double-prefix + a latent OAuth-decrypt miss.
+  2. Test gaps → added no-prefix + lowercase-bearer table cases and a new `TestAuthMiddlewareHonorsAuthorizationWithConfigURL` pinning the OAuth-disabled and OAuth-decrypt-fail config-URL branches.
+- **Public-repo hygiene:** `signoz-mcp-server` is public; scrubbed the internal tracker name and private issue URLs from all code/docs/plan files added here. (Pre-existing committed leaks remain in `internal/handler/tools/param_schema_test.go` and `plans/param-consistency-cleanup.*` — flagged to owner, not cleaned here.)
+- **Live E2E — PASSED** (read-only subagent, two staging instances, no resources created, no credential leak):
+  - Direct upstream: JWT and opaque tokens both → HTTP 200 on `/api/v2/users/me` via `Authorization: Bearer`; opaque token via `SIGNOZ-API-KEY` on `/api/v1/service_accounts/me` → 401 (confirms it is a user token, not a PAT — exactly the old bug). JWT identity round-tripped (email/orgId match).
+  - Through `/mcp` (HTTP multi-tenant, `X-SigNoz-URL` branch): `signoz_list_services` returned real data for both tokens, forwarded on `Authorization` to the correct tenant, no 401/isError. Logs showed only the per-tenant client creation and no SIGNOZ-API-KEY/OAuth/auth-failure routes.
+  - Added a `DebugContext("Forwarding Authorization bearer token upstream")` line to the `customURL` branch (the only honored path that previously had no debug line) so the cutover is directly observable. Status → Done.
+
+### 2026-06-25 — Removed new debug logs (owner request)
+- Owner: "Why did we add new debug logs, remove them … Only remove new debug log, keep modified ones." Verified against origin/main: the `customURL` branch AND the OAuth-disabled `else` branch had **no** debug log before — both `"Forwarding Authorization bearer token upstream"` lines were new (the else-branch one slipped in during the earlier diff-fix). Removed both. Kept the one genuine modification: the OAuth-decrypt-fail branch message, updated from `"…falling back to raw API key"` → `"…forwarding as Authorization"`. The `config.APIKey`-branch log is untouched. Net debug-log delta vs main: that single message change.
+
+## Open Questions
+- [x] **Bridge strategy for legacy rows #5/#6** — RESOLVED 2026-06-25: clean cutover (Option A), deprecation window already elapsed.
+- [x] **Apply to all three `Authorization` branches?** — RESOLVED: yes, all three.
+- [ ] Live E2E probe against staging to *operationally* re-confirm the source-derived contract (PAT via `Authorization` → reject; opaque user token via `Authorization` → 200). Delegate to a subagent per CLAUDE.md; never print credentials. (Verification step, not a blocker for the code change.)
+- [ ] Optional follow-up: WARN/metric when an `authModeAuthorizationBearer` request gets an upstream 401 (spots legacy stragglers post-cutover). Deferred — crosses into the client layer; not required for the clean fix.

--- a/plans/opaque-user-token-auth.plan.md
+++ b/plans/opaque-user-token-auth.plan.md
@@ -1,0 +1,57 @@
+# Plan: Opaque User-Token Auth
+
+## Status
+Done
+
+## Context
+The MCP auth middleware decides which header to forward upstream to SigNoz: `SIGNOZ-API-KEY: <pat>` (service-account) or `Authorization: Bearer <token>` (user/session). For the `Authorization` ingress it currently sniffs token **shape** via `isJWTToken()` (`server.go:1124`, sole caller `:1284`): JWT-shaped → forward `Authorization`; otherwise → reroute to `SIGNOZ-API-KEY`.
+
+That shape-sniff is the **opaque-user-token bug**: an opaque (non-JWT) user/session token is rerouted to `SIGNOZ-API-KEY`, which SigNoz rejects (401). It is also exactly the heuristic the **JWT-detection-deprecation issue** wants to delete. The two issues share one root cause.
+
+**Verified backend contract (high confidence, from SigNoz source + docs):** SigNoz discriminates credentials by **header name**, not shape. `Authorization` → tokenizer (JWT *or* opaque user tokens); `SIGNOZ-API-KEY` → service-account PATs. A PAT on `Authorization` is **rejected**; an opaque user token on `Authorization` is **accepted**. So MCP should stop second-guessing the header — the header name is canonical. The only casualty is the legacy/undocumented path where a client puts a PAT in `Authorization` (diagram rows #5/#6), which today works only because MCP reroutes it.
+
+## Behavior table — before vs after (honor-the-header end state)
+| # | Client sends | Today → upstream | After → upstream | Change |
+|---|---|---|---|---|
+| 1 | `SIGNOZ-API-KEY: pat` | `SIGNOZ-API-KEY: pat` | same | — |
+| 2 | `SIGNOZ-API-KEY: Bearer pat` | `SIGNOZ-API-KEY: pat` | same | — |
+| 3 | `Authorization: Bearer <JWT>` | `Authorization: Bearer <JWT>` | same | — |
+| 4 | `Authorization: <JWT>` (no prefix) | `Authorization: Bearer <JWT>` | same | — |
+| **#10** | `Authorization: Bearer <opaque user token>` | `SIGNOZ-API-KEY: <token>` → **401** | `Authorization: Bearer <token>` → **200** | **FIXED** |
+| 5 | `Authorization: pat` (legacy) | `SIGNOZ-API-KEY: pat` → 200 | `Authorization: Bearer pat` → **401** | **BREAKS** (needs bridge) |
+| 6 | `Authorization: Bearer pat` (legacy) | `SIGNOZ-API-KEY: pat` → 200 | `Authorization: Bearer pat` → **401** | **BREAKS** (needs bridge) |
+| 7 | no headers, env `SIGNOZ_API_KEY` | `SIGNOZ-API-KEY: <env>` | same | — |
+| 9 | stdio `SIGNOZ_API_KEY=pat` | `SIGNOZ-API-KEY: pat` | same | — |
+
+## Approach
+**Clean cutover** (decided 2026-06-25): the #12 deprecation notice already went out ~3 months ago and the owner confirms no Cloud users use the legacy PAT-via-`Authorization` route, so we honor the ingress header directly with **no measurement gate and no try-both fallback**. #10 is fixed and #12 is completed in one PR. Legacy rows #5/#6 are intentionally retired (must move to `SIGNOZ-API-KEY`).
+
+1. **Honor the ingress header** for every raw (non-OAuth) `Authorization` token. Replace the `isJWTToken` if/else at `server.go:1283-1296` and apply the same to the other two raw-token branches — OAuth-disabled no-`customURL` `else` (`:1338-1342`) and OAuth-decrypt-fail legacy fallback (`:1332-1335`). In each: `apiKey = "Bearer " + token`; `SetAuthHeader(ctx, "Authorization")`; `authMode = authModeAuthorizationBearer`. **Load-bearing invariant:** `client.go:271/360` does `req.Header.Set(authHeaderName, apiKey)` verbatim — it does NOT add `"Bearer "`, so the middleware must bake the prefix into `apiKey`.
+2. **Delete `isJWTToken`** (`server.go:1124-1126`, now caller-less) — the concrete deliverable of **#12**. Collapse `authModeAuthorizationJWT` and `authModeAuthorizationAPIKey` into the single `authModeAuthorizationBearer` (remove the now-unused constants).
+3. **Cache-key hardening:** include the auth-header name in `HashTenantKey` (`pkg/util/context.go:154`, caller `handler.go:81`) so mode isolation is explicit, not an accident of the `"Bearer "` prefix.
+4. **Untouched:** OAuth-decrypt success (`:1297-1306`), OAuth-expired rejection, the invalid-OAuth-no-URL rejection guard, and the OAuth setup-form validation (`oauth/handlers.go:333`) all stay on `SIGNOZ-API-KEY` — they are service-account-backed and orthogonal to #10.
+
+Deferred (not in this PR): a WARN/metric when an `authModeAuthorizationBearer` request gets an upstream 401 (would spot any legacy straggler) — crosses into the client layer and isn't needed given zero Cloud traffic on the route.
+
+## Files to Modify
+- `internal/mcp-server/server.go` — `:1283-1296` honor-header (primary fix); `:1326-1342` consistency for the other two Authorization branches; `:1124-1126` delete `isJWTToken` (#12); `:1128-1135` authMode constants (distinct legacy mode + telemetry); `:1262-1267` update the contract comment.
+- `pkg/util/context.go` — `HashTenantKey` to include auth-header name (`:154`).
+- `internal/handler/tools/handler.go` — pass auth-header into the cache key at `:81` (consumes the `context.go` change). `GetClient` is otherwise mode-agnostic; no logic change.
+- `internal/client/client.go` — no change for Phase 1 (already honors `authHeaderName`, switches `/me` endpoint). Bridge **(B)** would add one-time mode resolution here.
+- **Tests:**
+  - `internal/mcp-server/server_test.go` — `TestAuthMiddlewareFallsBackToRawAPIKey` pins rows #5/#6; update to assert honored `Authorization` + `"Bearer "`-prefixed key (and rename). `TestAuthMiddlewareAuthFailureTelemetryBranches/invalid_SigNoz_URL` (`:756`) pins the old authMode; update. **Add** a parametrized test proving a JWT-shaped *and* an opaque token via `Authorization` both forward identically (the #10 regression guard). Other auth tests are review-only.
+  - `internal/client/client_test.go` — optional table row with an opaque (non-`eyJ`) value in `Authorization` mode to lock out future shape-sniffing.
+- **Docs/metadata (per CLAUDE.md doc-sync):**
+  - `docs/architecture.md` — rewrite the auth-flow Mermaid (`RAWKEY`/`PARSE` nodes ~`:44-45`) and Backward-Compatibility section (`:172`) to the honor-the-header model + note the #5/#6 change.
+  - `README.md` — review for stale `Authorization`/`Bearer` routing claims (likely no functional change; state the review outcome in the PR).
+  - `manifest.json` — **no change** (no tool/resource/config added or renamed); state explicitly in PR.
+  - **SigNoz/agent-skills** — **no change**: this alters only internal upstream-forwarding classification, not the client-facing tool contract; state outcome in PR, no companion PR needed.
+
+## Verification
+- Unit: updated `server_test.go` (honored Authorization for opaque + JWT), cache-key includes auth-header, telemetry split asserted.
+- **Live E2E (delegate to subagent against staging, per CLAUDE.md; never print credentials):**
+  - opaque user token via `Authorization: Bearer` → tool call returns 200 (the #10 repro now passes); confirm forwarded header is `Authorization`.
+  - service-account PAT via `SIGNOZ-API-KEY` → still 200 (rows #1/#7/#9 unchanged).
+  - service-account PAT via `Authorization: Bearer` → operationally confirm the source-derived **reject** (decides whether bridge B is required); the `e2e_family*_test.go` helpers already build Authorization-mode clients and are the natural harness.
+  - delete nothing it didn't create; report which fields round-tripped.
+- Observability: confirm the new `mcp.auth.mode` value and the upstream-401 WARN/metric fire on a simulated legacy PAT-via-`Authorization` request.


### PR DESCRIPTION
## Problem

The auth middleware classified `Authorization` bearer tokens by **shape** (`isJWTToken`) and rerouted any non-JWT token to the `SIGNOZ-API-KEY` header. Opaque user/session tokens are not JWT-shaped, so they were rerouted and rejected upstream with **401** — even though SigNoz accepts them on the `Authorization` header.

The shape heuristic existed only as a backward-compat shim for legacy clients that sent a service-account API key on `Authorization`. It conflated those (which need `SIGNOZ-API-KEY`) with opaque user tokens (which need `Authorization`) — and they are indistinguishable by shape.

## Root cause (verified)

SigNoz classifies credentials **by header name, not token shape**:

| Ingress header | Upstream provider | Accepts | Rejects |
|---|---|---|---|
| `Authorization: Bearer` | tokenizer (JWT signature **or** opaque token-store lookup) | user/session tokens (JWT **and** opaque) | service-account API keys |
| `SIGNOZ-API-KEY` | service-account store | service-account API keys | user/session tokens |

So the MCP server should stop second-guessing the header.

## Change

- **Honor the ingress header** for every raw (non-OAuth) `Authorization` token — forward it upstream as `Authorization: Bearer <token>` regardless of shape — across all three `Authorization` branches (`X-SigNoz-URL` present, OAuth-decrypt-fail with a config URL, OAuth disabled).
- **Remove `isJWTToken`** and the now-unused `authorization-jwt` / `authorization-api-key` auth modes; consolidate on `authorization-bearer`.
- Bearer-scheme stripping is now **case-insensitive** (RFC 7235), matching the SigNoz backend's own parser; fixes a `bearer ` double-prefix and a latent OAuth-decrypt miss.
- `HashTenantKey` now includes the **auth-header name** so the same raw token in two modes never shares a cached client.
- The **OAuth-issued-token path is unchanged** (decrypts to a stored service-account key, forwarded on `SIGNOZ-API-KEY`), as is the OAuth setup-form validation.

## Breaking change

Legacy clients sending a **service-account API key on the `Authorization` header** must move to the `SIGNOZ-API-KEY` header. This route was deprecated previously and has no remaining real usage; honoring the header is the completion of that deprecation.

## Tests & verification

- Rewrote the legacy `Authorization`-fallback test into a table proving opaque, JWT-shaped, no-prefix, and lowercase-`bearer` inputs all forward identically; added a test pinning the two config-URL branches. Full suite green; `gofmt`/`vet` clean.
- Independent code review (no blocker/high findings; two mediums — case-sensitivity and test coverage — addressed).
- **Live E2E** against two staging instances (read-only, no resources created): a JWT and an opaque user token both return **200** via `Authorization` directly and end-to-end through `/mcp` (`signoz_list_services` returned real data, forwarded to the correct tenant). The opaque token via `SIGNOZ-API-KEY` returns **401**, confirming the original bug.

## Docs & metadata sync

- `docs/architecture.md` — auth-flow updated (header-honoring model + removed-heuristic note).
- `README.md` — reviewed; no functional change (it documents `SIGNOZ-API-KEY`/OAuth, not the internal header classification).
- `manifest.json` — no change (no tool/resource/config added, renamed, or removed).
- **agent-skills** — no change needed: this alters only the server's internal upstream-forwarding classification, not the client-facing tool contract.
- Design notes added under `plans/opaque-user-token-auth.*`.
