### PR TITLE
fix(mcp): classify upstream authz errors

### DIFF
--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -40,6 +40,20 @@ const (
 
 var ErrUnauthorized = errors.New("signoz credentials rejected")
 
+// HTTPStatusError preserves status and response details from a non-2xx SigNoz API response.
+type HTTPStatusError struct {
+	StatusCode int
+	Body       string
+}
+
+func (e *HTTPStatusError) Error() string {
+	return fmt.Sprintf("unexpected status %d: %s", e.StatusCode, e.truncatedBody())
+}
+
+func (e *HTTPStatusError) truncatedBody() string {
+	return logpkg.TruncBody([]byte(e.Body))
+}
+
 // AnalyticsIdentity is the identity tuple used for analytics attribution.
 // UserID holds the service-account ID for API-key sessions, or the SigNoz
 // user ID for auth-token sessions. Name is the service-account name or the
@@ -413,13 +427,13 @@ func (s *SigNoz) doRequest(ctx context.Context, method, reqURL string, body io.R
 
 		// Retry on transient server errors.
 		if isRetryableStatus(resp.StatusCode) && attempt < maxRetries-1 {
-			truncatedBody := logpkg.TruncBody(respBody)
-			lastErr = fmt.Errorf("unexpected status %d: %s", resp.StatusCode, truncatedBody)
+			statusErr := newHTTPStatusError(resp.StatusCode, respBody)
+			lastErr = statusErr
 			s.logger.DebugContext(ctx, "Retryable status, will retry",
 				slog.String("url", reqURL),
 				slog.Int("status", resp.StatusCode),
 				slog.Int("attempt", attempt+1),
-				slog.String("response", truncatedBody))
+				slog.String("response", statusErr.truncatedBody()))
 			select {
 			case <-ctx.Done():
 				return nil, fmt.Errorf("retry aborted: %w", lastErr)
@@ -430,22 +444,29 @@ func (s *SigNoz) doRequest(ctx context.Context, method, reqURL string, body io.R
 		}
 
 		retryable := isRetryableStatus(resp.StatusCode)
-		truncatedBody := logpkg.TruncBody(respBody)
+		statusErr := newHTTPStatusError(resp.StatusCode, respBody)
 		attrs := []any{
 			slog.String("url", reqURL),
 			slog.Int("status", resp.StatusCode),
 			slog.Int("attempt", attempt+1),
 			slog.Bool("retryable", retryable),
-			slog.String("response", truncatedBody),
+			slog.String("response", statusErr.truncatedBody()),
 		}
 		if retryable {
 			attrs = append(attrs, slog.Bool("retries_exhausted", true))
 		}
 		s.logger.WarnContext(ctx, "SigNoz request returned unexpected status", attrs...)
-		return nil, fmt.Errorf("unexpected status %d: %s", resp.StatusCode, truncatedBody)
+		return nil, statusErr
 	}
 
 	return nil, lastErr
+}
+
+func newHTTPStatusError(statusCode int, respBody []byte) *HTTPStatusError {
+	return &HTTPStatusError{
+		StatusCode: statusCode,
+		Body:       string(respBody),
+	}
 }
 
 func isRetryableStatus(code int) bool {

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -553,6 +554,67 @@ func TestDoRequest_NonRetryableStatusOmitsRetriesExhausted(t *testing.T) {
 
 	assert.False(t, sawRetryDebug, "did not expect retry log for non-retryable status")
 	assert.True(t, sawTerminalWarn, "expected terminal non-retryable warning log")
+}
+
+func TestDoRequest_NonRetryableStatusReturnsHTTPStatusError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte(`{"status":"error","error":{"type":"forbidden","code":"authz_forbidden","message":"only editors/admins can access this resource"}}`))
+	}))
+	defer server.Close()
+
+	client := NewClient(logpkg.New("error"), server.URL, "test-api-key", "SIGNOZ-API-KEY", nil)
+
+	_, err := client.doRequest(context.Background(), http.MethodPost, server.URL, strings.NewReader(`{}`), time.Second)
+	require.Error(t, err)
+
+	var statusErr *HTTPStatusError
+	require.True(t, errors.As(err, &statusErr), "expected HTTPStatusError, got %T: %v", err, err)
+	assert.Equal(t, http.StatusForbidden, statusErr.StatusCode)
+	assert.Contains(t, statusErr.Body, "authz_forbidden")
+	assert.Contains(t, err.Error(), "unexpected status 403")
+}
+
+func TestDoRequest_HTTPStatusErrorPreservesFullBodyForParsing(t *testing.T) {
+	var logBuf bytes.Buffer
+	longMessage := strings.Repeat("x", 5000) + "tail"
+	responseBody, err := json.Marshal(map[string]any{
+		"status": "error",
+		"error": map[string]any{
+			"type":    "forbidden",
+			"code":    "forbidden",
+			"message": longMessage,
+		},
+	})
+	require.NoError(t, err)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write(responseBody)
+	}))
+	defer server.Close()
+
+	client := NewClient(newBufferedLogger(&logBuf, slog.LevelWarn), server.URL, "test-api-key", "SIGNOZ-API-KEY", nil)
+
+	_, err = client.doRequest(context.Background(), http.MethodPost, server.URL, strings.NewReader(`{}`), time.Second)
+	require.Error(t, err)
+
+	var statusErr *HTTPStatusError
+	require.True(t, errors.As(err, &statusErr), "expected HTTPStatusError, got %T: %v", err, err)
+	assert.Equal(t, http.StatusForbidden, statusErr.StatusCode)
+	assert.True(t, json.Valid([]byte(statusErr.Body)), "stored body should remain parseable JSON")
+	assert.Contains(t, statusErr.Body, longMessage)
+	assert.Contains(t, err.Error(), "...(truncated)")
+	assert.NotContains(t, err.Error(), "tail")
+
+	lines := strings.Split(strings.TrimSpace(logBuf.String()), "\n")
+	require.NotEmpty(t, lines)
+	var rec map[string]any
+	require.NoError(t, json.Unmarshal([]byte(lines[len(lines)-1]), &rec))
+	assert.Equal(t, "SigNoz request returned unexpected status", rec["msg"])
+	response, _ := rec["response"].(string)
+	assert.Contains(t, response, "...(truncated)")
+	assert.NotContains(t, response, "tail")
 }
 
 func TestListMetricKeys(t *testing.T) {

--- a/internal/handler/tools/alerts_test.go
+++ b/internal/handler/tools/alerts_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/http"
 	"strings"
 	"testing"
 
@@ -782,6 +783,84 @@ func TestHandleCreateAlert_ClientError(t *testing.T) {
 	}
 	if !result.IsError {
 		t.Error("expected error result when client returns error")
+	}
+}
+
+func TestHandleCreateAlert_ForbiddenClientError(t *testing.T) {
+	mock := &client.MockClient{
+		ListNotificationChannelsFn: func(ctx context.Context) (json.RawMessage, error) {
+			return json.RawMessage(`{"data":[{"name":"slack-alerts","type":"slack"}]}`), nil
+		},
+		CreateAlertRuleFn: func(ctx context.Context, alertJSON []byte) (json.RawMessage, error) {
+			return nil, &client.HTTPStatusError{
+				StatusCode: http.StatusForbidden,
+				Body:       `{"status":"error","error":{"type":"forbidden","code":"authz_forbidden","message":"only editors/admins can access this resource","errors":[],"suggestions":[]}}`,
+			}
+		},
+	}
+	h := newTestHandler(mock)
+	req := makeToolRequest("signoz_create_alert", validThresholdAlertArgs())
+
+	result, err := h.handleCreateAlert(testCtx(), req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !result.IsError {
+		t.Fatal("expected error result when upstream returns 403")
+	}
+	if code := resultCode(t, result); code != CodePermissionDenied {
+		t.Fatalf("code = %q, want %q", code, CodePermissionDenied)
+	}
+	structured := resultStructuredMap(t, result)
+	if got := structured["status"]; got != http.StatusForbidden {
+		t.Fatalf("status = %v, want %d", got, http.StatusForbidden)
+	}
+	if got := structured["upstreamCode"]; got != "authz_forbidden" {
+		t.Fatalf("upstreamCode = %v, want authz_forbidden", got)
+	}
+	if got := structured["upstreamMessage"]; got != "only editors/admins can access this resource" {
+		t.Fatalf("upstreamMessage = %v, want backend message", got)
+	}
+	if text := textContent(t, result); !strings.Contains(text, "only editors/admins can access this resource") {
+		t.Fatalf("error text should preserve backend message, got %q", text)
+	}
+}
+
+func validThresholdAlertArgs() map[string]any {
+	return map[string]any{
+		"alert":     "Test Alert",
+		"alertType": "METRIC_BASED_ALERT",
+		"ruleType":  "threshold_rule",
+		"condition": map[string]any{
+			"compositeQuery": map[string]any{
+				"queryType": "builder",
+				"queries": []any{
+					map[string]any{
+						"type": "builder_query",
+						"spec": map[string]any{
+							"name":   "A",
+							"signal": "metrics",
+							"aggregations": []any{
+								map[string]any{"expression": "count()"},
+							},
+							"filter": map[string]any{"expression": ""},
+						},
+					},
+				},
+			},
+			"thresholds": map[string]any{
+				"kind": "basic",
+				"spec": []any{
+					map[string]any{
+						"name":      "warning",
+						"target":    float64(100),
+						"op":        "1",
+						"matchType": "1",
+						"channels":  []any{"slack-alerts"},
+					},
+				},
+			},
+		},
 	}
 }
 

--- a/internal/handler/tools/e2e_familyc_test.go
+++ b/internal/handler/tools/e2e_familyc_test.go
@@ -265,7 +265,7 @@ func firstMetricName(raw []byte) string {
 
 // TestE2EFamilyC_ErrorCodes verifies the error-code taxonomy against live
 // behavior: a missing required arg yields VALIDATION_FAILED locally, and a
-// well-formed but nonexistent id yields an UPSTREAM_ERROR from the backend.
+// well-formed but nonexistent id yields NOT_FOUND from the backend.
 func TestE2EFamilyC_ErrorCodes(t *testing.T) {
 	h, ctx := e2eHandlerC(t)
 
@@ -282,10 +282,10 @@ func TestE2EFamilyC_ErrorCodes(t *testing.T) {
 	}
 	t.Logf("PASS validation error: get_dashboard(no uuid) -> %s", CodeValidationFailed)
 
-	// UPSTREAM_ERROR: a well-formed-but-nonexistent UUIDv7 ruleId. Use the
+	// NOT_FOUND: a well-formed-but-nonexistent UUIDv7 ruleId. Use the
 	// NON-DESTRUCTIVE get_alert read (never a delete) so the probe cannot touch
 	// real user data even if the id ever collides with a live rule. get_alert
-	// wraps the backend 404 in upstreamError -> UPSTREAM_ERROR.
+	// wraps the backend 404 in upstreamError -> NOT_FOUND.
 	const ghostRule = "0196634d-5d66-75c4-b778-e317f49dab7a"
 	gres, err := h.handleGetAlert(ctx, makeToolRequest("signoz_get_alert", map[string]any{"ruleId": ghostRule}))
 	if err != nil {
@@ -296,10 +296,10 @@ func TestE2EFamilyC_ErrorCodes(t *testing.T) {
 		// read is harmless) rather than a false failure.
 		t.Logf("WARN get_alert(ghost) returned success unexpectedly; skipping upstream-code assertion")
 	} else {
-		if code := codeOf(t, gres); code != CodeUpstreamError {
-			t.Fatalf("get_alert(ghost): code = %q, want %q (text=%s)", code, CodeUpstreamError, firstText(gres))
+		if code := codeOf(t, gres); code != CodeNotFound {
+			t.Fatalf("get_alert(ghost): code = %q, want %q (text=%s)", code, CodeNotFound, firstText(gres))
 		}
-		t.Logf("PASS upstream error: get_alert(ghost ruleId) -> %s", CodeUpstreamError)
+		t.Logf("PASS upstream not found: get_alert(ghost ruleId) -> %s", CodeNotFound)
 	}
 }
 

--- a/internal/handler/tools/errs.go
+++ b/internal/handler/tools/errs.go
@@ -6,19 +6,23 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net/http"
+	"strings"
 
 	"github.com/mark3labs/mcp-go/mcp"
+
+	signozclient "github.com/SigNoz/signoz-mcp-server/internal/client"
+	logpkg "github.com/SigNoz/signoz-mcp-server/pkg/log"
 )
 
 // Shared error/validation string helpers used across the MCP tool handlers.
 // Converging on these keeps the strings uniform so the AI assistant can tell a
 // user/parameter mistake (fix and re-call) apart from an upstream SigNoz
-// failure (retryable).
+// failure (inspect status/code before retrying).
 //
 // Error results also carry a machine-readable `code` via StructuredContent
-// ({"code": ...}), leaving the text block unchanged, so clients can branch on a
-// stable token instead of string-matching the prose. The code is derived from
-// the helper that produced the result, so call sites need no changes.
+// (and sometimes extra fields like status), leaving the text block unchanged,
+// so clients can branch on stable fields instead of string-matching prose.
 
 const (
 	// validationErrorPrefix is the canonical prefix for all parameter/validation failures.
@@ -41,27 +45,73 @@ const (
 // the docs tools' {code,...} pattern (internal/docs/errors.go).
 const (
 	// CodeValidationFailed marks a fixable parameter/validation mistake: the
-	// caller should correct the arguments and retry. Emitted by
-	// validationError/validationErrorf and the arguments-guard helpers.
+	// caller should correct the arguments and retry. Emitted by local
+	// validation helpers and upstream HTTP 400 responses.
 	CodeValidationFailed = "VALIDATION_FAILED"
 
-	// CodeUpstreamError marks a SigNoz backend failure: typically retryable
-	// without changing arguments. Emitted by upstreamError.
+	// CodeUpstreamError marks a generic SigNoz backend failure. Emitted by
+	// upstreamError when no more precise status-derived code applies.
 	CodeUpstreamError = "UPSTREAM_ERROR"
 
+	// CodeUnauthorized marks a SigNoz backend 401. The caller should re-authenticate
+	// or provide valid credentials rather than blindly retrying.
+	CodeUnauthorized = "UNAUTHORIZED"
+
+	// CodePermissionDenied marks a SigNoz backend 403. The caller should ask for
+	// permissions or use an account with the required role.
+	CodePermissionDenied = "PERMISSION_DENIED"
+
 	// CodeNotFound marks a missing resource (bad id/uuid) — re-discover the id
-	// rather than blindly retry. RESERVED: upstream 404s currently surface as
-	// UPSTREAM_ERROR (the backend signals not-found only via prose, which #365
-	// won't string-match); kept as the stable home for a future typed signal.
+	// rather than blindly retry. Emitted by local guards and upstream HTTP 404s.
 	CodeNotFound = "NOT_FOUND"
+
+	// CodeConflict marks an upstream HTTP 409.
+	CodeConflict = "CONFLICT"
+
+	// CodeRateLimited marks an upstream HTTP 429.
+	CodeRateLimited = "RATE_LIMITED"
+
+	// CodeUnsupported marks an upstream HTTP 501.
+	CodeUnsupported = "UNSUPPORTED"
+
+	// CodeLicenseUnavailable marks an upstream HTTP 451.
+	CodeLicenseUnavailable = "LICENSE_UNAVAILABLE"
+
+	// CodeCanceled marks an upstream/client-closed HTTP 499.
+	CodeCanceled = "CANCELED"
+
+	// CodeTimeout marks an upstream HTTP timeout response.
+	CodeTimeout = "TIMEOUT"
 )
+
+const statusClientClosedConnection = 499
+
+var assistantAuthEnvelopeCodes = map[string]struct{}{
+	"forbidden":       {},
+	"token_expired":   {},
+	"unauthenticated": {},
+}
 
 // errorWithCode builds an error result whose text block is message and whose
 // StructuredContent carries {"code": code} — the single shaping point for all
 // coded error results.
 func errorWithCode(code, message string) *mcp.CallToolResult {
+	return errorWithStructuredContent(code, message, nil)
+}
+
+func errorWithStructuredContent(code, message string, fields map[string]any) *mcp.CallToolResult {
 	res := mcp.NewToolResultError(message)
-	res.StructuredContent = map[string]any{"code": code}
+	structured := map[string]any{"code": code}
+	for key, value := range fields {
+		if key == "code" || value == nil {
+			continue
+		}
+		if text, ok := value.(string); ok && text == "" {
+			continue
+		}
+		structured[key] = value
+	}
+	res.StructuredContent = structured
 	return res
 }
 
@@ -147,11 +197,140 @@ func notAConfigObjectError() *mcp.CallToolResult {
 	return errorWithCode(CodeValidationFailed, notAConfigObjectMessage)
 }
 
-// upstreamError wraps a SigNoz backend client error in the uniform upstream
-// prefix, so the LLM can distinguish a backend problem (retry) from a parameter
-// problem (fix).
+// upstreamError wraps a SigNoz backend client error with the uniform text prefix
+// and the most specific structured code we can derive from the HTTP response.
 func upstreamError(err error) *mcp.CallToolResult {
-	return errorWithCode(CodeUpstreamError, fmt.Sprintf("%s %s", upstreamErrorPrefix, err.Error()))
+	var statusErr *signozclient.HTTPStatusError
+	if !errors.As(err, &statusErr) {
+		return errorWithCode(CodeUpstreamError, fmt.Sprintf("%s %s", upstreamErrorPrefix, err.Error()))
+	}
+
+	upstreamCode, upstreamMessage, upstreamType, parsedUpstreamBody := parseUpstreamErrorBody(statusErr.Body)
+	message := upstreamHTTPErrorMessage(err, statusErr, upstreamMessage, parsedUpstreamBody)
+	fields := map[string]any{
+		"status": statusErr.StatusCode,
+	}
+	if upstreamCode != "" {
+		fields["upstreamCode"] = upstreamCode
+	}
+	if upstreamMessage != "" {
+		fields["upstreamMessage"] = boundedErrorDetail(upstreamMessage)
+	}
+	if upstreamType != "" {
+		fields["upstreamType"] = upstreamType
+	}
+	if statusErr.StatusCode == http.StatusUnauthorized {
+		if _, ok := assistantAuthEnvelopeCodes[upstreamCode]; ok {
+			fields["upstreamAuth"] = map[string]string{"code": upstreamCode}
+		}
+	}
+
+	return errorWithStructuredContent(upstreamCodeForStatus(statusErr.StatusCode, upstreamType), message, fields)
+}
+
+func upstreamCodeForStatus(status int, upstreamType string) string {
+	switch status {
+	case http.StatusBadRequest:
+		return CodeValidationFailed
+	case http.StatusUnauthorized:
+		return CodeUnauthorized
+	case http.StatusForbidden:
+		return CodePermissionDenied
+	case http.StatusNotFound:
+		return CodeNotFound
+	case http.StatusConflict:
+		return CodeConflict
+	case http.StatusTooManyRequests:
+		return CodeRateLimited
+	case http.StatusNotImplemented:
+		return CodeUnsupported
+	case http.StatusUnavailableForLegalReasons:
+		return CodeLicenseUnavailable
+	case statusClientClosedConnection:
+		return CodeCanceled
+	case http.StatusGatewayTimeout:
+		return CodeTimeout
+	default:
+		if status == http.StatusServiceUnavailable {
+			switch upstreamType {
+			case "canceled":
+				return CodeCanceled
+			case "timeout":
+				return CodeTimeout
+			}
+		}
+		return CodeUpstreamError
+	}
+}
+
+func upstreamHTTPErrorMessage(err error, statusErr *signozclient.HTTPStatusError, upstreamMessage string, parsedUpstreamBody bool) string {
+	statusText := upstreamHTTPStatusText(statusErr, upstreamMessage, parsedUpstreamBody)
+	rawMessage := err.Error()
+	if rawStatusText := statusErr.Error(); rawStatusText != "" && strings.Contains(rawMessage, rawStatusText) {
+		rawMessage = strings.Replace(rawMessage, rawStatusText, statusText, 1)
+	} else {
+		rawMessage = statusText
+	}
+	return fmt.Sprintf("%s %s", upstreamErrorPrefix, rawMessage)
+}
+
+func upstreamHTTPStatusText(statusErr *signozclient.HTTPStatusError, upstreamMessage string, parsedUpstreamBody bool) string {
+	message := fmt.Sprintf("unexpected status %d", statusErr.StatusCode)
+	detail := upstreamMessage
+	if detail == "" && !parsedUpstreamBody {
+		detail = statusErr.Body
+	}
+	if detail = boundedErrorDetail(detail); detail != "" {
+		return fmt.Sprintf("%s: %s", message, detail)
+	}
+	return message
+}
+
+func boundedErrorDetail(detail string) string {
+	return logpkg.TruncBody([]byte(strings.TrimSpace(detail)))
+}
+
+func parseUpstreamErrorBody(body string) (upstreamCode, upstreamMessage, upstreamType string, parsed bool) {
+	var envelope struct {
+		Error     json.RawMessage `json:"error"`
+		ErrorType string          `json:"errorType"`
+		Type      string          `json:"type"`
+		Code      string          `json:"code"`
+		Message   string          `json:"message"`
+	}
+	if err := json.Unmarshal([]byte(body), &envelope); err != nil {
+		return "", "", "", false
+	}
+	if len(envelope.Error) > 0 && string(envelope.Error) != "null" {
+		var nested struct {
+			Type    string `json:"type"`
+			Code    string `json:"code"`
+			Message string `json:"message"`
+		}
+		if err := json.Unmarshal(envelope.Error, &nested); err == nil {
+			upstreamType = nested.Type
+			upstreamCode = nested.Code
+			upstreamMessage = nested.Message
+		} else {
+			var message string
+			if err := json.Unmarshal(envelope.Error, &message); err == nil {
+				upstreamMessage = message
+			}
+		}
+	}
+	if upstreamType == "" {
+		upstreamType = envelope.Type
+	}
+	if upstreamType == "" {
+		upstreamType = envelope.ErrorType
+	}
+	if upstreamCode == "" {
+		upstreamCode = envelope.Code
+	}
+	if upstreamMessage == "" {
+		upstreamMessage = envelope.Message
+	}
+	return upstreamCode, upstreamMessage, upstreamType, true
 }
 
 // notFoundError marks a referenced resource that does not exist. The message is

--- a/internal/handler/tools/errs_test.go
+++ b/internal/handler/tools/errs_test.go
@@ -1,10 +1,16 @@
 package tools
 
 import (
+	"encoding/json"
 	"errors"
+	"fmt"
+	"net/http"
+	"strings"
 	"testing"
 
 	"github.com/mark3labs/mcp-go/mcp"
+
+	signozclient "github.com/SigNoz/signoz-mcp-server/internal/client"
 )
 
 // resultText extracts the first text content block of a tool result, asserting
@@ -33,6 +39,16 @@ func resultText(t *testing.T, r *mcp.CallToolResult) string {
 // on the code (retry vs fix args), so it must always be set.
 func resultCode(t *testing.T, r *mcp.CallToolResult) string {
 	t.Helper()
+	m := resultStructuredMap(t, r)
+	code, ok := m["code"].(string)
+	if !ok {
+		t.Fatalf("StructuredContent has no string \"code\": %#v", r.StructuredContent)
+	}
+	return code
+}
+
+func resultStructuredMap(t *testing.T, r *mcp.CallToolResult) map[string]any {
+	t.Helper()
 	if r == nil {
 		t.Fatal("nil result")
 	}
@@ -43,11 +59,7 @@ func resultCode(t *testing.T, r *mcp.CallToolResult) string {
 	if !ok {
 		t.Fatalf("StructuredContent is %T, want map[string]any", r.StructuredContent)
 	}
-	code, ok := m["code"].(string)
-	if !ok {
-		t.Fatalf("StructuredContent has no string \"code\": %#v", r.StructuredContent)
-	}
-	return code
+	return m
 }
 
 func TestValidationError_CanonicalForm(t *testing.T) {
@@ -249,9 +261,383 @@ func TestUpstreamError_UniformPrefix(t *testing.T) {
 	}
 }
 
+func TestUpstreamError_ForbiddenHTTPStatus(t *testing.T) {
+	statusErr := &signozclient.HTTPStatusError{
+		StatusCode: http.StatusForbidden,
+		Body:       `{"status":"error","error":{"type":"forbidden","code":"authz_forbidden","message":"only editors/admins can access this resource","errors":[],"suggestions":[]}}`,
+	}
+
+	res := upstreamError(statusErr)
+
+	if got := resultText(t, res); got != "SigNoz API error: unexpected status 403: only editors/admins can access this resource" {
+		t.Fatalf("upstreamError text = %q, want message-only status error", got)
+	}
+	structured := resultStructuredMap(t, res)
+	if got := structured["code"]; got != CodePermissionDenied {
+		t.Fatalf("code = %v, want %s", got, CodePermissionDenied)
+	}
+	if got := structured["status"]; got != http.StatusForbidden {
+		t.Fatalf("status = %v, want %d", got, http.StatusForbidden)
+	}
+	if got := structured["upstreamCode"]; got != "authz_forbidden" {
+		t.Fatalf("upstreamCode = %v, want authz_forbidden", got)
+	}
+	if got := structured["upstreamMessage"]; got != "only editors/admins can access this resource" {
+		t.Fatalf("upstreamMessage = %v, want backend message", got)
+	}
+	if got := structured["upstreamType"]; got != "forbidden" {
+		t.Fatalf("upstreamType = %v, want forbidden", got)
+	}
+}
+
+func TestUpstreamError_HTTPStatusPreservesWrapperContext(t *testing.T) {
+	statusErr := &signozclient.HTTPStatusError{
+		StatusCode: http.StatusForbidden,
+		Body:       `{"status":"error","error":{"type":"forbidden","code":"authz_forbidden","message":"only editors/admins can access this resource"}}`,
+	}
+	wrapped := fmt.Errorf("failed to auto-fetch metadata for formula query %q (%s): %w", "A", "cpu.usage", statusErr)
+
+	res := upstreamError(wrapped)
+
+	text := resultText(t, res)
+	want := `SigNoz API error: failed to auto-fetch metadata for formula query "A" (cpu.usage): unexpected status 403: only editors/admins can access this resource`
+	if text != want {
+		t.Fatalf("text = %q, want wrapper context preserved", text)
+	}
+	if strings.Contains(text, `"code":"authz_forbidden"`) {
+		t.Fatalf("text leaked raw upstream JSON: %s", text)
+	}
+	if code := resultCode(t, res); code != CodePermissionDenied {
+		t.Fatalf("code = %q, want %q", code, CodePermissionDenied)
+	}
+}
+
+func TestUpstreamError_ForbiddenGenericCodeDoesNotLeakAuthEnvelopeInText(t *testing.T) {
+	res := upstreamError(&signozclient.HTTPStatusError{
+		StatusCode: http.StatusForbidden,
+		Body:       `{"status":"error","error":{"type":"forbidden","code":"forbidden","message":"permission denied"}}`,
+	})
+
+	text := resultText(t, res)
+	if strings.Contains(text, `"code":"forbidden"`) || strings.Contains(text, `"code": "forbidden"`) {
+		t.Fatalf("text leaked raw auth-looking upstream code: %s", text)
+	}
+	structured := resultStructuredMap(t, res)
+	if got := structured["code"]; got != CodePermissionDenied {
+		t.Fatalf("code = %v, want %s", got, CodePermissionDenied)
+	}
+	if got := structured["upstreamCode"]; got != "forbidden" {
+		t.Fatalf("upstreamCode = %v, want forbidden", got)
+	}
+	if got := structured["upstreamMessage"]; got != "permission denied" {
+		t.Fatalf("upstreamMessage = %v, want permission denied", got)
+	}
+	if _, ok := structured["upstreamAuth"]; ok {
+		t.Fatalf("unexpected upstreamAuth for authorization denial: %#v", structured)
+	}
+}
+
+func TestUpstreamError_ParseableEnvelopeWithoutMessageDoesNotLeakRawJSON(t *testing.T) {
+	res := upstreamError(&signozclient.HTTPStatusError{
+		StatusCode: http.StatusForbidden,
+		Body:       `{"status":"error","error":{"type":"forbidden","code":"forbidden"}}`,
+	})
+
+	text := resultText(t, res)
+	if text != "SigNoz API error: unexpected status 403" {
+		t.Fatalf("text = %q, want status-only text for message-less parseable envelope", text)
+	}
+	if strings.Contains(text, `"code":"forbidden"`) || strings.Contains(text, `"code": "forbidden"`) {
+		t.Fatalf("text leaked raw auth-looking upstream code: %s", text)
+	}
+	structured := resultStructuredMap(t, res)
+	if got := structured["code"]; got != CodePermissionDenied {
+		t.Fatalf("code = %v, want %s", got, CodePermissionDenied)
+	}
+	if got := structured["upstreamCode"]; got != "forbidden" {
+		t.Fatalf("upstreamCode = %v, want forbidden", got)
+	}
+	if got := structured["upstreamType"]; got != "forbidden" {
+		t.Fatalf("upstreamType = %v, want forbidden", got)
+	}
+	if _, ok := structured["upstreamMessage"]; ok {
+		t.Fatalf("unexpected upstreamMessage for message-less envelope: %#v", structured)
+	}
+	if _, ok := structured["upstreamAuth"]; ok {
+		t.Fatalf("unexpected upstreamAuth for 403: %#v", structured)
+	}
+}
+
+func TestUpstreamError_HTTPErrorTextIsBounded(t *testing.T) {
+	longMessage := strings.Repeat("x", 5000) + "tail"
+	bodyBytes, err := json.Marshal(map[string]any{
+		"status": "error",
+		"error": map[string]any{
+			"type":    "forbidden",
+			"code":    "authz_forbidden",
+			"message": longMessage,
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	res := upstreamError(&signozclient.HTTPStatusError{
+		StatusCode: http.StatusForbidden,
+		Body:       string(bodyBytes),
+	})
+
+	text := resultText(t, res)
+	if !strings.Contains(text, "...(truncated)") {
+		t.Fatalf("text = %q, want truncated marker", text)
+	}
+	if strings.Contains(text, "tail") {
+		t.Fatalf("text leaked end of overlarge upstream message: %s", text)
+	}
+	structured := resultStructuredMap(t, res)
+	upstreamMessage, ok := structured["upstreamMessage"].(string)
+	if !ok {
+		t.Fatalf("missing upstreamMessage: %#v", structured)
+	}
+	if !strings.Contains(upstreamMessage, "...(truncated)") {
+		t.Fatalf("upstreamMessage = %q, want truncated marker", upstreamMessage)
+	}
+	if strings.Contains(upstreamMessage, "tail") {
+		t.Fatalf("upstreamMessage leaked end of overlarge upstream message")
+	}
+
+	unparseable := strings.Repeat("<html>", 1000) + "tail"
+	res = upstreamError(&signozclient.HTTPStatusError{
+		StatusCode: http.StatusBadGateway,
+		Body:       unparseable,
+	})
+	text = resultText(t, res)
+	if !strings.Contains(text, "...(truncated)") {
+		t.Fatalf("unparseable text = %q, want truncated marker", text)
+	}
+	if strings.Contains(text, "tail") {
+		t.Fatalf("unparseable text leaked end of overlarge upstream body")
+	}
+}
+
+func TestUpstreamError_ForbiddenHTTPStatusWithUnparseableBody(t *testing.T) {
+	res := upstreamError(&signozclient.HTTPStatusError{
+		StatusCode: http.StatusForbidden,
+		Body:       `permission denied`,
+	})
+
+	structured := resultStructuredMap(t, res)
+	if got := structured["code"]; got != CodePermissionDenied {
+		t.Fatalf("code = %v, want %s", got, CodePermissionDenied)
+	}
+	if got := structured["status"]; got != http.StatusForbidden {
+		t.Fatalf("status = %v, want %d", got, http.StatusForbidden)
+	}
+	if _, ok := structured["upstreamCode"]; ok {
+		t.Fatalf("unexpected upstreamCode for unparseable body: %#v", structured)
+	}
+	if text := resultText(t, res); text != "SigNoz API error: unexpected status 403: permission denied" {
+		t.Fatalf("text = %q, want preserved status body", text)
+	}
+}
+
+func TestUpstreamError_UnauthorizedHTTPStatus(t *testing.T) {
+	res := upstreamError(&signozclient.HTTPStatusError{
+		StatusCode: http.StatusUnauthorized,
+		Body:       `{"status":"error","error":{"type":"unauthorized","code":"unauthenticated","message":"invalid token"}}`,
+	})
+
+	if code := resultCode(t, res); code != CodeUnauthorized {
+		t.Fatalf("code = %q, want %q", code, CodeUnauthorized)
+	}
+	if got := resultStructuredMap(t, res)["status"]; got != http.StatusUnauthorized {
+		t.Fatalf("status = %v, want %d", got, http.StatusUnauthorized)
+	}
+	structured := resultStructuredMap(t, res)
+	upstreamAuth, ok := structured["upstreamAuth"].(map[string]string)
+	if !ok {
+		t.Fatalf("missing upstreamAuth classifier bridge: %#v", structured)
+	}
+	if got := upstreamAuth["code"]; got != "unauthenticated" {
+		t.Fatalf("upstreamAuth.code = %q, want unauthenticated", got)
+	}
+	payload, err := json.Marshal(structured)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(payload), `"code":"unauthenticated"`) {
+		t.Fatalf("structured content no longer carries assistant-compatible auth code: %s", payload)
+	}
+}
+
+func TestUpstreamError_GenericHTTPStatusKeepsUpstreamCode(t *testing.T) {
+	res := upstreamError(&signozclient.HTTPStatusError{
+		StatusCode: http.StatusInternalServerError,
+		Body:       `{"status":"error","message":"temporary outage"}`,
+	})
+
+	if code := resultCode(t, res); code != CodeUpstreamError {
+		t.Fatalf("code = %q, want %q", code, CodeUpstreamError)
+	}
+	if got := resultStructuredMap(t, res)["status"]; got != http.StatusInternalServerError {
+		t.Fatalf("status = %v, want %d", got, http.StatusInternalServerError)
+	}
+}
+
+func TestUpstreamError_LegacyErrorBody(t *testing.T) {
+	res := upstreamError(&signozclient.HTTPStatusError{
+		StatusCode: http.StatusUnprocessableEntity,
+		Body:       `{"status":"error","errorType":"exec","error":"query execution failed"}`,
+	})
+
+	if got := resultText(t, res); got != "SigNoz API error: unexpected status 422: query execution failed" {
+		t.Fatalf("text = %q, want legacy error message", got)
+	}
+	structured := resultStructuredMap(t, res)
+	if got := structured["code"]; got != CodeUpstreamError {
+		t.Fatalf("code = %v, want %s", got, CodeUpstreamError)
+	}
+	if got := structured["status"]; got != http.StatusUnprocessableEntity {
+		t.Fatalf("status = %v, want %d", got, http.StatusUnprocessableEntity)
+	}
+	if got := structured["upstreamType"]; got != "exec" {
+		t.Fatalf("upstreamType = %v, want exec", got)
+	}
+	if got := structured["upstreamMessage"]; got != "query execution failed" {
+		t.Fatalf("upstreamMessage = %v, want query execution failed", got)
+	}
+	if _, ok := structured["upstreamCode"]; ok {
+		t.Fatalf("unexpected upstreamCode for legacy body: %#v", structured)
+	}
+}
+
+func TestUpstreamError_NotFoundHTTPStatus(t *testing.T) {
+	res := upstreamError(&signozclient.HTTPStatusError{
+		StatusCode: http.StatusNotFound,
+		Body:       `{"status":"error","error":{"type":"not-found","code":"not_found","message":"rule does not exist"}}`,
+	})
+
+	structured := resultStructuredMap(t, res)
+	if got := structured["code"]; got != CodeNotFound {
+		t.Fatalf("code = %v, want %s", got, CodeNotFound)
+	}
+	if got := structured["status"]; got != http.StatusNotFound {
+		t.Fatalf("status = %v, want %d", got, http.StatusNotFound)
+	}
+	if got := structured["upstreamCode"]; got != "not_found" {
+		t.Fatalf("upstreamCode = %v, want not_found", got)
+	}
+	if got := structured["upstreamMessage"]; got != "rule does not exist" {
+		t.Fatalf("upstreamMessage = %v, want backend message", got)
+	}
+}
+
+func TestUpstreamError_StatusDerivedCodes(t *testing.T) {
+	cases := []struct {
+		name   string
+		status int
+		body   string
+		want   string
+	}{
+		{
+			name:   "bad request",
+			status: http.StatusBadRequest,
+			body:   `{"status":"error","error":{"type":"invalid-input","code":"invalid_input","message":"bad request"}}`,
+			want:   CodeValidationFailed,
+		},
+		{
+			name:   "conflict",
+			status: http.StatusConflict,
+			body:   `{"status":"error","error":{"type":"already-exists","code":"already_exists","message":"already exists"}}`,
+			want:   CodeConflict,
+		},
+		{
+			name:   "rate limited",
+			status: http.StatusTooManyRequests,
+			body:   `{"status":"error","error":{"type":"too-many-requests","code":"too_many_requests","message":"slow down"}}`,
+			want:   CodeRateLimited,
+		},
+		{
+			name:   "unsupported",
+			status: http.StatusNotImplemented,
+			body:   `{"status":"error","error":{"type":"unsupported","code":"unsupported","message":"not supported"}}`,
+			want:   CodeUnsupported,
+		},
+		{
+			name:   "license unavailable",
+			status: http.StatusUnavailableForLegalReasons,
+			body:   `{"status":"error","error":{"type":"license-unavailable","code":"license_unavailable","message":"license unavailable"}}`,
+			want:   CodeLicenseUnavailable,
+		},
+		{
+			name:   "client closed",
+			status: statusClientClosedConnection,
+			body:   `{"status":"error","error":{"type":"canceled","code":"canceled","message":"client closed"}}`,
+			want:   CodeCanceled,
+		},
+		{
+			name:   "gateway timeout",
+			status: http.StatusGatewayTimeout,
+			body:   `{"status":"error","error":{"type":"timeout","code":"timeout","message":"timed out"}}`,
+			want:   CodeTimeout,
+		},
+		{
+			name:   "internal remains upstream error",
+			status: http.StatusInternalServerError,
+			body:   `{"status":"error","error":{"type":"internal","code":"internal","message":"boom"}}`,
+			want:   CodeUpstreamError,
+		},
+		{
+			name:   "legacy execution error remains upstream error",
+			status: http.StatusUnprocessableEntity,
+			body:   `{"status":"error","errorType":"exec","error":"query execution failed"}`,
+			want:   CodeUpstreamError,
+		},
+		{
+			name:   "unrendered method-not-allowed remains upstream error",
+			status: http.StatusMethodNotAllowed,
+			body:   `{"status":"error","error":{"type":"method-not-allowed","code":"method_not_allowed","message":"wrong method"}}`,
+			want:   CodeUpstreamError,
+		},
+		{
+			name:   "request timeout remains upstream error",
+			status: http.StatusRequestTimeout,
+			body:   `{"status":"error","error":{"type":"timeout","code":"timeout","message":"timed out"}}`,
+			want:   CodeUpstreamError,
+		},
+		{
+			name:   "legacy timeout service unavailable",
+			status: http.StatusServiceUnavailable,
+			body:   `{"status":"error","errorType":"timeout","error":"query timed out"}`,
+			want:   CodeTimeout,
+		},
+		{
+			name:   "legacy canceled service unavailable",
+			status: http.StatusServiceUnavailable,
+			body:   `{"status":"error","errorType":"canceled","error":"query canceled"}`,
+			want:   CodeCanceled,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			res := upstreamError(&signozclient.HTTPStatusError{StatusCode: tc.status, Body: tc.body})
+			structured := resultStructuredMap(t, res)
+			if got := structured["code"]; got != tc.want {
+				t.Fatalf("code = %v, want %s", got, tc.want)
+			}
+			if got := structured["status"]; got != tc.status {
+				t.Fatalf("status = %v, want %d", got, tc.status)
+			}
+			if got := structured["upstreamCode"]; strings.Contains(tc.body, `"code"`) && got == "" {
+				t.Fatalf("expected upstreamCode to be preserved: %#v", structured)
+			}
+		})
+	}
+}
+
 // TestErrorHelpers_StructuredCodes pins the full code taxonomy each helper
-// emits in StructuredContent. The text block stays unchanged (covered by the
-// per-helper tests above); this asserts the additive machine-readable code.
+// emits in StructuredContent. Text behavior is covered by the per-helper tests
+// above; this asserts the machine-readable code.
 func TestErrorHelpers_StructuredCodes(t *testing.T) {
 	cases := []struct {
 		name string
@@ -265,6 +651,11 @@ func TestErrorHelpers_StructuredCodes(t *testing.T) {
 		{"notAJSONObjectError", notAJSONObjectError(), CodeValidationFailed},
 		{"notAConfigObjectError", notAConfigObjectError(), CodeValidationFailed},
 		{"upstreamError", upstreamError(errors.New("boom")), CodeUpstreamError},
+		{"upstreamError-unauthorized", upstreamError(&signozclient.HTTPStatusError{StatusCode: http.StatusUnauthorized, Body: `{}`}), CodeUnauthorized},
+		{"upstreamError-forbidden", upstreamError(&signozclient.HTTPStatusError{StatusCode: http.StatusForbidden, Body: `{}`}), CodePermissionDenied},
+		{"upstreamError-not-found", upstreamError(&signozclient.HTTPStatusError{StatusCode: http.StatusNotFound, Body: `{}`}), CodeNotFound},
+		{"upstreamError-conflict", upstreamError(&signozclient.HTTPStatusError{StatusCode: http.StatusConflict, Body: `{}`}), CodeConflict},
+		{"upstreamError-rate-limited", upstreamError(&signozclient.HTTPStatusError{StatusCode: http.StatusTooManyRequests, Body: `{}`}), CodeRateLimited},
 		{"notFoundError", notFoundError("no such alert"), CodeNotFound},
 	}
 	for _, tc := range cases {

--- a/plans/upstream-authz-error-classification.context.md
+++ b/plans/upstream-authz-error-classification.context.md
@@ -1,0 +1,64 @@
+# Feature: Upstream Authz Error Classification — Context & Discussion
+
+## Original Prompt
+> Let's work on this issue. After making changes spin up independent agents for review and then create PR
+
+## Reference Links
+- [SigNoz/nerve-pod#27](https://github.com/SigNoz/nerve-pod/issues/27)
+
+## Key Decisions & Discussion Log
+### 2026-07-03 — Initial scope
+- Production evidence from the Momentic tenant showed `signoz_create_alert` failed on `POST /api/v2/rules` with upstream HTTP 403 and backend code `authz_forbidden`.
+- The current MCP contract collapses that non-retryable authorization failure into structured code `UPSTREAM_ERROR`.
+- Fix scope: classify upstream HTTP 401/403 failures into a more actionable structured error while preserving the existing visible text.
+
+### 2026-07-03 — Downstream auth classifier compatibility
+- Independent review found that a top-level MCP code of `FORBIDDEN` would collide with the AI assistant's exact-match auth-expiry heuristic for SigNoz upstream envelope code `forbidden`.
+- Decision: use top-level MCP code `PERMISSION_DENIED` for HTTP 403 while preserving `status: 403` and backend `upstreamCode: authz_forbidden`.
+
+### 2026-07-03 — Future-proofing and staging e2e
+- Status-derived classification is the durable boundary: HTTP 401/403 classification works even if the upstream JSON error envelope changes or becomes non-JSON.
+- Added a regression test for HTTP 403 with an unparseable body to prove `PERMISSION_DENIED` does not depend on `error.code` or `error.message` parsing.
+- Staging e2e against `https://app.us.staging.signoz.cloud` with the supplied user token succeeded for alert create/delete, so the 403 path did not fire for that token. Cleanup was confirmed by a subsequent `get_alert` returning upstream 404.
+
+### 2026-07-03 — Upstream 404 classification
+- Follow-up decision: HTTP 404 from the SigNoz backend should map to top-level MCP code `NOT_FOUND`, not generic `UPSTREAM_ERROR`.
+- The staging cleanup probe exposed the old behavior (`UPSTREAM_ERROR` with `status: 404`), so the status-derived classifier now routes 404 to `NOT_FOUND` while still preserving parsed `upstreamCode` / `upstreamMessage`.
+
+### 2026-07-03 — Backend error class alignment
+- Checked `~/signoz/signoz/pkg/errors` and `~/signoz/signoz/pkg/http/render/render.go` for the upstream error vocabulary and renderer status mapping.
+- Also checked the legacy query-service responder and found HTTP 422 is `ErrorExec`, not validation.
+- Decision: keep MCP top-level codes distinct from the raw SigNoz envelope, but classify by durable HTTP status classes: validation, unauthorized, permission denied, not found, conflict, rate limited, unsupported, license unavailable, canceled, and timeout.
+- Unknown statuses and backend internals remain `UPSTREAM_ERROR`, with `status`, `upstreamType`, `upstreamCode`, and `upstreamMessage` attached when available.
+
+### 2026-07-03 — Review tightening
+- Independent review caught two over-broad mappings: 422 looked validation-like by HTTP convention but is legacy query execution in SigNoz, and 405 is defined in `pkg/errors` but not emitted by the checked renderer path.
+- Decision: remove 422/405 status classification and pin them as `UPSTREAM_ERROR` unless SigNoz later exposes them through the renderer contract.
+- Live read-only staging probe for `signoz_get_alert` with a nonexistent UUID confirmed MCP `code: NOT_FOUND`, `status: 404`, `upstreamCode: not_found`, and no resource creation.
+
+### 2026-07-03 — Downstream scanner hardening
+- Independent review noted that a future backend 403 with generic envelope code `forbidden` could still trip the AI assistant's auth-expiry scanner if the raw upstream JSON remained in the MCP text block.
+- Decision: for parseable upstream HTTP error envelopes, show `unexpected status <status>: <upstream message>` in the text block and keep `upstreamCode`, `upstreamType`, and `upstreamMessage` in structured content. Unparseable bodies still fall back to the raw body.
+- Added legacy `errorType` / string `error` parsing so legacy query-service errors expose `upstreamType` and `upstreamMessage` even when they stay `UPSTREAM_ERROR`.
+- Updated the 429 fixture to use the canonical backend `too_many_requests` code.
+
+### 2026-07-03 — PR review body preservation
+- GitHub review noted that storing a logging-truncated response body on `HTTPStatusError` could break JSON parsing for long but valid upstream envelopes.
+- Decision: keep the full response body in `HTTPStatusError.Body` for parsing, and truncate only when rendering `Error()` or writing log fields.
+- Added regression coverage proving a long JSON error envelope remains parseable while the error string and log response stay truncated.
+
+### 2026-07-03 — PR review wrapper context and text bounds
+- Follow-up GitHub review noted that sanitizing HTTP status text dropped caller wrapper context such as formula-query metadata fallback guidance.
+- Decision: replace only the inner `HTTPStatusError` text inside `err.Error()` with sanitized status/detail text, preserving caller context while avoiding raw upstream JSON in text.
+- Follow-up review also noted that full parseable messages or unparseable bodies could be returned unbounded in MCP error text.
+- Decision: bound all returned upstream message/body text and structured `upstreamMessage` values with the same truncation helper used for logs.
+
+### 2026-07-03 — Multi-agent review fixes
+- Independent review found that stripping raw 401 JSON also removed the assistant's existing auth-expired classifier signal.
+- Decision: for upstream HTTP 401 only, expose a nested `upstreamAuth.code` bridge when the backend code is one of the assistant's existing auth envelope codes. This keeps 401 auth-expired behavior without letting 403 `forbidden` permission denials trip the same scanner.
+- Independent review found that parseable envelopes without a `message` still fell back to raw JSON text.
+- Decision: once an upstream body parses as an envelope, never return the raw body in MCP text just because the message is absent; use status-only text instead.
+- Also classified legacy query-service `503` responses with `errorType: timeout` / `canceled` into `TIMEOUT` / `CANCELED`, while leaving other 503s as `UPSTREAM_ERROR`.
+
+## Open Questions
+- [x] Should alert creation succeed for the Momentic user? No. The backend correctly rejects non-editor/non-admin users; the MCP server should make that denial machine-actionable.

--- a/plans/upstream-authz-error-classification.plan.md
+++ b/plans/upstream-authz-error-classification.plan.md
@@ -1,0 +1,32 @@
+# Plan: Upstream Authz Error Classification
+
+## Status
+In Progress
+
+## Context
+MCP tools currently wrap all SigNoz backend client failures with `UPSTREAM_ERROR`. That is too broad for authorization failures such as upstream HTTP 403 `authz_forbidden`, because clients and agents treat the result like a generic backend outage instead of a permission issue.
+
+## Approach
+- Add a typed upstream HTTP error in the SigNoz client that preserves status code and raw response body while keeping the existing error string.
+- Keep `HTTPStatusError.Body` parseable for long JSON envelopes; truncate only in `Error()` and log output.
+- Teach `upstreamError` to classify upstream status classes aligned with SigNoz backend rendering: validation, unauthorized, permission denied, not found, conflict, rate limited, unsupported, license unavailable, canceled, and timeout.
+- Include machine-readable structured fields such as `status`, `upstreamCode`, `upstreamType`, and `upstreamMessage`.
+- For parseable upstream envelopes, keep raw JSON out of the human text block and show the backend message instead, avoiding downstream scanners that look for exact upstream `code` strings in text.
+- Preserve caller wrapper context by replacing only the inner HTTP status text, and bound all returned upstream message/body text.
+- Keep assistant auth-expired compatibility for upstream 401s through a nested `upstreamAuth.code` bridge, without exposing that bridge for upstream 403 permission denials.
+- Treat parseable message-less upstream envelopes as status-only text rather than raw JSON; classify legacy query-service `503` timeout/canceled envelopes by `errorType`.
+- Use `PERMISSION_DENIED` for HTTP 403 to avoid colliding with downstream auth-expiry checks that reserve exact upstream code `forbidden` for auth failures.
+- Keep unknown statuses and generic backend failures on `UPSTREAM_ERROR` for backwards compatibility.
+- Add focused tests for generic upstream errors and alert-create 403 behavior.
+
+## Files to Modify
+- `internal/client/client.go` — preserve status/body details on non-2xx backend responses.
+- `internal/handler/tools/errs.go` — classify upstream auth failures and enrich structured content.
+- `internal/handler/tools/errs_test.go` — pin helper-level structured content behavior.
+- `internal/handler/tools/alerts_test.go` — pin `signoz_create_alert` 403 behavior.
+
+## Verification
+- Run focused Go tests for client/error/alert tool handling.
+- Run broader relevant package tests if focused checks pass.
+- Spin up independent review agents after implementation and address actionable findings before publishing.
+- Verify staging alert create/delete through MCP with a real token; if the token has write permission, confirm cleanup and rely on unit coverage for the 403 branch.


### PR DESCRIPTION
## Summary

- Preserve non-2xx SigNoz API status/body details as a typed client error.
- Keep `HTTPStatusError.Body` as the full response body for parsing long valid JSON envelopes; truncate only `Error()` text and log fields.
- Classify durable upstream status classes in MCP structured error content: `VALIDATION_FAILED` (400), `UNAUTHORIZED` (401), `PERMISSION_DENIED` (403), `NOT_FOUND` (404), `CONFLICT` (409), `RATE_LIMITED` (429), `LICENSE_UNAVAILABLE` (451), `UNSUPPORTED` (501), `CANCELED` (499), and `TIMEOUT` (504).
- Keep unknown statuses, legacy execution failures such as 422, and backend internals on `UPSTREAM_ERROR` with `status` plus parsed upstream details when available.
- Parse both current SigNoz `{error:{type,code,message}}` envelopes and legacy `{errorType,error}` bodies.
- Preserve wrapper context around upstream HTTP errors while sanitizing the inner status text, and bound all returned upstream message/body text.
- Keep assistant auth-expired compatibility for upstream HTTP 401s through nested structured `upstreamAuth.code`, without exposing that bridge for HTTP 403 permission denials.
- Treat parseable message-less upstream envelopes as status-only text rather than raw JSON, and classify legacy query-service 503 `errorType: timeout/canceled` as `TIMEOUT`/`CANCELED`.
- Added the required plan/context pair under `plans/`.

Fixes SigNoz/nerve-pod#27.

## Root Cause

`upstreamError` collapsed every SigNoz backend client failure into `UPSTREAM_ERROR`. For Momentic alert creation, the real backend response was HTTP 403 `authz_forbidden` (`only editors/admins can access this resource`), but clients only saw the generic structured code.

## Compatibility Notes

- Generic backend failures still use `UPSTREAM_ERROR`.
- For parseable upstream error envelopes, the text block now uses `SigNoz API error: <caller context>: unexpected status <status>: <bounded upstream message>` instead of embedding raw upstream JSON. This keeps user-facing detail while avoiding downstream scanners mistaking a permission envelope like `code:"forbidden"` for auth expiry.
- Parsed backend details are preserved in structured fields: `status`, `upstreamCode`, bounded `upstreamMessage`, and `upstreamType`.
- HTTP 401 may include `upstreamAuth: {code: <auth-code>}` for known assistant auth-expired codes so existing downstream auth handling keeps working after raw JSON is removed from text.
- HTTP 403 uses `PERMISSION_DENIED` rather than `FORBIDDEN` to avoid colliding with downstream AI-assistant auth-expiry checks that reserve exact upstream code `forbidden` for auth failures.
- Status-derived classification works even when parsing fails; unparseable 403 still returns `PERMISSION_DENIED` with `status: 403` and bounded body text.
- Checked `~/signoz/signoz/pkg/errors`, `~/signoz/signoz/pkg/http/render/render.go`, and the legacy query-service responder. We deliberately do not classify 422 as validation because legacy SigNoz uses it for query execution failures.

## Docs and Metadata

- README/manifest/docs: no update needed; this does not add, remove, rename, or change MCP tool inputs/resources/configuration.
- SigNoz/agent-skills companion check: no change needed; skills do not teach this structured error-code taxonomy or alert payload/schema behavior.

## Review

- GitHub inline review: addressed truncated-body parsing risk by preserving full `HTTPStatusError.Body` while truncating only rendered/logged forms.
- GitHub inline review: addressed wrapper-context loss by replacing only the inner `HTTPStatusError` text, preserving caller guidance around wrapped errors.
- GitHub inline review: addressed unbounded MCP error text by truncating returned upstream message/body text and structured `upstreamMessage` values.
- Independent review agent 1: caught over-broad 422 and 405 classification. Addressed by keeping 422/405 on `UPSTREAM_ERROR` unless SigNoz exposes them through the checked renderer contract.
- Independent review agent 2: caught the possible `code:"forbidden"` downstream scanner collision, missing legacy body parsing, and non-canonical 429 fixture. Addressed all three.
- Independent review follow-up: caught that removing raw 401 envelopes could break assistant auth-expired detection. Addressed with the HTTP-401-only `upstreamAuth.code` bridge.
- Independent review follow-up: caught parseable message-less envelopes falling back to raw JSON. Addressed with status-only text for parsed envelopes without messages.
- Independent review follow-up: caught legacy query-service 503 timeout/canceled envelopes. Addressed by mapping `errorType: timeout/canceled` on HTTP 503 to `TIMEOUT`/`CANCELED`.
- Earlier review caught the `FORBIDDEN` top-level code collision; addressed by using `PERMISSION_DENIED`.

## Live Verification

Staging e2e against `https://app.us.staging.signoz.cloud` with the supplied user token:

- MCP initialize: `200`; initialized notification: `202`.
- `signoz_list_notification_channels`: MCP `200`, upstream `GET /api/v1/channels` -> `200`.
- `signoz_create_alert`: MCP `200`, upstream `POST /api/v2/rules` -> `201`.
- `signoz_delete_alert`: MCP `200`, upstream `DELETE /api/v2/rules/{ruleId}` -> `204`.
- Cleanup check `signoz_get_alert`: upstream `GET /api/v2/rules/{ruleId}` -> `404`; after this patch the MCP tool result is `isError: true` with structured `{code: NOT_FOUND, status: 404, upstreamCode: not_found, upstreamType: not-found}`.

The supplied token had permission to create alerts, so the live 403 branch did not fire. Temporary alert rules were deleted and confirmed gone. A later read-only 404 probe created no resources.

## Tests

- `go test ./internal/handler/tools -run 'TestUpstreamError'`
- `go test ./internal/client ./internal/handler/tools`
- `go test ./...`
- `git diff --check`
