### PR TITLE
Add Beacon Agent Manifest for AI agent discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # SigNoz MCP Server
 
+[![Beacon Verified](https://registry-ruby.vercel.app/api/v1/agents/SigNoz%2Fsignoz-mcp-server/badge.svg)](https://portal-five-phi-54.vercel.app/?q=signoz+mcp)
+
 [![Go Version](https://img.shields.io/badge/Go-1.25+-blue.svg)](https://golang.org)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)
 [![MCP Version](https://img.shields.io/badge/MCP-0.37.0-orange.svg)](https://modelcontextprotocol.io)

--- a/beacon.json
+++ b/beacon.json
@@ -1,0 +1,14 @@
+{
+  "beacon_manifest": "0.1",
+  "id": "SigNoz/signoz-mcp-server",
+  "name": "SigNoz MCP Server",
+  "description": "MCP server for querying SigNoz metrics, traces, logs, alerts, and dashboards via AI.",
+  "capabilities": ["mcp-server", "observability", "monitoring", "opentelemetry", "signoz"],
+  "interfaces": [
+    { "type": "http", "endpoint": "https://signoz.io/docs/ai/signoz-mcp-server/" },
+    { "type": "mcp", "endpoint": "https://github.com/SigNoz/signoz-mcp-server" }
+  ],
+  "source": "https://github.com/SigNoz/signoz-mcp-server",
+  "homepage": "https://signoz.io/docs/ai/signoz-mcp-server/",
+  "license": "MIT"
+}


### PR DESCRIPTION
## Beacon Agent Manifest (optional, ~2 min review)

[Beacon](https://portal-five-phi-54.vercel.app) is an open agent registry (33k+ MCP servers & agents). You are already indexed from GitHub.

This PR adds:
- **`beacon.json`** — [open v0.1 standard](https://github.com/enrichgateagent-png/beacon-agent-manifest) for machine-readable agent discovery (Claude, Cursor MCP, etc.)
- **README badge** — live verification link back to your listing

No API keys, no accounts. Hosting `beacon.json` in your repo is the verification (location = proof).

If merged, Beacon auto-upgrades your listing to **verified manifest** on the next scan.

Spec: https://github.com/enrichgateagent-png/beacon-agent-manifest · [llms.txt](https://registry-ruby.vercel.app/llms.txt)