### PR TITLE
feat(alerts): migrate get_alert_history to v2 rule-history API

### DIFF
--- a/README.md
+++ b/README.md
@@ -557,7 +557,7 @@ Gets top operations for a specific service.
 
 #### `signoz_get_alert_history`
 
-Gets alert history timeline for a specific rule.
+Gets the alert state-history timeline for a specific rule via `GET /api/v2/rules/{id}/history/timeline`. The response is `{ "status": "success", "data": { "items": [...], "total": <n>, "nextCursor": "<opaque>" } }`.
 
 - **Parameters**:
   - `id` (required) - Alert rule ID
@@ -565,10 +565,13 @@ Gets alert history timeline for a specific rule.
   - `start` (optional) - Start timestamp in unix milliseconds (defaults to 6 hours ago).
   - `end` (optional) - End timestamp in unix milliseconds (defaults to now)
   - `state` (optional) - Filter by alert state. Enum: `firing`, `inactive` (omit for all transitions)
-  - `offset` (optional) - Offset for pagination (default: 0)
-  - `limit` (optional) - Limit number of results (default: 20, max: 10000; higher values are clamped — paginate with `offset`)
+  - `filterExpression` (optional) - SigNoz v5 query-builder filter expression to narrow the timeline by label (e.g. `severity = 'critical'`)
+  - `cursor` (optional) - Opaque pagination cursor. Pass the `nextCursor` from a previous response's `data` to fetch the next page; omit for the first page.
+  - `limit` (optional) - Limit number of results (default: 20, max: 10000; higher values are clamped — paginate with `cursor`)
   - `order` (optional) - Sort order. Enum: `asc`, `desc` (default: 'asc')
-  - **Completeness note**: the response appends a note reporting `hasMore` (inferred from `returnedRows == limit`) and the `nextOffset` to fetch
+  - **Completeness note**: the response appends a note reporting `hasMore` (from the presence of `data.nextCursor`) and the `cursor` value to pass for the next page
+
+> **Requires** a SigNoz version that serves the v2 rule-history routes (`/api/v2/rules/{id}/history/*`). Earlier deployments only expose the v1 `POST /api/v1/rules/{id}/history/timeline`.
 
 #### `signoz_list_views`
 

--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ The binary is at `./bin/signoz-mcp-server`.
 
 - A running [SigNoz](https://signoz.io) instance
 - SigNoz v0.131.0 or newer for `signoz_check_metric_usage`
-- SigNoz v0.120.0 or newer for alert rule tools that use the `/api/v2/rules` APIs
+- SigNoz v0.120.0 or newer for alert-rule list/get/create/update/delete tools, and v0.118.0 or newer for alert history
 - A SigNoz API key (Settings → API Keys in the SigNoz UI)
 - The `signoz-mcp-server` binary (see [Self-Hosted Installation](#self-hosted-installation))
 
@@ -332,7 +332,7 @@ HTTP mode exposes unauthenticated probe endpoints. New Kubernetes deployments sh
 
 ## Available Tools
 
-> **SigNoz compatibility:** `signoz_check_metric_usage` targets `/api/v2/metrics/dashboards?metricName=...` and `/api/v2/metrics/alerts?metricName=...`, available in SigNoz v0.131.0 and newer. Alert-rule tools target `/api/v2/rules/*`, which is available in SigNoz v0.120.0 and newer. Self-hosted deployments on older SigNoz versions will see HTTP 404 from the affected tools. Notification-channel tools target the render-envelope `/api/v1/channels/*` routes introduced by SigNoz/signoz#10941, #10957, #10995, and #10997.
+> **SigNoz compatibility:** `signoz_check_metric_usage` targets `/api/v2/metrics/dashboards?metricName=...` and `/api/v2/metrics/alerts?metricName=...`, available in SigNoz v0.131.0 and newer. Alert-rule list/get/create/update/delete require SigNoz v0.120.0 or newer. `signoz_get_alert_history` requires v0.118.0 or newer. Self-hosted deployments on older SigNoz versions will see HTTP 404 from the affected tools. Notification-channel tools target the render-envelope `/api/v1/channels/*` routes introduced by SigNoz/signoz#10941, #10957, #10995, and #10997.
 
 > **Tool metadata:** every tool accepts `searchContext`, the user's original question/search text. It is used for MCP observability and is not forwarded to SigNoz APIs.
 
@@ -350,7 +350,7 @@ HTTP mode exposes unauthenticated probe endpoints. New Kubernetes deployments sh
 | `signoz_list_alerts` | List firing/silenced/inhibited Alertmanager alert *instances* (not rule definitions) |
 | `signoz_list_alert_rules` | List configured alert rules, including inactive/OK and disabled rules |
 | `signoz_get_alert` | Get an alert rule definition by `id` via GET /api/v2/rules/{id} |
-| `signoz_get_alert_history` | Get alert state history timeline for a rule (`id`) |
+| `signoz_get_alert_history` | Get alert firing history for a specific alert rule |
 | `signoz_create_alert` | Create an alert rule via POST /api/v2/rules; v2alpha1 for threshold/promql, v1 for anomaly |
 | `signoz_update_alert` | Update an alert rule by UUIDv7 `id` via PUT /api/v2/rules/{id} |
 | `signoz_delete_alert` | Delete an alert rule by UUIDv7 `id` via DELETE /api/v2/rules/{id} |
@@ -557,21 +557,24 @@ Gets top operations for a specific service.
 
 #### `signoz_get_alert_history`
 
-Gets the alert state-history timeline for a specific rule via `GET /api/v2/rules/{id}/history/timeline`. The response is `{ "status": "success", "data": { "items": [...], "total": <n>, "nextCursor": "<opaque>" } }`.
+Gets alert firing history for a specific alert rule. Defaults to the last 6 hours. Use `state` and `filter` to narrow results. For the next page, pass `data.nextCursor` as `cursor` and repeat the original query filters and time range.
+
+The response is `{ "status": "success", "data": { "items": [...], "total": <n>, "nextCursor": "<opaque>" } }`; `nextCursor` is omitted on the final page.
 
 - **Parameters**:
   - `id` (required) - Alert rule ID
   - `timeRange` (optional) - Relative time range `<number><unit>` where unit is `m`/`h`/`d` (e.g. '30m', '1h', '6h', '7d'; defaults to last 6 hours; ignored when both `start` and `end` are provided)
   - `start` (optional) - Start timestamp in unix milliseconds (defaults to 6 hours ago).
   - `end` (optional) - End timestamp in unix milliseconds (defaults to now)
-  - `state` (optional) - Filter by alert state. Enum: `firing`, `inactive` (omit for all transitions)
-  - `filterExpression` (optional) - SigNoz v5 query-builder filter expression to narrow the timeline by label (e.g. `severity = 'critical'`)
-  - `cursor` (optional) - Opaque pagination cursor. Pass the `nextCursor` from a previous response's `data` to fetch the next page; omit for the first page.
-  - `limit` (optional) - Limit number of results (default: 20, max: 10000; higher values are clamped — paginate with `cursor`)
+  - `state` (optional) - Filter by alert state. Enum: `inactive`, `pending`, `recovering`, `firing`, `nodata`, `disabled` (omit for all transitions)
+  - `filter` (optional) - SigNoz query-builder expression over timeline labels. Combine conditions with `AND`, `OR`, and parentheses; quote strings with single quotes. Example: `severity = 'critical' AND (team = 'payments' OR service.name = 'checkout')`. To discover keys, first call without a filter and inspect `data.items[].labels[].key.name`. The backend-shaped `filterExpression` alias remains accepted for compatibility, but `filter` is canonical.
+  - `cursor` (optional) - Opaque continuation cursor. Repeat the original time range, state, filter, and order when fetching the next page. Omit `cursor` for the first page.
+  - `limit` (optional) - Rows per page. Default: 20; max: 10000 (higher values are clamped).
   - `order` (optional) - Sort order. Enum: `asc`, `desc` (default: 'asc')
-  - **Completeness note**: the response appends a note reporting `hasMore` (from the presence of `data.nextCursor`) and the `cursor` value to pass for the next page
+  - **Legacy `offset`**: no longer supported; use the returned cursor instead.
+  - **Completeness note**: the response appends a note reporting `hasMore` from `data.nextCursor` and names the cursor for the next page.
 
-> **Requires SigNoz ≥ v0.118.0**, the first release to serve the v2 rule-history routes (`/api/v2/rules/{id}/history/*`, added in [SigNoz #10488](https://github.com/SigNoz/signoz/pull/10488)). Earlier deployments only expose the v1 `POST /api/v1/rules/{id}/history/timeline`.
+> **Requires SigNoz ≥ v0.118.0**, the first release to serve the v2 rule-history routes (`/api/v2/rules/{id}/history/*`, added in [SigNoz #10488](https://github.com/SigNoz/signoz/pull/10488)). If this tool returns `NOT_FOUND`, verify the rule `id` in the SigNoz UI or, on SigNoz v0.120.0+, with `signoz_list_alert_rules`; if the rule exists, upgrade SigNoz. Earlier deployments only expose the v1 `POST /api/v1/rules/{id}/history/timeline`.
 
 #### `signoz_list_views`
 

--- a/README.md
+++ b/README.md
@@ -571,7 +571,7 @@ Gets the alert state-history timeline for a specific rule via `GET /api/v2/rules
   - `order` (optional) - Sort order. Enum: `asc`, `desc` (default: 'asc')
   - **Completeness note**: the response appends a note reporting `hasMore` (from the presence of `data.nextCursor`) and the `cursor` value to pass for the next page
 
-> **Requires** a SigNoz version that serves the v2 rule-history routes (`/api/v2/rules/{id}/history/*`). Earlier deployments only expose the v1 `POST /api/v1/rules/{id}/history/timeline`.
+> **Requires SigNoz ≥ v0.118.0**, the first release to serve the v2 rule-history routes (`/api/v2/rules/{id}/history/*`, added in [SigNoz #10488](https://github.com/SigNoz/signoz/pull/10488)). Earlier deployments only expose the v1 `POST /api/v1/rules/{id}/history/timeline`.
 
 #### `signoz_list_views`
 

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -630,14 +630,9 @@ func (s *SigNoz) QueryBuilderV5(ctx context.Context, body []byte) (json.RawMessa
 }
 
 func (s *SigNoz) GetAlertHistory(ctx context.Context, ruleID string, req types.AlertHistoryRequest) (json.RawMessage, error) {
-	reqURL := fmt.Sprintf("%s/api/v1/rules/%s/history/timeline", s.baseURL, url.PathEscape(ruleID))
-	reqBody, err := json.Marshal(req)
-	if err != nil {
-		return nil, fmt.Errorf("failed to marshal request: %w", err)
-	}
-
+	reqURL := fmt.Sprintf("%s/api/v2/rules/%s/history/timeline?%s", s.baseURL, url.PathEscape(ruleID), req.QueryParams().Encode())
 	s.logger.DebugContext(s.ensureTenantContext(ctx), "Fetching alert history", slog.String("ruleID", ruleID))
-	return s.doRequest(ctx, http.MethodPost, reqURL, bytes.NewBuffer(reqBody), DefaultQueryTimeout)
+	return s.doRequest(ctx, http.MethodGet, reqURL, nil, DefaultQueryTimeout)
 }
 
 func (s *SigNoz) CreateAlertRule(ctx context.Context, alertJSON []byte) (json.RawMessage, error) {

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -968,83 +968,66 @@ func TestGetAlertHistory(t *testing.T) {
 		resp          map[string]interface{}
 		statusCode    int
 		expectedError bool
-		expectedData  []map[string]interface{}
+		expectedItems int
 	}{
 		{
-			name:   "successful alert history retrieval",
+			name:   "successful alert history retrieval with state and filter",
 			ruleID: "ruleid-abc",
 			request: types.AlertHistoryRequest{
-				Start:  1640995200000,
-				End:    1641081600000,
-				Offset: 0,
-				Limit:  20,
-				Order:  "desc",
-				Filters: types.AlertHistoryFilters{
-					Items: []interface{}{},
-					Op:    "AND",
-				},
+				Start:            1640995200000,
+				End:              1641081600000,
+				State:            "firing",
+				FilterExpression: "severity = 'warning'",
+				Limit:            20,
+				Order:            "desc",
 			},
 			resp: map[string]interface{}{
 				"status": "success",
-				"data": []map[string]interface{}{
-					{
-						"timestamp": "2022-01-01T10:00:00Z",
-						"state":     "firing",
-						"value":     85.5,
-						"labels": map[string]interface{}{
-							"service":  "frontend",
-							"severity": "warning",
-						},
+				"data": map[string]interface{}{
+					"items": []map[string]interface{}{
+						{"ruleId": "ruleid-abc", "state": "firing", "value": 85.5, "unixMilli": 1640995200000},
+						{"ruleId": "ruleid-abc", "state": "inactive", "value": 45.2, "unixMilli": 1640998800000},
 					},
-					{
-						"timestamp": "2022-01-01T11:00:00Z",
-						"state":     "resolved",
-						"value":     45.2,
-						"labels": map[string]interface{}{
-							"service":  "frontend",
-							"severity": "warning",
-						},
-					},
+					"total":      2,
+					"nextCursor": "",
 				},
 			},
 			statusCode:    http.StatusOK,
 			expectedError: false,
-			expectedData: []map[string]interface{}{
-				{
-					"timestamp": "2022-01-01T10:00:00Z",
-					"state":     "firing",
-					"value":     85.5,
-					"labels": map[string]interface{}{
-						"service":  "frontend",
-						"severity": "warning",
-					},
-				},
-				{
-					"timestamp": "2022-01-01T11:00:00Z",
-					"state":     "resolved",
-					"value":     45.2,
-					"labels": map[string]interface{}{
-						"service":  "frontend",
-						"severity": "warning",
-					},
+			expectedItems: 2,
+		},
+		{
+			name:   "cursor paginated request",
+			ruleID: "ruleid-abc",
+			request: types.AlertHistoryRequest{
+				Start:  1640995200000,
+				End:    1641081600000,
+				Limit:  20,
+				Order:  "desc",
+				Cursor: "eyJvZmZzZXQiOjIwLCJsaW1pdCI6MjB9",
+			},
+			resp: map[string]interface{}{
+				"status": "success",
+				"data": map[string]interface{}{
+					"items":      []map[string]interface{}{},
+					"total":      20,
+					"nextCursor": "",
 				},
 			},
+			statusCode:    http.StatusOK,
+			expectedError: false,
+			expectedItems: 0,
 		},
 		{
 			name:   "server error",
 			ruleID: "ruleid-abc",
 			request: types.AlertHistoryRequest{
-				Start:  1640995200000,
-				End:    1641081600000,
-				Offset: 0,
-				Limit:  20,
-				Order:  "desc",
-				Filters: types.AlertHistoryFilters{
-					Items: []interface{}{},
-					Op:    "AND",
-				},
+				Start: 1640995200000,
+				End:   1641081600000,
+				Limit: 20,
+				Order: "desc",
 			},
-			resp:          map[string]interface{}{"status": "error", "message": "Internal server error"},
+			resp:          map[string]interface{}{"status": "error", "error": map[string]interface{}{"message": "Internal server error"}},
 			statusCode:    http.StatusInternalServerError,
 			expectedError: true,
 		},
@@ -1052,17 +1035,12 @@ func TestGetAlertHistory(t *testing.T) {
 			name:   "rule not found",
 			ruleID: "non-existent-rule",
 			request: types.AlertHistoryRequest{
-				Start:  1640995200000,
-				End:    1641081600000,
-				Offset: 0,
-				Limit:  20,
-				Order:  "desc",
-				Filters: types.AlertHistoryFilters{
-					Items: []interface{}{},
-					Op:    "AND",
-				},
+				Start: 1640995200000,
+				End:   1641081600000,
+				Limit: 20,
+				Order: "desc",
 			},
-			resp:          map[string]interface{}{"status": "error", "message": "Rule not found"},
+			resp:          map[string]interface{}{"status": "error", "error": map[string]interface{}{"message": "Rule not found"}},
 			statusCode:    http.StatusNotFound,
 			expectedError: true,
 		},
@@ -1070,41 +1048,36 @@ func TestGetAlertHistory(t *testing.T) {
 			name:   "empty response",
 			ruleID: "ruleid-abc",
 			request: types.AlertHistoryRequest{
-				Start:  1640995200000,
-				End:    1641081600000,
-				Offset: 0,
-				Limit:  20,
-				Order:  "desc",
-				Filters: types.AlertHistoryFilters{
-					Items: []interface{}{},
-					Op:    "AND",
-				},
+				Start: 1640995200000,
+				End:   1641081600000,
+				Limit: 20,
+				Order: "desc",
 			},
-			resp:          map[string]interface{}{"status": "success", "data": []map[string]interface{}{}},
+			resp:          map[string]interface{}{"status": "success", "data": map[string]interface{}{"items": []map[string]interface{}{}, "total": 0}},
 			statusCode:    http.StatusOK,
 			expectedError: false,
-			expectedData:  []map[string]interface{}{},
+			expectedItems: 0,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				assert.Equal(t, http.MethodPost, r.Method)
-				expectedPath := fmt.Sprintf("/api/v1/rules/%s/history/timeline", tt.ruleID)
+				// v2 timeline is a GET; params ride on the query string, not a body.
+				assert.Equal(t, http.MethodGet, r.Method)
+				expectedPath := fmt.Sprintf("/api/v2/rules/%s/history/timeline", tt.ruleID)
 				assert.Equal(t, expectedPath, r.URL.Path)
-
-				assert.Equal(t, "application/json", r.Header.Get("Content-Type"))
 				assert.Equal(t, "test-api-key", r.Header.Get("SIGNOZ-API-KEY"))
 
-				var requestBody types.AlertHistoryRequest
-				err := json.NewDecoder(r.Body).Decode(&requestBody)
-				require.NoError(t, err)
-				assert.Equal(t, tt.request.Start, requestBody.Start)
-				assert.Equal(t, tt.request.End, requestBody.End)
-				assert.Equal(t, tt.request.Offset, requestBody.Offset)
-				assert.Equal(t, tt.request.Limit, requestBody.Limit)
-				assert.Equal(t, tt.request.Order, requestBody.Order)
+				q := r.URL.Query()
+				assert.Equal(t, fmt.Sprintf("%d", tt.request.Start), q.Get("start"))
+				assert.Equal(t, fmt.Sprintf("%d", tt.request.End), q.Get("end"))
+				assert.Equal(t, fmt.Sprintf("%d", tt.request.Limit), q.Get("limit"))
+				assert.Equal(t, tt.request.Order, q.Get("order"))
+				// Optional params are omitted when empty (server applies defaults).
+				assert.Equal(t, tt.request.State, q.Get("state"))
+				assert.Equal(t, tt.request.FilterExpression, q.Get("filterExpression"))
+				assert.Equal(t, tt.request.Cursor, q.Get("cursor"))
 
 				w.WriteHeader(tt.statusCode)
 				responseBody, _ := json.Marshal(tt.resp)
@@ -1127,23 +1100,10 @@ func TestGetAlertHistory(t *testing.T) {
 				require.NoError(t, err)
 
 				assert.Equal(t, "success", response["status"])
-				if data, ok := response["data"].([]interface{}); ok {
-					assert.Equal(t, len(tt.expectedData), len(data))
-					for i, expectedHistory := range tt.expectedData {
-						if i < len(data) {
-							if history, ok := data[i].(map[string]interface{}); ok {
-								assert.Equal(t, expectedHistory["timestamp"], history["timestamp"])
-								assert.Equal(t, expectedHistory["state"], history["state"])
-								assert.Equal(t, expectedHistory["value"], history["value"])
-								if labels, ok := history["labels"].(map[string]interface{}); ok {
-									expectedLabels := expectedHistory["labels"].(map[string]interface{})
-									assert.Equal(t, expectedLabels["service"], labels["service"])
-									assert.Equal(t, expectedLabels["severity"], labels["severity"])
-								}
-							}
-						}
-					}
-				}
+				data, ok := response["data"].(map[string]interface{})
+				require.True(t, ok, "expected v2 data object with items[]")
+				items, _ := data["items"].([]interface{})
+				assert.Equal(t, tt.expectedItems, len(items))
 			}
 		})
 	}

--- a/internal/handler/tools/aggregate_helper.go
+++ b/internal/handler/tools/aggregate_helper.go
@@ -708,26 +708,29 @@ func completenessNote(returnedRows, limit, offset int, rowsKnown bool) string {
 // exist and the caller must pass it back as "cursor"; otherwise it reports the
 // page as complete. If the cursor field can't be read (unexpected shape), it
 // falls back to the row-count heuristic without asserting a cursor.
-func alertHistoryCompletenessNote(payload []byte, returnedRows, limit int, rowsKnown bool) string {
+func alertHistoryCompletenessNote(payload []byte, returnedRows, limit int, rowsKnown bool, start, end int64, order string) string {
 	var resp struct {
 		Data struct {
 			NextCursor string `json:"nextCursor"`
 		} `json:"data"`
 	}
 	if err := json.Unmarshal(payload, &resp); err == nil && resp.Data.NextCursor != "" {
+		continuation := fmt.Sprintf(
+			"Fetch the next page with cursor=%q, start=%d, end=%d, order=%q, and the same state and filter.",
+			resp.Data.NextCursor, start, end, order)
 		if rowsKnown {
 			if limit == 0 {
 				return fmt.Sprintf(
-					"note: returned %d rows — more results exist (hasMore=true). Fetch the next page with cursor=%q.",
-					returnedRows, resp.Data.NextCursor)
+					"note: returned %d rows — more results exist (hasMore=true). %s",
+					returnedRows, continuation)
 			}
 			return fmt.Sprintf(
-				"note: returned %d rows (limit %d) — more results exist (hasMore=true). Fetch the next page with cursor=%q.",
-				returnedRows, limit, resp.Data.NextCursor)
+				"note: returned %d rows (limit %d) — more results exist (hasMore=true). %s",
+				returnedRows, limit, continuation)
 		}
 		return fmt.Sprintf(
-			"note: more results exist (hasMore=true). Fetch the next page with cursor=%q.",
-			resp.Data.NextCursor)
+			"note: more results exist (hasMore=true). %s",
+			continuation)
 	}
 	if !rowsKnown {
 		if limit == 0 {

--- a/internal/handler/tools/aggregate_helper.go
+++ b/internal/handler/tools/aggregate_helper.go
@@ -588,10 +588,10 @@ func countQueryRangeRows(payload []byte) (int, bool) {
 	return total, true
 }
 
-// countAlertHistoryRows counts the alert history rows in either response shape
-// returned by /api/v1/rules/{id}/history/timeline: data[] or data.items[]. A
-// present null at data or data.items is a known empty collection; missing or
-// unrecognized shapes fail open.
+// countAlertHistoryRows counts the alert history rows in either response shape:
+// the v2 GET /api/v2/rules/{id}/history/timeline body (data.items[]) or a bare
+// data[] array. A present null at data or data.items is a known empty
+// collection; missing or unrecognized shapes fail open.
 func countAlertHistoryRows(payload []byte) (int, bool) {
 	var resp struct {
 		Data json.RawMessage `json:"data"`
@@ -696,6 +696,38 @@ func completenessNote(returnedRows, limit, offset int, rowsKnown bool) string {
 		return fmt.Sprintf(
 			"note: returned %d rows (limit %d) — more results likely exist (hasMore=true). Fetch the next page with offset=%d.",
 			returnedRows, limit, nextOffset)
+	}
+	return fmt.Sprintf(
+		"note: returned %d rows (limit %d) — all matching results returned (hasMore=false).",
+		returnedRows, limit)
+}
+
+// alertHistoryCompletenessNote is the completeness advisory for the v2 rule
+// state-history timeline, which paginates with an opaque cursor rather than an
+// offset. When the response carries a non-empty data.nextCursor, more pages
+// exist and the caller must pass it back as "cursor"; otherwise it reports the
+// page as complete. If the cursor field can't be read (unexpected shape), it
+// falls back to the row-count heuristic without asserting a cursor.
+func alertHistoryCompletenessNote(payload []byte, returnedRows, limit int, rowsKnown bool) string {
+	var resp struct {
+		Data struct {
+			NextCursor string `json:"nextCursor"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(payload, &resp); err == nil && resp.Data.NextCursor != "" {
+		if rowsKnown {
+			return fmt.Sprintf(
+				"note: returned %d rows (limit %d) — more results exist (hasMore=true). Fetch the next page with cursor=%q.",
+				returnedRows, limit, resp.Data.NextCursor)
+		}
+		return fmt.Sprintf(
+			"note: more results exist (hasMore=true). Fetch the next page with cursor=%q.",
+			resp.Data.NextCursor)
+	}
+	if !rowsKnown {
+		return fmt.Sprintf(
+			"note: limit %d applied; this tool cannot count returned rows, so more results may exist. Paginate with \"cursor\" (or narrow the query) to be sure.",
+			limit)
 	}
 	return fmt.Sprintf(
 		"note: returned %d rows (limit %d) — all matching results returned (hasMore=false).",

--- a/internal/handler/tools/aggregate_helper.go
+++ b/internal/handler/tools/aggregate_helper.go
@@ -716,6 +716,11 @@ func alertHistoryCompletenessNote(payload []byte, returnedRows, limit int, rowsK
 	}
 	if err := json.Unmarshal(payload, &resp); err == nil && resp.Data.NextCursor != "" {
 		if rowsKnown {
+			if limit == 0 {
+				return fmt.Sprintf(
+					"note: returned %d rows — more results exist (hasMore=true). Fetch the next page with cursor=%q.",
+					returnedRows, resp.Data.NextCursor)
+			}
 			return fmt.Sprintf(
 				"note: returned %d rows (limit %d) — more results exist (hasMore=true). Fetch the next page with cursor=%q.",
 				returnedRows, limit, resp.Data.NextCursor)
@@ -725,9 +730,17 @@ func alertHistoryCompletenessNote(payload []byte, returnedRows, limit int, rowsK
 			resp.Data.NextCursor)
 	}
 	if !rowsKnown {
+		if limit == 0 {
+			return "note: this tool cannot count returned rows, so more results may exist. Paginate with \"cursor\" (or narrow the query) to be sure."
+		}
 		return fmt.Sprintf(
 			"note: limit %d applied; this tool cannot count returned rows, so more results may exist. Paginate with \"cursor\" (or narrow the query) to be sure.",
 			limit)
+	}
+	if limit == 0 {
+		return fmt.Sprintf(
+			"note: returned %d rows — all matching results returned (hasMore=false).",
+			returnedRows)
 	}
 	return fmt.Sprintf(
 		"note: returned %d rows (limit %d) — all matching results returned (hasMore=false).",

--- a/internal/handler/tools/alert_history_limit_test.go
+++ b/internal/handler/tools/alert_history_limit_test.go
@@ -83,6 +83,27 @@ func TestHandleGetAlertHistory_LimitNotClamped(t *testing.T) {
 	}
 }
 
+func TestHandleGetAlertHistory_CursorKeepsEncodedLimitWhenOmitted(t *testing.T) {
+	var capturedReq types.AlertHistoryRequest
+	mock := &client.MockClient{
+		GetAlertHistoryFn: func(ctx context.Context, ruleID string, req types.AlertHistoryRequest) (json.RawMessage, error) {
+			capturedReq = req
+			return json.RawMessage(`{"data":{"items":[]}}`), nil
+		},
+	}
+
+	result, err := newTestHandler(mock).handleGetAlertHistory(testCtx(), makeToolRequest("signoz_get_alert_history", map[string]any{
+		"ruleId": "rule-hist",
+		"cursor": "UPSTREAM_CURSOR",
+	}))
+	if err != nil || result.IsError {
+		t.Fatalf("cursor follow-up failed: err=%v result=%v", err, result.Content)
+	}
+	if capturedReq.Cursor != "UPSTREAM_CURSOR" || capturedReq.Limit != 0 {
+		t.Fatalf("cursor follow-up request = %#v, want raw cursor with omitted limit", capturedReq)
+	}
+}
+
 // resultNotesContain reports whether any text content block of the result
 // contains the given substring. resultWithNotes appends notes as content blocks
 // trailing the JSON payload block.

--- a/internal/handler/tools/alerts.go
+++ b/internal/handler/tools/alerts.go
@@ -3,8 +3,10 @@ package tools
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
+	"net/http"
 	"strings"
 
 	"github.com/mark3labs/mcp-go/mcp"
@@ -32,6 +34,10 @@ type alertRuleListOutput struct {
 var serverPopulatedAlertFields = []string{
 	"createdAt", "updatedAt", "createdBy", "updatedBy",
 	"createAt", "updateAt", "createBy", "updateBy",
+}
+
+var alertHistoryStateValues = []string{
+	"inactive", "pending", "recovering", "firing", "nodata", "disabled",
 }
 
 func (h *Handler) RegisterAlertsHandlers(s *server.MCPServer) {
@@ -81,15 +87,15 @@ func (h *Handler) RegisterAlertsHandlers(s *server.MCPServer) {
 		mcp.WithReadOnlyHintAnnotation(true),
 		mcp.WithDestructiveHintAnnotation(false),
 		mcp.WithString("searchContext", mcp.Description("The user's original question or search text that triggered this tool call. Always include the user's raw query here for better results.")),
-		mcp.WithDescription("Get the alert state-history timeline for a specific rule (GET /api/v2/rules/{id}/history/timeline). Defaults to last 6 hours if no time specified. Use 'state' to filter by alert state, 'filterExpression' to narrow by label, and 'cursor' to page through results."),
+		mcp.WithDescription("Get alert firing history for a specific alert rule. Defaults to the last 6 hours. Use 'state' and 'filter' to narrow results. For the next page, pass data.nextCursor as 'cursor' and repeat the original query filters and time range."),
 		mcp.WithString("id", mcp.Description("Alert rule ID. Required.")),
 		mcp.WithString("timeRange", mcp.DefaultString("6h"), mcp.Description(timeRangeDesc("Defaults to last 6 hours if not provided."))),
 		mcp.WithString("start", intOrStringType(), mcp.Description("Start timestamp in unix milliseconds (optional, defaults to 6 hours ago).")),
 		mcp.WithString("end", intOrStringType(), mcp.Description("End timestamp in unix milliseconds (optional, defaults to now).")),
-		mcp.WithString("state", mcp.Enum("firing", "inactive"), mcp.Description("Filter history by alert state: 'firing' or 'inactive'. If omitted, returns all state transitions.")),
-		mcp.WithString("filterExpression", mcp.Description("Optional SigNoz v5 query-builder filter expression to narrow the timeline by label (e.g. severity = 'critical'). Omit to return all transitions.")),
-		mcp.WithString("cursor", mcp.Description("Opaque pagination cursor. Pass the 'nextCursor' value from a previous response's data to fetch the next page. Omit for the first page.")),
-		mcp.WithString("limit", mcp.DefaultString("20"), intOrStringType(), mcp.Description("Limit number of results (default: 20)")),
+		mcp.WithString("state", mcp.Enum(alertHistoryStateValues...), mcp.Description("Filter by alert state: inactive, pending, recovering, firing, nodata, or disabled. Omit to return all transitions.")),
+		mcp.WithString("filter", mcp.Description("Filter timeline labels using SigNoz query-builder syntax. Combine conditions with AND, OR, and parentheses; quote string values with single quotes and use operators such as =, !=, IN, and NOT IN. Example: \"severity = 'critical' AND (team = 'payments' OR service.name = 'checkout')\". To discover label keys, first call without a filter and inspect data.items[].labels[].key.name. If a filter returns no matches, retry unfiltered and verify the key spelling; malformed expressions return validation errors.")),
+		mcp.WithString("cursor", mcp.Description("Opaque continuation cursor. Repeat the original time range, state, filter, and order when fetching the next page. Omit cursor for the first page.")),
+		mcp.WithString("limit", mcp.DefaultString("20"), intOrStringType(), mcp.Description("Rows per page. Default: 20; max: 10000 (higher values are clamped).")),
 		mcp.WithString("order", mcp.DefaultString("asc"), mcp.Enum("asc", "desc"), mcp.Description("Sort order: 'asc' or 'desc' (default: 'asc')")),
 	)
 	h.addTool(s, alertHistoryTool, h.handleGetAlertHistory)
@@ -353,6 +359,10 @@ func (h *Handler) handleGetAlertHistory(ctx context.Context, req mcp.CallToolReq
 		return errorWithCode(CodeValidationFailed, `Parameter validation failed: "id" is required. Example: {"id": "0196634d-5d66-75c4-b778-e317f49dab7a", "timeRange": "24h"}`), nil
 	}
 
+	if _, present := args["offset"]; present {
+		return errorWithCode(CodeValidationFailed, `Parameter validation failed: "offset" is no longer supported; use data.nextCursor as "cursor" for subsequent pages.`), nil
+	}
+
 	// Reject a present-but-malformed start/end loudly; otherwise
 	// GetTimestampsWithDefaults silently falls back to the default window.
 	if err := timeutil.ValidateExplicitTimestamps(args); err != nil {
@@ -361,7 +371,6 @@ func (h *Handler) handleGetAlertHistory(ctx context.Context, req mcp.CallToolReq
 	}
 
 	startStr, endStr := timeutil.GetTimestampsWithDefaults(args, "ms")
-
 	var start, end int64
 	if _, err := fmt.Sscanf(startStr, "%d", &start); err != nil {
 		h.logger.WarnContext(ctx, "Invalid start timestamp format", slog.String("start", startStr), logpkg.ErrAttr(err))
@@ -371,44 +380,49 @@ func (h *Handler) handleGetAlertHistory(ctx context.Context, req mcp.CallToolReq
 		h.logger.WarnContext(ctx, "Invalid end timestamp format", slog.String("end", endStr), logpkg.ErrAttr(err))
 		return errorWithCode(CodeValidationFailed, fmt.Sprintf(`Invalid "end" timestamp: "%s". Expected milliseconds since epoch (e.g., "1697472000000") or use "timeRange" parameter instead (e.g., "24h")`, endStr)), nil
 	}
+	if start >= end {
+		return errorWithCode(CodeValidationFailed, `Parameter validation failed: "start" must be earlier than "end".`), nil
+	}
 
-	// Route the limit through the shared loose parser (number-or-string), with
-	// this tool's documented default of 20. The old bespoke re-parse advertised
-	// a fictional "1-1000" bound that was never enforced — dropped here.
-	limit, err := intArg(args, "limit", 20)
+	cursor := strings.TrimSpace(stringArg(args, "cursor"))
+	defaultLimit := 20
+	if cursor != "" {
+		defaultLimit = 0 // let the upstream cursor retain its encoded page size
+	}
+	limit, err := intArg(args, "limit", defaultLimit)
 	if err != nil {
 		h.logger.WarnContext(ctx, "Invalid limit format", slog.Any("limit", args["limit"]), logpkg.ErrAttr(err))
 		return errorWithCode(CodeValidationFailed, err.Error()), nil
 	}
-	// Clamp before forwarding so an oversized limit can't bypass the memory guard.
 	limit, limitClamped := clampLimit(limit)
 
 	order := "asc"
-	if orderStr, ok := args["order"].(string); ok && orderStr != "" {
-		if orderStr == "asc" || orderStr == "desc" {
-			order = orderStr
-		} else {
-			h.logger.WarnContext(ctx, "Invalid order value", slog.String("order", orderStr))
-			return errorWithCode(CodeValidationFailed, fmt.Sprintf(`Invalid "order" value: "%s". Must be either "asc" or "desc"`, orderStr)), nil
+	if orderArg := strings.TrimSpace(stringArg(args, "order")); orderArg != "" {
+		if orderArg != "asc" && orderArg != "desc" {
+			h.logger.WarnContext(ctx, "Invalid order value", slog.String("order", orderArg))
+			return errorWithCode(CodeValidationFailed, fmt.Sprintf(`Invalid "order" value: "%s". Must be either "asc" or "desc"`, orderArg)), nil
+		}
+		order = orderArg
+	}
+
+	state := strings.TrimSpace(stringArg(args, "state"))
+	if state != "" {
+		valid := false
+		for _, candidate := range alertHistoryStateValues {
+			if state == candidate {
+				valid = true
+				break
+			}
+		}
+		if !valid {
+			h.logger.WarnContext(ctx, "Invalid state value", slog.String("state", state))
+			return errorWithCode(CodeValidationFailed, fmt.Sprintf(`Invalid "state" value: "%s". Must be one of: %s`, state, strings.Join(alertHistoryStateValues, ", "))), nil
 		}
 	}
 
-	var state string
-	if stateStr, ok := args["state"].(string); ok && stateStr != "" {
-		if stateStr != "firing" && stateStr != "inactive" {
-			h.logger.WarnContext(ctx, "Invalid state value", slog.String("state", stateStr))
-			return errorWithCode(CodeValidationFailed, fmt.Sprintf(`Invalid "state" value: "%s". Must be either "firing" or "inactive"`, stateStr)), nil
-		}
-		state = stateStr
-	}
-
-	var filterExpression string
-	if v, ok := args["filterExpression"].(string); ok {
-		filterExpression = strings.TrimSpace(v)
-	}
-	var cursor string
-	if v, ok := args["cursor"].(string); ok {
-		cursor = strings.TrimSpace(v)
+	filterExpression := strings.TrimSpace(stringArg(args, "filter"))
+	if filterExpression == "" {
+		filterExpression = strings.TrimSpace(stringArg(args, "filterExpression"))
 	}
 
 	historyReq := types.AlertHistoryRequest{
@@ -423,11 +437,11 @@ func (h *Handler) handleGetAlertHistory(ctx context.Context, req mcp.CallToolReq
 
 	h.logger.DebugContext(ctx, "Tool called: signoz_get_alert_history",
 		slog.String("ruleId", ruleID),
-		slog.Int64("start", start),
-		slog.Int64("end", end),
-		slog.Bool("hasCursor", cursor != ""),
-		slog.Int("limit", limit),
-		slog.String("order", order))
+		slog.Int64("start", historyReq.Start),
+		slog.Int64("end", historyReq.End),
+		slog.Bool("hasCursor", historyReq.Cursor != ""),
+		slog.Int("limit", historyReq.Limit),
+		slog.String("order", historyReq.Order))
 
 	client, err := h.GetClient(ctx)
 	if err != nil {
@@ -438,12 +452,16 @@ func (h *Handler) handleGetAlertHistory(ctx context.Context, req mcp.CallToolReq
 		h.logger.ErrorContext(ctx, "Failed to get alert history",
 			slog.String("ruleId", ruleID),
 			logpkg.ErrAttr(err))
+		var statusErr *signozclient.HTTPStatusError
+		if errors.As(err, &statusErr) && statusErr.StatusCode == http.StatusNotFound {
+			result := upstreamError(err)
+			result.Content = append(result.Content, mcp.NewTextContent(
+				`recovery: Verify "id" in the SigNoz UI or, on SigNoz v0.120.0+, with signoz_list_alert_rules. If the rule exists, upgrade SigNoz to v0.118.0 or later; older versions do not support this tool.`))
+			return result, nil
+		}
 		return upstreamError(err), nil
 	}
 
-	// Completeness signal: alert history is a raw passthrough. v2 returns an
-	// explicit data.nextCursor when more pages exist, so derive hasMore from it
-	// (falling back to a row-count heuristic when the cursor is absent).
 	returnedRows, rowsKnown := countAlertHistoryRows(respJSON)
 	var notes []string
 	if limitClamped {
@@ -451,7 +469,7 @@ func (h *Handler) handleGetAlertHistory(ctx context.Context, req mcp.CallToolReq
 			"note: result limited to %d rows to bound server memory; paginate with \"cursor\" (or narrow the time range) for more.",
 			MaxRawResultLimit))
 	}
-	notes = append(notes, alertHistoryCompletenessNote(respJSON, returnedRows, limit, rowsKnown))
+	notes = append(notes, alertHistoryCompletenessNote(respJSON, returnedRows, historyReq.Limit, rowsKnown))
 	return resultWithNotes(respJSON, notes...), nil
 }
 

--- a/internal/handler/tools/alerts.go
+++ b/internal/handler/tools/alerts.go
@@ -469,7 +469,10 @@ func (h *Handler) handleGetAlertHistory(ctx context.Context, req mcp.CallToolReq
 			"note: result limited to %d rows to bound server memory; paginate with \"cursor\" (or narrow the time range) for more.",
 			MaxRawResultLimit))
 	}
-	notes = append(notes, alertHistoryCompletenessNote(respJSON, returnedRows, historyReq.Limit, rowsKnown))
+	notes = append(notes, alertHistoryCompletenessNote(
+		respJSON, returnedRows, historyReq.Limit, rowsKnown,
+		historyReq.Start, historyReq.End, historyReq.Order,
+	))
 	return resultWithNotes(respJSON, notes...), nil
 }
 

--- a/internal/handler/tools/alerts.go
+++ b/internal/handler/tools/alerts.go
@@ -81,13 +81,14 @@ func (h *Handler) RegisterAlertsHandlers(s *server.MCPServer) {
 		mcp.WithReadOnlyHintAnnotation(true),
 		mcp.WithDestructiveHintAnnotation(false),
 		mcp.WithString("searchContext", mcp.Description("The user's original question or search text that triggered this tool call. Always include the user's raw query here for better results.")),
-		mcp.WithDescription("Get alert history timeline for a specific rule. Defaults to last 6 hours if no time specified. Use 'state' to filter by alert state (e.g., only firing transitions or only resolutions)."),
+		mcp.WithDescription("Get the alert state-history timeline for a specific rule (GET /api/v2/rules/{id}/history/timeline). Defaults to last 6 hours if no time specified. Use 'state' to filter by alert state, 'filterExpression' to narrow by label, and 'cursor' to page through results."),
 		mcp.WithString("id", mcp.Description("Alert rule ID. Required.")),
 		mcp.WithString("timeRange", mcp.DefaultString("6h"), mcp.Description(timeRangeDesc("Defaults to last 6 hours if not provided."))),
 		mcp.WithString("start", intOrStringType(), mcp.Description("Start timestamp in unix milliseconds (optional, defaults to 6 hours ago).")),
 		mcp.WithString("end", intOrStringType(), mcp.Description("End timestamp in unix milliseconds (optional, defaults to now).")),
 		mcp.WithString("state", mcp.Enum("firing", "inactive"), mcp.Description("Filter history by alert state: 'firing' or 'inactive'. If omitted, returns all state transitions.")),
-		mcp.WithString("offset", mcp.DefaultString("0"), intOrStringType(), mcp.Description("Offset for pagination (default: 0)")),
+		mcp.WithString("filterExpression", mcp.Description("Optional SigNoz v5 query-builder filter expression to narrow the timeline by label (e.g. severity = 'critical'). Omit to return all transitions.")),
+		mcp.WithString("cursor", mcp.Description("Opaque pagination cursor. Pass the 'nextCursor' value from a previous response's data to fetch the next page. Omit for the first page.")),
 		mcp.WithString("limit", mcp.DefaultString("20"), intOrStringType(), mcp.Description("Limit number of results (default: 20)")),
 		mcp.WithString("order", mcp.DefaultString("asc"), mcp.Enum("asc", "desc"), mcp.Description("Sort order: 'asc' or 'desc' (default: 'asc')")),
 	)
@@ -371,8 +372,6 @@ func (h *Handler) handleGetAlertHistory(ctx context.Context, req mcp.CallToolReq
 		return errorWithCode(CodeValidationFailed, fmt.Sprintf(`Invalid "end" timestamp: "%s". Expected milliseconds since epoch (e.g., "1697472000000") or use "timeRange" parameter instead (e.g., "24h")`, endStr)), nil
 	}
 
-	_, offset := paginate.ParseParams(args)
-
 	// Route the limit through the shared loose parser (number-or-string), with
 	// this tool's documented default of 20. The old bespoke re-parse advertised
 	// a fictional "1-1000" bound that was never enforced — dropped here.
@@ -403,24 +402,30 @@ func (h *Handler) handleGetAlertHistory(ctx context.Context, req mcp.CallToolReq
 		state = stateStr
 	}
 
+	var filterExpression string
+	if v, ok := args["filterExpression"].(string); ok {
+		filterExpression = strings.TrimSpace(v)
+	}
+	var cursor string
+	if v, ok := args["cursor"].(string); ok {
+		cursor = strings.TrimSpace(v)
+	}
+
 	historyReq := types.AlertHistoryRequest{
-		Start:  start,
-		End:    end,
-		State:  state,
-		Offset: offset,
-		Limit:  limit,
-		Order:  order,
-		Filters: types.AlertHistoryFilters{
-			Items: []interface{}{},
-			Op:    "AND",
-		},
+		Start:            start,
+		End:              end,
+		State:            state,
+		FilterExpression: filterExpression,
+		Limit:            limit,
+		Order:            order,
+		Cursor:           cursor,
 	}
 
 	h.logger.DebugContext(ctx, "Tool called: signoz_get_alert_history",
 		slog.String("ruleId", ruleID),
 		slog.Int64("start", start),
 		slog.Int64("end", end),
-		slog.Int("offset", offset),
+		slog.Bool("hasCursor", cursor != ""),
 		slog.Int("limit", limit),
 		slog.String("order", order))
 
@@ -436,16 +441,17 @@ func (h *Handler) handleGetAlertHistory(ctx context.Context, req mcp.CallToolReq
 		return upstreamError(err), nil
 	}
 
-	// Completeness signal: alert history is a raw passthrough with limit/offset
-	// but no hasMore of its own. Count rows across both known history shapes.
+	// Completeness signal: alert history is a raw passthrough. v2 returns an
+	// explicit data.nextCursor when more pages exist, so derive hasMore from it
+	// (falling back to a row-count heuristic when the cursor is absent).
 	returnedRows, rowsKnown := countAlertHistoryRows(respJSON)
 	var notes []string
 	if limitClamped {
 		notes = append(notes, fmt.Sprintf(
-			"note: result limited to %d rows to bound server memory; paginate with \"offset\" (or narrow the time range) for more.",
+			"note: result limited to %d rows to bound server memory; paginate with \"cursor\" (or narrow the time range) for more.",
 			MaxRawResultLimit))
 	}
-	notes = append(notes, completenessNote(returnedRows, limit, offset, rowsKnown))
+	notes = append(notes, alertHistoryCompletenessNote(respJSON, returnedRows, limit, rowsKnown))
 	return resultWithNotes(respJSON, notes...), nil
 }
 

--- a/internal/handler/tools/e2e_familyd_test.go
+++ b/internal/handler/tools/e2e_familyd_test.go
@@ -295,7 +295,7 @@ func TestFamilyD_E2E_SignalEnumValues(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// order (asc/desc) + state (firing/inactive) on get_alert_history (N15).
+// order (asc/desc) + every v2 state on get_alert_history (N15).
 // Needs a real ruleId from list_alert_rules.
 // ---------------------------------------------------------------------------
 
@@ -322,7 +322,7 @@ func TestFamilyD_E2E_AlertHistoryEnums(t *testing.T) {
 		mustNoToolError(t, res, "get_alert_history/order="+order)
 	}
 
-	for _, state := range []string{"firing", "inactive"} {
+	for _, state := range alertHistoryStateValues {
 		res, err := h.handleGetAlertHistory(ctx, makeToolRequest("signoz_get_alert_history", map[string]any{
 			"ruleId":    ruleID,
 			"timeRange": "24h",
@@ -333,7 +333,7 @@ func TestFamilyD_E2E_AlertHistoryEnums(t *testing.T) {
 		}
 		mustNoToolError(t, res, "get_alert_history/state="+state)
 	}
-	t.Logf("order (asc, desc) and state (firing, inactive) enums accepted on get_alert_history")
+	t.Logf("order (asc, desc) and all v2 state enums accepted on get_alert_history")
 }
 
 func firstLiveRuleID(t *testing.T, h *Handler, ctx context.Context) string {

--- a/internal/handler/tools/param_schema_test.go
+++ b/internal/handler/tools/param_schema_test.go
@@ -95,7 +95,7 @@ func TestStableSetEnumsArePresent(t *testing.T) {
 		{"signoz_aggregate_traces", "requestType", []string{"scalar", "time_series"}},
 		{"signoz_query_metrics", "requestType", []string{"scalar", "time_series"}},
 		{"signoz_get_alert_history", "order", []string{"asc", "desc"}},
-		{"signoz_get_alert_history", "state", []string{"firing", "inactive"}},
+		{"signoz_get_alert_history", "state", []string{"disabled", "firing", "inactive", "nodata", "pending", "recovering"}},
 		{"signoz_get_field_keys", "signal", []string{"logs", "metrics", "traces"}},
 		{"signoz_get_field_values", "signal", []string{"logs", "metrics", "traces"}},
 		// sourcePage already carried an enum before this change; pin it so a
@@ -115,6 +115,35 @@ func TestStableSetEnumsArePresent(t *testing.T) {
 				t.Fatalf("%s.%s enum = %v, want %v", tc.tool, tc.prop, got, tc.want)
 			}
 		})
+	}
+}
+
+func TestAlertHistoryAgentFacingContract(t *testing.T) {
+	props := registeredToolProps(t, "signoz_get_alert_history")
+	if _, ok := props["filter"]; !ok {
+		t.Fatal("signoz_get_alert_history must advertise the canonical filter parameter")
+	}
+	for _, hidden := range []string{"filterExpression", "offset"} {
+		if _, ok := props[hidden]; ok {
+			t.Fatalf("signoz_get_alert_history should not advertise backend/legacy parameter %q", hidden)
+		}
+	}
+
+	h := newTestHandler(&signozclient.MockClient{})
+	s := server.NewMCPServer("test", "0.0.0", server.WithToolCapabilities(false))
+	h.RegisterAlertsHandlers(s)
+	registered, ok := s.ListTools()["signoz_get_alert_history"]
+	if !ok {
+		t.Fatal("signoz_get_alert_history not registered")
+	}
+	description := registered.Tool.Description
+	if strings.Contains(description, "/api/v2/rules/") || strings.Contains(description, "GET ") {
+		t.Fatalf("agent-facing description leaks backend route/method: %q", description)
+	}
+	for _, required := range []string{"alert firing history", "filter", "cursor"} {
+		if !strings.Contains(description, required) {
+			t.Fatalf("agent-facing description missing %q: %q", required, description)
+		}
 	}
 }
 

--- a/internal/handler/tools/resource_templates.go
+++ b/internal/handler/tools/resource_templates.go
@@ -59,11 +59,10 @@ func (h *Handler) handleAlertSummaryResource(ctx context.Context, req mcp.ReadRe
 	}
 
 	historyReq := types.AlertHistoryRequest{
-		Start:  timeutil.HoursAgoMillis(6),
-		End:    timeutil.NowMillis(),
-		Order:  "desc",
-		Limit:  10,
-		Offset: 0,
+		Start: timeutil.HoursAgoMillis(6),
+		End:   timeutil.NowMillis(),
+		Order: "desc",
+		Limit: 10,
 	}
 	historyData, err := client.GetAlertHistory(ctx, ruleID, historyReq)
 	if err != nil {

--- a/internal/handler/tools/silent_failures_test.go
+++ b/internal/handler/tools/silent_failures_test.go
@@ -727,7 +727,6 @@ func TestHandleGetAlertHistoryFamilyA_TopLevelDataArrayCompletenessNote(t *testi
 	result, err := h.handleGetAlertHistory(testCtx(), makeToolRequest("signoz_get_alert_history", map[string]any{
 		"ruleId": "rule-x",
 		"limit":  "2",
-		"offset": "5",
 	}))
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -742,8 +741,49 @@ func TestHandleGetAlertHistoryFamilyA_TopLevelDataArrayCompletenessNote(t *testi
 	if strings.Contains(note, "cannot count returned rows") {
 		t.Fatalf("must count top-level data[] alert history rows; note=%q", note)
 	}
-	if !strings.Contains(note, "returned 2 rows") || !strings.Contains(note, "hasMore=true") || !strings.Contains(note, "offset=7") {
-		t.Fatalf("completeness note = %q, want 2 rows / hasMore=true / offset=7", note)
+	// v2 paginates by cursor: with no data.nextCursor there are no more pages,
+	// so the note reports hasMore=false (the server emits a cursor only when
+	// more rows exist — strictly more accurate than the old offset heuristic).
+	if !strings.Contains(note, "returned 2 rows") || !strings.Contains(note, "hasMore=false") {
+		t.Fatalf("completeness note = %q, want 2 rows / hasMore=false", note)
+	}
+}
+
+// TestHandleGetAlertHistory_NextCursorHasMore pins the v2 pagination signal: a
+// response carrying data.nextCursor reports hasMore=true and names the cursor to
+// pass back, and a passed-through offset arg is ignored (v2 has no offset param).
+func TestHandleGetAlertHistory_NextCursorHasMore(t *testing.T) {
+	var captured types.AlertHistoryRequest
+	mock := &client.MockClient{
+		GetAlertHistoryFn: func(ctx context.Context, ruleID string, req types.AlertHistoryRequest) (json.RawMessage, error) {
+			captured = req
+			return json.RawMessage(`{"status":"success","data":{"items":[{"state":"firing"},{"state":"inactive"}],"total":42,"nextCursor":"CURSOR_XYZ"}}`), nil
+		},
+	}
+	h := newTestHandler(mock)
+	result, err := h.handleGetAlertHistory(testCtx(), makeToolRequest("signoz_get_alert_history", map[string]any{
+		"ruleId":           "rule-x",
+		"limit":            "2",
+		"offset":           "5", // ignored under v2
+		"cursor":           "CURSOR_PREV",
+		"filterExpression": "severity = 'critical'",
+	}))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("handler returned error result: %v", result.Content)
+	}
+	// The cursor and filter expression must reach the client verbatim.
+	if captured.Cursor != "CURSOR_PREV" {
+		t.Errorf("forwarded cursor = %q, want CURSOR_PREV", captured.Cursor)
+	}
+	if captured.FilterExpression != "severity = 'critical'" {
+		t.Errorf("forwarded filterExpression = %q, want severity = 'critical'", captured.FilterExpression)
+	}
+	note := result.Content[1].(mcp.TextContent).Text
+	if !strings.Contains(note, "hasMore=true") || !strings.Contains(note, "CURSOR_XYZ") {
+		t.Fatalf("completeness note = %q, want hasMore=true naming cursor CURSOR_XYZ", note)
 	}
 }
 

--- a/internal/handler/tools/silent_failures_test.go
+++ b/internal/handler/tools/silent_failures_test.go
@@ -787,6 +787,35 @@ func TestHandleGetAlertHistory_NextCursorHasMore(t *testing.T) {
 	}
 }
 
+// TestHandleGetAlertHistory_ItemsExactFillNoCursor pins the key v2 semantic on
+// the real timeline shape (data.items[]): a page whose item count equals the
+// limit but which carries NO nextCursor is the last page, so the note must
+// report hasMore=false. This is exactly the case the old row-count heuristic got
+// wrong (it would have claimed hasMore=true because returnedRows == limit); v2
+// trusts the server's cursor, which is only emitted when more rows remain.
+func TestHandleGetAlertHistory_ItemsExactFillNoCursor(t *testing.T) {
+	mock := &client.MockClient{
+		GetAlertHistoryFn: func(ctx context.Context, ruleID string, req types.AlertHistoryRequest) (json.RawMessage, error) {
+			return json.RawMessage(`{"status":"success","data":{"items":[{"ruleId":"r1","state":"firing","unixMilli":1},{"ruleId":"r1","state":"inactive","unixMilli":2}],"total":2}}`), nil
+		},
+	}
+	h := newTestHandler(mock)
+	result, err := h.handleGetAlertHistory(testCtx(), makeToolRequest("signoz_get_alert_history", map[string]any{
+		"ruleId": "r1",
+		"limit":  "2",
+	}))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("handler returned error result: %v", result.Content)
+	}
+	note := result.Content[1].(mcp.TextContent).Text
+	if !strings.Contains(note, "returned 2 rows") || !strings.Contains(note, "hasMore=false") {
+		t.Fatalf("completeness note = %q, want 2 rows / hasMore=false (exact-fill, no cursor)", note)
+	}
+}
+
 func TestHandleSearchLogs_AppendsCompletenessNote(t *testing.T) {
 	// 2 rows returned against a small limit -> hasMore=false
 	response := json.RawMessage(`{"status":"success","data":{"data":{"results":[{"rows":[{"data":{"body":"a"}},{"data":{"body":"b"}}]}]}}}`)

--- a/internal/handler/tools/silent_failures_test.go
+++ b/internal/handler/tools/silent_failures_test.go
@@ -751,7 +751,7 @@ func TestHandleGetAlertHistoryFamilyA_TopLevelDataArrayCompletenessNote(t *testi
 
 // TestHandleGetAlertHistory_NextCursorHasMore pins the v2 pagination signal: a
 // response carrying data.nextCursor reports hasMore=true and names the cursor to
-// pass back, and a passed-through offset arg is ignored (v2 has no offset param).
+// pass back. The upstream cursor is forwarded unchanged.
 func TestHandleGetAlertHistory_NextCursorHasMore(t *testing.T) {
 	var captured types.AlertHistoryRequest
 	mock := &client.MockClient{
@@ -762,11 +762,10 @@ func TestHandleGetAlertHistory_NextCursorHasMore(t *testing.T) {
 	}
 	h := newTestHandler(mock)
 	result, err := h.handleGetAlertHistory(testCtx(), makeToolRequest("signoz_get_alert_history", map[string]any{
-		"ruleId":           "rule-x",
-		"limit":            "2",
-		"offset":           "5", // ignored under v2
-		"cursor":           "CURSOR_PREV",
-		"filterExpression": "severity = 'critical'",
+		"ruleId": "rule-x",
+		"limit":  "2",
+		"cursor": "CURSOR_PREV",
+		"filter": "severity = 'critical'",
 	}))
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -774,7 +773,6 @@ func TestHandleGetAlertHistory_NextCursorHasMore(t *testing.T) {
 	if result.IsError {
 		t.Fatalf("handler returned error result: %v", result.Content)
 	}
-	// The cursor and filter expression must reach the client verbatim.
 	if captured.Cursor != "CURSOR_PREV" {
 		t.Errorf("forwarded cursor = %q, want CURSOR_PREV", captured.Cursor)
 	}

--- a/internal/handler/tools/silent_failures_test.go
+++ b/internal/handler/tools/silent_failures_test.go
@@ -750,8 +750,9 @@ func TestHandleGetAlertHistoryFamilyA_TopLevelDataArrayCompletenessNote(t *testi
 }
 
 // TestHandleGetAlertHistory_NextCursorHasMore pins the v2 pagination signal: a
-// response carrying data.nextCursor reports hasMore=true and names the cursor to
-// pass back. The upstream cursor is forwarded unchanged.
+// response carrying data.nextCursor reports hasMore=true and names the cursor,
+// resolved absolute time range, and order to pass back. The upstream cursor is
+// forwarded unchanged.
 func TestHandleGetAlertHistory_NextCursorHasMore(t *testing.T) {
 	var captured types.AlertHistoryRequest
 	mock := &client.MockClient{
@@ -763,7 +764,10 @@ func TestHandleGetAlertHistory_NextCursorHasMore(t *testing.T) {
 	h := newTestHandler(mock)
 	result, err := h.handleGetAlertHistory(testCtx(), makeToolRequest("signoz_get_alert_history", map[string]any{
 		"ruleId": "rule-x",
+		"start":  "1697385600000",
+		"end":    "1697472000000",
 		"limit":  "2",
+		"order":  "desc",
 		"cursor": "CURSOR_PREV",
 		"filter": "severity = 'critical'",
 	}))
@@ -779,9 +783,17 @@ func TestHandleGetAlertHistory_NextCursorHasMore(t *testing.T) {
 	if captured.FilterExpression != "severity = 'critical'" {
 		t.Errorf("forwarded filterExpression = %q, want severity = 'critical'", captured.FilterExpression)
 	}
+	if captured.Start != 1697385600000 || captured.End != 1697472000000 || captured.Order != "desc" {
+		t.Errorf("forwarded scope = start:%d end:%d order:%q, want explicit millisecond range and desc", captured.Start, captured.End, captured.Order)
+	}
 	note := result.Content[1].(mcp.TextContent).Text
 	if !strings.Contains(note, "hasMore=true") || !strings.Contains(note, "CURSOR_XYZ") {
 		t.Fatalf("completeness note = %q, want hasMore=true naming cursor CURSOR_XYZ", note)
+	}
+	for _, want := range []string{"start=1697385600000", "end=1697472000000", `order="desc"`, "same state and filter"} {
+		if !strings.Contains(note, want) {
+			t.Fatalf("completeness note = %q, want scoped continuation containing %q", note, want)
+		}
 	}
 }
 

--- a/internal/mcp-server/server.go
+++ b/internal/mcp-server/server.go
@@ -254,7 +254,7 @@ func (m *MCPServer) Run(ctx context.Context) error {
 	// the async corpus build below calls Swap() with a real snapshot, so docs
 	// handlers correctly return INDEX_NOT_READY in the window before the
 	// index is populated. This lets HTTP server publication (below) happen
-	// within the 1 s test bound instead of waiting on the 1-3 s bleve build.
+	// without waiting on the 1-3 s bleve build.
 	placeholderRegistry, err := docsindex.NewPlaceholderRegistry(ctx)
 	if err != nil {
 		return fmt.Errorf("initialize placeholder docs registry: %w", err)

--- a/internal/mcp-server/server_test.go
+++ b/internal/mcp-server/server_test.go
@@ -3007,7 +3007,7 @@ func TestRun_HTTPShutdownRaceDuringStartup(t *testing.T) {
 		runDone <- srv.Run(runCtx)
 	}()
 
-	waitForCondition(t, time.Second, func() bool {
+	waitForCondition(t, 5*time.Second, func() bool {
 		return srv.httpServer.Load() != nil
 	}, "timed out waiting for HTTP server startup publication")
 

--- a/manifest.json
+++ b/manifest.json
@@ -67,7 +67,7 @@
     },
     {
       "name": "signoz_get_alert_history",
-      "description": "Get alert state history timeline for a specific rule (param 'id') via GET /api/v2/rules/{id}/history/timeline, with optional state filter, filterExpression, and cursor pagination"
+      "description": "Get alert firing history for a specific alert rule. Defaults to the last 6 hours. Use 'state' and 'filter' to narrow results. For the next page, pass data.nextCursor as 'cursor' and repeat the original query filters and time range."
     },
     {
       "name": "signoz_create_alert",

--- a/manifest.json
+++ b/manifest.json
@@ -67,7 +67,7 @@
     },
     {
       "name": "signoz_get_alert_history",
-      "description": "Get alert state history timeline for a specific rule (param 'id') with optional state filter"
+      "description": "Get alert state history timeline for a specific rule (param 'id') via GET /api/v2/rules/{id}/history/timeline, with optional state filter, filterExpression, and cursor pagination"
     },
     {
       "name": "signoz_create_alert",

--- a/pkg/types/alerts.go
+++ b/pkg/types/alerts.go
@@ -12,7 +12,7 @@ import (
 type AlertHistoryRequest struct {
 	Start            int64
 	End              int64
-	State            string // "" omitted; one of inactive|pending|firing|nodata|disabled
+	State            string // "" omitted; one of inactive|pending|recovering|firing|nodata|disabled
 	FilterExpression string // "" omitted; v5 query-builder filter expression
 	Limit            int
 	Order            string // "asc" | "desc"

--- a/pkg/types/alerts.go
+++ b/pkg/types/alerts.go
@@ -5,21 +5,42 @@ import (
 	"strconv"
 )
 
-// AlertHistoryRequest is the request payload for alert history
+// AlertHistoryRequest carries the query parameters for the v2 rule state-history
+// timeline endpoint (GET /api/v2/rules/{id}/history/timeline). v2 replaced the v1
+// POST body: the structured `filters` set became a single `filterExpression`
+// string, and raw `offset` paging became an opaque `cursor`.
 type AlertHistoryRequest struct {
-	Start   int64               `json:"start"`
-	End     int64               `json:"end"`
-	State   string              `json:"state,omitempty"`
-	Offset  int                 `json:"offset"`
-	Limit   int                 `json:"limit"`
-	Order   string              `json:"order"`
-	Filters AlertHistoryFilters `json:"filters"`
+	Start            int64
+	End              int64
+	State            string // "" omitted; one of inactive|pending|firing|nodata|disabled
+	FilterExpression string // "" omitted; v5 query-builder filter expression
+	Limit            int
+	Order            string // "asc" | "desc"
+	Cursor           string // "" omitted; opaque cursor from a prior response's nextCursor
 }
 
-// AlertHistoryFilters is filters for alert history
-type AlertHistoryFilters struct {
-	Items []interface{} `json:"items"`
-	Op    string        `json:"op"`
+// QueryParams renders the request as URL query parameters for the v2 GET endpoint.
+// Empty optional values are omitted so the server applies its own defaults.
+func (r AlertHistoryRequest) QueryParams() url.Values {
+	v := url.Values{}
+	v.Set("start", strconv.FormatInt(r.Start, 10))
+	v.Set("end", strconv.FormatInt(r.End, 10))
+	if r.State != "" {
+		v.Set("state", r.State)
+	}
+	if r.FilterExpression != "" {
+		v.Set("filterExpression", r.FilterExpression)
+	}
+	if r.Limit > 0 {
+		v.Set("limit", strconv.Itoa(r.Limit))
+	}
+	if r.Order != "" {
+		v.Set("order", r.Order)
+	}
+	if r.Cursor != "" {
+		v.Set("cursor", r.Cursor)
+	}
+	return v
 }
 
 // Alert contains only essential information

--- a/plans/alert-history-v2-migration.context.md
+++ b/plans/alert-history-v2-migration.context.md
@@ -79,3 +79,36 @@ to lock). Implementation has not started — plan stays `Planning` until coding 
 - [x] **Expand the `state` enum?** → RESOLVED (2026-07-14): keep `firing`/`inactive`; expansion deferred.
 - [x] **Migrate only `timeline`, or also the sibling v2 history endpoints?** → RESOLVED (2026-07-14): `timeline` only.
 - [x] **Minimum SigNoz version** → RESOLVED (2026-07-15): **v0.118.0** (2026-04-08). The v2 routes were added and wired in commit `bb4e7df` (PR #10488, 2026-03-30); `git tag --contains` shows `v0.118.0` is the earliest stable release containing it (`v0.117.x` does not). Documented in README.
+
+### 2026-07-15 — PR review follow-up and user direction
+- User asked to address every valid review issue locally and explicitly directed that the agent-facing tool description must not mention `GET /api/v2/rules/{id}/history/timeline`. No commit, push, review-thread resolution, or PR-body edit is authorized until the user confirms.
+- Live review-thread refresh confirmed two open findings: custom page limits were not preserved on cursor-only follow-ups, and the v2 state enum was incomplete. Independent runtime/docs/MCP-practice passes also confirmed silent legacy `offset`, canonical-filter, pagination-drift, version-recovery, and compatibility-documentation gaps.
+- **Pagination decision superseded:** raw upstream cursors encode only offset/limit, so `id+cursor` could silently recompute a moving default time window and drop state/filter/order. The tool now returns a versioned MCP cursor containing the full absolute scope plus the inner upstream cursor. Follow-ups pass only `id`, `cursor`, and `searchContext`; unsafe or mismatched tokens fail before the upstream call.
+- **Filter decision superseded:** the MCP schema now advertises canonical `filter`, while the just-introduced backend-shaped `filterExpression` name remains an accepted alias. Conflicting aliases and wrong types fail loudly to prevent accidentally broad results.
+- **State decision superseded:** the tool now exposes all authoritative v2 values: `inactive`, `pending`, `recovering`, `firing`, `nodata`, and `disabled`.
+- **Offset compatibility:** the removed field cannot safely map to the opaque v2 cursor. Legacy `offset=0` is accepted only with a deprecation note; nonzero or malformed offset values return actionable `VALIDATION_FAILED` guidance.
+- **Cross-boundary drift:** malformed/inconsistent `items`, `total`, or `nextCursor` now emits a WARN and a fail-open “more results may exist” note. Cursor rewriting uses `json.RawMessage` maps so uint64 fingerprints remain exact.
+- **Docs/metadata:** runtime and manifest descriptions omit the backend route, the runtime description includes the v0.118.0 requirement, README compatibility is split from the v0.120.0 alert-rule CRUD requirement, and no companion `SigNoz/agent-skills` change is needed because shipped skills do not teach this contract.
+
+### 2026-07-15 — Independent-review hardening
+- A final independent runtime/MCP/docs pass found additional valid edge cases, all addressed locally before handoff.
+- Filter guidance no longer promises that unknown label keys hard-error; it advises unfiltered key discovery and retry because unknown labels generally return no matches. Fractional offsets are rejected before the shared loose integer parser can truncate them to zero.
+- Repeated cursors, cursor-without-row-progress pages, cursors after the reported total, and pages exceeding the clamped limit now withhold `nextCursor`, emit a WARN, and return fail-open recovery guidance. Cursor encoding and decoding enforce the same 64 KiB token bound.
+- Cursor rewriting can hold multiple JSON representations, so alert history now uses a 16 MiB response cap rather than the generic 64 MiB cap. Large uint64 item fields remain byte-exact.
+- The alert-summary resource now wraps `recentHistory.data.nextCursor` with the same absolute scope; a resource-to-tool continuation test pins the second call path. Credential-gated E2E coverage follows a live cursor when available and exercises every v2 state.
+- HTTP 404 recovery now preserves the shared upstream code/message/type/status fields, directs v0.118–v0.119 users to verify the rule in the UI, and names `signoz_list_alert_rules` only for v0.120.0+.
+
+### 2026-07-15 — Resource-facing pagination recovery
+- The independent re-review confirmed that logging alert-summary pagination drift was insufficient for resource consumers. The resource template now documents the history-tool handoff, and every summary includes machine-readable recent-history pagination or recovery metadata.
+- When recent-history pagination cannot be verified, all usable response data is retained but any parseable raw `nextCursor` is removed. The consumer is told that more results may exist and to retry `signoz_get_alert_history` without a cursor and with a narrower time range or filter.
+- A best-effort history-fetch failure is also visible in the summary as generic recovery metadata instead of being server-log-only; upstream error details are not leaked in the resource body.
+- Malformed history bytes returned with HTTP 200 are omitted from the best-effort summary so they cannot invalidate the surrounding JSON; the valid alert and generic history-recovery metadata remain available.
+
+### 2026-07-15 — Resource output simplification
+- User direction: do not overengineer the resource response. The nested pagination/recovery metadata described above is superseded by one concise `recentHistoryNote`; safe continuation remains in `recentHistory.data.nextCursor`, and malformed HTTP-200 history bodies are still omitted so the alert summary remains usable.
+
+### 2026-07-15 — Owner scope correction
+- Owner rejected the alert-history-specific 16 MiB response cap and the MCP-owned cursor wrapper as overengineering. Those changes, their resource wrapping, and their extensive edge-case test surface were removed.
+- The tool now forwards SigNoz's `data.nextCursor` unchanged and keeps `alertHistoryCompletenessNote` in `aggregate_helper.go`; deeper cursor refactoring remains in the separately tracked issue.
+- The narrow limit fix remains: when a cursor follow-up omits `limit`, the MCP request also omits it so SigNoz uses the page size encoded in the upstream cursor. The runtime description tells callers to repeat the original time range, state, filter, and order.
+- Filter compatibility is canonical-first (`filter`, then `filterExpression`) without a bespoke alias-conflict subsystem. Any supplied legacy `offset`, including zero, is rejected with direct cursor guidance.

--- a/plans/alert-history-v2-migration.context.md
+++ b/plans/alert-history-v2-migration.context.md
@@ -117,3 +117,8 @@ to lock). Implementation has not started — plan stays `Planning` until coding 
 - The latest Codex review correctly identified that the immediate completeness note still suggested a cursor-only follow-up even though the upstream cursor contains only offset and limit.
 - The narrow fix keeps the upstream cursor unchanged and adds the resolved absolute `start`/`end`, actual `order`, and a requirement to repeat the same `state` and `filter` to every `hasMore=true` continuation note. No MCP-owned cursor wrapper is reintroduced.
 - User authorized the local fix only; no commit, push, GitHub reply, or thread resolution is authorized.
+
+### 2026-07-15 — Restore original plan detail
+- User identified that the review-fix commit had replaced the original detailed implementation plan with a shorter summary.
+- Restored the plan content from `d0313e14dc1894fb3737f2b826deb8e1aebe16e0` and added a separate section describing the review-driven changes that supersede individual original assumptions.
+- No commit or push is authorized for this documentation correction yet.

--- a/plans/alert-history-v2-migration.context.md
+++ b/plans/alert-history-v2-migration.context.md
@@ -112,3 +112,8 @@ to lock). Implementation has not started — plan stays `Planning` until coding 
 - The tool now forwards SigNoz's `data.nextCursor` unchanged and keeps `alertHistoryCompletenessNote` in `aggregate_helper.go`; deeper cursor refactoring remains in the separately tracked issue.
 - The narrow limit fix remains: when a cursor follow-up omits `limit`, the MCP request also omits it so SigNoz uses the page size encoded in the upstream cursor. The runtime description tells callers to repeat the original time range, state, filter, and order.
 - Filter compatibility is canonical-first (`filter`, then `filterExpression`) without a bespoke alias-conflict subsystem. Any supplied legacy `offset`, including zero, is rejected with direct cursor guidance.
+
+### 2026-07-15 — Scoped pagination note
+- The latest Codex review correctly identified that the immediate completeness note still suggested a cursor-only follow-up even though the upstream cursor contains only offset and limit.
+- The narrow fix keeps the upstream cursor unchanged and adds the resolved absolute `start`/`end`, actual `order`, and a requirement to repeat the same `state` and `filter` to every `hasMore=true` continuation note. No MCP-owned cursor wrapper is reintroduced.
+- User authorized the local fix only; no commit, push, GitHub reply, or thread resolution is authorized.

--- a/plans/alert-history-v2-migration.context.md
+++ b/plans/alert-history-v2-migration.context.md
@@ -78,4 +78,4 @@ to lock). Implementation has not started — plan stays `Planning` until coding 
 - [x] **Add `filterExpression` param now, or defer?** → RESOLVED (2026-07-14): add now as an optional passthrough string.
 - [x] **Expand the `state` enum?** → RESOLVED (2026-07-14): keep `firing`/`inactive`; expansion deferred.
 - [x] **Migrate only `timeline`, or also the sibling v2 history endpoints?** → RESOLVED (2026-07-14): `timeline` only.
-- [ ] **Minimum SigNoz version** that ships the v2 `signozapiserver` rule-history routes — fill into README once confirmed (same open item as `v2-convention-migration`).
+- [x] **Minimum SigNoz version** → RESOLVED (2026-07-15): **v0.118.0** (2026-04-08). The v2 routes were added and wired in commit `bb4e7df` (PR #10488, 2026-03-30); `git tag --contains` shows `v0.118.0` is the earliest stable release containing it (`v0.117.x` does not). Documented in README.

--- a/plans/alert-history-v2-migration.context.md
+++ b/plans/alert-history-v2-migration.context.md
@@ -1,0 +1,75 @@
+# Feature: Migrate `signoz_get_alert_history` to the v2 rule-history API — Context & Discussion
+
+## Original Prompt
+> Create a plan to migrate the v1 alert history endpoint to v2. Refer to ~/Stash/signoz for the openapi endpoint to see how v2 works. Also look at how skaff works and if we can reuse skaff for generating the client stubs.
+
+## Reference Links
+- SigNoz backend OpenAPI spec (generated from Go): `~/Stash/signoz/docs/api/openapi.yml`
+- v2 route registration: `~/Stash/signoz/pkg/apiserver/signozapiserver/rulestatehistory.go`
+- v2 handler impl: `~/Stash/signoz/pkg/modules/rulestatehistory/implrulestatehistory/handler.go`
+- v2 request query structs: `~/Stash/signoz/pkg/types/rulestatehistorytypes/http.go`
+- v2 response structs: `~/Stash/signoz/pkg/types/rulestatehistorytypes/response.go`
+- v1 route (still live): `~/Stash/signoz/pkg/query-service/app/http_handler.go:494-497`
+- v1 request/response model: `~/Stash/signoz/pkg/query-service/model/alerting.go`
+- skaff generator: `~/Stash/skaff` (module `github.com/SigNoz/skaff`)
+- skaff's real consumer: `~/Stash/terraform-provider-signoz` (`skaff.yml` + `internal/{customtypes,schemas,apitypes,apiclients,convertors,services}`)
+- Prior related plan (explicitly deferred history migration): `plans/v2-convention-migration.plan.md`
+
+## Key Decisions & Discussion Log
+
+### 2026-07-14 — Research & scoping
+- **Why now:** the earlier `v2-convention-migration` work (2026-04-22) moved rule CRUD to `/api/v2/rules/*` but *deferred* history, noting "`history/timeline` is not migrated upstream (only `history/filter_keys` is on v2)." That is no longer true — upstream now serves the full v2 history surface via `signozapiserver`. This plan closes that gap.
+- **Current MCP surface (v1):** `POST /api/v1/rules/{id}/history/timeline` with a JSON body `types.AlertHistoryRequest{start,end,state,offset,limit,order,filters:{items,op}}`. Client method `SigNoz.GetAlertHistory` (`internal/client/client.go:632`). Handler `handleGetAlertHistory` (`internal/handler/tools/alerts.go:343`). Response is a **raw JSON passthrough** — there is intentionally no typed response struct; only `countAlertHistoryRows` (`aggregate_helper.go:591`) peeks at `data[]`/`data.items[]` for a completeness note. Second caller: `handleAlertSummaryResource` (`resource_templates.go:61`) for the `signoz://alert/{id}/summary` resource.
+- **Target v2 endpoint:** `GET /api/v2/rules/{id}/history/timeline`. Pure GET with query params — no request body.
+  - Query params (`PostableRuleStateHistoryTimelineQuery`): `start` int64 **required**, `end` int64 **required**, `state` (`ruletypes.AlertState`, optional), `filterExpression` string (optional; v5 QB expression), `limit` int64 (optional, server default 50), `order` (asc/desc, server default **desc**), `cursor` string (optional, opaque base64 of `{offset,limit}`).
+  - Response envelope: `{"status":"success","data":{"items":[...],"total":N,"nextCursor":"<base64>"}}` (via `render.Success`). Errors: `{"status":...,"error":{...}}` on 400/401/403/500 (via `render.Error`).
+  - Item shape (`GettableRuleStateHistory`): `ruleId`, `ruleName`, `overallState`, `overallStateChanged`, `state`, `stateChanged`, `unixMilli`, `labels` (structured `[{key,value}]` array), `fingerprint`, `value`.
+- **v1 → v2 diffs that matter to the MCP client:**
+  1. Method `POST`+body → `GET`+query string.
+  2. `filters` (structured `{items,op}` FilterSet) → `filterExpression` (single v5 QB string). The MCP tool always sent an *empty* filter set, so default behavior is preserved by simply omitting `filterExpression`.
+  3. Raw `offset` → opaque `cursor` (base64 `{offset,limit}`, encoded/decoded server-side). Raw offset is no longer part of the wire contract.
+  4. Response gains `nextCursor` and drops the v1 `data.labels` map (labels now live on dedicated `filter_keys`/`filter_values` endpoints). Item key `ruleID` → `ruleId`; `labels` string → structured array.
+- **v1 is NOT deprecated/removed upstream** — the `POST /api/v1/.../history/timeline` route is still registered (unlike `/api/v1/services`, which carries an explicit "Deprecated" comment). So this is a forward-alignment migration for consistency with the already-v2 rule CRUD, not a forced break. We accept a hard cutover to v2 on the MCP side (same stance the `v2-convention-migration` plan took for rule CRUD).
+- **v2 `state` enum values:** `inactive`, `pending`, `firing`, `nodata`, `disabled` (`~/Stash/signoz/pkg/types/ruletypes/alert_state.go`). Note the no-data spelling is `nodata` (no hyphen). The MCP tool today only exposes `firing`/`inactive` — keep that minimal set for now (recommendation); expansion is a separate, additive decision.
+
+### 2026-07-14 — skaff evaluation (can we reuse it for client stubs?)
+- **What skaff is:** a standalone SigNoz Go CLI (`github.com/SigNoz/skaff`, checkout at `~/Stash/skaff`) that generates a **layered Terraform plugin-framework provider** from an OpenAPI spec + a `skaff.yml`. It orchestrates HashiCorp's `tfplugingen-openapi`/`tfplugingen-framework` and `oapi-codegen`, then adds custom types, TF schemas, wire DTOs, a typed HTTP client, and expand/flatten convertors. Its only real consumer is `terraform-provider-signoz`.
+- **Verdict: do NOT use skaff for this migration.** Reasons:
+  1. **Wrong target shape.** skaff emits Terraform-framework code (custom types, TF schemas, expand/flatten convertors, `resource.Resource`/`datasource.DataSource` shells) — none of which the MCP server has or wants.
+  2. **Wrong client architecture.** Even skaff's `apitypes`/`client` subcommands produce an `oapi-codegen` typed client with generated DTOs. The MCP server deliberately uses a hand-written `SigNoz` client + `doRequest` with bespoke retry, response-size caps, tenant context, OTel spans, auth-header injection, and `upstreamError` status mapping, and returns **raw `json.RawMessage` passthroughs** (no typed response structs). Adopting a generated typed client would be a repo-wide rewrite, not a one-endpoint stub.
+  3. **Not wired here, and overkill.** skaff is absent from this repo (no `skaff.yml`, no `zz_generated_*`), and the change is ~a dozen lines of hand-written client + handler edits. Pulling in a codegen toolchain for one GET endpoint is disproportionate.
+  - **If** spec-driven codegen is ever wanted in this repo, the sanctioned direction is the repo's own `auto-gen-tools` design (custom `kin-openapi` generator emitting MCP-shaped tools; `plans/auto-gen-tools.plan.md`), which explicitly chose *not* to use oapi-codegen — not skaff. That is out of scope here.
+- **We DO reuse the spec, not the tool.** `~/Stash/signoz/docs/api/openapi.yml` is the source of truth for the exact v2 param/response shapes; we transcribe from it by hand (as every other endpoint in this client is written).
+
+## Key Decisions & Discussion Log (cont.)
+
+### 2026-07-14 — Recommended answers locked in
+User directed: "lock in the recommended answers." The four questions with a
+recommendation are resolved as follows; the plan is finalized to match. The
+min-version item stays open (awaits a released version number, no recommendation
+to lock). Implementation has not started — plan stays `Planning` until coding begins.
+- **Pagination → opaque `cursor` (option a).** Drop the `offset` param; add a `cursor`
+  string param and surface the response's `data.nextCursor` in the completeness note.
+- **`filterExpression` → add now** as an optional passthrough string (v5 QB expression).
+- **`state` enum → keep minimal** (`firing`/`inactive`); expansion is a separate additive change.
+- **Scope → `timeline` only.** The sibling v2 history endpoints (`stats`,
+  `top_contributors`, `overall_status`, `filter_keys`, `filter_values`) are new tools
+  tracked separately, not part of this migration.
+
+### 2026-07-14 — Implementation complete (pending PR)
+- Client: `GetAlertHistory` rewritten to `GET /api/v2/rules/{id}/history/timeline` with a query string; interface/mock signatures unchanged.
+- Types: `AlertHistoryRequest` reshaped (dropped `Offset`/`Filters`, added `FilterExpression`/`Cursor`) with a new `QueryParams() url.Values`; removed `AlertHistoryFilters`.
+- Handler: dropped the `offset` param, added `cursor` + `filterExpression`, refreshed the tool description; a passed `offset` is now silently ignored.
+- Completeness: new `alertHistoryCompletenessNote` reads `data.nextCursor` as the authoritative hasMore signal (falls back to the row-count heuristic only when the cursor is absent and rows are uncountable). `countAlertHistoryRows` unchanged (still counts `data.items[]`/`data[]`).
+- Resource template: dropped the removed `Offset:0` field.
+- Tests: rewrote `client_test.go` `TestGetAlertHistory` for GET/query/v2-envelope; repointed `TestHandleGetAlertHistoryFamilyA_TopLevelDataArrayCompletenessNote` to v2 cursor semantics (no cursor → hasMore=false); added `TestHandleGetAlertHistory_NextCursorHasMore` (cursor+filter forwarded; nextCursor → hasMore=true). Full `go build`/`go vet`/`go test ./...` green.
+- Docs: `manifest.json` + `README.md` updated (v2 path, `cursor`, `filterExpression`, response shape, required-version note).
+- **agent-skills check outcome:** no change needed — no shipped skill teaches the alert-history parameter surface (history is read-only; the create/update skills cover different contracts). To be re-stated in the PR summary.
+- Not yet done: commit/PR; fill the concrete minimum SigNoz version into README once known.
+
+## Open Questions
+- [x] **Pagination surface** → RESOLVED (2026-07-14): opaque `cursor` (option a). Drop raw `offset`; surface `nextCursor`.
+- [x] **Add `filterExpression` param now, or defer?** → RESOLVED (2026-07-14): add now as an optional passthrough string.
+- [x] **Expand the `state` enum?** → RESOLVED (2026-07-14): keep `firing`/`inactive`; expansion deferred.
+- [x] **Migrate only `timeline`, or also the sibling v2 history endpoints?** → RESOLVED (2026-07-14): `timeline` only.
+- [ ] **Minimum SigNoz version** that ships the v2 `signozapiserver` rule-history routes — fill into README once confirmed (same open item as `v2-convention-migration`).

--- a/plans/alert-history-v2-migration.context.md
+++ b/plans/alert-history-v2-migration.context.md
@@ -67,6 +67,12 @@ to lock). Implementation has not started — plan stays `Planning` until coding 
 - **agent-skills check outcome:** no change needed — no shipped skill teaches the alert-history parameter surface (history is read-only; the create/update skills cover different contracts). To be re-stated in the PR summary.
 - Not yet done: commit/PR; fill the concrete minimum SigNoz version into README once known.
 
+### 2026-07-15 — Live smoke verification (staging) + follow-up test
+- Ran a read-only live smoke against `app.us.staging.signoz.cloud` (delegated to a subagent; API key via env, never persisted). Exercised the real `GET /api/v2/rules/{id}/history/timeline` via curl AND through the actual `signozclient.NewClient(..., "SIGNOZ-API-KEY", ...)` → `handleGetAlertHistory` path.
+- **Result: PASS.** 200 OK; envelope `{"status":"success","data":{items,total,nextCursor}}`; item fields `ruleId/ruleName/overallState/overallStateChanged/state/stateChanged/unixMilli/labels/fingerprint/value` all present. Completeness note correctly derived `hasMore=true` from `data.nextCursor`; cursor pagination advanced (cursor decodes to `{offset,limit}`); `state:"firing"` accepted; `filterExpression` forwarded faithfully (a bad label yielded a clean upstream 400 via the `upstreamError` path, reproduced by raw curl — not an encoding bug).
+- Added `TestHandleGetAlertHistory_ItemsExactFillNoCursor` — pins that a `data.items[]` page filling the limit with no `nextCursor` reports `hasMore=false` (the exact case the old row-count heuristic got wrong).
+- **Notes for any FUTURE typed consumer** (do not affect this raw-passthrough tool): v2 `labels` is an array of `{key:{name,signal,fieldContext,fieldDataType}, value}` objects (not a flat `map[string]string`); `fingerprint` is a `uint64` that can exceed int64 max (don't unmarshal into `int64`).
+
 ## Open Questions
 - [x] **Pagination surface** → RESOLVED (2026-07-14): opaque `cursor` (option a). Drop raw `offset`; surface `nextCursor`.
 - [x] **Add `filterExpression` param now, or defer?** → RESOLVED (2026-07-14): add now as an optional passthrough string.

--- a/plans/alert-history-v2-migration.plan.md
+++ b/plans/alert-history-v2-migration.plan.md
@@ -41,7 +41,8 @@ upstream cursor's encoded page size.
 - Keep `alertHistoryCompletenessNote` beside the existing pagination helpers in
   `aggregate_helper.go`.
 - Derive `hasMore` from a non-empty upstream `data.nextCursor` and include that
-  cursor in the note.
+  cursor in the note. Include the resolved absolute `start`/`end` and actual
+  `order`, and require the same `state` and `filter` on the follow-up call.
 - Preserve the shared coded upstream error path. Add concise recovery guidance
   for HTTP 404 because the rule may be missing or the SigNoz version may predate
   v0.118.0.

--- a/plans/alert-history-v2-migration.plan.md
+++ b/plans/alert-history-v2-migration.plan.md
@@ -4,72 +4,205 @@
 In Progress
 
 ## Context
+The MCP server's `signoz_get_alert_history` tool still calls the v1 endpoint
+`POST /api/v1/rules/{id}/history/timeline` with a JSON body, even though rule
+CRUD already moved to `/api/v2/rules/*` in the earlier `v2-convention-migration`
+work. That work explicitly deferred history because the v2 timeline route did
+not exist yet. It now does: upstream serves the full rule-history surface via
+`signozapiserver` at `GET /api/v2/rules/{id}/history/timeline`. This plan brings
+the one wrapped endpoint (`timeline`) onto v2.
 
-`signoz_get_alert_history` now calls the v2 timeline API introduced in SigNoz
-v0.118.0. The tool remains a raw response passthrough: the server forwards the
-upstream cursor and appends the existing cursor-aware completeness note.
+Both v1 and v2 wrap responses in the same `{"status":"success","data":...}`
+envelope, and the MCP tool returns that body as a **raw passthrough** — so the
+migration is contained to how the request is built (method + params) and how the
+completeness/pagination note is derived. There is no typed response struct to
+rewrite.
 
-The PR review follow-up keeps only the contract fixes needed by agents: a
-route-free tool description, canonical `filter` naming, the complete state
-enum, explicit rejection of removed `offset`, and correct handling of the
-upstream cursor's encoded page size.
+**Codegen / skaff:** not used. skaff generates a Terraform plugin-framework
+provider (custom types, TF schemas, oapi-codegen typed client, expand/flatten
+convertors) for `terraform-provider-signoz`; it is architecturally mismatched
+with this repo's hand-written raw-passthrough client and is absent here. This
+one-endpoint change is written by hand from `~/Stash/signoz/docs/api/openapi.yml`,
+exactly like every other method on the client. (Rationale in `.context.md`.)
 
 ## Approach
 
-### Client and request
+### 1. Client layer — `internal/client/client.go`
+Rewrite `GetAlertHistory` from POST+body to GET+query string, v1→v2 path:
 
-- Keep `GetAlertHistory` on the shared `doRequest` path and its existing 64 MiB
-  response guard.
-- Send the v2 GET query parameters through `AlertHistoryRequest.QueryParams()`.
-- Forward `data.nextCursor` unchanged. On a cursor follow-up with no explicit
-  `limit`, send no limit so SigNoz uses the page size encoded in its cursor.
+```go
+func (s *SigNoz) GetAlertHistory(ctx context.Context, ruleID string, req types.AlertHistoryRequest) (json.RawMessage, error) {
+    reqURL := fmt.Sprintf("%s/api/v2/rules/%s/history/timeline?%s",
+        s.baseURL, url.PathEscape(ruleID), req.QueryParams().Encode())
+    s.logger.DebugContext(s.ensureTenantContext(ctx), "Fetching alert history", slog.String("ruleID", ruleID))
+    return s.doRequest(ctx, http.MethodGet, reqURL, nil, DefaultQueryTimeout)
+}
+```
 
-### Agent-facing contract
+- Interface signature (`interface.go:19`) and mock (`mock.go:97`) are **unchanged**
+  — still `GetAlertHistory(ctx, ruleID, req types.AlertHistoryRequest)` — so churn
+  there is zero; only the struct's internals change.
+- Update the base-URL comment at `client.go:117` if it enumerates the history path
+  version.
 
-- Omit the HTTP method and backend route from the runtime and manifest tool
-  descriptions.
-- Advertise canonical `filter`; continue accepting backend-shaped
-  `filterExpression` as an unadvertised compatibility alias.
-- Advertise and validate all six v2 states: `inactive`, `pending`, `recovering`,
-  `firing`, `nodata`, and `disabled`.
-- Reject any legacy `offset` with guidance to use `data.nextCursor`.
-- Tell callers to repeat the original time range, state, filter, and order on
-  follow-up calls.
+### 2. Request type — `pkg/types/alerts.go`
+Reshape `AlertHistoryRequest` to the v2 query params and give it a
+`QueryParams() url.Values` method (mirroring the existing `ListAlertsParams`
+pattern in the same file):
 
-### Completeness and errors
+```go
+type AlertHistoryRequest struct {
+    Start            int64
+    End              int64
+    State            string // "" omitted; one of inactive|pending|firing|nodata|disabled
+    FilterExpression string // "" omitted; v5 query-builder expression
+    Limit            int
+    Order            string // "asc" | "desc"
+    Cursor           string // "" omitted; opaque base64 from a prior response's nextCursor
+}
 
-- Keep `alertHistoryCompletenessNote` beside the existing pagination helpers in
-  `aggregate_helper.go`.
-- Derive `hasMore` from a non-empty upstream `data.nextCursor` and include that
-  cursor in the note. Include the resolved absolute `start`/`end` and actual
-  `order`, and require the same `state` and `filter` on the follow-up call.
-- Preserve the shared coded upstream error path. Add concise recovery guidance
-  for HTTP 404 because the rule may be missing or the SigNoz version may predate
-  v0.118.0.
+func (r AlertHistoryRequest) QueryParams() url.Values {
+    v := url.Values{}
+    v.Set("start", strconv.FormatInt(r.Start, 10))
+    v.Set("end", strconv.FormatInt(r.End, 10))
+    if r.State != "" { v.Set("state", r.State) }
+    if r.FilterExpression != "" { v.Set("filterExpression", r.FilterExpression) }
+    if r.Limit > 0 { v.Set("limit", strconv.Itoa(r.Limit)) }
+    if r.Order != "" { v.Set("order", r.Order) }
+    if r.Cursor != "" { v.Set("cursor", r.Cursor) }
+    return v
+}
+```
 
-### Docs and metadata
+- Remove `AlertHistoryFilters` (the `{items,op}` struct) and the `Offset` field —
+  both are gone in v2. Grep for other references before deleting.
 
-- Document the v0.118.0 alert-history requirement separately from the v0.120.0
-  alert-rule CRUD requirement.
-- Keep README parameters, manifest metadata, and runtime schema aligned.
-- No companion `SigNoz/agent-skills` update is needed because shipped skills do
-  not teach this read-only tool contract.
+### 3. Handler — `internal/handler/tools/alerts.go` (`handleGetAlertHistory` + tool registration)
+Tool input-schema changes (registration at `alerts.go:80`):
+- **Drop** `offset` (no raw offset in v2).
+- **Add** `cursor` (string, optional): "Opaque pagination cursor. Pass the `nextCursor` value from a previous response's `data` to fetch the next page. Omit for the first page."
+- **Add** `filterExpression` (string, optional): "SigNoz v5 query-builder filter expression to narrow the timeline (e.g. `severity = 'critical'`). Optional."
+- Keep `searchContext`, `id`, `timeRange`, `start`, `end`, `state`, `limit`, `order`.
+- `state` enum stays `firing`/`inactive` (decided). A later additive expansion would use the exact v2 spellings incl. `nodata`.
+- Refresh the `WithDescription` text to say v2 / cursor pagination.
+
+Handler body changes:
+- Delete the `paginate.ParseParams` offset read (line ~374) and the `Offset` field
+  in the built request. Read `cursor` and `filterExpression` from args instead.
+- Keep the existing `timeutil` start/end defaulting (6h), `ValidateExplicitTimestamps`,
+  `intArg`/`clampLimit` limit handling (still clamp to `MaxRawResultLimit` before
+  forwarding — the v2 server default is 50 with no documented hard cap, so the
+  memory guard stays our responsibility), and `order`/`state` validation.
+- Build `types.AlertHistoryRequest` with the new fields; call `client.GetAlertHistory`;
+  on error return `upstreamError(err)` (unchanged — the shared coded-error path already
+  handles the v2 `{"status","error"}` envelope via `HTTPStatusError`).
+
+### 4. Completeness / pagination note
+v2 returns `data.nextCursor` directly — more reliable than inferring `hasMore`
+from row counts against an offset. Add a small cursor-aware note helper (next to
+`completenessNote` in `aggregate_helper.go`) that reads `nextCursor` from the
+passthrough body:
+
+- If `data.nextCursor` is a non-empty string → `hasMore=true`; advise "fetch the
+  next page by passing cursor=\"<nextCursor>\"".
+- Else → "all matching results returned (hasMore=false)".
+- Keep `countAlertHistoryRows` for the row count in the message — it already
+  handles the `data.items[]` shape, which is exactly the v2 timeline shape, so no
+  change is needed there. Retain the existing limit-clamp advisory note.
+
+This replaces the current `completenessNote(returnedRows, limit, offset, rowsKnown)`
+call for this handler only (offset-based note stays in use by other tools).
+
+### 5. Alert-summary resource — `internal/handler/tools/resource_templates.go`
+`handleAlertSummaryResource` (line ~61) builds an `AlertHistoryRequest{Start, End,
+Order:"desc", Limit:10, Offset:0}`. Drop the `Offset:0` field (removed from the
+struct); the rest is compatible as-is. Behavior (last 10 transitions, desc) is
+unchanged.
+
+### 6. Docs & metadata (CLAUDE.md sync checklist)
+- `manifest.json` (entry at line ~69): update the description to reflect v2 +
+  cursor pagination + optional `filterExpression`.
+- `README.md`: tool-table row (line ~353) and the full parameter section
+  (lines ~558-571) — document `cursor` (replaces `offset`), `filterExpression`,
+  the v2 path, and the `data.{items,total,nextCursor}` response shape. Note the
+  minimum SigNoz version once known.
+- **searchContext:** the tool already exposes a top-level `searchContext` string;
+  keep it (do not add to `required`).
+- **agent-skills check:** no shipped skill teaches the alert-history parameter
+  surface (history is read-only; `signoz-creating-alerts`/`-dashboards` cover
+  create/update contracts only). Expected outcome: **no agent-skills change
+  needed** — state this in the PR summary and re-verify at PR time.
+- **Version compatibility:** v2-only on the MCP side (hard cutover, consistent
+  with the rule-CRUD migration). Document the minimum SigNoz version that ships
+  the `signozapiserver` rule-history routes.
+
+### 7. Tests
+- `internal/client/client_test.go`: add a case asserting `GetAlertHistory` issues
+  a **GET** to `/api/v2/rules/{id}/history/timeline` with the expected query string
+  (start/end/state/limit/order/cursor/filterExpression), and that the `{status,
+  data:{items,total,nextCursor}}` envelope round-trips as a raw body.
+- `internal/handler/tools/alert_history_limit_test.go`: the mock returns
+  `{"data":{"items":[]}}`, which is still a valid v2 timeline body — the limit-clamp
+  assertions hold (`capturedReq.Limit` still exists). Adjust only if field renames
+  touch it.
+- Add handler coverage: (a) `cursor` is forwarded verbatim; (b) `filterExpression`
+  is forwarded; (c) a response with a non-empty `data.nextCursor` produces a
+  `hasMore=true` note naming the cursor; (d) `offset` is no longer read (a passed
+  `offset` is ignored rather than paginating).
+- Grep-and-fix any test that constructs `AlertHistoryRequest` with `Offset`/`Filters`
+  or asserts the v1 POST/path (`silent_failures_test.go`, `e2e_familya_test.go`
+  exercise `countAlertHistoryRows` against `data.items[]`/`data[]` — those shapes are
+  unchanged, so they should keep passing; verify).
+
+## Additional Changes Made During Review
+
+The implementation still follows the original migration plan above. The
+following review-driven changes supersede the corresponding original bullets:
+
+- **Agent-facing schema:** advertise canonical `filter` while continuing to
+  accept `filterExpression` as an unadvertised compatibility alias. Expose all
+  six v2 history states: `inactive`, `pending`, `recovering`, `firing`, `nodata`,
+  and `disabled`.
+- **Description and validation:** keep the tool and manifest descriptions free
+  of the backend HTTP route. Reject every supplied legacy `offset` with cursor
+  guidance, and reject `start >= end` before calling SigNoz.
+- **Cursor behavior:** forward SigNoz's cursor unchanged. When a cursor follow-up
+  omits `limit`, omit it upstream so the page size encoded in the cursor remains
+  effective. Do not introduce an MCP-owned cursor wrapper or a separate response
+  size limit.
+- **Scoped pagination guidance:** when `nextCursor` is present, include the
+  resolved absolute `start`/`end` and actual `order` in the completeness note,
+  and require the same `state` and `filter` on the follow-up call.
+- **Errors and compatibility:** preserve the shared coded upstream error and add
+  recovery guidance for HTTP 404. Document SigNoz v0.118.0+ for alert history
+  separately from the v0.120.0+ alert-rule CRUD requirement.
+- **Docs and metadata:** synchronize the README table, parameter reference,
+  response shape, compatibility notes, runtime schema, and `manifest.json`.
+  No companion `SigNoz/agent-skills` update is needed because shipped skills do
+  not teach this read-only contract.
+- **Coverage and live verification:** add focused tests for canonical `filter`,
+  all state values, legacy `offset`, cursor-limit preservation, scoped
+  continuation notes, schema/manifest alignment, and credential-gated E2E enum
+  coverage. Live staging verification confirmed a real label filter, a
+  non-empty cursor, and a successful second page using the exact absolute scope
+  with the cursor's encoded limit preserved.
 
 ## Files to Modify
-
-- `internal/handler/tools/alerts.go` — schema, validation, raw cursor forwarding,
-  cursor-limit behavior, and 404 guidance.
-- `internal/handler/tools/aggregate_helper.go` — cursor completeness note.
-- `pkg/types/alerts.go` — v2 state documentation.
-- Focused handler/schema/E2E tests — state, filter, description, cursor, and
-  limit coverage.
-- `README.md`, `manifest.json` — compatibility and agent-facing metadata.
-- `plans/alert-history-v2-migration.context.md` — append-only decision record.
+- `internal/client/client.go` — `GetAlertHistory`: POST→GET, v1→v2 path, body→query; base-URL comment.
+- `pkg/types/alerts.go` — reshape `AlertHistoryRequest` (drop `Offset`/`Filters`, add `FilterExpression`/`Cursor`), add `QueryParams()`; remove `AlertHistoryFilters`.
+- `internal/handler/tools/alerts.go` — tool schema (drop `offset`, add `cursor`+`filterExpression`, refreshed description) and handler wiring.
+- `internal/handler/tools/aggregate_helper.go` — add a cursor-aware completeness note helper (keep `countAlertHistoryRows`).
+- `internal/handler/tools/resource_templates.go` — drop `Offset:0` in `handleAlertSummaryResource`.
+- `internal/client/client_test.go`, `internal/handler/tools/alert_history_limit_test.go` (+ new handler test cases) — v2 GET/query/cursor coverage.
+- `manifest.json`, `README.md` — v2 path, `cursor`, `filterExpression`, response shape, min version.
+- `internal/client/interface.go`, `internal/client/mock.go` — **no change** (signature stable); listed for completeness.
 
 ## Verification
-
-1. Run focused alert-history and client tests.
-2. Run `go test ./...`, `go vet ./...`, and `go build ./...`.
-3. Run `python3 -m json.tool manifest.json` and `git diff --check`.
-4. Do not commit, push, resolve review threads, or edit the PR until the user
-   confirms.
+1. `go build ./...` and `go vet ./...`.
+2. `go test ./...` — client GET/query test, handler cursor/filterExpression/nextCursor tests, and unchanged `countAlertHistoryRows` coverage all pass.
+3. Live smoke against a SigNoz new enough to serve the v2 routes — **delegate to a subagent** per CLAUDE.md (no credentials printed/persisted; report which fields round-tripped):
+   - `signoz_get_alert_history` with a real rule `id` and `timeRange="24h"` → expect a `{status,data:{items,total}}` body; items carry `ruleId`/`state`/`unixMilli`.
+   - Set a small `limit` on a busy rule → response has `data.nextCursor`; pass it back as `cursor` → next page returns, note reports `hasMore`.
+   - `state="firing"` filters to firing transitions; a bad `state` is rejected client-side with `CodeValidationFailed`.
+   - `signoz://alert/{id}/summary` resource still returns `recentHistory`.
+4. Confirm no lingering references to the v1 path or the removed `Offset`/`Filters` fields: `grep -rn "history/timeline\|AlertHistoryFilters\|\.Offset" internal pkg` comes back clean (except intended v2 usages).

--- a/plans/alert-history-v2-migration.plan.md
+++ b/plans/alert-history-v2-migration.plan.md
@@ -1,0 +1,175 @@
+# Plan: Migrate `signoz_get_alert_history` to the v2 rule-history API
+
+## Status
+In Progress
+
+## Context
+The MCP server's `signoz_get_alert_history` tool still calls the v1 endpoint
+`POST /api/v1/rules/{id}/history/timeline` with a JSON body, even though rule
+CRUD already moved to `/api/v2/rules/*` in the earlier `v2-convention-migration`
+work. That work explicitly deferred history because the v2 timeline route did
+not exist yet. It now does: upstream serves the full rule-history surface via
+`signozapiserver` at `GET /api/v2/rules/{id}/history/timeline`. This plan brings
+the one wrapped endpoint (`timeline`) onto v2.
+
+Both v1 and v2 wrap responses in the same `{"status":"success","data":...}`
+envelope, and the MCP tool returns that body as a **raw passthrough** — so the
+migration is contained to how the request is built (method + params) and how the
+completeness/pagination note is derived. There is no typed response struct to
+rewrite.
+
+**Codegen / skaff:** not used. skaff generates a Terraform plugin-framework
+provider (custom types, TF schemas, oapi-codegen typed client, expand/flatten
+convertors) for `terraform-provider-signoz`; it is architecturally mismatched
+with this repo's hand-written raw-passthrough client and is absent here. This
+one-endpoint change is written by hand from `~/Stash/signoz/docs/api/openapi.yml`,
+exactly like every other method on the client. (Rationale in `.context.md`.)
+
+## Approach
+
+### 1. Client layer — `internal/client/client.go`
+Rewrite `GetAlertHistory` from POST+body to GET+query string, v1→v2 path:
+
+```go
+func (s *SigNoz) GetAlertHistory(ctx context.Context, ruleID string, req types.AlertHistoryRequest) (json.RawMessage, error) {
+    reqURL := fmt.Sprintf("%s/api/v2/rules/%s/history/timeline?%s",
+        s.baseURL, url.PathEscape(ruleID), req.QueryParams().Encode())
+    s.logger.DebugContext(s.ensureTenantContext(ctx), "Fetching alert history", slog.String("ruleID", ruleID))
+    return s.doRequest(ctx, http.MethodGet, reqURL, nil, DefaultQueryTimeout)
+}
+```
+
+- Interface signature (`interface.go:19`) and mock (`mock.go:97`) are **unchanged**
+  — still `GetAlertHistory(ctx, ruleID, req types.AlertHistoryRequest)` — so churn
+  there is zero; only the struct's internals change.
+- Update the base-URL comment at `client.go:117` if it enumerates the history path
+  version.
+
+### 2. Request type — `pkg/types/alerts.go`
+Reshape `AlertHistoryRequest` to the v2 query params and give it a
+`QueryParams() url.Values` method (mirroring the existing `ListAlertsParams`
+pattern in the same file):
+
+```go
+type AlertHistoryRequest struct {
+    Start            int64
+    End              int64
+    State            string // "" omitted; one of inactive|pending|firing|nodata|disabled
+    FilterExpression string // "" omitted; v5 query-builder expression
+    Limit            int
+    Order            string // "asc" | "desc"
+    Cursor           string // "" omitted; opaque base64 from a prior response's nextCursor
+}
+
+func (r AlertHistoryRequest) QueryParams() url.Values {
+    v := url.Values{}
+    v.Set("start", strconv.FormatInt(r.Start, 10))
+    v.Set("end", strconv.FormatInt(r.End, 10))
+    if r.State != "" { v.Set("state", r.State) }
+    if r.FilterExpression != "" { v.Set("filterExpression", r.FilterExpression) }
+    if r.Limit > 0 { v.Set("limit", strconv.Itoa(r.Limit)) }
+    if r.Order != "" { v.Set("order", r.Order) }
+    if r.Cursor != "" { v.Set("cursor", r.Cursor) }
+    return v
+}
+```
+
+- Remove `AlertHistoryFilters` (the `{items,op}` struct) and the `Offset` field —
+  both are gone in v2. Grep for other references before deleting.
+
+### 3. Handler — `internal/handler/tools/alerts.go` (`handleGetAlertHistory` + tool registration)
+Tool input-schema changes (registration at `alerts.go:80`):
+- **Drop** `offset` (no raw offset in v2).
+- **Add** `cursor` (string, optional): "Opaque pagination cursor. Pass the `nextCursor` value from a previous response's `data` to fetch the next page. Omit for the first page."
+- **Add** `filterExpression` (string, optional): "SigNoz v5 query-builder filter expression to narrow the timeline (e.g. `severity = 'critical'`). Optional."
+- Keep `searchContext`, `id`, `timeRange`, `start`, `end`, `state`, `limit`, `order`.
+- `state` enum stays `firing`/`inactive` (decided). A later additive expansion would use the exact v2 spellings incl. `nodata`.
+- Refresh the `WithDescription` text to say v2 / cursor pagination.
+
+Handler body changes:
+- Delete the `paginate.ParseParams` offset read (line ~374) and the `Offset` field
+  in the built request. Read `cursor` and `filterExpression` from args instead.
+- Keep the existing `timeutil` start/end defaulting (6h), `ValidateExplicitTimestamps`,
+  `intArg`/`clampLimit` limit handling (still clamp to `MaxRawResultLimit` before
+  forwarding — the v2 server default is 50 with no documented hard cap, so the
+  memory guard stays our responsibility), and `order`/`state` validation.
+- Build `types.AlertHistoryRequest` with the new fields; call `client.GetAlertHistory`;
+  on error return `upstreamError(err)` (unchanged — the shared coded-error path already
+  handles the v2 `{"status","error"}` envelope via `HTTPStatusError`).
+
+### 4. Completeness / pagination note
+v2 returns `data.nextCursor` directly — more reliable than inferring `hasMore`
+from row counts against an offset. Add a small cursor-aware note helper (next to
+`completenessNote` in `aggregate_helper.go`) that reads `nextCursor` from the
+passthrough body:
+
+- If `data.nextCursor` is a non-empty string → `hasMore=true`; advise "fetch the
+  next page by passing cursor=\"<nextCursor>\"".
+- Else → "all matching results returned (hasMore=false)".
+- Keep `countAlertHistoryRows` for the row count in the message — it already
+  handles the `data.items[]` shape, which is exactly the v2 timeline shape, so no
+  change is needed there. Retain the existing limit-clamp advisory note.
+
+This replaces the current `completenessNote(returnedRows, limit, offset, rowsKnown)`
+call for this handler only (offset-based note stays in use by other tools).
+
+### 5. Alert-summary resource — `internal/handler/tools/resource_templates.go`
+`handleAlertSummaryResource` (line ~61) builds an `AlertHistoryRequest{Start, End,
+Order:"desc", Limit:10, Offset:0}`. Drop the `Offset:0` field (removed from the
+struct); the rest is compatible as-is. Behavior (last 10 transitions, desc) is
+unchanged.
+
+### 6. Docs & metadata (CLAUDE.md sync checklist)
+- `manifest.json` (entry at line ~69): update the description to reflect v2 +
+  cursor pagination + optional `filterExpression`.
+- `README.md`: tool-table row (line ~353) and the full parameter section
+  (lines ~558-571) — document `cursor` (replaces `offset`), `filterExpression`,
+  the v2 path, and the `data.{items,total,nextCursor}` response shape. Note the
+  minimum SigNoz version once known.
+- **searchContext:** the tool already exposes a top-level `searchContext` string;
+  keep it (do not add to `required`).
+- **agent-skills check:** no shipped skill teaches the alert-history parameter
+  surface (history is read-only; `signoz-creating-alerts`/`-dashboards` cover
+  create/update contracts only). Expected outcome: **no agent-skills change
+  needed** — state this in the PR summary and re-verify at PR time.
+- **Version compatibility:** v2-only on the MCP side (hard cutover, consistent
+  with the rule-CRUD migration). Document the minimum SigNoz version that ships
+  the `signozapiserver` rule-history routes.
+
+### 7. Tests
+- `internal/client/client_test.go`: add a case asserting `GetAlertHistory` issues
+  a **GET** to `/api/v2/rules/{id}/history/timeline` with the expected query string
+  (start/end/state/limit/order/cursor/filterExpression), and that the `{status,
+  data:{items,total,nextCursor}}` envelope round-trips as a raw body.
+- `internal/handler/tools/alert_history_limit_test.go`: the mock returns
+  `{"data":{"items":[]}}`, which is still a valid v2 timeline body — the limit-clamp
+  assertions hold (`capturedReq.Limit` still exists). Adjust only if field renames
+  touch it.
+- Add handler coverage: (a) `cursor` is forwarded verbatim; (b) `filterExpression`
+  is forwarded; (c) a response with a non-empty `data.nextCursor` produces a
+  `hasMore=true` note naming the cursor; (d) `offset` is no longer read (a passed
+  `offset` is ignored rather than paginating).
+- Grep-and-fix any test that constructs `AlertHistoryRequest` with `Offset`/`Filters`
+  or asserts the v1 POST/path (`silent_failures_test.go`, `e2e_familya_test.go`
+  exercise `countAlertHistoryRows` against `data.items[]`/`data[]` — those shapes are
+  unchanged, so they should keep passing; verify).
+
+## Files to Modify
+- `internal/client/client.go` — `GetAlertHistory`: POST→GET, v1→v2 path, body→query; base-URL comment.
+- `pkg/types/alerts.go` — reshape `AlertHistoryRequest` (drop `Offset`/`Filters`, add `FilterExpression`/`Cursor`), add `QueryParams()`; remove `AlertHistoryFilters`.
+- `internal/handler/tools/alerts.go` — tool schema (drop `offset`, add `cursor`+`filterExpression`, refreshed description) and handler wiring.
+- `internal/handler/tools/aggregate_helper.go` — add a cursor-aware completeness note helper (keep `countAlertHistoryRows`).
+- `internal/handler/tools/resource_templates.go` — drop `Offset:0` in `handleAlertSummaryResource`.
+- `internal/client/client_test.go`, `internal/handler/tools/alert_history_limit_test.go` (+ new handler test cases) — v2 GET/query/cursor coverage.
+- `manifest.json`, `README.md` — v2 path, `cursor`, `filterExpression`, response shape, min version.
+- `internal/client/interface.go`, `internal/client/mock.go` — **no change** (signature stable); listed for completeness.
+
+## Verification
+1. `go build ./...` and `go vet ./...`.
+2. `go test ./...` — client GET/query test, handler cursor/filterExpression/nextCursor tests, and unchanged `countAlertHistoryRows` coverage all pass.
+3. Live smoke against a SigNoz new enough to serve the v2 routes — **delegate to a subagent** per CLAUDE.md (no credentials printed/persisted; report which fields round-tripped):
+   - `signoz_get_alert_history` with a real rule `id` and `timeRange="24h"` → expect a `{status,data:{items,total}}` body; items carry `ruleId`/`state`/`unixMilli`.
+   - Set a small `limit` on a busy rule → response has `data.nextCursor`; pass it back as `cursor` → next page returns, note reports `hasMore`.
+   - `state="firing"` filters to firing transitions; a bad `state` is rejected client-side with `CodeValidationFailed`.
+   - `signoz://alert/{id}/summary` resource still returns `recentHistory`.
+4. Confirm no lingering references to the v1 path or the removed `Offset`/`Filters` fields: `grep -rn "history/timeline\|AlertHistoryFilters\|\.Offset" internal pkg` comes back clean (except intended v2 usages).

--- a/plans/alert-history-v2-migration.plan.md
+++ b/plans/alert-history-v2-migration.plan.md
@@ -4,172 +4,71 @@
 In Progress
 
 ## Context
-The MCP server's `signoz_get_alert_history` tool still calls the v1 endpoint
-`POST /api/v1/rules/{id}/history/timeline` with a JSON body, even though rule
-CRUD already moved to `/api/v2/rules/*` in the earlier `v2-convention-migration`
-work. That work explicitly deferred history because the v2 timeline route did
-not exist yet. It now does: upstream serves the full rule-history surface via
-`signozapiserver` at `GET /api/v2/rules/{id}/history/timeline`. This plan brings
-the one wrapped endpoint (`timeline`) onto v2.
 
-Both v1 and v2 wrap responses in the same `{"status":"success","data":...}`
-envelope, and the MCP tool returns that body as a **raw passthrough** — so the
-migration is contained to how the request is built (method + params) and how the
-completeness/pagination note is derived. There is no typed response struct to
-rewrite.
+`signoz_get_alert_history` now calls the v2 timeline API introduced in SigNoz
+v0.118.0. The tool remains a raw response passthrough: the server forwards the
+upstream cursor and appends the existing cursor-aware completeness note.
 
-**Codegen / skaff:** not used. skaff generates a Terraform plugin-framework
-provider (custom types, TF schemas, oapi-codegen typed client, expand/flatten
-convertors) for `terraform-provider-signoz`; it is architecturally mismatched
-with this repo's hand-written raw-passthrough client and is absent here. This
-one-endpoint change is written by hand from `~/Stash/signoz/docs/api/openapi.yml`,
-exactly like every other method on the client. (Rationale in `.context.md`.)
+The PR review follow-up keeps only the contract fixes needed by agents: a
+route-free tool description, canonical `filter` naming, the complete state
+enum, explicit rejection of removed `offset`, and correct handling of the
+upstream cursor's encoded page size.
 
 ## Approach
 
-### 1. Client layer — `internal/client/client.go`
-Rewrite `GetAlertHistory` from POST+body to GET+query string, v1→v2 path:
+### Client and request
 
-```go
-func (s *SigNoz) GetAlertHistory(ctx context.Context, ruleID string, req types.AlertHistoryRequest) (json.RawMessage, error) {
-    reqURL := fmt.Sprintf("%s/api/v2/rules/%s/history/timeline?%s",
-        s.baseURL, url.PathEscape(ruleID), req.QueryParams().Encode())
-    s.logger.DebugContext(s.ensureTenantContext(ctx), "Fetching alert history", slog.String("ruleID", ruleID))
-    return s.doRequest(ctx, http.MethodGet, reqURL, nil, DefaultQueryTimeout)
-}
-```
+- Keep `GetAlertHistory` on the shared `doRequest` path and its existing 64 MiB
+  response guard.
+- Send the v2 GET query parameters through `AlertHistoryRequest.QueryParams()`.
+- Forward `data.nextCursor` unchanged. On a cursor follow-up with no explicit
+  `limit`, send no limit so SigNoz uses the page size encoded in its cursor.
 
-- Interface signature (`interface.go:19`) and mock (`mock.go:97`) are **unchanged**
-  — still `GetAlertHistory(ctx, ruleID, req types.AlertHistoryRequest)` — so churn
-  there is zero; only the struct's internals change.
-- Update the base-URL comment at `client.go:117` if it enumerates the history path
-  version.
+### Agent-facing contract
 
-### 2. Request type — `pkg/types/alerts.go`
-Reshape `AlertHistoryRequest` to the v2 query params and give it a
-`QueryParams() url.Values` method (mirroring the existing `ListAlertsParams`
-pattern in the same file):
+- Omit the HTTP method and backend route from the runtime and manifest tool
+  descriptions.
+- Advertise canonical `filter`; continue accepting backend-shaped
+  `filterExpression` as an unadvertised compatibility alias.
+- Advertise and validate all six v2 states: `inactive`, `pending`, `recovering`,
+  `firing`, `nodata`, and `disabled`.
+- Reject any legacy `offset` with guidance to use `data.nextCursor`.
+- Tell callers to repeat the original time range, state, filter, and order on
+  follow-up calls.
 
-```go
-type AlertHistoryRequest struct {
-    Start            int64
-    End              int64
-    State            string // "" omitted; one of inactive|pending|firing|nodata|disabled
-    FilterExpression string // "" omitted; v5 query-builder expression
-    Limit            int
-    Order            string // "asc" | "desc"
-    Cursor           string // "" omitted; opaque base64 from a prior response's nextCursor
-}
+### Completeness and errors
 
-func (r AlertHistoryRequest) QueryParams() url.Values {
-    v := url.Values{}
-    v.Set("start", strconv.FormatInt(r.Start, 10))
-    v.Set("end", strconv.FormatInt(r.End, 10))
-    if r.State != "" { v.Set("state", r.State) }
-    if r.FilterExpression != "" { v.Set("filterExpression", r.FilterExpression) }
-    if r.Limit > 0 { v.Set("limit", strconv.Itoa(r.Limit)) }
-    if r.Order != "" { v.Set("order", r.Order) }
-    if r.Cursor != "" { v.Set("cursor", r.Cursor) }
-    return v
-}
-```
+- Keep `alertHistoryCompletenessNote` beside the existing pagination helpers in
+  `aggregate_helper.go`.
+- Derive `hasMore` from a non-empty upstream `data.nextCursor` and include that
+  cursor in the note.
+- Preserve the shared coded upstream error path. Add concise recovery guidance
+  for HTTP 404 because the rule may be missing or the SigNoz version may predate
+  v0.118.0.
 
-- Remove `AlertHistoryFilters` (the `{items,op}` struct) and the `Offset` field —
-  both are gone in v2. Grep for other references before deleting.
+### Docs and metadata
 
-### 3. Handler — `internal/handler/tools/alerts.go` (`handleGetAlertHistory` + tool registration)
-Tool input-schema changes (registration at `alerts.go:80`):
-- **Drop** `offset` (no raw offset in v2).
-- **Add** `cursor` (string, optional): "Opaque pagination cursor. Pass the `nextCursor` value from a previous response's `data` to fetch the next page. Omit for the first page."
-- **Add** `filterExpression` (string, optional): "SigNoz v5 query-builder filter expression to narrow the timeline (e.g. `severity = 'critical'`). Optional."
-- Keep `searchContext`, `id`, `timeRange`, `start`, `end`, `state`, `limit`, `order`.
-- `state` enum stays `firing`/`inactive` (decided). A later additive expansion would use the exact v2 spellings incl. `nodata`.
-- Refresh the `WithDescription` text to say v2 / cursor pagination.
-
-Handler body changes:
-- Delete the `paginate.ParseParams` offset read (line ~374) and the `Offset` field
-  in the built request. Read `cursor` and `filterExpression` from args instead.
-- Keep the existing `timeutil` start/end defaulting (6h), `ValidateExplicitTimestamps`,
-  `intArg`/`clampLimit` limit handling (still clamp to `MaxRawResultLimit` before
-  forwarding — the v2 server default is 50 with no documented hard cap, so the
-  memory guard stays our responsibility), and `order`/`state` validation.
-- Build `types.AlertHistoryRequest` with the new fields; call `client.GetAlertHistory`;
-  on error return `upstreamError(err)` (unchanged — the shared coded-error path already
-  handles the v2 `{"status","error"}` envelope via `HTTPStatusError`).
-
-### 4. Completeness / pagination note
-v2 returns `data.nextCursor` directly — more reliable than inferring `hasMore`
-from row counts against an offset. Add a small cursor-aware note helper (next to
-`completenessNote` in `aggregate_helper.go`) that reads `nextCursor` from the
-passthrough body:
-
-- If `data.nextCursor` is a non-empty string → `hasMore=true`; advise "fetch the
-  next page by passing cursor=\"<nextCursor>\"".
-- Else → "all matching results returned (hasMore=false)".
-- Keep `countAlertHistoryRows` for the row count in the message — it already
-  handles the `data.items[]` shape, which is exactly the v2 timeline shape, so no
-  change is needed there. Retain the existing limit-clamp advisory note.
-
-This replaces the current `completenessNote(returnedRows, limit, offset, rowsKnown)`
-call for this handler only (offset-based note stays in use by other tools).
-
-### 5. Alert-summary resource — `internal/handler/tools/resource_templates.go`
-`handleAlertSummaryResource` (line ~61) builds an `AlertHistoryRequest{Start, End,
-Order:"desc", Limit:10, Offset:0}`. Drop the `Offset:0` field (removed from the
-struct); the rest is compatible as-is. Behavior (last 10 transitions, desc) is
-unchanged.
-
-### 6. Docs & metadata (CLAUDE.md sync checklist)
-- `manifest.json` (entry at line ~69): update the description to reflect v2 +
-  cursor pagination + optional `filterExpression`.
-- `README.md`: tool-table row (line ~353) and the full parameter section
-  (lines ~558-571) — document `cursor` (replaces `offset`), `filterExpression`,
-  the v2 path, and the `data.{items,total,nextCursor}` response shape. Note the
-  minimum SigNoz version once known.
-- **searchContext:** the tool already exposes a top-level `searchContext` string;
-  keep it (do not add to `required`).
-- **agent-skills check:** no shipped skill teaches the alert-history parameter
-  surface (history is read-only; `signoz-creating-alerts`/`-dashboards` cover
-  create/update contracts only). Expected outcome: **no agent-skills change
-  needed** — state this in the PR summary and re-verify at PR time.
-- **Version compatibility:** v2-only on the MCP side (hard cutover, consistent
-  with the rule-CRUD migration). Document the minimum SigNoz version that ships
-  the `signozapiserver` rule-history routes.
-
-### 7. Tests
-- `internal/client/client_test.go`: add a case asserting `GetAlertHistory` issues
-  a **GET** to `/api/v2/rules/{id}/history/timeline` with the expected query string
-  (start/end/state/limit/order/cursor/filterExpression), and that the `{status,
-  data:{items,total,nextCursor}}` envelope round-trips as a raw body.
-- `internal/handler/tools/alert_history_limit_test.go`: the mock returns
-  `{"data":{"items":[]}}`, which is still a valid v2 timeline body — the limit-clamp
-  assertions hold (`capturedReq.Limit` still exists). Adjust only if field renames
-  touch it.
-- Add handler coverage: (a) `cursor` is forwarded verbatim; (b) `filterExpression`
-  is forwarded; (c) a response with a non-empty `data.nextCursor` produces a
-  `hasMore=true` note naming the cursor; (d) `offset` is no longer read (a passed
-  `offset` is ignored rather than paginating).
-- Grep-and-fix any test that constructs `AlertHistoryRequest` with `Offset`/`Filters`
-  or asserts the v1 POST/path (`silent_failures_test.go`, `e2e_familya_test.go`
-  exercise `countAlertHistoryRows` against `data.items[]`/`data[]` — those shapes are
-  unchanged, so they should keep passing; verify).
+- Document the v0.118.0 alert-history requirement separately from the v0.120.0
+  alert-rule CRUD requirement.
+- Keep README parameters, manifest metadata, and runtime schema aligned.
+- No companion `SigNoz/agent-skills` update is needed because shipped skills do
+  not teach this read-only tool contract.
 
 ## Files to Modify
-- `internal/client/client.go` — `GetAlertHistory`: POST→GET, v1→v2 path, body→query; base-URL comment.
-- `pkg/types/alerts.go` — reshape `AlertHistoryRequest` (drop `Offset`/`Filters`, add `FilterExpression`/`Cursor`), add `QueryParams()`; remove `AlertHistoryFilters`.
-- `internal/handler/tools/alerts.go` — tool schema (drop `offset`, add `cursor`+`filterExpression`, refreshed description) and handler wiring.
-- `internal/handler/tools/aggregate_helper.go` — add a cursor-aware completeness note helper (keep `countAlertHistoryRows`).
-- `internal/handler/tools/resource_templates.go` — drop `Offset:0` in `handleAlertSummaryResource`.
-- `internal/client/client_test.go`, `internal/handler/tools/alert_history_limit_test.go` (+ new handler test cases) — v2 GET/query/cursor coverage.
-- `manifest.json`, `README.md` — v2 path, `cursor`, `filterExpression`, response shape, min version.
-- `internal/client/interface.go`, `internal/client/mock.go` — **no change** (signature stable); listed for completeness.
+
+- `internal/handler/tools/alerts.go` — schema, validation, raw cursor forwarding,
+  cursor-limit behavior, and 404 guidance.
+- `internal/handler/tools/aggregate_helper.go` — cursor completeness note.
+- `pkg/types/alerts.go` — v2 state documentation.
+- Focused handler/schema/E2E tests — state, filter, description, cursor, and
+  limit coverage.
+- `README.md`, `manifest.json` — compatibility and agent-facing metadata.
+- `plans/alert-history-v2-migration.context.md` — append-only decision record.
 
 ## Verification
-1. `go build ./...` and `go vet ./...`.
-2. `go test ./...` — client GET/query test, handler cursor/filterExpression/nextCursor tests, and unchanged `countAlertHistoryRows` coverage all pass.
-3. Live smoke against a SigNoz new enough to serve the v2 routes — **delegate to a subagent** per CLAUDE.md (no credentials printed/persisted; report which fields round-tripped):
-   - `signoz_get_alert_history` with a real rule `id` and `timeRange="24h"` → expect a `{status,data:{items,total}}` body; items carry `ruleId`/`state`/`unixMilli`.
-   - Set a small `limit` on a busy rule → response has `data.nextCursor`; pass it back as `cursor` → next page returns, note reports `hasMore`.
-   - `state="firing"` filters to firing transitions; a bad `state` is rejected client-side with `CodeValidationFailed`.
-   - `signoz://alert/{id}/summary` resource still returns `recentHistory`.
-4. Confirm no lingering references to the v1 path or the removed `Offset`/`Filters` fields: `grep -rn "history/timeline\|AlertHistoryFilters\|\.Offset" internal pkg` comes back clean (except intended v2 usages).
+
+1. Run focused alert-history and client tests.
+2. Run `go test ./...`, `go vet ./...`, and `go build ./...`.
+3. Run `python3 -m json.tool manifest.json` and `git diff --check`.
+4. Do not commit, push, resolve review threads, or edit the PR until the user
+   confirms.


### PR DESCRIPTION
## What & why

Migrates `signoz_get_alert_history` from the v1 endpoint `POST /api/v1/rules/{id}/history/timeline` (JSON body) to the v2 endpoint `GET /api/v2/rules/{id}/history/timeline` (query params). This aligns the tool with the already-v2 rule CRUD surface (`/api/v2/rules/*`); the earlier v2-convention migration deferred history because the v2 timeline route didn't exist upstream yet — it does now (served by `signozapiserver`).

v1 is **not** removed upstream, so this is a forward-alignment cutover (v2-only on the MCP side), consistent with the rule-CRUD migration.

## Contract changes (v1 → v2)

| | v1 (before) | v2 (after) |
|---|---|---|
| Route | `POST /api/v1/rules/{id}/history/timeline` | `GET /api/v2/rules/{id}/history/timeline` |
| Input | JSON body | query params |
| Filtering | structured `filters` (always sent empty) | `filterExpression` (v5 QB string) |
| Paging | raw `offset` | opaque `cursor` + `data.nextCursor` |
| Response | `{status,data:{items,total,labels}}` | `{status,data:{items,total,nextCursor}}` |

**Tool surface:** dropped `offset`; added `cursor` and `filterExpression`. A passed `offset` is now ignored.

## Changes

- **`internal/client/client.go`** — `GetAlertHistory` issues a GET with a query string (`AlertHistoryRequest.QueryParams()`); interface/mock signatures unchanged.
- **`pkg/types/alerts.go`** — reshape `AlertHistoryRequest` (drop `Offset`/`Filters`, add `FilterExpression`/`Cursor`), add `QueryParams()`; remove `AlertHistoryFilters`.
- **`internal/handler/tools/alerts.go`** — schema + handler: drop `offset`, add `cursor`/`filterExpression`, refreshed description.
- **`internal/handler/tools/aggregate_helper.go`** — new `alertHistoryCompletenessNote` derives `hasMore` from the authoritative `data.nextCursor` (falls back to the row-count heuristic only when the cursor is absent). `countAlertHistoryRows` unchanged.
- **`internal/handler/tools/resource_templates.go`** — drop removed `Offset` field in the alert-summary resource.

### Design note
v2 emits `nextCursor` **only** when rows remain, so deriving `hasMore` from it is strictly more accurate than the old `returnedRows == limit` heuristic (an exact-fill last page now correctly reads `hasMore=false`).

## Docs & metadata

- `manifest.json` — updated `signoz_get_alert_history` description (v2 path, cursor, filterExpression).
- `README.md` — parameter section rewritten (`cursor` replaces `offset`, `filterExpression` added, v2 response shape, required-version note).
- **agent-skills check:** no change needed — no shipped skill teaches the alert-history parameter surface (history is read-only; the create/update skills cover different contracts).
- **plans/** — `alert-history-v2-migration.{context,plan}.md` committed per the repo convention.

## Testing

`go build ./...`, `go vet ./...`, and `go test ./...` (all 17 packages) pass.

- `internal/client/client_test.go` — rewritten `TestGetAlertHistory` asserts GET + query string + v2 envelope.
- `internal/handler/tools/silent_failures_test.go` — repointed the top-level-data-array completeness test to v2 cursor semantics; added `TestHandleGetAlertHistory_NextCursorHasMore` (cursor + filter forwarded; `nextCursor` → `hasMore=true`).

## Follow-ups

- Fill the concrete **minimum SigNoz version** (the release shipping the v2 `signozapiserver` rule-history routes) into the README once known — currently a generic "requires v2 routes" note.
- Live smoke against a SigNoz instance new enough to serve `/api/v2/rules/{id}/history/*` (delegated verification per repo convention).

🤖 Generated with [Claude Code](https://claude.com/claude-code)