### PR TITLE
fix(metrics): support legacy metric metadata lookup

### DIFF
--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -493,7 +493,83 @@ func (s *SigNoz) ListMetrics(ctx context.Context, start, end int64, limit int, s
 
 	reqURL := fmt.Sprintf("%s/api/v2/metrics?%s", s.baseURL, params.Encode())
 	s.logger.DebugContext(s.ensureTenantContext(ctx), "Listing metrics", slog.String("searchText", searchText))
-	return s.doRequest(ctx, http.MethodGet, reqURL, nil, DefaultQueryTimeout)
+	body, err := s.doRequest(ctx, http.MethodGet, reqURL, nil, DefaultQueryTimeout)
+	if err != nil {
+		return nil, err
+	}
+	if !looksLikeHTML(body) {
+		return body, nil
+	}
+
+	// SigNoz v0.108 routes the newer /api/v2/metrics catalog endpoint to the
+	// frontend SPA, but still exposes exact metric metadata at
+	// /api/v2/metrics/metadata?metricName=... . Preserve the ListMetrics shape
+	// for callers that use an exact metric name, especially query_metrics'
+	// metadata auto-fetch path.
+	metricName := strings.TrimSpace(searchText)
+	if source != "" || metricName == "" {
+		return nil, fmt.Errorf("metrics catalog endpoint returned HTML; this SigNoz version may not support /api/v2/metrics listing")
+	}
+	return s.getLegacyMetricMetadataAsListMetrics(ctx, metricName)
+}
+
+func looksLikeHTML(body []byte) bool {
+	trimmed := bytes.TrimSpace(body)
+	lower := bytes.ToLower(trimmed)
+	return bytes.HasPrefix(lower, []byte("<!doctype html")) || bytes.HasPrefix(lower, []byte("<html"))
+}
+
+func (s *SigNoz) getLegacyMetricMetadataAsListMetrics(ctx context.Context, metricName string) (json.RawMessage, error) {
+	params := url.Values{}
+	params.Set("metricName", metricName)
+
+	reqURL := fmt.Sprintf("%s/api/v2/metrics/metadata?%s", s.baseURL, params.Encode())
+	s.logger.DebugContext(s.ensureTenantContext(ctx), "Fetching legacy metric metadata", slog.String("metric", metricName))
+	body, err := s.doRequest(ctx, http.MethodGet, reqURL, nil, DefaultQueryTimeout)
+	if err != nil {
+		return nil, fmt.Errorf("legacy metric metadata lookup for %q: %w", metricName, err)
+	}
+	if looksLikeHTML(body) {
+		return nil, fmt.Errorf("legacy metric metadata endpoint returned HTML for %q", metricName)
+	}
+
+	var resp struct {
+		Status string `json:"status"`
+		Data   struct {
+			Description string `json:"description"`
+			Type        string `json:"type"`
+			Unit        string `json:"unit"`
+			Temporality string `json:"temporality"`
+			IsMonotonic bool   `json:"isMonotonic"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(body, &resp); err != nil {
+		return nil, fmt.Errorf("parse legacy metric metadata for %q: %w", metricName, err)
+	}
+	if resp.Data.Type == "" {
+		return nil, fmt.Errorf("legacy metric metadata for %q did not include a metric type", metricName)
+	}
+	status := resp.Status
+	if status == "" {
+		status = "success"
+	}
+
+	out := map[string]any{
+		"status": status,
+		"data": map[string]any{
+			"metrics": []map[string]any{
+				{
+					"metricName":  metricName,
+					"description": resp.Data.Description,
+					"type":        resp.Data.Type,
+					"unit":        resp.Data.Unit,
+					"temporality": resp.Data.Temporality,
+					"isMonotonic": resp.Data.IsMonotonic,
+				},
+			},
+		},
+	}
+	return json.Marshal(out)
 }
 
 func (s *SigNoz) ListMetricKeys(ctx context.Context) (json.RawMessage, error) {

--- a/internal/client/metrics_compat_test.go
+++ b/internal/client/metrics_compat_test.go
@@ -1,0 +1,65 @@
+package client
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	logpkg "github.com/SigNoz/signoz-mcp-server/pkg/log"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestListMetrics_FallsBackToLegacyMetadataWhenV2CatalogReturnsHTML(t *testing.T) {
+	const metricName = "k8s.node.cpu.usage"
+
+	var gotCatalogPath, gotMetadataPath, gotMetadataName string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v2/metrics":
+			gotCatalogPath = r.URL.Path
+			w.Header().Set("Content-Type", "text/html; charset=utf-8")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`<!doctype html><html><body>SigNoz UI</body></html>`))
+		case "/api/v2/metrics/metadata":
+			gotMetadataPath = r.URL.Path
+			gotMetadataName = r.URL.Query().Get("metricName")
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"status":"success","data":{"description":"Total CPU usage","type":"gauge","unit":"{cpu}","temporality":"unspecified","isMonotonic":false}}`))
+		default:
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	c := NewClient(logpkg.New("debug"), srv.URL, "test-api-key", "SIGNOZ-API-KEY", nil)
+
+	result, err := c.ListMetrics(context.Background(), 0, 0, 10, metricName, "")
+	require.NoError(t, err)
+
+	assert.Equal(t, "/api/v2/metrics", gotCatalogPath)
+	assert.Equal(t, "/api/v2/metrics/metadata", gotMetadataPath)
+	assert.Equal(t, metricName, gotMetadataName)
+
+	var resp struct {
+		Status string `json:"status"`
+		Data   struct {
+			Metrics []struct {
+				MetricName  string `json:"metricName"`
+				Type        string `json:"type"`
+				Temporality string `json:"temporality"`
+				IsMonotonic bool   `json:"isMonotonic"`
+			} `json:"metrics"`
+		} `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(result, &resp))
+	require.Len(t, resp.Data.Metrics, 1)
+	assert.Equal(t, "success", resp.Status)
+	assert.Equal(t, metricName, resp.Data.Metrics[0].MetricName)
+	assert.Equal(t, "gauge", resp.Data.Metrics[0].Type)
+	assert.Equal(t, "unspecified", resp.Data.Metrics[0].Temporality)
+	assert.False(t, resp.Data.Metrics[0].IsMonotonic)
+}

--- a/plans/legacy-metrics-metadata-fallback.context.md
+++ b/plans/legacy-metrics-metadata-fallback.context.md
@@ -1,0 +1,17 @@
+# Feature: Legacy Metrics Metadata Fallback - Context & Discussion
+
+## Original Prompt
+> OK, let's fix Signoz MCP now.
+
+## Reference Links
+- Xylem SigNoz: `https://signoz.xylem.10upmanaged.com`
+
+## Key Decisions & Discussion Log
+### 2026-07-14 - Xylem v0.108 compatibility
+- Xylem SigNoz reports version `v0.108.0`.
+- `/api/v2/metrics` and `/api/v2/metrics/attributes` return the SigNoz frontend HTML on this deployment.
+- `/api/v2/metrics/metadata?metricName=...` returns exact metric metadata with `type`, `temporality`, and `isMonotonic`.
+- Added a narrow fallback for exact metric lookups so `signoz_query_metrics` can auto-fetch metadata on older SigNoz deployments without changing the public MCP tool contract.
+
+## Open Questions
+- [ ] Should broad metric catalog listing on pre-v0.131 SigNoz be supported through another route, or should those deployments be upgraded?

--- a/plans/legacy-metrics-metadata-fallback.plan.md
+++ b/plans/legacy-metrics-metadata-fallback.plan.md
@@ -1,0 +1,32 @@
+# Plan: Legacy Metrics Metadata Fallback
+
+## Status
+Done
+
+## Context
+Xylem runs SigNoz `v0.108.0`. The MCP server's current metric catalog path, `/api/v2/metrics`, is available on newer SigNoz versions but routes to the frontend SPA HTML on Xylem. That breaks `signoz_list_metrics` and also breaks `signoz_query_metrics` when metric metadata is not provided manually.
+
+## Approach
+When `ListMetrics` receives HTML from `/api/v2/metrics` and the caller supplied an exact `searchText`, call the legacy exact metadata endpoint:
+
+```text
+/api/v2/metrics/metadata?metricName=<metric>
+```
+
+Then synthesize the existing list-metrics response shape:
+
+```json
+{"status":"success","data":{"metrics":[{"metricName":"...","type":"...","temporality":"...","isMonotonic":false}]}}
+```
+
+This keeps downstream parsing unchanged and limits the compatibility behavior to exact metric metadata lookups. Broad catalog listing remains unsupported on this older deployment.
+
+## Files Modified
+- `internal/client/client.go` - detect HTML from the newer catalog route and fall back to legacy exact metric metadata.
+- `internal/client/metrics_compat_test.go` - regression test for v0.108-style HTML catalog response plus working legacy metadata endpoint.
+
+## Verification
+- `go test ./internal/client -run TestListMetrics_FallsBackToLegacyMetadataWhenV2CatalogReturnsHTML -count=1`
+- `go test ./internal/client -count=1`
+- `go test ./...`
+- `go build -ldflags "...Version=$(git describe --tags --always --dirty)" -o bin/signoz-mcp-server ./cmd/server/...`


### PR DESCRIPTION
## Summary
- add a fallback for older SigNoz deployments where /api/v2/metrics returns the frontend HTML
- use /api/v2/metrics/metadata?metricName=... for exact metric metadata lookups
- preserve the existing ListMetrics response shape so query_metrics auto-metadata keeps working

## Verification
- go test ./internal/client -run TestListMetrics_FallsBackToLegacyMetadataWhenV2CatalogReturnsHTML -count=1
- go test ./internal/client ./internal/handler/tools -count=1
- go test ./...
- go build -ldflags "-X github.com/SigNoz/signoz-mcp-server/pkg/version.Version=v0.7.0-1-g5004a59" -o bin/signoz-mcp-server ./cmd/server/...

Companion agent-skills repo: no change needed; this is an internal compatibility fallback with no public tool contract change.