### PR TITLE
fix(traces): migrate trace fields to snake_case

### DIFF
--- a/README.md
+++ b/README.md
@@ -682,7 +682,7 @@ Get possible values for a specific field key for a given signal.
 Search traces/spans with flexible filtering.
 
 - **Parameters**:
-  - `filter` (optional) - Filter expression using SigNoz search syntax. Combine conditions with AND, OR, and parentheses (e.g., "service.name = 'payment-svc' AND (hasError = true OR responseStatusCode >= 500)"). Legacy `query` is still accepted for backward compatibility, but `filter` is canonical. See `signoz://traces/query-builder-guide`
+  - `filter` (optional) - Filter expression using SigNoz search syntax. Combine conditions with AND, OR, and parentheses (e.g., "service.name = 'payment-svc' AND (has_error = true OR attribute.http.response.status_code >= 500)"). Legacy `query` is still accepted for backward compatibility, but `filter` is canonical. See `signoz://traces/query-builder-guide`
   - `service` (optional) - Service name to filter by
   - `operation` (optional) - Operation/span name to filter by
   - `error` (optional) - Filter by error status. Boolean (or the strings `"true"`/`"false"`). An invalid value is rejected rather than silently dropped
@@ -692,6 +692,7 @@ Search traces/spans with flexible filtering.
   - `limit` (optional) - Maximum number of traces to return (default: 100, max: 10000; higher values are clamped — paginate with `offset`)
   - `offset` (optional) - Offset for pagination (default: 0)
   - **Completeness note**: the response appends a note reporting `hasMore` (inferred from `returnedRows == limit`) and the `nextOffset` to fetch, so a truncated page is never mistaken for the full result set
+  - **Output note**: raw result row keys follow canonical Query Builder field names (for example `trace_id`, `span_id`, `duration_nano`, `has_error`). Legacy caller-provided filters such as `hasError` still pass through to the backend alias layer, but new response parsers should read the canonical snake_case keys.
 
 #### `signoz_aggregate_traces`
 
@@ -699,13 +700,13 @@ Aggregate trace statistics like count, average, sum, min, max, or percentiles ov
 
 - **Parameters**:
   - `aggregation` (required) - Aggregation function: count, count_distinct, avg, sum, min, max, p50, p75, p90, p95, p99, rate
-  - `aggregateOn` (optional) - Field to aggregate on (e.g., 'durationNano'). Required for all except count and rate
+  - `aggregateOn` (optional) - Field to aggregate on (e.g., 'duration_nano'). Required for all except count and rate
   - `groupBy` (optional) - Comma-separated fields to group by (e.g., 'service.name, name')
   - `filter` (optional) - Filter expression using SigNoz search syntax. Combine conditions with AND, OR, and parentheses. Unknown keys hard-error; ambiguous keys default to resource context. See `signoz://traces/query-builder-guide`
   - `service` (optional) - Shortcut filter for service name
   - `operation` (optional) - Shortcut filter for span/operation name
   - `error` (optional) - Shortcut filter for error spans. Boolean (or the strings `"true"`/`"false"`). An invalid value is rejected rather than silently dropped
-  - `orderBy` (optional) - Order expression and direction (e.g., 'avg(durationNano) desc')
+  - `orderBy` (optional) - Order expression and direction (e.g., 'avg(duration_nano) desc')
   - `limit` (optional) - Maximum number of groups to return (default: 10, max: 10000; higher values are clamped to bound server memory)
   - `timeRange` (optional) - Relative time range `<number><unit>` where unit is `m`/`h`/`d` (e.g. '30m', '1h', '6h', '24h', '7d'; default: '1h'; ignored when both `start` and `end` are provided)
   - `start` / `end` (optional) - Start/end time in unix milliseconds. When both are provided, they override `timeRange`.

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -732,7 +732,7 @@ func (s *SigNoz) GetTraceDetails(ctx context.Context, traceID string, includeSpa
 		return nil, fmt.Errorf("start and end time parameters are required")
 	}
 
-	filterExpression := fmt.Sprintf("traceID = '%s'", traceID)
+	filterExpression := fmt.Sprintf("trace_id = '%s'", traceID)
 	limit := 1000
 
 	queryPayload := types.BuildTracesQueryPayload(startTime, endTime, filterExpression, limit, 0)

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -1251,6 +1251,31 @@ func TestQueryBuilderV5(t *testing.T) {
 	}
 }
 
+func TestGetTraceDetails_UsesCanonicalTraceIDFilter(t *testing.T) {
+	var captured []byte
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, "/api/v5/query_range", r.URL.Path)
+		body, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+		captured = body
+
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"status":"success","data":{"result":[]}}`))
+	}))
+	defer server.Close()
+
+	logger := logpkg.New("debug")
+	client := NewClient(logger, server.URL, "test-api-key", "SIGNOZ-API-KEY", nil)
+
+	_, err := client.GetTraceDetails(context.Background(), "abc123", true, 1711123200000, 1711130400000)
+	require.NoError(t, err)
+
+	payload := string(captured)
+	require.Contains(t, payload, `"expression":"trace_id = 'abc123'"`)
+	require.NotContains(t, payload, `"expression":"traceID = 'abc123'"`)
+}
+
 func TestCreateDashboard(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodPost, r.Method)

--- a/internal/handler/tools/aggregate_helper.go
+++ b/internal/handler/tools/aggregate_helper.go
@@ -40,6 +40,60 @@ const allowedAggregations = "avg, count, count_distinct, max, min, p50, p75, p90
 
 const conflictingFilterAliasError = "both 'filter' and 'query' were provided with different values; use only 'filter' (the 'query' alias is legacy)"
 
+var traceGroupByFieldMetadata = map[string]types.SelectField{
+	"trace_id":             {Name: "trace_id", FieldDataType: "string", Signal: "traces", FieldContext: "span"},
+	"span_id":              {Name: "span_id", FieldDataType: "string", Signal: "traces", FieldContext: "span"},
+	"parent_span_id":       {Name: "parent_span_id", FieldDataType: "string", Signal: "traces", FieldContext: "span"},
+	"name":                 {Name: "name", FieldDataType: "string", Signal: "traces", FieldContext: "span"},
+	"duration_nano":        {Name: "duration_nano", FieldDataType: "number", Signal: "traces", FieldContext: "span"},
+	"timestamp":            {Name: "timestamp", FieldDataType: "number", Signal: "traces", FieldContext: "span"},
+	"has_error":            {Name: "has_error", FieldDataType: "bool", Signal: "traces", FieldContext: "span"},
+	"status_code":          {Name: "status_code", FieldDataType: "number", Signal: "traces", FieldContext: "span"},
+	"status_code_string":   {Name: "status_code_string", FieldDataType: "string", Signal: "traces", FieldContext: "span"},
+	"http_method":          {Name: "http_method", FieldDataType: "string", Signal: "traces", FieldContext: "span"},
+	"http_url":             {Name: "http_url", FieldDataType: "string", Signal: "traces", FieldContext: "span"},
+	"kind_string":          {Name: "kind_string", FieldDataType: "string", Signal: "traces", FieldContext: "span"},
+	"kind":                 {Name: "kind", FieldDataType: "number", Signal: "traces", FieldContext: "span"},
+	"response_status_code": {Name: "response_status_code", FieldDataType: "string", Signal: "traces", FieldContext: "span"},
+	"status_message":       {Name: "status_message", FieldDataType: "string", Signal: "traces", FieldContext: "span"},
+
+	"service.name":            {Name: "service.name", FieldDataType: "string", Signal: "traces", FieldContext: "resource"},
+	"cloud.account.id":        {Name: "cloud.account.id", FieldDataType: "string", Signal: "traces", FieldContext: "resource"},
+	"cloud.platform":          {Name: "cloud.platform", FieldDataType: "string", Signal: "traces", FieldContext: "resource"},
+	"cloud.provider":          {Name: "cloud.provider", FieldDataType: "string", Signal: "traces", FieldContext: "resource"},
+	"cloud.region":            {Name: "cloud.region", FieldDataType: "string", Signal: "traces", FieldContext: "resource"},
+	"deployment.environment":  {Name: "deployment.environment", FieldDataType: "string", Signal: "traces", FieldContext: "resource"},
+	"host.name":               {Name: "host.name", FieldDataType: "string", Signal: "traces", FieldContext: "resource"},
+	"k8s.cluster.name":        {Name: "k8s.cluster.name", FieldDataType: "string", Signal: "traces", FieldContext: "resource"},
+	"k8s.namespace.name":      {Name: "k8s.namespace.name", FieldDataType: "string", Signal: "traces", FieldContext: "resource"},
+	"k8s.node.name":           {Name: "k8s.node.name", FieldDataType: "string", Signal: "traces", FieldContext: "resource"},
+	"k8s.pod.name":            {Name: "k8s.pod.name", FieldDataType: "string", Signal: "traces", FieldContext: "resource"},
+	"k8s.pod.start_time":      {Name: "k8s.pod.start_time", FieldDataType: "string", Signal: "traces", FieldContext: "resource"},
+	"k8s.pod.uid":             {Name: "k8s.pod.uid", FieldDataType: "string", Signal: "traces", FieldContext: "resource"},
+	"k8s.statefulset.name":    {Name: "k8s.statefulset.name", FieldDataType: "string", Signal: "traces", FieldContext: "resource"},
+	"service.version":         {Name: "service.version", FieldDataType: "string", Signal: "traces", FieldContext: "resource"},
+	"signoz.deployment.tier":  {Name: "signoz.deployment.tier", FieldDataType: "string", Signal: "traces", FieldContext: "resource"},
+	"signoz.workload":         {Name: "signoz.workload", FieldDataType: "string", Signal: "traces", FieldContext: "resource"},
+	"signoz.workspace.key.id": {Name: "signoz.workspace.key.id", FieldDataType: "string", Signal: "traces", FieldContext: "resource"},
+
+	"client.address":            {Name: "client.address", FieldDataType: "string", Signal: "traces", FieldContext: "tag"},
+	"http.request.method":       {Name: "http.request.method", FieldDataType: "string", Signal: "traces", FieldContext: "tag"},
+	"http.response.body.size":   {Name: "http.response.body.size", FieldDataType: "string", Signal: "traces", FieldContext: "tag"},
+	"http.response.status_code": {Name: "http.response.status_code", FieldDataType: "number", Signal: "traces", FieldContext: "tag"},
+	"http.route":                {Name: "http.route", FieldDataType: "string", Signal: "traces", FieldContext: "tag"},
+	"rpc.method":                {Name: "rpc.method", FieldDataType: "string", Signal: "traces", FieldContext: "tag"},
+	"network.peer.address":      {Name: "network.peer.address", FieldDataType: "string", Signal: "traces", FieldContext: "tag"},
+	"network.peer.port":         {Name: "network.peer.port", FieldDataType: "string", Signal: "traces", FieldContext: "tag"},
+	"network.protocol.version":  {Name: "network.protocol.version", FieldDataType: "string", Signal: "traces", FieldContext: "tag"},
+	"server.address":            {Name: "server.address", FieldDataType: "string", Signal: "traces", FieldContext: "tag"},
+	"url.path":                  {Name: "url.path", FieldDataType: "string", Signal: "traces", FieldContext: "tag"},
+	"url.scheme":                {Name: "url.scheme", FieldDataType: "string", Signal: "traces", FieldContext: "tag"},
+	"db.operation":              {Name: "db.operation", FieldDataType: "string", Signal: "traces", FieldContext: "tag"},
+	"db.statement":              {Name: "db.statement", FieldDataType: "string", Signal: "traces", FieldContext: "tag"},
+	"db.system":                 {Name: "db.system", FieldDataType: "string", Signal: "traces", FieldContext: "tag"},
+	"messaging.system":          {Name: "messaging.system", FieldDataType: "string", Signal: "traces", FieldContext: "tag"},
+}
+
 // timeRangeDesc builds the shared "timeRange" description. All time-windowed
 // tools use one parser (timeutil.ParseTimeRange), so only the per-tool default
 // window differs — defaultDesc is that trailing sentence (e.g. "Defaults to
@@ -176,7 +230,7 @@ func parseAggregateArgs(args map[string]any, signal string, filterExpr string) (
 		for _, field := range strings.Split(groupByStr, ",") {
 			field = strings.TrimSpace(field)
 			if field != "" {
-				groupByFields = append(groupByFields, types.SelectField{Name: field, Signal: signal})
+				groupByFields = append(groupByFields, aggregateGroupByField(signal, field))
 			}
 		}
 	}
@@ -237,6 +291,15 @@ func parseAggregateArgs(args map[string]any, signal string, filterExpr string) (
 		StepInterval:        stepInterval,
 		StepIntervalWarning: stepIntervalWarning,
 	}, nil
+}
+
+func aggregateGroupByField(signal, name string) types.SelectField {
+	if signal == "traces" {
+		if field, ok := traceGroupByFieldMetadata[name]; ok {
+			return field
+		}
+	}
+	return types.SelectField{Name: name, Signal: signal}
 }
 
 func resolveTimestamps(args map[string]any, defaultRange string) (int64, int64, error) {

--- a/internal/handler/tools/e2e_familya_test.go
+++ b/internal/handler/tools/e2e_familya_test.go
@@ -623,8 +623,8 @@ func e2eFindTraceID(t *testing.T, h *Handler, ctx context.Context) string {
 		return ""
 	}
 	body := firstTextBlock(t, res)
-	// Walk data.data.results[].rows[].data.traceID (the same shape the row
-	// counter uses); fall back to a loose scan for any "traceID"/"trace_id".
+	// Walk data.data.results[].rows[].data trace id fields. Prefer the
+	// canonical trace_id key, with legacy fallbacks for older raw responses.
 	var env struct {
 		Data struct {
 			Data struct {
@@ -639,7 +639,7 @@ func e2eFindTraceID(t *testing.T, h *Handler, ctx context.Context) string {
 	if err := json.Unmarshal([]byte(body), &env); err == nil {
 		for _, r := range env.Data.Data.Results {
 			for _, row := range r.Rows {
-				for _, k := range []string{"traceID", "trace_id", "traceId"} {
+				for _, k := range []string{"trace_id", "traceID", "traceId"} {
 					if v, ok := row.Data[k].(string); ok && v != "" {
 						return v
 					}

--- a/internal/handler/tools/e2e_familyd_test.go
+++ b/internal/handler/tools/e2e_familyd_test.go
@@ -372,7 +372,7 @@ func TestFamilyD_E2E_AggregationSetMatchesBackend(t *testing.T) {
 
 	// "count" and "rate" need no field; the rest need an aggregateOn. Use a
 	// field that exists on traces everywhere.
-	const numericField = "durationNano"
+	const numericField = "duration_nano"
 	var rejected []string
 	for agg := range validAggregations {
 		args := map[string]any{

--- a/internal/handler/tools/e2e_trace_fields_test.go
+++ b/internal/handler/tools/e2e_trace_fields_test.go
@@ -1,0 +1,207 @@
+//go:build e2e
+
+// Live E2E coverage for the trace field snake_case migration. These tests are
+// read-only and use existing trace data from the target SigNoz instance.
+package tools
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestE2ETraceFields_SnakeCaseMigration(t *testing.T) {
+	h, ctx := e2eHandlerC(t)
+	const traceWindow = "24h"
+
+	search := callOK(t, h.handleSearchTraces, ctx, "signoz_search_traces", map[string]any{
+		"timeRange": traceWindow,
+		"limit":     "5",
+	})
+	rows := traceFieldRows(t, firstText(search))
+	if len(rows) == 0 {
+		t.Skip("no traces found on staging; cannot verify trace field migration live")
+	}
+
+	row, traceID, ok := firstTraceFieldRowWithID(rows)
+	if !ok {
+		t.Fatalf("search_traces returned rows but none carried canonical trace_id; body prefix: %s", truncForLog(firstText(search)))
+	}
+	for _, key := range []string{"trace_id", "span_id", "duration_nano", "has_error", "service.name", "webUrl"} {
+		if _, ok := row[key]; !ok {
+			t.Fatalf("search_traces row missing canonical field %q; row keys: %v", key, traceFieldKeys(row))
+		}
+	}
+	for _, deprecated := range []string{"traceID", "spanID", "durationNano", "hasError"} {
+		if _, ok := row[deprecated]; ok {
+			t.Fatalf("search_traces row still contains deprecated field %q; row keys: %v", deprecated, traceFieldKeys(row))
+		}
+	}
+	if webURL := rawJSONString(row["webUrl"]); !strings.Contains(webURL, "/trace/") {
+		t.Fatalf("search_traces row webUrl = %q, want trace deep link", webURL)
+	}
+	t.Logf("search_traces canonical row fields round-tripped: trace_id/span_id/duration_nano/has_error/service.name/webUrl")
+
+	callOK(t, h.handleSearchTraces, ctx, "signoz_search_traces", map[string]any{
+		"timeRange":   traceWindow,
+		"limit":       "1",
+		"error":       false,
+		"minDuration": "0",
+		"maxDuration": "86400000000000",
+	})
+	t.Logf("search_traces canonical shortcut filters accepted: has_error=false and duration_nano bounds")
+
+	callOK(t, h.handleSearchTraces, ctx, "signoz_search_traces", map[string]any{
+		"timeRange": traceWindow,
+		"limit":     "1",
+		"filter":    "durationNano >= 0",
+	})
+	t.Logf("search_traces legacy free-form durationNano filter still passes through")
+
+	callOK(t, h.handleAggregateTraces, ctx, "signoz_aggregate_traces", map[string]any{
+		"timeRange":   traceWindow,
+		"aggregation": "p99",
+		"aggregateOn": "duration_nano",
+		"requestType": "scalar",
+	})
+	t.Logf("aggregate_traces canonical duration_nano aggregation accepted")
+
+	grouped := callOK(t, h.handleAggregateTraces, ctx, "signoz_aggregate_traces", map[string]any{
+		"timeRange":   traceWindow,
+		"aggregation": "count",
+		"groupBy":     "service.name",
+		"limit":       "5",
+		"requestType": "scalar",
+	})
+	columns, groupedRows := traceAggregateColumnsAndRowCount(t, firstText(grouped))
+	if groupedRows == 0 {
+		t.Fatalf("aggregate_traces groupBy=service.name returned no aggregate rows despite recent trace rows")
+	}
+	if !traceContainsString(columns, "service.name") {
+		t.Fatalf("aggregate_traces groupBy columns missing service.name; columns: %v; body prefix: %s", columns, truncForLog(firstText(grouped)))
+	}
+	t.Logf("aggregate_traces groupBy=service.name accepted and returned service.name groups")
+
+	details := callOK(t, h.handleGetTraceDetails, ctx, "signoz_get_trace_details", map[string]any{
+		"traceId":      traceID,
+		"timeRange":    traceWindow,
+		"includeSpans": true,
+	})
+	if body := firstText(details); !strings.Contains(body, `"webUrl"`) || !strings.Contains(body, "/trace/") {
+		t.Fatalf("get_trace_details response missing trace webUrl; body prefix: %s", truncForLog(body))
+	}
+	t.Logf("get_trace_details found trace via canonical trace_id-backed lookup and returned webUrl")
+}
+
+type traceFieldRow map[string]json.RawMessage
+
+func traceFieldRows(t *testing.T, body string) []traceFieldRow {
+	t.Helper()
+	var env struct {
+		Data struct {
+			Data struct {
+				Results []struct {
+					Rows []struct {
+						Data traceFieldRow `json:"data"`
+					} `json:"rows"`
+				} `json:"results"`
+			} `json:"data"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal([]byte(body), &env); err != nil {
+		t.Fatalf("unmarshal query_range body: %v; body prefix: %s", err, truncForLog(body))
+	}
+	var rows []traceFieldRow
+	for _, result := range env.Data.Data.Results {
+		for _, row := range result.Rows {
+			if row.Data != nil {
+				rows = append(rows, row.Data)
+			}
+		}
+	}
+	return rows
+}
+
+func firstTraceFieldRowWithID(rows []traceFieldRow) (traceFieldRow, string, bool) {
+	for _, row := range rows {
+		if id := rawJSONString(row["trace_id"]); id != "" {
+			return row, id, true
+		}
+	}
+	return nil, "", false
+}
+
+func rawJSONString(raw json.RawMessage) string {
+	var s string
+	if err := json.Unmarshal(raw, &s); err != nil {
+		return ""
+	}
+	return s
+}
+
+func traceFieldKeys(row traceFieldRow) []string {
+	keys := make([]string, 0, len(row))
+	for key := range row {
+		keys = append(keys, key)
+	}
+	return keys
+}
+
+func traceAggregateColumnsAndRowCount(t *testing.T, body string) ([]string, int) {
+	t.Helper()
+	var env struct {
+		Data struct {
+			Data struct {
+				Results []struct {
+					Columns []json.RawMessage `json:"columns"`
+					Data    json.RawMessage   `json:"data"`
+				} `json:"results"`
+			} `json:"data"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal([]byte(body), &env); err != nil {
+		t.Fatalf("unmarshal aggregate query_range body: %v; body prefix: %s", err, truncForLog(body))
+	}
+
+	var columns []string
+	rowCount := 0
+	for _, result := range env.Data.Data.Results {
+		for _, rawColumn := range result.Columns {
+			if name := aggregateColumnName(rawColumn); name != "" {
+				columns = append(columns, name)
+			}
+		}
+		if len(result.Data) == 0 || strings.TrimSpace(string(result.Data)) == "null" {
+			continue
+		}
+		var rows []json.RawMessage
+		if err := json.Unmarshal(result.Data, &rows); err != nil {
+			t.Fatalf("unmarshal aggregate data rows: %v; body prefix: %s", err, truncForLog(body))
+		}
+		rowCount += len(rows)
+	}
+	return columns, rowCount
+}
+
+func aggregateColumnName(raw json.RawMessage) string {
+	var obj struct {
+		Name string `json:"name"`
+	}
+	if err := json.Unmarshal(raw, &obj); err == nil && obj.Name != "" {
+		return obj.Name
+	}
+	var s string
+	if err := json.Unmarshal(raw, &s); err == nil {
+		return s
+	}
+	return ""
+}
+
+func traceContainsString(values []string, want string) bool {
+	for _, value := range values {
+		if value == want {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/handler/tools/query_builder.go
+++ b/internal/handler/tools/query_builder.go
@@ -24,7 +24,7 @@ func (h *Handler) RegisterQueryBuilderV5Handlers(s *server.MCPServer) {
 		mcp.WithDescription(
 			"Execute a SigNoz Query Builder v5 query.\n\n"+
 				"REQUIRED: Read signoz://traces/query-builder-guide BEFORE building any query. "+
-				"It documents filter expression syntax, correct field names (camelCase vs dot notation), "+
+				"It documents filter expression syntax, canonical field names, field contexts, "+
 				"and complete working examples.\n\n"+
 				"When compositeQuery.queryType=\"promql\" ALSO read signoz://promql/instructions — "+
 				"OTel metric names with dots MUST use the Prometheus 3.x UTF-8 quoted-selector form ({\"metric.name.with.dots\"}). "+
@@ -39,7 +39,7 @@ func (h *Handler) RegisterQueryBuilderV5Handlers(s *server.MCPServer) {
 	tracesQueryBuilderGuide := mcp.NewResource(
 		"signoz://traces/query-builder-guide",
 		"Traces Query Builder Guide",
-		mcp.WithResourceDescription("SigNoz Query Builder v5 traces guide: filter expression syntax (string, not structured object), built-in span column names (camelCase, no fieldContext), resource/tag attribute naming (dot notation + fieldContext), and complete working examples for raw, aggregation, and time series queries."),
+		mcp.WithResourceDescription("SigNoz Query Builder v5 traces guide: filter expression syntax (string, not structured object), canonical built-in span column names (snake_case with fieldContext span), resource/tag attribute naming (dot notation + fieldContext), and complete working examples for raw, aggregation, and time series queries."),
 		mcp.WithMIMEType("text/plain"),
 	)
 

--- a/internal/handler/tools/silent_failures_test.go
+++ b/internal/handler/tools/silent_failures_test.go
@@ -57,31 +57,31 @@ func TestParseBoolArg(t *testing.T) {
 // N3: the `error` trace filter must hard-error on garbage rather than silently
 // dropping the filter (which widened results).
 func TestParseSearchTracesArgs_ErrorFilter(t *testing.T) {
-	// real bool true -> hasError = true
+	// real bool true -> has_error = true
 	reqTrue, err := parseSearchTracesArgs(map[string]any{"error": true})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if !strings.Contains(reqTrue.FilterExpression, "hasError = true") {
-		t.Fatalf("expected hasError = true in filter, got %q", reqTrue.FilterExpression)
+	if !strings.Contains(reqTrue.FilterExpression, "has_error = true") {
+		t.Fatalf("expected has_error = true in filter, got %q", reqTrue.FilterExpression)
 	}
 
-	// string "false" -> hasError = false
+	// string "false" -> has_error = false
 	reqFalse, err := parseSearchTracesArgs(map[string]any{"error": "false"})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if !strings.Contains(reqFalse.FilterExpression, "hasError = false") {
-		t.Fatalf("expected hasError = false in filter, got %q", reqFalse.FilterExpression)
+	if !strings.Contains(reqFalse.FilterExpression, "has_error = false") {
+		t.Fatalf("expected has_error = false in filter, got %q", reqFalse.FilterExpression)
 	}
 
-	// absent -> no hasError clause
+	// absent -> no generated error clause
 	reqAbsent, err := parseSearchTracesArgs(map[string]any{})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if strings.Contains(reqAbsent.FilterExpression, "hasError") {
-		t.Fatalf("expected no hasError clause when absent, got %q", reqAbsent.FilterExpression)
+	if strings.Contains(reqAbsent.FilterExpression, "has_error") {
+		t.Fatalf("expected no has_error clause when absent, got %q", reqAbsent.FilterExpression)
 	}
 
 	// garbage -> hard error (previously silently dropped + widened results)

--- a/internal/handler/tools/traces.go
+++ b/internal/handler/tools/traces.go
@@ -15,7 +15,7 @@ import (
 	"github.com/SigNoz/signoz-mcp-server/pkg/util"
 )
 
-const tracesFilterParamDescription = "Filter expression using SigNoz search syntax (see signoz://traces/query-builder-guide). Combine conditions with AND, OR, and parentheses for precedence. Unknown keys hard-error; keys present in multiple contexts default to resource context. Disambiguate with attribute.<key> or resource.<key>. Discover valid keys with signoz_get_field_keys, then confirm values with signoz_get_field_values, before filtering. Examples: \"service.name = 'payment-svc' AND hasError = true\", \"httpMethod = 'POST' AND (responseStatusCode >= 500 OR durationNano > 1000000000)\"."
+const tracesFilterParamDescription = "Filter expression using SigNoz search syntax (see signoz://traces/query-builder-guide). Combine conditions with AND, OR, and parentheses for precedence. Unknown keys hard-error; keys present in multiple contexts default to resource context. Disambiguate with attribute.<key>, resource.<key>, or span.<key>. Discover valid keys with signoz_get_field_keys, then confirm values with signoz_get_field_values, before filtering. Examples: \"service.name = 'payment-svc' AND has_error = true\", \"http_method = 'POST' AND (has_error = true OR duration_nano > 1000000000)\"."
 
 func (h *Handler) RegisterTracesHandlers(s *server.MCPServer) {
 	h.logger.Debug("Registering traces handlers")
@@ -30,15 +30,15 @@ func (h *Handler) RegisterTracesHandlers(s *server.MCPServer) {
 			"Also use this for error analysis — set error='true' and groupBy='service.name' to analyze error patterns across services. "+
 			"Defaults to last 1 hour if no time specified."),
 		mcp.WithString("aggregation", mcp.Required(), mcp.Description("Aggregation function to apply. One of: count, count_distinct, avg, sum, min, max, p50, p75, p90, p95, p99, rate")),
-		mcp.WithString("aggregateOn", mcp.Description("Field name to aggregate on (e.g., 'durationNano'). Required for all aggregations except count and rate.")),
+		mcp.WithString("aggregateOn", mcp.Description("Field name to aggregate on (e.g., 'duration_nano'). Required for all aggregations except count and rate.")),
 		mcp.WithString("groupBy", mcp.Description("Comma-separated list of field names to group results by (e.g., 'service.name' or 'service.name, name'). Leave empty for a single aggregate value.")),
 		mcp.WithString("filter", mcp.Description(tracesFilterParamDescription+" Combined with service/operation/error/duration params using AND.")),
 		mcp.WithString("service", mcp.Description("Shortcut filter for service name. Equivalent to adding service.name = '<value>' to filter.")),
 		mcp.WithString("operation", mcp.Description("Shortcut filter for span/operation name. Equivalent to adding name = '<value>' to filter.")),
-		mcp.WithBoolean("error", mcp.Description("Shortcut filter for error spans (true or false). Equivalent to adding hasError = true/false to filter.")),
+		mcp.WithBoolean("error", mcp.Description("Shortcut filter for error spans (true or false). Equivalent to adding has_error = true/false to filter.")),
 		mcp.WithString("minDuration", mcp.Description("Minimum span duration in nanoseconds. Example: '500000000' for 500ms.")),
 		mcp.WithString("maxDuration", mcp.Description("Maximum span duration in nanoseconds. Example: '2000000000' for 2s.")),
-		mcp.WithString("orderBy", mcp.Description("How to order results. Format: '<expression> <direction>', e.g. 'count() desc' or 'avg(durationNano) asc'. Defaults to the aggregation expression descending.")),
+		mcp.WithString("orderBy", mcp.Description("How to order results. Format: '<expression> <direction>', e.g. 'count() desc' or 'avg(duration_nano) asc'. Defaults to the aggregation expression descending.")),
 		mcp.WithString("limit", mcp.DefaultString("10"), intOrStringType(), mcp.Description("Maximum number of groups to return (default: 10, max: 10000; higher values are clamped)")),
 		mcp.WithString("timeRange", mcp.DefaultString("1h"), mcp.Description(timeRangeDesc("Defaults to '1h'."))),
 		mcp.WithString("start", mcp.Description("Start time in unix milliseconds (optional). When both start and end are provided, they override timeRange.")),
@@ -218,16 +218,17 @@ func (h *Handler) handleGetTraceDetails(ctx context.Context, req mcp.CallToolReq
 
 // enrichTraceWebURL injects a webUrl deep link into a single-trace passthrough
 // body. Delegates to util.InjectWebURL, which preserves large int64 fields
-// (e.g. durationNano) and fails open on unparseable input.
+// (e.g. duration_nano) and fails open on unparseable input.
 func enrichTraceWebURL(ctx context.Context, data []byte, traceID string) []byte {
 	base, _ := util.GetSigNozURL(ctx)
 	return util.InjectWebURL(data, base, "trace", traceID)
 }
 
 // enrichSearchTracesWebURL injects a per-row webUrl deep link into a search
-// traces passthrough body, one per result row keyed off each row's traceID.
+// traces passthrough body, one per result row keyed off each row's trace_id
+// (with legacy traceID/traceId fallbacks during migration).
 // Delegates to util.InjectRowsWebURL, which preserves large int64 fields
-// (e.g. durationNano) and fails open on unparseable input.
+// (e.g. duration_nano) and fails open on unparseable input.
 //
 // Enrichment is fail-open, so a change to the upstream response would silently
 // stop producing links. The handler only runs on a 2xx /api/v5/query_range body
@@ -242,7 +243,7 @@ func (h *Handler) enrichSearchTracesWebURL(ctx context.Context, data []byte) []b
 		return data // no instance URL on the request — nothing to enrich, nothing to warn about
 	}
 
-	out, res := util.InjectRowsWebURL(data, base, "trace", "traceID")
+	out, res := util.InjectRowsWebURL(data, base, "trace", "trace_id", "traceID", "traceId")
 	switch {
 	case !res.ResultsReached:
 		h.logger.WarnContext(ctx,
@@ -251,10 +252,11 @@ func (h *Handler) enrichSearchTracesWebURL(ctx context.Context, data []byte) []b
 		h.logger.WarnContext(ctx,
 			"search_traces webUrl enrichment found result objects but no readable rows[] array; the per-result rows key may have changed",
 			slog.Int("resultCount", res.ResultCount))
-	case res.RowsSeen > 0 && res.RowsEnriched == 0:
+	case res.RowsSeen > res.RowsEnriched:
 		h.logger.WarnContext(ctx,
-			"search_traces webUrl enrichment found rows but enriched none; the traceID column alias may have changed",
-			slog.Int("rowsSeen", res.RowsSeen))
+			"search_traces webUrl enrichment found rows without supported trace id columns trace_id/traceID/traceId",
+			slog.Int("rowsSeen", res.RowsSeen),
+			slog.Int("rowsEnriched", res.RowsEnriched))
 	}
 	return out
 }

--- a/internal/handler/tools/traces_helper.go
+++ b/internal/handler/tools/traces_helper.go
@@ -92,16 +92,16 @@ func buildTraceFilterExpr(query, service, operation string, errorFilter, errorPr
 	}
 	if errorPresent {
 		if errorFilter {
-			parts = append(parts, "hasError = true")
+			parts = append(parts, "has_error = true")
 		} else {
-			parts = append(parts, "hasError = false")
+			parts = append(parts, "has_error = false")
 		}
 	}
 	if minDuration != "" {
-		parts = append(parts, fmt.Sprintf("durationNano >= %s", minDuration))
+		parts = append(parts, fmt.Sprintf("duration_nano >= %s", minDuration))
 	}
 	if maxDuration != "" {
-		parts = append(parts, fmt.Sprintf("durationNano <= %s", maxDuration))
+		parts = append(parts, fmt.Sprintf("duration_nano <= %s", maxDuration))
 	}
 	return strings.Join(parts, " AND ")
 }

--- a/internal/handler/tools/traces_test.go
+++ b/internal/handler/tools/traces_test.go
@@ -67,15 +67,9 @@ func TestHandleSearchTraces_ErrorAndDurationFilters(t *testing.T) {
 	if captured == nil {
 		t.Fatal("QueryBuilderV5 was not called")
 	}
-	payload := string(captured)
-	if !strings.Contains(payload, "has_error = true") {
-		t.Fatalf("expected canonical error filter, got: %s", payload)
-	}
-	if !strings.Contains(payload, "duration_nano >= 500000000") {
-		t.Fatalf("expected canonical min duration filter, got: %s", payload)
-	}
-	if !strings.Contains(payload, "duration_nano <= 2000000000") {
-		t.Fatalf("expected canonical max duration filter, got: %s", payload)
+	want := "has_error = true AND duration_nano >= 500000000 AND duration_nano <= 2000000000"
+	if got := payloadFilterExpression(t, captured); got != want {
+		t.Fatalf("payload filter = %q, want %q", got, want)
 	}
 }
 
@@ -132,12 +126,15 @@ func TestHandleAggregateTraces_CountByService(t *testing.T) {
 	if captured == nil {
 		t.Fatal("QueryBuilderV5 was not called")
 	}
-	payload := string(captured)
-	if !strings.Contains(payload, `"expression":"has_error = true"`) {
-		t.Fatalf("expected canonical error shortcut filter, got: %s", payload)
+	if got := payloadFilterExpression(t, captured); got != "has_error = true" {
+		t.Fatalf("payload filter = %q, want has_error = true", got)
 	}
-	if !strings.Contains(payload, `"name":"service.name"`) || !strings.Contains(payload, `"fieldContext":"resource"`) {
-		t.Fatalf("expected service.name resource groupBy, got: %s", payload)
+	groupBy := payloadGroupByFields(t, captured)
+	if len(groupBy) != 1 {
+		t.Fatalf("groupBy count = %d, want 1: %#v", len(groupBy), groupBy)
+	}
+	if got := groupBy[0]; got.Name != "service.name" || got.FieldContext != "resource" || got.FieldDataType != "string" {
+		t.Fatalf("groupBy[0] = %#v, want service.name resource string", got)
 	}
 }
 
@@ -229,10 +226,40 @@ func TestHandleSearchTraces_LegacyFreeFormFilterPassesThrough(t *testing.T) {
 	if result.IsError {
 		t.Fatalf("handler returned error result: %v", result.Content)
 	}
-	payload := string(captured)
-	if !strings.Contains(payload, "hasError = true AND durationNano > 1000") {
-		t.Fatalf("legacy free-form filter was not preserved in payload: %s", payload)
+	want := "hasError = true AND durationNano > 1000"
+	if got := payloadFilterExpression(t, captured); got != want {
+		t.Fatalf("payload filter = %q, want %q", got, want)
 	}
+}
+
+type payloadSelectField struct {
+	Name          string `json:"name"`
+	FieldDataType string `json:"fieldDataType"`
+	Signal        string `json:"signal"`
+	FieldContext  string `json:"fieldContext"`
+}
+
+func payloadGroupByFields(t *testing.T, payload []byte) []payloadSelectField {
+	t.Helper()
+	if len(payload) == 0 {
+		t.Fatal("payload was not captured")
+	}
+	var decoded struct {
+		CompositeQuery struct {
+			Queries []struct {
+				Spec struct {
+					GroupBy []payloadSelectField `json:"groupBy"`
+				} `json:"spec"`
+			} `json:"queries"`
+		} `json:"compositeQuery"`
+	}
+	if err := json.Unmarshal(payload, &decoded); err != nil {
+		t.Fatalf("unmarshal payload: %v", err)
+	}
+	if len(decoded.CompositeQuery.Queries) != 1 {
+		t.Fatalf("query count = %d, want 1", len(decoded.CompositeQuery.Queries))
+	}
+	return decoded.CompositeQuery.Queries[0].Spec.GroupBy
 }
 
 func TestHandleAggregateTraces_MissingAggregation(t *testing.T) {

--- a/internal/handler/tools/traces_test.go
+++ b/internal/handler/tools/traces_test.go
@@ -67,6 +67,16 @@ func TestHandleSearchTraces_ErrorAndDurationFilters(t *testing.T) {
 	if captured == nil {
 		t.Fatal("QueryBuilderV5 was not called")
 	}
+	payload := string(captured)
+	if !strings.Contains(payload, "has_error = true") {
+		t.Fatalf("expected canonical error filter, got: %s", payload)
+	}
+	if !strings.Contains(payload, "duration_nano >= 500000000") {
+		t.Fatalf("expected canonical min duration filter, got: %s", payload)
+	}
+	if !strings.Contains(payload, "duration_nano <= 2000000000") {
+		t.Fatalf("expected canonical max duration filter, got: %s", payload)
+	}
 }
 
 func TestHandleSearchTraces_OperationFilter(t *testing.T) {
@@ -97,10 +107,10 @@ func TestHandleSearchTraces_OperationFilter(t *testing.T) {
 }
 
 func TestHandleAggregateTraces_CountByService(t *testing.T) {
-	called := false
+	var captured []byte
 	mock := &client.MockClient{
 		QueryBuilderV5Fn: func(ctx context.Context, body []byte) (json.RawMessage, error) {
-			called = true
+			captured = body
 			return json.RawMessage(`{"status":"success","result":[{"value":100}]}`), nil
 		},
 	}
@@ -119,23 +129,30 @@ func TestHandleAggregateTraces_CountByService(t *testing.T) {
 	if result.IsError {
 		t.Fatalf("handler returned error result: %v", result.Content)
 	}
-	if !called {
+	if captured == nil {
 		t.Fatal("QueryBuilderV5 was not called")
+	}
+	payload := string(captured)
+	if !strings.Contains(payload, `"expression":"has_error = true"`) {
+		t.Fatalf("expected canonical error shortcut filter, got: %s", payload)
+	}
+	if !strings.Contains(payload, `"name":"service.name"`) || !strings.Contains(payload, `"fieldContext":"resource"`) {
+		t.Fatalf("expected service.name resource groupBy, got: %s", payload)
 	}
 }
 
 func TestHandleAggregateTraces_P99Latency(t *testing.T) {
-	called := false
+	var captured []byte
 	mock := &client.MockClient{
 		QueryBuilderV5Fn: func(ctx context.Context, body []byte) (json.RawMessage, error) {
-			called = true
+			captured = body
 			return json.RawMessage(`{"status":"success"}`), nil
 		},
 	}
 	h := newTestHandler(mock)
 	req := makeToolRequest("signoz_aggregate_traces", map[string]any{
 		"aggregation": "p99",
-		"aggregateOn": "durationNano",
+		"aggregateOn": "duration_nano",
 		"service":     "checkout-svc",
 		"timeRange":   "6h",
 	})
@@ -147,8 +164,74 @@ func TestHandleAggregateTraces_P99Latency(t *testing.T) {
 	if result.IsError {
 		t.Fatalf("handler returned error result: %v", result.Content)
 	}
-	if !called {
+	if captured == nil {
 		t.Fatal("QueryBuilderV5 was not called")
+	}
+	payload := string(captured)
+	if !strings.Contains(payload, `"expression":"p99(duration_nano)"`) {
+		t.Fatalf("expected canonical p99 latency aggregation, got: %s", payload)
+	}
+	if !strings.Contains(payload, `"expression":"service.name = 'checkout-svc'"`) {
+		t.Fatalf("expected service shortcut filter, got: %s", payload)
+	}
+}
+
+func TestHandleAggregateTraces_LegacyFreeFormFieldsPassThrough(t *testing.T) {
+	var captured []byte
+	mock := &client.MockClient{
+		QueryBuilderV5Fn: func(ctx context.Context, body []byte) (json.RawMessage, error) {
+			captured = body
+			return json.RawMessage(`{"status":"success"}`), nil
+		},
+	}
+	h := newTestHandler(mock)
+	req := makeToolRequest("signoz_aggregate_traces", map[string]any{
+		"aggregation": "avg",
+		"aggregateOn": "durationNano",
+		"filter":      "hasError = true",
+		"orderBy":     "avg(durationNano) asc",
+		"timeRange":   "6h",
+	})
+
+	result, err := h.handleAggregateTraces(testCtx(), req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("handler returned error result: %v", result.Content)
+	}
+	payload := string(captured)
+	for _, want := range []string{"avg(durationNano)", "hasError = true"} {
+		if !strings.Contains(payload, want) {
+			t.Fatalf("legacy free-form value %q was not preserved in payload: %s", want, payload)
+		}
+	}
+}
+
+func TestHandleSearchTraces_LegacyFreeFormFilterPassesThrough(t *testing.T) {
+	var captured []byte
+	mock := &client.MockClient{
+		QueryBuilderV5Fn: func(ctx context.Context, body []byte) (json.RawMessage, error) {
+			captured = body
+			return json.RawMessage(`{"status":"success"}`), nil
+		},
+	}
+	h := newTestHandler(mock)
+	req := makeToolRequest("signoz_search_traces", map[string]any{
+		"filter":    "hasError = true AND durationNano > 1000",
+		"timeRange": "1h",
+	})
+
+	result, err := h.handleSearchTraces(testCtx(), req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("handler returned error result: %v", result.Content)
+	}
+	payload := string(captured)
+	if !strings.Contains(payload, "hasError = true AND durationNano > 1000") {
+		t.Fatalf("legacy free-form filter was not preserved in payload: %s", payload)
 	}
 }
 
@@ -366,10 +449,10 @@ func TestHandleGetTraceDetails_OmitsWebURLWhenNoBaseURL(t *testing.T) {
 
 // rawSearchTracesBody is a realistic query-builder v5 "raw" response (a
 // render.Success envelope wrapping QueryRangeResponse) with two rows. The second
-// row's durationNano exceeds float64's exact-integer range to guard precision.
+// row's duration_nano exceeds float64's exact-integer range to guard precision.
 const rawSearchTracesBody = `{"status":"success","data":{"type":"raw","data":{"results":[{"queryName":"A","rows":[` +
-	`{"timestamp":"2026-06-19T10:00:00Z","data":{"traceID":"abc-123","durationNano":9007199254740993,"name":"GET /cart"}},` +
-	`{"timestamp":"2026-06-19T10:00:01Z","data":{"traceID":"def-456","durationNano":42,"name":"POST /checkout"}}` +
+	`{"timestamp":"2026-06-19T10:00:00Z","data":{"trace_id":"abc-123","duration_nano":9007199254740993,"name":"GET /cart"}},` +
+	`{"timestamp":"2026-06-19T10:00:01Z","data":{"trace_id":"def-456","duration_nano":42,"name":"POST /checkout"}}` +
 	`]}]},"meta":{}}}`
 
 func TestHandleSearchTraces_RowsGetWebURL(t *testing.T) {
@@ -395,9 +478,9 @@ func TestHandleSearchTraces_RowsGetWebURL(t *testing.T) {
 	if !strings.Contains(body, `"webUrl":"https://signoz.example.com/trace/def-456"`) {
 		t.Fatalf("expected second row webUrl, got: %s", body)
 	}
-	// durationNano (> 2^53) must survive the enrichment round-trip exactly.
+	// duration_nano (> 2^53) must survive the enrichment round-trip exactly.
 	if !strings.Contains(body, "9007199254740993") {
-		t.Fatalf("durationNano lost precision: %s", body)
+		t.Fatalf("duration_nano lost precision: %s", body)
 	}
 }
 
@@ -420,11 +503,11 @@ func TestHandleSearchTraces_OmitsWebURLWhenNoBaseURL(t *testing.T) {
 	}
 }
 
-// driftSearchTracesBody is a v5 raw response whose rows carry "trace_id" instead
-// of the "traceID" key the enrichment looks for — i.e. a simulated upstream shape
-// change. Rows are present but none are enrichable.
+// driftSearchTracesBody is a v5 raw response whose rows carry no supported trace
+// id key — i.e. a simulated upstream shape change. Rows are present but none are
+// enrichable.
 const driftSearchTracesBody = `{"status":"success","data":{"type":"raw","data":{"results":[{"queryName":"A","rows":[` +
-	`{"timestamp":"t","data":{"trace_id":"abc-123","name":"GET /cart"}}` +
+	`{"timestamp":"t","data":{"trace_identifier":"abc-123","name":"GET /cart"}}` +
 	`]}]},"meta":{}}}`
 
 // emptySearchTracesBody is an ordinary "no data" response: results present, zero rows.
@@ -451,8 +534,21 @@ func searchTracesWithCapturedLogs(t *testing.T, responseBody string) string {
 func TestHandleSearchTraces_WarnsOnProbableShapeDrift(t *testing.T) {
 	// Rows present but none enrichable -> WARN so the silent fail-open is detectable.
 	out := searchTracesWithCapturedLogs(t, driftSearchTracesBody)
-	if !strings.Contains(out, "enriched none") || !strings.Contains(out, "rowsSeen=1") {
+	if !strings.Contains(out, "rows without supported trace id") || !strings.Contains(out, "rowsSeen=1") || !strings.Contains(out, "rowsEnriched=0") {
 		t.Fatalf("expected a shape-drift WARN with rowsSeen, got logs: %q", out)
+	}
+}
+
+func TestHandleSearchTraces_WarnsOnPartialRowEnrichment(t *testing.T) {
+	// Mixed rows where only some carry supported trace-id aliases should warn
+	// because fail-open enrichment would otherwise drop links silently.
+	body := `{"status":"success","data":{"type":"raw","data":{"results":[{"queryName":"A","rows":[` +
+		`{"timestamp":"t","data":{"trace_id":"abc-123"}},` +
+		`{"timestamp":"t","data":{"trace_identifier":"missing"}}` +
+		`]}]},"meta":{}}}`
+	out := searchTracesWithCapturedLogs(t, body)
+	if !strings.Contains(out, "rows without supported trace id") || !strings.Contains(out, "rowsSeen=2") || !strings.Contains(out, "rowsEnriched=1") {
+		t.Fatalf("expected a partial-enrichment WARN with row counts, got logs: %q", out)
 	}
 }
 
@@ -468,7 +564,7 @@ func TestHandleSearchTraces_NoWarnWhenNoRows(t *testing.T) {
 // and non-empty, but the per-result "rows" key is renamed ("records") so no rows
 // array can be read — a simulated per-result shape change.
 const rowsKeyDriftSearchTracesBody = `{"status":"success","data":{"type":"raw","data":{"results":[{"queryName":"A","records":[` +
-	`{"timestamp":"t","data":{"traceID":"abc-123"}}` +
+	`{"timestamp":"t","data":{"trace_id":"abc-123"}}` +
 	`]}]},"meta":{}}}`
 
 func TestHandleSearchTraces_WarnsWhenRowsKeyMissing(t *testing.T) {
@@ -483,7 +579,7 @@ func TestHandleSearchTraces_WarnsWhenRowsKeyMissing(t *testing.T) {
 // renamed ("rezults"), so the envelope can't be walked even though it carries
 // rows — a simulated upstream envelope-shape change.
 const envelopeDriftSearchTracesBody = `{"status":"success","data":{"type":"raw","data":{"rezults":[{"queryName":"A","rows":[` +
-	`{"timestamp":"t","data":{"traceID":"abc-123"}}` +
+	`{"timestamp":"t","data":{"trace_id":"abc-123"}}` +
 	`]}]},"meta":{}}}`
 
 func TestHandleSearchTraces_WarnsWhenEnvelopeUnwalkable(t *testing.T) {

--- a/pkg/alert/resources.go
+++ b/pkg/alert/resources.go
@@ -781,7 +781,7 @@ Two disabled trace count queries (A = error spans, B = total spans) combined via
           "spec": {
             "name": "A", "signal": "traces", "stepInterval": 60, "disabled": true,
             "aggregations": [{"expression": "count()"}],
-            "filter": {"expression": "service.name = 'search-api' AND hasError = true"},
+            "filter": {"expression": "service.name = 'search-api' AND has_error = true"},
             "groupBy": [
               {"name": "service.name", "fieldContext": "resource", "fieldDataType": "string"},
               {"name": "http.route", "fieldContext": "attribute", "fieldDataType": "string"}

--- a/pkg/dashboard/query.go
+++ b/pkg/dashboard/query.go
@@ -506,7 +506,7 @@ Custom Interval (100ms):
 Group By Standard Attribute:
   SELECT toStartOfInterval(timestamp, INTERVAL 1 MINUTE) AS interval,
          attributes_string['http.method'] AS method,
-         toFloat64(avg(durationNano)) AS value
+         toFloat64(avg(duration_nano)) AS value
   FROM signoz_traces.distributed_signoz_index_v3
   WHERE attributes_string['http.method'] != ''
     AND timestamp > now() - INTERVAL 30 MINUTE
@@ -566,20 +566,20 @@ Extract Span Event Attributes:
 Latency Between Spans in Trace:
   SELECT interval, round(avg(time_diff), 2) AS avg_latency_ms
   FROM (
-      SELECT interval, traceID,
+      SELECT interval, trace_id,
              if(startTime1 != 0 AND startTime2 != 0,
                 (toUnixTimestamp64Nano(startTime2) - toUnixTimestamp64Nano(startTime1)) / 1000000,
                 nan) AS time_diff
       FROM (
           SELECT toStartOfInterval(timestamp, toIntervalMinute(1)) AS interval,
-                 traceID,
+                 trace_id,
                  minIf(timestamp, resource_string_service$$name='driver' AND name='/driver.DriverService/FindNearest') AS startTime1,
                  minIf(timestamp, resource_string_service$$name='route' AND name='HTTP GET /route') AS startTime2
           FROM signoz_traces.distributed_signoz_index_v3
           WHERE timestamp BETWEEN {{.start_datetime}} AND {{.end_datetime}}
             AND ts_bucket_start BETWEEN {{.start_timestamp}} - 1800 AND {{.end_timestamp}}
             AND resource_string_service$$name IN ('driver', 'route')
-          GROUP BY (interval, traceID)
+          GROUP BY (interval, trace_id)
       )
   )
   WHERE isNaN(time_diff) = 0
@@ -638,7 +638,7 @@ Common Fields:
   - has_error             - Boolean (span error status)
   - http_method           - String (GET, POST, etc.)
   - duration_nano         - UInt64 (span duration)
-  - traceID               - String (trace identifier)
+  - trace_id              - String (trace identifier)
   - resource_fingerprint  - UInt64 (for filtering)
   - events                - Array (span events)
 

--- a/pkg/prompts/prompts.go
+++ b/pkg/prompts/prompts.go
@@ -89,8 +89,8 @@ func handleLatencyAnalysis(_ context.Context, req mcp.GetPromptRequest) (*mcp.Ge
 					Type: "text",
 					Text: fmt.Sprintf(`Analyze p99 latency for the service "%s" over the last %s. Follow these steps:
 
-1. Use signoz_aggregate_traces with service="%s", aggregation="p99", aggregateOn="durationNano", groupBy="name", timeRange="%s" to find the slowest operations.
-2. Use signoz_aggregate_traces with service="%s", aggregation="p99", aggregateOn="durationNano", requestType="time_series", timeRange="%s" to see how latency has changed over time.
+1. Use signoz_aggregate_traces with service="%s", aggregation="p99", aggregateOn="duration_nano", groupBy="name", timeRange="%s" to find the slowest operations.
+2. Use signoz_aggregate_traces with service="%s", aggregation="p99", aggregateOn="duration_nano", requestType="time_series", timeRange="%s" to see how latency has changed over time.
 3. Use signoz_search_traces with service="%s", minDuration="1000000000", timeRange="%s" to find specific slow traces (>1s).
 4. For the slowest trace found, use signoz_get_trace_details to examine the span breakdown.
 5. Summarize: which operations are slow, whether latency is trending up, and what spans contribute most to latency.`, service, timeRange, service, timeRange, service, timeRange, service, timeRange),

--- a/pkg/querybuilder/traces_guide.go
+++ b/pkg/querybuilder/traces_guide.go
@@ -7,44 +7,49 @@ const TracesQueryBuilderGuide = `
 
 Filters are a STRING expression in filter.expression — NOT a structured {op, items} object.
 
-CORRECT:   "filter": {"expression": "hasError = true AND k8s.namespace.name = 'my-ns'"}
+CORRECT:   "filter": {"expression": "has_error = true AND k8s.namespace.name = 'my-ns'"}
 INCORRECT: "filter": {"op": "AND", "items": [...]}
 
 Operators: =  !=  >  >=  <  <=  IN  NOT IN  LIKE  NOT LIKE  ILIKE  NOT ILIKE  CONTAINS  NOT CONTAINS  REGEXP  NOT REGEXP  BETWEEN  NOT BETWEEN  EXISTS  NOT EXISTS
 Combine:   AND  OR  (use parentheses for precedence)
 
 Examples:
-  hasError = true
-  durationNano > 500000000
-  statusCodeString = 'Error'
+  has_error = true
+  duration_nano > 500000000
+  status_code_string = 'Error'
   name LIKE '%payment%'
-  hasError = true AND k8s.namespace.name = 'prod'
-  (hasError = true OR durationNano > 1000000000) AND service.name = 'checkout'
+  has_error = true AND k8s.namespace.name = 'prod'
+  (has_error = true OR duration_nano > 1000000000) AND service.name = 'checkout'
 
-== FIELD NAMES — TWO CATEGORIES ==
+== FIELD NAMES — THREE CATEGORIES ==
 
---- 1. Built-in span columns (camelCase, NO fieldContext) ---
+--- 1. Built-in span columns (snake_case, fieldContext: "span") ---
 
-Use these directly by name in filter expressions and selectFields without fieldContext:
+Use these directly by name in filter expressions. In selectFields, use fieldContext "span"
+to make the built-in/span-column intent explicit:
 
-  hasError           bool      — whether the span has an error
-  statusMessage      string    — OTel status message
-  statusCodeString   string    — span status: 'Ok', 'Error', or 'Unset' (prefer hasError = true for errors)
-  statusCode         int64     — numeric status code
-  durationNano       int64     — span duration in nanoseconds
-  traceID            string    — trace identifier
-  spanID             string    — span identifier
-  name               string    — span/operation name
-  timestamp          datetime  — span start timestamp
-  httpMethod         string    — HTTP method
-  httpUrl            string    — HTTP URL
-  spanKind           string    — 'Server', 'Client', 'Internal', 'Producer', 'Consumer'
-  responseStatusCode string    — HTTP response status as string
+  has_error            bool      — whether the span has an error
+  status_message       string    — OTel status message
+  status_code_string   string    — span status: 'Ok', 'Error', or 'Unset' (prefer has_error = true for errors)
+  status_code          number    — numeric OTel status code
+  duration_nano        number    — span duration in nanoseconds
+  trace_id             string    — trace identifier
+  span_id              string    — span identifier
+  parent_span_id       string    — parent span identifier
+  name                 string    — span/operation name
+  timestamp            datetime  — span start timestamp
+  http_method          string    — HTTP method
+  http_url             string    — HTTP URL
+  kind_string          string    — 'Server', 'Client', 'Internal', 'Producer', 'Consumer'
+  response_status_code string    — HTTP response status as string; do not use for numeric comparisons
 
-selectFields entry (no fieldContext needed):
-  {"name": "hasError", "fieldDataType": "bool", "signal": "traces"}
-  {"name": "durationNano", "fieldDataType": "int64", "signal": "traces"}
-  {"name": "name", "fieldDataType": "string", "signal": "traces"}
+For numeric HTTP status comparisons, use a numeric span/tag attribute such as
+attribute.http.response.status_code after verifying it exists for your data.
+
+selectFields entry:
+  {"name": "has_error", "fieldDataType": "bool", "signal": "traces", "fieldContext": "span"}
+  {"name": "duration_nano", "fieldDataType": "number", "signal": "traces", "fieldContext": "span"}
+  {"name": "name", "fieldDataType": "string", "signal": "traces", "fieldContext": "span"}
 
 --- 2. Resource attributes (dot notation, fieldContext: "resource") ---
 
@@ -66,14 +71,14 @@ selectFields entry (fieldContext: "resource" required):
 
 OTel span attributes set per-span:
 
-  http.status_code   int64  — HTTP status code attribute
+  http.response.status_code number — HTTP status code attribute
   db.system          string — database system (e.g. "postgresql")
   db.operation       string — database operation
   rpc.method         string — RPC method name
   messaging.system   string — messaging system (e.g. "kafka")
 
 selectFields entry (fieldContext: "tag" required):
-  {"name": "http.status_code", "fieldDataType": "int64", "signal": "traces", "fieldContext": "tag"}
+  {"name": "http.response.status_code", "fieldDataType": "number", "signal": "traces", "fieldContext": "tag"}
 
 == COMPLETE WORKING EXAMPLES ==
 
@@ -96,15 +101,15 @@ selectFields entry (fieldContext: "tag" required):
           "offset": 0,
           "order": [{"key": {"name": "timestamp"}, "direction": "desc"}],
           "having": {"expression": ""},
-          "filter": {"expression": "hasError = true AND k8s.namespace.name = 'prod'"},
+          "filter": {"expression": "has_error = true AND k8s.namespace.name = 'prod'"},
           "selectFields": [
             {"name": "service.name", "fieldDataType": "string", "signal": "traces", "fieldContext": "resource"},
-            {"name": "name",         "fieldDataType": "string", "signal": "traces"},
-            {"name": "hasError",     "fieldDataType": "bool",   "signal": "traces"},
-            {"name": "durationNano", "fieldDataType": "int64",  "signal": "traces"},
-            {"name": "statusMessage","fieldDataType": "string", "signal": "traces"},
-            {"name": "traceID",      "fieldDataType": "string", "signal": "traces"},
-            {"name": "spanID",       "fieldDataType": "string", "signal": "traces"}
+            {"name": "name",          "fieldDataType": "string", "signal": "traces", "fieldContext": "span"},
+            {"name": "has_error",     "fieldDataType": "bool",   "signal": "traces", "fieldContext": "span"},
+            {"name": "duration_nano", "fieldDataType": "number", "signal": "traces", "fieldContext": "span"},
+            {"name": "status_message","fieldDataType": "string", "signal": "traces", "fieldContext": "span"},
+            {"name": "trace_id",      "fieldDataType": "string", "signal": "traces", "fieldContext": "span"},
+            {"name": "span_id",       "fieldDataType": "string", "signal": "traces", "fieldContext": "span"}
           ]
         }
       }
@@ -132,7 +137,7 @@ selectFields entry (fieldContext: "tag" required):
           "limit": 20,
           "offset": 0,
           "having": {"expression": ""},
-          "filter": {"expression": "hasError = true"},
+          "filter": {"expression": "has_error = true"},
           "aggregations": [
             {"expression": "count()"}
           ],
@@ -167,7 +172,7 @@ selectFields entry (fieldContext: "tag" required):
           "having": {"expression": ""},
           "filter": {"expression": "service.name = 'checkout'"},
           "aggregations": [
-            {"expression": "p99(durationNano)"}
+            {"expression": "p99(duration_nano)"}
           ]
         }
       }
@@ -187,10 +192,12 @@ Prefer start/end to bound the time window. The built-in "timestamp" COLUMN is na
 
 | Need                        | Field              | fieldContext  |
 |-----------------------------|--------------------|---------------|
-| Is error span?              | hasError           | (none)        |
-| Span duration               | durationNano       | (none)        |
-| Operation name              | name               | (none)        |
+| Is error span?              | has_error          | span          |
+| Span duration               | duration_nano      | span          |
+| Operation name              | name               | span          |
+| Trace ID                    | trace_id           | span          |
+| Span ID                     | span_id            | span          |
 | Service name                | service.name       | resource      |
 | Kubernetes namespace        | k8s.namespace.name | resource      |
-| HTTP response code (attr)   | http.status_code   | tag           |
+| HTTP response code (attr)   | http.response.status_code | tag   |
 `

--- a/pkg/querybuilder/traces_guide.go
+++ b/pkg/querybuilder/traces_guide.go
@@ -37,7 +37,7 @@ to make the built-in/span-column intent explicit:
   span_id              string    — span identifier
   parent_span_id       string    — parent span identifier
   name                 string    — span/operation name
-  timestamp            datetime  — span start timestamp
+  timestamp            number    — span start timestamp
   http_method          string    — HTTP method
   http_url             string    — HTTP URL
   kind_string          string    — 'Server', 'Client', 'Internal', 'Producer', 'Consumer'

--- a/pkg/types/querybuilder.go
+++ b/pkg/types/querybuilder.go
@@ -162,7 +162,7 @@ type FormatOptions struct {
 }
 
 // QueryAggregation represents an aggregation expression for QB v5 queries (logs, traces).
-// Example expressions: "count()", "avg(duration)", "p99(durationNano)", "count_distinct(user_id)"
+// Example expressions: "count()", "avg(duration)", "p99(duration_nano)", "count_distinct(user_id)"
 type QueryAggregation struct {
 	Expression string `json:"expression"`
 }
@@ -338,7 +338,7 @@ func BuildLogsQueryPayload(startTime, endTime int64, filterExpression string, li
 }
 
 // BuildAggregateQueryPayload creates a QueryPayload for aggregation queries, signal is "logs" or "traces".
-// aggregationExpr is a QB v5 expression like "count()", "avg(duration)", "p99(durationNano)".
+// aggregationExpr is a QB v5 expression like "count()", "avg(duration)", "p99(duration_nano)".
 // groupBy is a list of fields to group by.
 // orderByExpr is the expression to order by (e.g. "count()"), orderDir is "asc" or "desc".
 func BuildAggregateQueryPayload(signal string, startTime, endTime int64, aggregationExpr string, filterExpression string, groupBy []SelectField, orderByExpr string, orderDir string, limit int, requestType string, stepInterval *int64) *QueryPayload {
@@ -570,22 +570,21 @@ func BuildTracesQueryPayload(startTime, endTime int64, filterExpression string, 
 						Having: Having{Expression: ""},
 						SelectFields: []SelectField{
 							// Top-level span fields
-							{Name: "traceID", FieldDataType: "string", Signal: "traces"},
-							{Name: "spanID", FieldDataType: "string", Signal: "traces"},
-							{Name: "parentSpanID", FieldDataType: "string", Signal: "traces"},
-							{Name: "name", FieldDataType: "string", Signal: "traces"},
-							{Name: "durationNano", FieldDataType: "int64", Signal: "traces"},
-							{Name: "timestamp", FieldDataType: "string", Signal: "traces"},
-							{Name: "hasError", FieldDataType: "bool", Signal: "traces"},
-							{Name: "statusCode", FieldDataType: "string", Signal: "traces"},
-							{Name: "statusCodeString", FieldDataType: "string", Signal: "traces"},
-							{Name: "httpMethod", FieldDataType: "string", Signal: "traces"},
-							{Name: "httpUrl", FieldDataType: "string", Signal: "traces"},
-							{Name: "spanKind", FieldDataType: "string", Signal: "traces"},
-							{Name: "rpcMethod", FieldDataType: "string", Signal: "traces"},
-							{Name: "kind", FieldDataType: "int32", Signal: "traces"},
-							{Name: "responseStatusCode", FieldDataType: "string", Signal: "traces"},
-							{Name: "statusMessage", FieldDataType: "string", Signal: "traces"},
+							{Name: "trace_id", FieldDataType: "string", Signal: "traces", FieldContext: "span"},
+							{Name: "span_id", FieldDataType: "string", Signal: "traces", FieldContext: "span"},
+							{Name: "parent_span_id", FieldDataType: "string", Signal: "traces", FieldContext: "span"},
+							{Name: "name", FieldDataType: "string", Signal: "traces", FieldContext: "span"},
+							{Name: "duration_nano", FieldDataType: "number", Signal: "traces", FieldContext: "span"},
+							{Name: "timestamp", FieldDataType: "number", Signal: "traces", FieldContext: "span"},
+							{Name: "has_error", FieldDataType: "bool", Signal: "traces", FieldContext: "span"},
+							{Name: "status_code", FieldDataType: "number", Signal: "traces", FieldContext: "span"},
+							{Name: "status_code_string", FieldDataType: "string", Signal: "traces", FieldContext: "span"},
+							{Name: "http_method", FieldDataType: "string", Signal: "traces", FieldContext: "span"},
+							{Name: "http_url", FieldDataType: "string", Signal: "traces", FieldContext: "span"},
+							{Name: "kind_string", FieldDataType: "string", Signal: "traces", FieldContext: "span"},
+							{Name: "kind", FieldDataType: "number", Signal: "traces", FieldContext: "span"},
+							{Name: "response_status_code", FieldDataType: "string", Signal: "traces", FieldContext: "span"},
+							{Name: "status_message", FieldDataType: "string", Signal: "traces", FieldContext: "span"},
 							// Resource attributes
 							{Name: "service.name", FieldDataType: "string", Signal: "traces", FieldContext: "resource"},
 							{Name: "cloud.account.id", FieldDataType: "string", Signal: "traces", FieldContext: "resource"},
@@ -610,8 +609,9 @@ func BuildTracesQueryPayload(startTime, endTime int64, filterExpression string, 
 							{Name: "client.address", FieldDataType: "string", Signal: "traces", FieldContext: "tag"},
 							{Name: "http.request.method", FieldDataType: "string", Signal: "traces", FieldContext: "tag"},
 							{Name: "http.response.body.size", FieldDataType: "string", Signal: "traces", FieldContext: "tag"},
-							{Name: "http.response.status_code", FieldDataType: "string", Signal: "traces", FieldContext: "tag"},
+							{Name: "http.response.status_code", FieldDataType: "number", Signal: "traces", FieldContext: "tag"},
 							{Name: "http.route", FieldDataType: "string", Signal: "traces", FieldContext: "tag"},
+							{Name: "rpc.method", FieldDataType: "string", Signal: "traces", FieldContext: "tag"},
 							{Name: "network.peer.address", FieldDataType: "string", Signal: "traces", FieldContext: "tag"},
 							{Name: "network.peer.port", FieldDataType: "string", Signal: "traces", FieldContext: "tag"},
 							{Name: "network.protocol.version", FieldDataType: "string", Signal: "traces", FieldContext: "tag"},

--- a/pkg/types/querybuilder_test.go
+++ b/pkg/types/querybuilder_test.go
@@ -527,3 +527,91 @@ func TestBuildTracesQueryPayload_PropagatesOffset(t *testing.T) {
 	require.Equal(t, 50, spec.Limit)
 	require.Equal(t, 25, spec.Offset, "offset must propagate into the traces query")
 }
+
+func TestBuildTracesQueryPayload_UsesCanonicalTraceFields(t *testing.T) {
+	payload := BuildTracesQueryPayload(1000, 2000, "service.name = 'x'", 50, 0)
+	spec, ok := payload.CompositeQuery.Queries[0].Spec.(QuerySpec)
+	require.True(t, ok, "expected QuerySpec, got %T", payload.CompositeQuery.Queries[0].Spec)
+
+	fields := map[string]SelectField{}
+	for _, field := range spec.SelectFields {
+		fields[field.Name] = field
+	}
+
+	for _, deprecated := range []string{
+		"traceID",
+		"spanID",
+		"parentSpanID",
+		"durationNano",
+		"hasError",
+		"statusCode",
+		"statusCodeString",
+		"statusMessage",
+		"spanKind",
+		"httpMethod",
+		"httpUrl",
+		"responseStatusCode",
+		"rpcMethod",
+	} {
+		_, found := fields[deprecated]
+		require.False(t, found, "deprecated trace field %q must not be selected", deprecated)
+	}
+
+	expected := map[string]SelectField{
+		"trace_id": {
+			Name: "trace_id", FieldDataType: "string", Signal: "traces", FieldContext: "span",
+		},
+		"span_id": {
+			Name: "span_id", FieldDataType: "string", Signal: "traces", FieldContext: "span",
+		},
+		"parent_span_id": {
+			Name: "parent_span_id", FieldDataType: "string", Signal: "traces", FieldContext: "span",
+		},
+		"name": {
+			Name: "name", FieldDataType: "string", Signal: "traces", FieldContext: "span",
+		},
+		"duration_nano": {
+			Name: "duration_nano", FieldDataType: "number", Signal: "traces", FieldContext: "span",
+		},
+		"timestamp": {
+			Name: "timestamp", FieldDataType: "number", Signal: "traces", FieldContext: "span",
+		},
+		"has_error": {
+			Name: "has_error", FieldDataType: "bool", Signal: "traces", FieldContext: "span",
+		},
+		"status_code": {
+			Name: "status_code", FieldDataType: "number", Signal: "traces", FieldContext: "span",
+		},
+		"status_code_string": {
+			Name: "status_code_string", FieldDataType: "string", Signal: "traces", FieldContext: "span",
+		},
+		"status_message": {
+			Name: "status_message", FieldDataType: "string", Signal: "traces", FieldContext: "span",
+		},
+		"http_method": {
+			Name: "http_method", FieldDataType: "string", Signal: "traces", FieldContext: "span",
+		},
+		"http_url": {
+			Name: "http_url", FieldDataType: "string", Signal: "traces", FieldContext: "span",
+		},
+		"kind_string": {
+			Name: "kind_string", FieldDataType: "string", Signal: "traces", FieldContext: "span",
+		},
+		"kind": {
+			Name: "kind", FieldDataType: "number", Signal: "traces", FieldContext: "span",
+		},
+		"response_status_code": {
+			Name: "response_status_code", FieldDataType: "string", Signal: "traces", FieldContext: "span",
+		},
+		"rpc.method": {
+			Name: "rpc.method", FieldDataType: "string", Signal: "traces", FieldContext: "tag",
+		},
+		"http.response.status_code": {
+			Name: "http.response.status_code", FieldDataType: "number", Signal: "traces", FieldContext: "tag",
+		},
+	}
+
+	for name, want := range expected {
+		require.Equal(t, want, fields[name], "select field %q", name)
+	}
+}

--- a/pkg/util/weburl.go
+++ b/pkg/util/weburl.go
@@ -41,7 +41,7 @@ func ResourceWebURL(base, resourceType, id string) (string, bool) {
 //
 // The body is decoded only one level deep (two for the {"data": {...}} wrap)
 // into map[string]json.RawMessage, so everything below the injection level —
-// span trees, large int64 fields like durationNano, number formatting, key
+// span trees, large int64 fields like duration_nano, number formatting, key
 // order — passes through as verbatim bytes rather than being re-encoded. On
 // any failure — empty base, unsupported type, or a body that is not a JSON
 // object — it returns the original bytes unchanged so enrichment can never
@@ -112,16 +112,17 @@ type InjectRowsResult struct {
 // many rows it saw versus enriched.
 //
 // The expected nesting (a render.Success envelope wrapping a QueryRangeResponse)
-// is data.data.results[].rows[].data, with the id under rows[].data[idKey]; for
-// traces that is data.traceID. Like InjectWebURL it decodes only as deep as each
-// mutated level, leaving siblings — large int64 fields like durationNano, number
+// is data.data.results[].rows[].data, with the id under the first matching
+// rows[].data[idKeys] entry; for traces that is data.trace_id, with legacy
+// fallback keys during migration. Like InjectWebURL it decodes only as deep as each
+// mutated level, leaving siblings — large int64 fields like duration_nano, number
 // formatting, key order — as verbatim json.RawMessage. Rows whose id is missing,
 // empty, or non-string are left untouched. On any failure — empty base or a body
 // that does not match the expected shape — it returns the original bytes
 // unchanged so enrichment can never corrupt a working response.
-func InjectRowsWebURL(data []byte, base, resourceType, idKey string) ([]byte, InjectRowsResult) {
+func InjectRowsWebURL(data []byte, base, resourceType string, idKeys ...string) ([]byte, InjectRowsResult) {
 	var res InjectRowsResult
-	if strings.TrimSpace(base) == "" {
+	if strings.TrimSpace(base) == "" || len(idKeys) == 0 {
 		return data, res
 	}
 
@@ -167,7 +168,7 @@ func InjectRowsWebURL(data []byte, base, resourceType, idKey string) ([]byte, In
 		rowsChanged := false
 		for i, rawRow := range rows {
 			res.RowsSeen++
-			injected, ok := injectRowWebURL(rawRow, base, resourceType, idKey)
+			injected, ok := injectRowWebURL(rawRow, base, resourceType, idKeys)
 			if !ok {
 				continue
 			}
@@ -213,10 +214,11 @@ func InjectRowsWebURL(data []byte, base, resourceType, idKey string) ([]byte, In
 }
 
 // injectRowWebURL adds a webUrl sibling to a single raw row's inner "data"
-// object using rows[].data[idKey] as the resource id. ok is false (and the row
+// object using the first non-empty rows[].data[idKeys] string as the resource id.
+// ok is false (and the row
 // is left untouched) when the row shape is unexpected, the id is missing/empty,
 // or no link can be built for the type.
-func injectRowWebURL(rawRow json.RawMessage, base, resourceType, idKey string) (json.RawMessage, bool) {
+func injectRowWebURL(rawRow json.RawMessage, base, resourceType string, idKeys []string) (json.RawMessage, bool) {
 	row, ok := decodeShallowObject(rawRow)
 	if !ok {
 		return nil, false
@@ -226,8 +228,8 @@ func injectRowWebURL(rawRow json.RawMessage, base, resourceType, idKey string) (
 		return nil, false
 	}
 
-	var id string
-	if err := json.Unmarshal(rowData[idKey], &id); err != nil {
+	id, ok := firstStringValue(rowData, idKeys)
+	if !ok {
 		return nil, false
 	}
 	webURL, ok := ResourceWebURL(base, resourceType, id)
@@ -250,6 +252,22 @@ func injectRowWebURL(rawRow json.RawMessage, base, resourceType, idKey string) (
 		return nil, false
 	}
 	return rowJSON, true
+}
+
+func firstStringValue(obj map[string]json.RawMessage, keys []string) (string, bool) {
+	for _, key := range keys {
+		if strings.TrimSpace(key) == "" {
+			continue
+		}
+		var value string
+		if err := json.Unmarshal(obj[key], &value); err != nil {
+			continue
+		}
+		if strings.TrimSpace(value) != "" {
+			return value, true
+		}
+	}
+	return "", false
 }
 
 // remarshalUp re-encodes the queryData -> qrr -> envelope nesting after results

--- a/pkg/util/weburl_inject_test.go
+++ b/pkg/util/weburl_inject_test.go
@@ -6,12 +6,12 @@ import (
 )
 
 func TestInjectWebURL_PreservesLargeInt64(t *testing.T) {
-	// A durationNano-style int64 that exceeds float64's exact-integer range
+	// A duration_nano-style int64 that exceeds float64's exact-integer range
 	// (2^53). A naive Unmarshal->map[string]any->Marshal round-trip would coerce
 	// it through float64 and round it; the shallow RawMessage decode must pass
 	// it through as verbatim bytes.
 	const bigInt = "9007199254740993" // 2^53 + 1, not exactly representable as float64
-	in := []byte(`{"data":{"durationNano":` + bigInt + `,"name":"GET /cart"}}`)
+	in := []byte(`{"data":{"duration_nano":` + bigInt + `,"name":"GET /cart"}}`)
 
 	out := InjectWebURL(in, "https://signoz.example.com", "trace", "abc-123")
 	s := string(out)
@@ -38,7 +38,7 @@ func TestInjectWebURL_BareBody(t *testing.T) {
 func TestInjectWebURL_PreservesInnerBytesVerbatim(t *testing.T) {
 	// Values nested below the injection level must pass through as verbatim
 	// bytes: a full-tree decode/re-marshal would sort zKey/aKey alphabetically.
-	in := []byte(`{"data":{"spans":[{"zKey":1,"aKey":2.50}],"durationNano":9007199254740993}}`)
+	in := []byte(`{"data":{"spans":[{"zKey":1,"aKey":2.50}],"duration_nano":9007199254740993}}`)
 	out := InjectWebURL(in, "https://signoz.example.com", "trace", "abc-123")
 	s := string(out)
 
@@ -83,7 +83,7 @@ func TestInjectWebURL_ArrayDataInjectsTopLevel(t *testing.T) {
 }
 
 func TestInjectWebURL_NoBaseReturnsOriginal(t *testing.T) {
-	in := []byte(`{"data":{"durationNano":9007199254740993}}`)
+	in := []byte(`{"data":{"duration_nano":9007199254740993}}`)
 	out := InjectWebURL(in, "", "trace", "abc-123")
 	if string(out) != string(in) {
 		t.Fatalf("expected original bytes when base empty, got: %s", out)
@@ -108,18 +108,18 @@ func TestInjectWebURL_MalformedReturnsOriginal(t *testing.T) {
 
 // rawTracesBody returns a realistic query-builder v5 "raw" passthrough body — a
 // render.Success envelope wrapping QueryRangeResponse — with two rows. The
-// second row's durationNano exceeds float64's exact-integer range to guard the
-// precision bug. The selected trace-id field is "traceID", matching the column
-// alias the backend emits for the traceID select field.
+// second row's duration_nano exceeds float64's exact-integer range to guard the
+// precision bug. The selected trace-id field is "trace_id", matching the column
+// alias the backend emits for the canonical trace_id select field.
 func rawTracesBody() []byte {
 	return []byte(`{"status":"success","data":{"type":"raw","data":{"results":[{"queryName":"A","rows":[` +
-		`{"timestamp":"2026-06-19T10:00:00Z","data":{"traceID":"abc-123","durationNano":9007199254740993,"name":"GET /cart"}},` +
-		`{"timestamp":"2026-06-19T10:00:01Z","data":{"traceID":"def-456","durationNano":42,"name":"POST /checkout"}}` +
+		`{"timestamp":"2026-06-19T10:00:00Z","data":{"trace_id":"abc-123","duration_nano":9007199254740993,"name":"GET /cart"}},` +
+		`{"timestamp":"2026-06-19T10:00:01Z","data":{"trace_id":"def-456","duration_nano":42,"name":"POST /checkout"}}` +
 		`]}]},"meta":{}}}`)
 }
 
 func TestInjectRowsWebURL_InjectsPerRow(t *testing.T) {
-	out, _ := InjectRowsWebURL(rawTracesBody(), "https://signoz.example.com", "trace", "traceID")
+	out, _ := InjectRowsWebURL(rawTracesBody(), "https://signoz.example.com", "trace", "trace_id")
 	s := string(out)
 
 	if !strings.Contains(s, `"webUrl":"https://signoz.example.com/trace/abc-123"`) {
@@ -130,11 +130,30 @@ func TestInjectRowsWebURL_InjectsPerRow(t *testing.T) {
 	}
 }
 
+func TestInjectRowsWebURL_UsesTraceIDFallbackKeys(t *testing.T) {
+	in := []byte(`{"status":"success","data":{"type":"raw","data":{"results":[{"queryName":"A","rows":[` +
+		`{"timestamp":"t","data":{"trace_id":"canonical"}},` +
+		`{"timestamp":"t","data":{"traceID":"legacy-caps"}},` +
+		`{"timestamp":"t","data":{"traceId":"legacy-camel"}}` +
+		`]}]},"meta":{}}}`)
+	out, res := InjectRowsWebURL(in, "https://signoz.example.com", "trace", "trace_id", "traceID", "traceId")
+	s := string(out)
+
+	if res.RowsSeen != 3 || res.RowsEnriched != 3 {
+		t.Fatalf("expected all mixed trace-id rows enriched, got seen=%d enriched=%d body=%s", res.RowsSeen, res.RowsEnriched, s)
+	}
+	for _, id := range []string{"canonical", "legacy-caps", "legacy-camel"} {
+		if !strings.Contains(s, `"webUrl":"https://signoz.example.com/trace/`+id+`"`) {
+			t.Fatalf("expected webUrl for %s, got: %s", id, s)
+		}
+	}
+}
+
 func TestInjectRowsWebURL_PreservesLargeInt64(t *testing.T) {
-	// 2^53 + 1: a durationNano-style int64 that loses precision if coerced
+	// 2^53 + 1: a duration_nano-style int64 that loses precision if coerced
 	// through float64. The shallow RawMessage decode must pass it through verbatim.
 	const bigInt = "9007199254740993"
-	out, _ := InjectRowsWebURL(rawTracesBody(), "https://signoz.example.com", "trace", "traceID")
+	out, _ := InjectRowsWebURL(rawTracesBody(), "https://signoz.example.com", "trace", "trace_id")
 	s := string(out)
 
 	if !strings.Contains(s, bigInt) {
@@ -147,20 +166,20 @@ func TestInjectRowsWebURL_PreservesLargeInt64(t *testing.T) {
 
 func TestInjectRowsWebURL_NoBaseReturnsOriginal(t *testing.T) {
 	in := rawTracesBody()
-	out, _ := InjectRowsWebURL(in, "", "trace", "traceID")
+	out, _ := InjectRowsWebURL(in, "", "trace", "trace_id")
 	if string(out) != string(in) {
 		t.Fatalf("expected original bytes when base empty, got: %s", out)
 	}
 }
 
 func TestInjectRowsWebURL_MissingOrEmptyIDLeftUntouched(t *testing.T) {
-	// One row has no traceID, one has an empty traceID, one is well-formed.
+	// One row has no trace_id, one has an empty trace_id, one is well-formed.
 	in := []byte(`{"status":"success","data":{"type":"raw","data":{"results":[{"queryName":"A","rows":[` +
 		`{"timestamp":"t","data":{"name":"no-id"}},` +
-		`{"timestamp":"t","data":{"traceID":"","name":"empty-id"}},` +
-		`{"timestamp":"t","data":{"traceID":"ok-789","name":"good"}}` +
+		`{"timestamp":"t","data":{"trace_id":"","name":"empty-id"}},` +
+		`{"timestamp":"t","data":{"trace_id":"ok-789","name":"good"}}` +
 		`]}]},"meta":{}}}`)
-	out, _ := InjectRowsWebURL(in, "https://signoz.example.com", "trace", "traceID")
+	out, _ := InjectRowsWebURL(in, "https://signoz.example.com", "trace", "trace_id")
 	s := string(out)
 
 	if strings.Count(s, `"webUrl"`) != 1 {
@@ -179,9 +198,9 @@ func TestInjectRowsWebURL_PreservesSiblingBytesVerbatim(t *testing.T) {
 	// through verbatim; a full-tree re-marshal would reorder keys or reformat
 	// numbers. nextCursor and the meta block sit alongside the mutated results.
 	in := []byte(`{"status":"success","data":{"type":"raw","data":{"results":[{"queryName":"A","nextCursor":"zKey","rows":[` +
-		`{"timestamp":"t","data":{"traceID":"abc-123","durationNano":9007199254740993}}` +
+		`{"timestamp":"t","data":{"traceID":"abc-123","duration_nano":9007199254740993}}` +
 		`]}]},"meta":{"rowsScanned":2.50}}}`)
-	out, _ := InjectRowsWebURL(in, "https://signoz.example.com", "trace", "traceID")
+	out, _ := InjectRowsWebURL(in, "https://signoz.example.com", "trace", "trace_id", "traceID")
 	s := string(out)
 
 	if !strings.Contains(s, `"nextCursor":"zKey"`) {
@@ -210,7 +229,7 @@ func TestInjectRowsWebURL_MalformedReturnsOriginal(t *testing.T) {
 	}
 	for name, in := range cases {
 		t.Run(name, func(t *testing.T) {
-			out, _ := InjectRowsWebURL(in, "https://signoz.example.com", "trace", "traceID")
+			out, _ := InjectRowsWebURL(in, "https://signoz.example.com", "trace", "trace_id")
 			if string(out) != string(in) {
 				t.Fatalf("expected original bytes unchanged, got: %s", out)
 			}
@@ -222,9 +241,9 @@ func TestInjectRowsWebURL_OverwritesExistingWebURL(t *testing.T) {
 	// A row that already carries a (stale) webUrl must end up with the freshly
 	// built one and exactly one webUrl key — never a duplicate.
 	in := []byte(`{"status":"success","data":{"type":"raw","data":{"results":[{"rows":[` +
-		`{"data":{"traceID":"abc-123","webUrl":"https://stale.example.com/trace/old"}}` +
+		`{"data":{"trace_id":"abc-123","webUrl":"https://stale.example.com/trace/old"}}` +
 		`]}]},"meta":{}}}`)
-	out, _ := InjectRowsWebURL(in, "https://signoz.example.com", "trace", "traceID")
+	out, _ := InjectRowsWebURL(in, "https://signoz.example.com", "trace", "trace_id")
 	s := string(out)
 
 	if strings.Count(s, `"webUrl"`) != 1 {
@@ -242,9 +261,9 @@ func TestInjectRowsWebURL_EscapesTraceID(t *testing.T) {
 	// Trace ids flow through url.PathEscape in ResourceWebURL; a value with
 	// reserved characters must be percent-encoded in the row's webUrl.
 	in := []byte(`{"status":"success","data":{"type":"raw","data":{"results":[{"rows":[` +
-		`{"data":{"traceID":"a/b c"}}` +
+		`{"data":{"trace_id":"a/b c"}}` +
 		`]}]},"meta":{}}}`)
-	out, _ := InjectRowsWebURL(in, "https://signoz.example.com", "trace", "traceID")
+	out, _ := InjectRowsWebURL(in, "https://signoz.example.com", "trace", "trace_id")
 	s := string(out)
 
 	if !strings.Contains(s, `"webUrl":"https://signoz.example.com/trace/a%2Fb%20c"`) {
@@ -256,10 +275,10 @@ func TestInjectRowsWebURL_MultipleResultsMixed(t *testing.T) {
 	// Enrichment must span every result in the array (not just the first) and
 	// skip malformed rows within each result independently.
 	in := []byte(`{"status":"success","data":{"type":"raw","data":{"results":[` +
-		`{"queryName":"A","rows":[{"data":{"traceID":"a-1"}},{"data":{"name":"no-id"}}]},` +
-		`{"queryName":"B","rows":[{"data":{"traceID":"b-1"}}]}` +
+		`{"queryName":"A","rows":[{"data":{"trace_id":"a-1"}},{"data":{"name":"no-id"}}]},` +
+		`{"queryName":"B","rows":[{"data":{"trace_id":"b-1"}}]}` +
 		`]},"meta":{}}}`)
-	out, _ := InjectRowsWebURL(in, "https://signoz.example.com", "trace", "traceID")
+	out, _ := InjectRowsWebURL(in, "https://signoz.example.com", "trace", "trace_id")
 	s := string(out)
 
 	if !strings.Contains(s, `"webUrl":"https://signoz.example.com/trace/a-1"`) {
@@ -275,7 +294,7 @@ func TestInjectRowsWebURL_MultipleResultsMixed(t *testing.T) {
 
 func TestInjectRowsWebURL_ReportsCounts(t *testing.T) {
 	// Happy path: results reached, two rows seen, two enriched.
-	_, res := InjectRowsWebURL(rawTracesBody(), "https://signoz.example.com", "trace", "traceID")
+	_, res := InjectRowsWebURL(rawTracesBody(), "https://signoz.example.com", "trace", "trace_id")
 	if !res.ResultsReached || res.RowsSeen != 2 || res.RowsEnriched != 2 {
 		t.Fatalf("happy path: got ResultsReached=%v RowsSeen=%d RowsEnriched=%d, want true/2/2",
 			res.ResultsReached, res.RowsSeen, res.RowsEnriched)
@@ -287,7 +306,7 @@ func TestInjectRowsWebURL_ReportsColumnAliasDriftVsNoData(t *testing.T) {
 	// the expected id key, so RowsSeen > 0 while RowsEnriched == 0. The handler
 	// turns this into a WARN. The body is still returned verbatim.
 	drift := rawTracesBody()
-	out, res := InjectRowsWebURL(drift, "https://signoz.example.com", "trace", "trace_id") // wrong key
+	out, res := InjectRowsWebURL(drift, "https://signoz.example.com", "trace", "traceID") // wrong key
 	if !res.ResultsReached || res.RowsSeen == 0 || res.RowsEnriched != 0 {
 		t.Fatalf("drift: got ResultsReached=%v RowsSeen=%d RowsEnriched=%d, want true/>0/0",
 			res.ResultsReached, res.RowsSeen, res.RowsEnriched)
@@ -299,7 +318,7 @@ func TestInjectRowsWebURL_ReportsColumnAliasDriftVsNoData(t *testing.T) {
 	// Ordinary "no data": results reached but zero rows — the handler stays
 	// silent (no false drift warning).
 	noData := []byte(`{"status":"success","data":{"type":"raw","data":{"results":[{"queryName":"A","rows":[]}]}},"meta":{}}`)
-	_, res = InjectRowsWebURL(noData, "https://signoz.example.com", "trace", "traceID")
+	_, res = InjectRowsWebURL(noData, "https://signoz.example.com", "trace", "trace_id")
 	if !res.ResultsReached || res.RowsSeen != 0 || res.RowsEnriched != 0 {
 		t.Fatalf("no-data: got ResultsReached=%v RowsSeen=%d RowsEnriched=%d, want true/0/0",
 			res.ResultsReached, res.RowsSeen, res.RowsEnriched)
@@ -311,13 +330,13 @@ func TestInjectRowsWebURL_FlagsUnwalkableEnvelope(t *testing.T) {
 	// so the expected nesting can't be walked. ResultsReached must be false
 	// (distinct from an empty result), and the body is returned verbatim.
 	cases := map[string][]byte{
-		"results renamed":    []byte(`{"status":"success","data":{"type":"raw","data":{"rezults":[{"rows":[{"data":{"traceID":"x"}}]}]}},"meta":{}}`),
-		"inner data renamed": []byte(`{"status":"success","data":{"type":"raw","payload":{"results":[{"rows":[{"data":{"traceID":"x"}}]}]}},"meta":{}}`),
+		"results renamed":    []byte(`{"status":"success","data":{"type":"raw","data":{"rezults":[{"rows":[{"data":{"trace_id":"x"}}]}]}},"meta":{}}`),
+		"inner data renamed": []byte(`{"status":"success","data":{"type":"raw","payload":{"results":[{"rows":[{"data":{"trace_id":"x"}}]}]}},"meta":{}}`),
 		"results not array":  []byte(`{"status":"success","data":{"type":"raw","data":{"results":{"rows":[]}}}}`),
 	}
 	for name, in := range cases {
 		t.Run(name, func(t *testing.T) {
-			out, res := InjectRowsWebURL(in, "https://signoz.example.com", "trace", "traceID")
+			out, res := InjectRowsWebURL(in, "https://signoz.example.com", "trace", "trace_id")
 			if res.ResultsReached {
 				t.Fatalf("expected ResultsReached=false for unwalkable envelope, got true")
 			}
@@ -334,13 +353,13 @@ func TestInjectRowsWebURL_FlagsRowsKeyDrift(t *testing.T) {
 	// drift (ResultCount > 0, RowsArraysReached == 0), distinct from an empty
 	// result. The body is returned verbatim.
 	drift := map[string][]byte{
-		"rows renamed": []byte(`{"status":"success","data":{"type":"raw","data":{"results":[{"queryName":"A","records":[{"data":{"traceID":"x"}}]}]}},"meta":{}}`),
+		"rows renamed": []byte(`{"status":"success","data":{"type":"raw","data":{"results":[{"queryName":"A","records":[{"data":{"trace_id":"x"}}]}]}},"meta":{}}`),
 		"rows absent":  []byte(`{"status":"success","data":{"type":"raw","data":{"results":[{"queryName":"A"}]}},"meta":{}}`),
-		"rows object":  []byte(`{"status":"success","data":{"type":"raw","data":{"results":[{"queryName":"A","rows":{"0":{"data":{"traceID":"x"}}}}]}},"meta":{}}`),
+		"rows object":  []byte(`{"status":"success","data":{"type":"raw","data":{"results":[{"queryName":"A","rows":{"0":{"data":{"trace_id":"x"}}}}]}},"meta":{}}`),
 	}
 	for name, in := range drift {
 		t.Run(name, func(t *testing.T) {
-			out, res := InjectRowsWebURL(in, "https://signoz.example.com", "trace", "traceID")
+			out, res := InjectRowsWebURL(in, "https://signoz.example.com", "trace", "trace_id")
 			if !res.ResultsReached || res.ResultCount == 0 || res.RowsArraysReached != 0 {
 				t.Fatalf("%s: got ResultsReached=%v ResultCount=%d RowsArraysReached=%d, want true/>0/0",
 					name, res.ResultsReached, res.ResultCount, res.RowsArraysReached)
@@ -359,7 +378,7 @@ func TestInjectRowsWebURL_FlagsRowsKeyDrift(t *testing.T) {
 	}
 	for name, in := range empty {
 		t.Run(name, func(t *testing.T) {
-			_, res := InjectRowsWebURL(in, "https://signoz.example.com", "trace", "traceID")
+			_, res := InjectRowsWebURL(in, "https://signoz.example.com", "trace", "trace_id")
 			if res.RowsArraysReached == 0 || res.RowsSeen != 0 {
 				t.Fatalf("%s: got RowsArraysReached=%d RowsSeen=%d, want >0/0 (not drift)",
 					name, res.RowsArraysReached, res.RowsSeen)

--- a/pkg/views/examples.go
+++ b/pkg/views/examples.go
@@ -53,7 +53,7 @@ Meter Explorer views (sourcePage "meter" + signal "metrics" + source "meter").
             "signal": "traces",
             "source": "",
             "stepInterval": 0,
-            "filter": { "expression": "hasError = true" },
+            "filter": { "expression": "has_error = true" },
             "having": { "expression": "" }
           }
         }]

--- a/plans/trace-field-snake-case-migration.context.md
+++ b/plans/trace-field-snake-case-migration.context.md
@@ -1,0 +1,68 @@
+# Feature: Trace Field Snake Case Migration - Context & Discussion
+
+## Original Prompt
+> Let's plan to work on this: [https://github.com/SigNoz/signoz-ai-assistant/issues/361](https://github.com/SigNoz/signoz-ai-assistant/issues/361)
+
+## Reference Links
+- [SigNoz/signoz-ai-assistant#361](https://github.com/SigNoz/signoz-ai-assistant/issues/361)
+- [SigNoz/signoz-mcp-server#213](https://github.com/SigNoz/signoz-mcp-server/pull/213)
+
+## Local References
+- `/Users/makeavish-m1/signoz/signoz/pkg/telemetrytraces/const.go`
+- `/Users/makeavish-m1/signoz/signoz/pkg/telemetrytraces/field_mapper.go`
+
+## Key Decisions & Discussion Log
+### 2026-06-27 - Issue Intake
+- Issue #361 tracks migrating trace query-builder field names from deprecated camelCase aliases to canonical snake_case names.
+- No existing plan/context pair matched this feature in `plans/`.
+- The guide and server-emitted query-builder payloads must move together so `signoz://traces/query-builder-guide`, `signoz_search_traces`, `signoz_aggregate_traces`, and `signoz_get_trace_details` do not teach or emit conflicting field names.
+
+### 2026-06-27 - Backend Mapping Verification
+- Local backend checkout confirms the canonical trace mappings in `telemetrytraces`:
+  `traceID -> trace_id`, `spanID -> span_id`, `parentSpanID -> parent_span_id`,
+  `durationNano -> duration_nano`, `statusCode -> status_code`,
+  `statusMessage -> status_message`, `statusCodeString -> status_code_string`,
+  `spanKind -> kind_string`, `httpMethod -> http_method`, `httpUrl -> http_url`,
+  `responseStatusCode -> response_status_code`, and `hasError -> has_error`.
+- `name` and `timestamp` remain canonical as-is.
+- `rpcMethod` is a deprecated calculated alias mapped to `attribute_string_rpc$$method`, not a canonical span field. The likely canonical query-builder representation is the span/tag attribute `rpc.method` with `fieldContext: "tag"`.
+
+### 2026-06-27 - Scope Notes
+- Besides the issue-listed files, repo scan found stale trace-name examples in `README.md`, `internal/handler/tools/traces.go`, `internal/client/client.go`, `pkg/prompts/prompts.go`, `pkg/views/examples.go`, `pkg/alert/resources.go`, and `pkg/dashboard/query.go`.
+- `manifest.json` trace descriptions are generic and may not need changes, but it should be reviewed under the docs/metadata sync checklist.
+- There is no local `/Users/makeavish-m1/signoz/agent-skills` checkout. The companion skills check should be completed during implementation through GitHub or by checking out the repo.
+
+### 2026-06-27 - Compatibility Posture
+- Initial migration should not rewrite arbitrary user-provided free-form `filter`, `aggregateOn`, or `orderBy` strings. Backend aliases still keep legacy caller input working while updated docs/tool descriptions steer models toward canonical names.
+- Server-generated shortcut clauses should switch to canonical names (`has_error`, `duration_nano`) because those are emitted by this server.
+
+### 2026-06-27 - Multi-Agent Review
+- Three parallel reviewers checked the plan from backend-contract, MCP implementation/docs/tests, and rollout-compatibility angles.
+- Backend review confirmed the core mappings and recommended explicit `fieldContext: "span"` for server-authored intrinsic/calculated `selectFields`, plus explicit data types. Backend examples under `/Users/makeavish-m1/signoz/signoz` use `fieldContext: "span"` for trace built-ins; `tag` is accepted as an alias for `attribute`.
+- Reviewers flagged that raw `signoz_search_traces` row keys will change when `selectFields` names change because the backend aliases output columns to the requested field name. The plan now treats this as a downstream output-contract risk, not only an upstream backend-compatibility fix.
+- Reviewers agreed `webUrl` enrichment should support `trace_id` primarily with `traceID` and `traceId` fallbacks during rollout.
+- Reviewers identified `internal/handler/tools/query_builder.go` as an explicit stale metadata surface because it says trace built-in columns are camelCase.
+- Reviewers warned that `response_status_code` is a string field; numeric HTTP status comparisons should use a verified numeric attribute such as `http.response.status_code`, or error-focused examples should use `has_error = true` / `status_code_string = 'Error'`.
+- Reviewers recommended keeping `includeSpans` behavior out of this migration and making live verification a concrete matrix.
+
+### 2026-06-27 - Implementation Start
+- Status moved to `In Progress`.
+- Implementation will migrate server-authored trace payloads and docs to canonical snake_case names while preserving legacy free-form caller input.
+
+### 2026-06-27 - Post-Implementation Review
+- Three post-implementation reviewers checked backend field contracts, Go/test/docs consistency, and rollout compatibility.
+- Backend-contract review found no blocking issues and confirmed the migrated span fields match `telemetrytraces` canonical names and contexts. It flagged `http.response.status_code` as incorrectly typed as string in the default select list; implementation updated it to `fieldDataType: "number"` and pinned that in `BuildTracesQueryPayload` tests.
+- Compatibility review found that partial `webUrl` enrichment could still fail silently if some rows had supported trace-id keys and some did not. Implementation now warns when `RowsSeen > RowsEnriched` and logs both counts.
+- Compatibility review also confirmed the raw `signoz_search_traces` output key migration is a downstream contract risk. Decision: document the snake_case raw row keys in README/PR notes rather than duplicating deprecated aliases in this pass.
+- Test/docs review found no stale deprecated trace field names in README/docs/manifest/tool/resource descriptions outside intentional compatibility tests and planning notes. It recommended stronger aggregate trace payload assertions; implementation now asserts canonical shortcut filters and `p99(duration_nano)` payloads.
+- Manifest review: no `manifest.json` change needed because trace descriptions are generic and already refer to canonical filter expressions.
+- Companion skills review via GitHub found `SigNoz/agent-skills` still teaches deprecated trace fields (`durationNano`, `hasError`) in published skills. Outcome: a matching agent-skills PR is required and should be linked from this PR summary.
+- Local verification is limited by missing `go`/`gofmt` binaries on PATH; `git diff --check` is clean.
+
+## Open Questions
+- [x] Should `search_traces` web URL enrichment accept both `trace_id` and `traceID` during rollout, or should it switch directly to `trace_id` with drift warnings covering old responses? Resolved 2026-06-27: use `trace_id` as the primary key and support `traceID` / `traceId` fallback, warning when rows are present and any row cannot be enriched.
+- [x] Should the default raw trace select list replace `rpcMethod` with the tag field `rpc.method`, omit it, or keep it temporarily for response-shape compatibility? Resolved 2026-06-27: replace `rpcMethod` with `rpc.method` using `fieldContext: "tag"` and document that the raw row key changes.
+- [x] Does `SigNoz/agent-skills` teach any of the old trace field names, requiring a companion PR? Resolved 2026-06-27: yes; a companion PR is required because published skills still teach `durationNano` / `hasError`.
+- [x] Are raw `signoz_search_traces` row keys a public downstream contract that needs a temporary response-compatibility layer, or is the snake_case output-key migration acceptable with explicit PR/release notes? Resolved 2026-06-27: accept the snake_case output-key migration and document it in README plus PR/release notes; do not duplicate legacy aliases in this pass.
+- [x] Should the current numeric `kind` select field be kept as `kind` with `fieldContext: "span"` and numeric type, or dropped in favor of `kind_string` only? Resolved 2026-06-27: keep numeric `kind` and also select `kind_string`.
+- [ ] Which backend versions/environments must pass live verification before rollout?

--- a/plans/trace-field-snake-case-migration.context.md
+++ b/plans/trace-field-snake-case-migration.context.md
@@ -59,6 +59,17 @@
 - Companion skills review via GitHub found `SigNoz/agent-skills` still teaches deprecated trace fields (`durationNano`, `hasError`) in published skills. Outcome: a matching agent-skills PR is required and should be linked from this PR summary.
 - Local verification is limited by missing `go`/`gofmt` binaries on PATH; `git diff --check` is clean.
 
+### 2026-06-28 - CI Failure Follow-up
+- GitHub Actions showed only `test / go` failing; `build`, `fmt`, `lint`, and `deps` passed on the previous PR head.
+- Two failures were brittle raw-JSON test assertions: `json.Marshal` escaped `>` / `<` as `\u003e` / `\u003c`, while the decoded filter expressions were correct.
+- The remaining failure exposed a trace aggregate payload gap: `groupBy=service.name` was emitted with only `name` and `signal`, missing the resource `fieldContext` and string `fieldDataType` documented in the trace guide.
+- Fix direction: decode captured query payloads in tests, attach known trace field metadata to aggregate `groupBy` fields, and align the trace guide's `timestamp` type with backend/MCP metadata (`number`).
+
+### 2026-06-28 - CI Fix Review
+- A follow-up multi-agent review found no blockers in the decoded test assertions or trace-scoped aggregate metadata path.
+- One reviewer noted `messaging.system` was documented as a trace tag but missing from the aggregate metadata map; implementation added it before commit.
+- Reviewers confirmed the direct CI failures are addressed, while noting the new aggregate metadata map duplicates the raw trace select-field list and should be kept in sync with future trace field changes.
+
 ## Open Questions
 - [x] Should `search_traces` web URL enrichment accept both `trace_id` and `traceID` during rollout, or should it switch directly to `trace_id` with drift warnings covering old responses? Resolved 2026-06-27: use `trace_id` as the primary key and support `traceID` / `traceId` fallback, warning when rows are present and any row cannot be enriched.
 - [x] Should the default raw trace select list replace `rpcMethod` with the tag field `rpc.method`, omit it, or keep it temporarily for response-shape compatibility? Resolved 2026-06-27: replace `rpcMethod` with `rpc.method` using `fieldContext: "tag"` and document that the raw row key changes.

--- a/plans/trace-field-snake-case-migration.context.md
+++ b/plans/trace-field-snake-case-migration.context.md
@@ -70,10 +70,23 @@
 - One reviewer noted `messaging.system` was documented as a trace tag but missing from the aggregate metadata map; implementation added it before commit.
 - Reviewers confirmed the direct CI failures are addressed, while noting the new aggregate metadata map duplicates the raw trace select-field list and should be kept in sync with future trace field changes.
 
+### 2026-06-29 - Live E2E Coverage
+- User requested live E2E verification against `https://app.us.staging.signoz.cloud` for the updated trace-field migration cases.
+- Added a read-only `e2e`-tagged trace-field migration test that uses existing trace data and creates no resources.
+- The live matrix covers canonical `search_traces` row keys and `webUrl`, canonical shortcut filters, legacy free-form `durationNano` pass-through, `aggregate_traces` with `duration_nano`, `aggregate_traces` grouped by `service.name`, and `get_trace_details` using a trace discovered from search.
+- Credential handling remains env-only in the test; credentials are not hardcoded, logged, or persisted.
+
+### 2026-06-29 - Live E2E Result
+- Local non-credentialed compile/skip check passed for `go test -tags=e2e -run '^TestE2ETraceFields_SnakeCaseMigration$' -v ./internal/handler/tools/`.
+- Focused local packages passed: `go test ./internal/handler/tools ./pkg/types ./internal/client ./pkg/util`.
+- Delegated staging run initially exposed a test-parser issue: scalar aggregate responses return `columns` + `data`, not raw `rows[].data`. The test was updated to assert `service.name` in aggregate columns and non-empty grouped data rows.
+- A subsequent delegated staging run briefly hit HTTP 503 while the staging workspace was updating, then passed on retry.
+- Verified live fields/behaviors: canonical `search_traces` row fields `trace_id`, `span_id`, `duration_nano`, `has_error`, `service.name`, and `webUrl`; canonical shortcut filters using `has_error` and `duration_nano`; legacy free-form `durationNano` pass-through; `aggregate_traces` with `duration_nano`; `aggregate_traces groupBy=service.name`; and `get_trace_details` via a trace discovered from canonical `trace_id`.
+
 ## Open Questions
 - [x] Should `search_traces` web URL enrichment accept both `trace_id` and `traceID` during rollout, or should it switch directly to `trace_id` with drift warnings covering old responses? Resolved 2026-06-27: use `trace_id` as the primary key and support `traceID` / `traceId` fallback, warning when rows are present and any row cannot be enriched.
 - [x] Should the default raw trace select list replace `rpcMethod` with the tag field `rpc.method`, omit it, or keep it temporarily for response-shape compatibility? Resolved 2026-06-27: replace `rpcMethod` with `rpc.method` using `fieldContext: "tag"` and document that the raw row key changes.
 - [x] Does `SigNoz/agent-skills` teach any of the old trace field names, requiring a companion PR? Resolved 2026-06-27: yes; a companion PR is required because published skills still teach `durationNano` / `hasError`.
 - [x] Are raw `signoz_search_traces` row keys a public downstream contract that needs a temporary response-compatibility layer, or is the snake_case output-key migration acceptable with explicit PR/release notes? Resolved 2026-06-27: accept the snake_case output-key migration and document it in README plus PR/release notes; do not duplicate legacy aliases in this pass.
 - [x] Should the current numeric `kind` select field be kept as `kind` with `fieldContext: "span"` and numeric type, or dropped in favor of `kind_string` only? Resolved 2026-06-27: keep numeric `kind` and also select `kind_string`.
-- [ ] Which backend versions/environments must pass live verification before rollout?
+- [x] Which backend versions/environments must pass live verification before rollout? Resolved 2026-06-29: run this PR's live trace-field verification against US staging (`https://app.us.staging.signoz.cloud`) using existing trace data; no live resource creation is needed for this read-only migration check.

--- a/plans/trace-field-snake-case-migration.context.md
+++ b/plans/trace-field-snake-case-migration.context.md
@@ -83,6 +83,12 @@
 - A subsequent delegated staging run briefly hit HTTP 503 while the staging workspace was updating, then passed on retry.
 - Verified live fields/behaviors: canonical `search_traces` row fields `trace_id`, `span_id`, `duration_nano`, `has_error`, `service.name`, and `webUrl`; canonical shortcut filters using `has_error` and `duration_nano`; legacy free-form `durationNano` pass-through; `aggregate_traces` with `duration_nano`; `aggregate_traces groupBy=service.name`; and `get_trace_details` via a trace discovered from canonical `trace_id`.
 
+### 2026-06-29 - Field Metadata Contract Follow-up
+- User clarified that MCP cannot fully own query-builder field metadata because SigNoz supports custom attributes, and the same field-metadata problem can affect other tool inputs such as select fields and analogous tools beyond trace aggregate `groupBy`.
+- Decision: treat the current trace aggregate metadata map as a tactical compatibility fix for known fields only, not the ideal long-term design.
+- Long-term options are dynamic field metadata resolution through SigNoz/query-builder APIs, updating high-level MCP tool payloads so callers provide structured field descriptors, or a hybrid approach.
+- Created cross-repo tracking issue [SigNoz/nerve-pod#20](https://github.com/SigNoz/nerve-pod/issues/20) to cover `signoz-mcp-server`, `signoz`, `agent-skills`, and `signoz-ai-assistant` contract alignment.
+
 ## Open Questions
 - [x] Should `search_traces` web URL enrichment accept both `trace_id` and `traceID` during rollout, or should it switch directly to `trace_id` with drift warnings covering old responses? Resolved 2026-06-27: use `trace_id` as the primary key and support `traceID` / `traceId` fallback, warning when rows are present and any row cannot be enriched.
 - [x] Should the default raw trace select list replace `rpcMethod` with the tag field `rpc.method`, omit it, or keep it temporarily for response-shape compatibility? Resolved 2026-06-27: replace `rpcMethod` with `rpc.method` using `fieldContext: "tag"` and document that the raw row key changes.
@@ -90,3 +96,4 @@
 - [x] Are raw `signoz_search_traces` row keys a public downstream contract that needs a temporary response-compatibility layer, or is the snake_case output-key migration acceptable with explicit PR/release notes? Resolved 2026-06-27: accept the snake_case output-key migration and document it in README plus PR/release notes; do not duplicate legacy aliases in this pass.
 - [x] Should the current numeric `kind` select field be kept as `kind` with `fieldContext: "span"` and numeric type, or dropped in favor of `kind_string` only? Resolved 2026-06-27: keep numeric `kind` and also select `kind_string`.
 - [x] Which backend versions/environments must pass live verification before rollout? Resolved 2026-06-29: run this PR's live trace-field verification against US staging (`https://app.us.staging.signoz.cloud`) using existing trace data; no live resource creation is needed for this read-only migration check.
+- [x] Is expanding MCP-owned static field metadata the ideal solution for custom attributes and similar tool inputs? Resolved 2026-06-29: no; static metadata is tactical for known MCP-authored fields only. Dynamic resolution or a structured payload contract is tracked in [SigNoz/nerve-pod#20](https://github.com/SigNoz/nerve-pod/issues/20).

--- a/plans/trace-field-snake-case-migration.plan.md
+++ b/plans/trace-field-snake-case-migration.plan.md
@@ -76,6 +76,7 @@ Migrate server-authored trace field names to canonical snake_case while preservi
 - `pkg/util/weburl.go` - comments and, if needed, helper support for multi-key row ID lookup.
 - `manifest.json` and `docs/` - review for stale trace-field metadata.
 - Tests under `pkg/types`, `internal/handler/tools`, `internal/client`, `pkg/util`, and live E2E families as needed.
+- `internal/handler/tools/e2e_trace_fields_test.go` - read-only live E2E coverage for the trace-field migration matrix.
 - Companion `SigNoz/agent-skills` - matching update needed because published skills still teach deprecated trace field names.
 
 ## Verification
@@ -87,6 +88,7 @@ Migrate server-authored trace field names to canonical snake_case while preservi
 - Add `internal/client` coverage that captures the `GetTraceDetails` `/api/v5/query_range` body and asserts `trace_id = '...'`.
 - Add mixed-row `webUrl` enrichment fixtures for `trace_id`, `traceID`, and `traceId`, preferring `trace_id` and warning when rows are present but one or more rows cannot be enriched.
 - Update live E2E contract coverage to use canonical `duration_nano` for trace aggregation drift checks.
+- Add focused live E2E coverage for canonical trace raw row keys, `webUrl`, shortcut filters, legacy free-form pass-through, aggregate `duration_nano`, aggregate `service.name` groupBy, and `get_trace_details` using a trace discovered from search.
 - Run focused tests when Go is available: `go test ./pkg/types ./internal/handler/tools ./internal/client ./pkg/util`.
 - Run `rg` for deprecated trace names after implementation and review remaining hits intentionally.
 - For live SigNoz verification, delegate to a subagent: run read-only trace search/aggregate/detail checks against a real instance, confirm canonical fields round-trip server-side, do not print or persist credentials, and report any fields that fail.

--- a/plans/trace-field-snake-case-migration.plan.md
+++ b/plans/trace-field-snake-case-migration.plan.md
@@ -13,6 +13,7 @@ Migrate server-authored trace field names to canonical snake_case while preservi
    - Change shortcut filters in `buildTraceFilterExpr` from `hasError`/`durationNano` to `has_error`/`duration_nano`.
    - Change `GetTraceDetails`' generated trace lookup from `traceID = ...` to `trace_id = ...`.
    - Change `BuildTracesQueryPayload` `SelectFields` to canonical names with explicit field metadata. Prefer `fieldContext: "span"` for intrinsic/calculated fields so server-authored payloads do not rely on backend ambiguity resolution.
+   - Attach the same known trace field metadata to server-authored aggregate `groupBy` fields, so resource/span/tag fields such as `service.name` serialize with their expected `fieldContext` and `fieldDataType`.
    - Keep `name` and `timestamp` unchanged.
    - Replace deprecated `rpcMethod` with the canonical span/tag attribute `rpc.method` using `fieldContext: "tag"`.
    - Keep numeric span `kind` with `fieldContext: "span"` and `fieldDataType: "number"` while also selecting `kind_string`.
@@ -63,6 +64,7 @@ Migrate server-authored trace field names to canonical snake_case while preservi
 - `pkg/querybuilder/traces_guide.go` - canonical trace field guide, selectFields examples, filter examples, quick reference.
 - `pkg/types/querybuilder.go` - canonical raw trace select fields and comments/examples.
 - `internal/handler/tools/traces_helper.go` - canonical shortcut filter clauses.
+- `internal/handler/tools/aggregate_helper.go` - trace aggregate `groupBy` field metadata for known canonical fields.
 - `internal/handler/tools/traces.go` - tool descriptions, enrichment key, warning text, comments.
 - `internal/handler/tools/query_builder.go` - Query Builder tool/resource metadata that currently says trace built-ins are camelCase.
 - `internal/client/client.go` - canonical `get_trace_details` trace lookup filter.
@@ -79,6 +81,7 @@ Migrate server-authored trace field names to canonical snake_case while preservi
 ## Verification
 - Add unit tests that assert `BuildTracesQueryPayload` selects canonical fields with expected `fieldContext`/`fieldDataType` metadata and omits deprecated aliases unless a legacy compatibility exception is documented.
 - Update shortcut parsing tests to expect generated `has_error` and `duration_nano` clauses.
+- Decode captured query payloads when asserting filter/groupBy fields so tests validate payload semantics rather than raw JSON escaping.
 - Add tests showing legacy free-form caller input still passes through unchanged: `filter`/`query` using `hasError`, `aggregateOn=durationNano`, and `orderBy=avg(durationNano) desc`.
 - Add or update client/handler tests to assert `get_trace_details` and `search_traces` emit canonical filters and row keys.
 - Add `internal/client` coverage that captures the `GetTraceDetails` `/api/v5/query_range` body and asserts `trace_id = '...'`.

--- a/plans/trace-field-snake-case-migration.plan.md
+++ b/plans/trace-field-snake-case-migration.plan.md
@@ -13,7 +13,7 @@ Migrate server-authored trace field names to canonical snake_case while preservi
    - Change shortcut filters in `buildTraceFilterExpr` from `hasError`/`durationNano` to `has_error`/`duration_nano`.
    - Change `GetTraceDetails`' generated trace lookup from `traceID = ...` to `trace_id = ...`.
    - Change `BuildTracesQueryPayload` `SelectFields` to canonical names with explicit field metadata. Prefer `fieldContext: "span"` for intrinsic/calculated fields so server-authored payloads do not rely on backend ambiguity resolution.
-   - Attach the same known trace field metadata to server-authored aggregate `groupBy` fields, so resource/span/tag fields such as `service.name` serialize with their expected `fieldContext` and `fieldDataType`.
+   - Attach the same known trace field metadata to server-authored aggregate `groupBy` fields, so resource/span/tag fields such as `service.name` serialize with their expected `fieldContext` and `fieldDataType`. Treat this as a tactical compatibility shim for known MCP-authored fields only; long-term handling for custom attributes and similar tool inputs is tracked in [SigNoz/nerve-pod#20](https://github.com/SigNoz/nerve-pod/issues/20).
    - Keep `name` and `timestamp` unchanged.
    - Replace deprecated `rpcMethod` with the canonical span/tag attribute `rpc.method` using `fieldContext: "tag"`.
    - Keep numeric span `kind` with `fieldContext: "span"` and `fieldDataType: "number"` while also selecting `kind_string`.

--- a/plans/trace-field-snake-case-migration.plan.md
+++ b/plans/trace-field-snake-case-migration.plan.md
@@ -1,0 +1,91 @@
+# Plan: Trace Field Snake Case Migration
+
+## Status
+In Progress
+
+## Context
+Trace query-builder docs and server-generated payloads used deprecated camelCase aliases for intrinsic and calculated trace fields. The SigNoz backend currently maps those aliases to canonical snake_case fields, but that alias layer is explicitly deprecated. This migration updates the MCP server's own emitted trace queries and user-facing guidance together so future backend alias removal does not break trace tools.
+
+## Approach
+Migrate server-authored trace field names to canonical snake_case while preserving compatibility for caller-provided free-form expressions.
+
+1. Update generated trace filters and payloads:
+   - Change shortcut filters in `buildTraceFilterExpr` from `hasError`/`durationNano` to `has_error`/`duration_nano`.
+   - Change `GetTraceDetails`' generated trace lookup from `traceID = ...` to `trace_id = ...`.
+   - Change `BuildTracesQueryPayload` `SelectFields` to canonical names with explicit field metadata. Prefer `fieldContext: "span"` for intrinsic/calculated fields so server-authored payloads do not rely on backend ambiguity resolution.
+   - Keep `name` and `timestamp` unchanged.
+   - Replace deprecated `rpcMethod` with the canonical span/tag attribute `rpc.method` using `fieldContext: "tag"`.
+   - Keep numeric span `kind` with `fieldContext: "span"` and `fieldDataType: "number"` while also selecting `kind_string`.
+
+2. Use this field metadata target for server-authored trace `selectFields`:
+
+   | Field | fieldContext | fieldDataType | Notes |
+   |---|---|---|---|
+   | `trace_id` | `span` | `string` | Replaces `traceID` |
+   | `span_id` | `span` | `string` | Replaces `spanID` |
+   | `parent_span_id` | `span` | `string` | Replaces `parentSpanID` |
+   | `name` | `span` | `string` | Already canonical |
+   | `timestamp` | `span` | `number` | Verify exact accepted payload spelling; backend treats this as a span field |
+   | `duration_nano` | `span` | `number` | Replaces `durationNano` |
+   | `has_error` | `span` | `bool` | Replaces `hasError` |
+   | `status_code` | `span` | `number` | Replaces `statusCode` |
+   | `status_code_string` | `span` | `string` | Replaces `statusCodeString` |
+   | `status_message` | `span` | `string` | Replaces `statusMessage` |
+   | `kind_string` | `span` | `string` | Replaces `spanKind` for string span kind values |
+   | `kind` | `span` | `number` | Kept for numeric span kind compatibility |
+   | `http_method` | `span` | `string` | Replaces `httpMethod` |
+   | `http_url` | `span` | `string` | Replaces `httpUrl` |
+   | `response_status_code` | `span` | `string` | Replaces `responseStatusCode`; do not use for numeric comparisons |
+   | `rpc.method` | `tag` | `string` | Replaces deprecated `rpcMethod` row key |
+   | `http.response.status_code` | `tag` | `number` | Numeric HTTP status attribute for comparisons |
+
+3. Update user-facing guidance and metadata:
+   - Rewrite `signoz://traces/query-builder-guide` examples and quick reference to canonical names.
+   - Update trace tool descriptions and README examples to use `has_error`, `duration_nano`, `status_code_string`, `http_method`, etc.
+   - Avoid translating numeric examples like `responseStatusCode >= 500` into `response_status_code >= 500`; use `has_error = true`, `status_code_string = 'Error'`, or a verified numeric attribute such as `http.response.status_code >= 500`.
+   - Update Query Builder resource/tool metadata in `internal/handler/tools/query_builder.go`; it currently describes trace built-ins as camelCase.
+   - Update stale examples in prompts, view examples, alert resources, and dashboard query guidance.
+   - Review `manifest.json` and `docs/` for trace-name drift; no manifest change is needed when descriptions remain generic and already refer to canonical field expressions.
+   - Treat `pkg/dashboard/query.go` carefully: it is ClickHouse SQL guidance, so update physical SQL column names only and do not apply Query Builder `fieldContext` rules there.
+
+4. Handle raw output compatibility and web URL enrichment:
+   - Raw `signoz_search_traces` rows will return keys matching the selected field names, so `traceID`/`durationNano` outputs become `trace_id`/`duration_nano` when the default select list migrates.
+   - Treat this as an acceptable downstream output-key migration for canonicalization, documented in README and PR/release notes. Do not duplicate legacy aliases in this pass.
+   - Update `enrichSearchTracesWebURL` to prefer `trace_id` and fall back to `traceID` / `traceId` for mixed rollout responses.
+   - Update `pkg/util/weburl.go` comments, drift warning text, and tests so warnings mention `trace_id` primary and fire when any rows cannot be enriched while rows are present.
+
+5. Keep legacy caller input fail-open:
+   - Do not normalize arbitrary user-provided filter/order/aggregation strings in this first pass.
+   - Continue accepting legacy inputs because backend aliases still resolve them today.
+   - Let docs/tool descriptions and server-generated shortcut filters produce only canonical names.
+
+## Files to Modify
+- `pkg/querybuilder/traces_guide.go` - canonical trace field guide, selectFields examples, filter examples, quick reference.
+- `pkg/types/querybuilder.go` - canonical raw trace select fields and comments/examples.
+- `internal/handler/tools/traces_helper.go` - canonical shortcut filter clauses.
+- `internal/handler/tools/traces.go` - tool descriptions, enrichment key, warning text, comments.
+- `internal/handler/tools/query_builder.go` - Query Builder tool/resource metadata that currently says trace built-ins are camelCase.
+- `internal/client/client.go` - canonical `get_trace_details` trace lookup filter.
+- `README.md` - trace tool parameter examples.
+- `pkg/prompts/prompts.go` - latency prompt aggregate field examples.
+- `pkg/views/examples.go` - trace view example filter.
+- `pkg/alert/resources.go` - trace alert example filter.
+- `pkg/dashboard/query.go` - trace SQL guidance examples that still use deprecated names.
+- `pkg/util/weburl.go` - comments and, if needed, helper support for multi-key row ID lookup.
+- `manifest.json` and `docs/` - review for stale trace-field metadata.
+- Tests under `pkg/types`, `internal/handler/tools`, `internal/client`, `pkg/util`, and live E2E families as needed.
+- Companion `SigNoz/agent-skills` - matching update needed because published skills still teach deprecated trace field names.
+
+## Verification
+- Add unit tests that assert `BuildTracesQueryPayload` selects canonical fields with expected `fieldContext`/`fieldDataType` metadata and omits deprecated aliases unless a legacy compatibility exception is documented.
+- Update shortcut parsing tests to expect generated `has_error` and `duration_nano` clauses.
+- Add tests showing legacy free-form caller input still passes through unchanged: `filter`/`query` using `hasError`, `aggregateOn=durationNano`, and `orderBy=avg(durationNano) desc`.
+- Add or update client/handler tests to assert `get_trace_details` and `search_traces` emit canonical filters and row keys.
+- Add `internal/client` coverage that captures the `GetTraceDetails` `/api/v5/query_range` body and asserts `trace_id = '...'`.
+- Add mixed-row `webUrl` enrichment fixtures for `trace_id`, `traceID`, and `traceId`, preferring `trace_id` and warning when rows are present but one or more rows cannot be enriched.
+- Update live E2E contract coverage to use canonical `duration_nano` for trace aggregation drift checks.
+- Run focused tests when Go is available: `go test ./pkg/types ./internal/handler/tools ./internal/client ./pkg/util`.
+- Run `rg` for deprecated trace names after implementation and review remaining hits intentionally.
+- For live SigNoz verification, delegate to a subagent: run read-only trace search/aggregate/detail checks against a real instance, confirm canonical fields round-trip server-side, do not print or persist credentials, and report any fields that fail.
+- Live verification matrix: canonical `search_traces` returns snake_case row keys and `webUrl`; legacy caller input still succeeds; `aggregate_traces` works with `duration_nano`; `get_trace_details` works with a trace found from search; `rpc.method` replacement behavior is confirmed or rejected.
+- State in the PR summary that `SigNoz/agent-skills` needs a matching update and link the companion PR when created.


### PR DESCRIPTION
## Summary
- Migrate server-authored trace Query Builder v5 fields from deprecated camelCase aliases to canonical snake_case names.
- Add canonical trace field metadata to aggregate `groupBy` fields for known span/resource/tag fields, including `service.name` as a resource string.
- Update trace guides, tool descriptions, README/examples, prompts, views, alerts, dashboard guidance, and query-builder metadata to teach canonical trace fields.
- Update search trace webUrl enrichment to prefer `trace_id` with `traceID` / `traceId` fallbacks, and warn on partial row enrichment drift.
- Add/refresh tests for canonical trace payloads, shortcut filters, legacy free-form pass-through, trace detail lookup, aggregate groupBy metadata, webUrl fallback/drift behavior, and read-only live trace-field E2E coverage.

Fixes SigNoz/signoz-ai-assistant#361.

## Contract Notes
- `signoz_search_traces` raw row keys now follow canonical Query Builder field names such as `trace_id`, `span_id`, `duration_nano`, and `has_error`.
- Trace aggregate `groupBy` fields now include `fieldContext` / `fieldDataType` for known canonical trace fields; unknown groupBy fields preserve the previous pass-through shape.
- The known-field aggregate metadata is a tactical compatibility shim, not the long-term solution for custom attributes or similar field inputs across tools. Dynamic metadata resolution or a structured payload contract is tracked in SigNoz/nerve-pod#20.
- Legacy caller-provided free-form filters/aggregations such as `hasError` and `durationNano` are still passed through to the backend alias layer; this PR only changes server-authored payloads and guidance.
- `manifest.json` was reviewed and does not need a change because trace entries already describe canonical filter expressions generically.
- `SigNoz/agent-skills` needs a companion update because published skills still teach deprecated trace fields such as `durationNano` and `hasError`.

## Validation
- GitHub Actions CI passed on run `28371913256`: `fmt / go`, `lint / go`, `deps / go`, `test / go`, and `build / go`.
- Live staging E2E passed against `https://app.us.staging.signoz.cloud`: `go test -tags=e2e -run '^TestE2ETraceFields_SnakeCaseMigration$' -v ./internal/handler/tools/`.
  - Verified canonical `search_traces` row fields: `trace_id`, `span_id`, `duration_nano`, `has_error`, `service.name`, and `webUrl`.
  - Verified canonical shortcut filters, legacy `durationNano` pass-through, `aggregate_traces` with `duration_nano`, `aggregate_traces groupBy=service.name`, and `get_trace_details` from a canonical `trace_id` search result.
- `go test -tags=e2e -run '^TestE2ETraceFields_SnakeCaseMigration$' -v ./internal/handler/tools/` without credentials compiles and skips.
- `go test ./internal/handler/tools ./pkg/types ./internal/client ./pkg/util`
- `git diff --check`
- `git diff --check HEAD~1 HEAD`
- Pre-commit staged diff check: `git diff --cached --check`
- Multi-agent implementation review covering backend field contracts, tests/docs consistency, and rollout compatibility; review findings were addressed.
- Follow-up multi-agent CI-fix review covering decoded payload assertions, trace aggregate groupBy metadata, docs/plan consistency, and `/Users/makeavish-m1/signoz/signoz` backend references; review findings were addressed.

Not run locally:
- Full `go test ./...` after adding the E2E test. Focused packages and CI-covered jobs were used instead.

