### PR TITLE
fix: align MCP telemetry and OAuth guidance

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -143,10 +143,11 @@ the per-session maps the MCP SDK would otherwise accumulate, and aligns with the
 `2026-07-28` spec direction of removing the protocol-level session model. Clients may still
 open a GET listening stream; a periodic heartbeat keeps it alive through intermediary proxies.
 
-One consequence: MCP client identity (name/version) is captured only on the
-`session_registered` analytics event, taken directly from the `initialize` request's
-`ClientInfo`. With no session to correlate against, it is not attached to later
-per-tool-call events.
+The successful `initialize` request emits `MCP Client: Initialized` with its client
+name/version and negotiated protocol version. This is client-adoption telemetry, not a
+session lifecycle signal: there is still no reliable cross-request session identity for
+attaching `ClientInfo` to later tool events. Per-request `clientSource` and assistant
+correlation headers remain available on tool telemetry.
 
 ## OAuth 2.1 — Stateless Token Design
 

--- a/internal/docs/errors.go
+++ b/internal/docs/errors.go
@@ -1,12 +1,15 @@
 package docs
 
-import "github.com/mark3labs/mcp-go/mcp"
+import (
+	"github.com/SigNoz/signoz-mcp-server/pkg/toolerrors"
+	"github.com/mark3labs/mcp-go/mcp"
+)
 
 const (
-	CodeOutOfScopeURL  = "OUT_OF_SCOPE_URL"
-	CodeDocNotFound    = "DOC_NOT_FOUND"
-	CodeHeadingMissing = "HEADING_NOT_FOUND"
-	CodeIndexNotReady  = "INDEX_NOT_READY"
+	CodeOutOfScopeURL  = toolerrors.CodeOutOfScopeURL
+	CodeDocNotFound    = toolerrors.CodeDocNotFound
+	CodeHeadingMissing = toolerrors.CodeHeadingMissing
+	CodeIndexNotReady  = toolerrors.CodeIndexNotReady
 )
 
 func ToolError(code, message string, extra map[string]any) *mcp.CallToolResult {

--- a/internal/docs/metrics.go
+++ b/internal/docs/metrics.go
@@ -2,7 +2,6 @@ package docs
 
 import (
 	"context"
-	"time"
 
 	otelpkg "github.com/SigNoz/signoz-mcp-server/pkg/otel"
 )
@@ -20,11 +19,6 @@ func (r *IndexRegistry) RecordMetrics(ctx context.Context, meters *otelpkg.Meter
 	defer release()
 
 	snapshot := entry.snapshot
-	age := time.Since(snapshot.BuiltAt)
-	if age < 0 {
-		age = 0
-	}
-	meters.DocsIndexAge.Record(ctx, age.Seconds())
 	meters.DocsIndexSizeBytes.Record(ctx, approximateCorpusSizeBytes(snapshot))
 	meters.DocsIndexDocCount.Record(ctx, int64(len(snapshot.Pages)))
 	meters.DocsIndexGeneration.Record(ctx, int64(entry.generation))

--- a/internal/docs/verification_test.go
+++ b/internal/docs/verification_test.go
@@ -150,7 +150,6 @@ func TestForcedFullRefresh(t *testing.T) {
 	require.Equal(t, int64(1), int64GaugeValue(t, metrics, "signoz_docs_index_doc_count"))
 	require.Equal(t, int64(2), int64GaugeValue(t, metrics, "signoz_docs_index_generation"))
 	require.Equal(t, approximateCorpusSizeBytes(snapshot), int64GaugeValue(t, metrics, "signoz_docs_index_size_bytes"))
-	require.Less(t, float64GaugeValue(t, metrics, "signoz_docs_index_age_seconds"), 10.0)
 }
 
 func TestSingleflightSerialization(t *testing.T) {
@@ -229,10 +228,6 @@ func TestRecordDocsIndexMetrics(t *testing.T) {
 	require.Equal(t, int64(len(snapshot.Pages)), int64GaugeValue(t, metrics, "signoz_docs_index_doc_count"))
 	require.Equal(t, int64(2), int64GaugeValue(t, metrics, "signoz_docs_index_generation"))
 	require.Equal(t, approximateCorpusSizeBytes(snapshot), int64GaugeValue(t, metrics, "signoz_docs_index_size_bytes"))
-
-	age := float64GaugeValue(t, metrics, "signoz_docs_index_age_seconds")
-	require.GreaterOrEqual(t, age, 2*time.Hour.Seconds())
-	require.Less(t, age, 2*time.Hour.Seconds()+10)
 }
 
 func TestAtomicSwapRace(t *testing.T) {
@@ -557,14 +552,6 @@ func collectDocsMetrics(t *testing.T, reader *sdkmetric.ManualReader) metricdata
 func int64GaugeValue(t *testing.T, rm metricdata.ResourceMetrics, name string) int64 {
 	t.Helper()
 	gauge, ok := oteltest.FindInt64GaugeMetric(rm, name)
-	require.True(t, ok, "metric %s not found", name)
-	require.NotEmpty(t, gauge.DataPoints, "metric %s has no data points", name)
-	return gauge.DataPoints[0].Value
-}
-
-func float64GaugeValue(t *testing.T, rm metricdata.ResourceMetrics, name string) float64 {
-	t.Helper()
-	gauge, ok := oteltest.FindFloat64GaugeMetric(rm, name)
 	require.True(t, ok, "metric %s not found", name)
 	require.NotEmpty(t, gauge.DataPoints, "metric %s has no data points", name)
 	return gauge.DataPoints[0].Value

--- a/internal/handler/tools/errs.go
+++ b/internal/handler/tools/errs.go
@@ -13,6 +13,7 @@ import (
 
 	signozclient "github.com/SigNoz/signoz-mcp-server/internal/client"
 	logpkg "github.com/SigNoz/signoz-mcp-server/pkg/log"
+	"github.com/SigNoz/signoz-mcp-server/pkg/toolerrors"
 )
 
 // Shared error/validation string helpers used across the MCP tool handlers.
@@ -47,41 +48,41 @@ const (
 	// CodeValidationFailed marks a fixable parameter/validation mistake: the
 	// caller should correct the arguments and retry. Emitted by local
 	// validation helpers and upstream HTTP 400 responses.
-	CodeValidationFailed = "VALIDATION_FAILED"
+	CodeValidationFailed = toolerrors.CodeValidationFailed
 
 	// CodeUpstreamError marks a generic SigNoz backend failure. Emitted by
 	// upstreamError when no more precise status-derived code applies.
-	CodeUpstreamError = "UPSTREAM_ERROR"
+	CodeUpstreamError = toolerrors.CodeUpstreamError
 
 	// CodeUnauthorized marks a SigNoz backend 401. The caller should re-authenticate
 	// or provide valid credentials rather than blindly retrying.
-	CodeUnauthorized = "UNAUTHORIZED"
+	CodeUnauthorized = toolerrors.CodeUnauthorized
 
 	// CodePermissionDenied marks a SigNoz backend 403. The caller should ask for
 	// permissions or use an account with the required role.
-	CodePermissionDenied = "PERMISSION_DENIED"
+	CodePermissionDenied = toolerrors.CodePermissionDenied
 
 	// CodeNotFound marks a missing resource (bad id/uuid) — re-discover the id
 	// rather than blindly retry. Emitted by local guards and upstream HTTP 404s.
-	CodeNotFound = "NOT_FOUND"
+	CodeNotFound = toolerrors.CodeNotFound
 
 	// CodeConflict marks an upstream HTTP 409.
-	CodeConflict = "CONFLICT"
+	CodeConflict = toolerrors.CodeConflict
 
 	// CodeRateLimited marks an upstream HTTP 429.
-	CodeRateLimited = "RATE_LIMITED"
+	CodeRateLimited = toolerrors.CodeRateLimited
 
 	// CodeUnsupported marks an upstream HTTP 501.
-	CodeUnsupported = "UNSUPPORTED"
+	CodeUnsupported = toolerrors.CodeUnsupported
 
 	// CodeLicenseUnavailable marks an upstream HTTP 451.
-	CodeLicenseUnavailable = "LICENSE_UNAVAILABLE"
+	CodeLicenseUnavailable = toolerrors.CodeLicenseUnavailable
 
 	// CodeCanceled marks an upstream/client-closed HTTP 499.
-	CodeCanceled = "CANCELED"
+	CodeCanceled = toolerrors.CodeCanceled
 
 	// CodeTimeout marks an upstream HTTP timeout response.
-	CodeTimeout = "TIMEOUT"
+	CodeTimeout = toolerrors.CodeTimeout
 )
 
 const statusClientClosedConnection = 499

--- a/internal/mcp-server/e2e_docs_test.go
+++ b/internal/mcp-server/e2e_docs_test.go
@@ -14,8 +14,6 @@ import (
 	"github.com/SigNoz/signoz-mcp-server/internal/config"
 	docsindex "github.com/SigNoz/signoz-mcp-server/internal/docs"
 	"github.com/SigNoz/signoz-mcp-server/internal/handler/tools"
-	otelpkg "github.com/SigNoz/signoz-mcp-server/pkg/otel"
-	"github.com/SigNoz/signoz-mcp-server/pkg/util"
 	"github.com/SigNoz/signoz-mcp-server/pkg/version"
 	"github.com/mark3labs/mcp-go/client"
 	"github.com/mark3labs/mcp-go/client/transport"
@@ -158,7 +156,7 @@ func TestE2EAuthFailureTelemetry(t *testing.T) {
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("User-Agent", "claude-code/2.1.133 (cli)")
 	req.Header.Set("X-Forwarded-For", "198.51.100.9, 10.0.0.2")
-	req.Header.Set(util.HeaderMCPSessionID, "mcp-session-e2e")
+	req.Header.Set("Mcp-Session-Id", "mcp-session-e2e")
 
 	resp, err := http.DefaultClient.Do(req)
 	require.NoError(t, err)
@@ -173,7 +171,8 @@ func TestE2EAuthFailureTelemetry(t *testing.T) {
 	require.Equal(t, authModeNone, rec["mcp.auth.mode"])
 	require.Equal(t, "198.51.100.9", rec["client.address"])
 	require.Equal(t, "claude-code/2.1.133 (cli)", rec["user_agent.original"])
-	require.Equal(t, "mcp-session-e2e", rec["mcp.session.id"])
+	_, hasSessionLogAttr := rec["mcp.session.id"]
+	require.False(t, hasSessionLogAttr, "incoming session header must not be logged")
 
 	var httpAttrs []attribute.KeyValue
 	for _, span := range traceExporter.GetSpans() {
@@ -188,12 +187,13 @@ func TestE2EAuthFailureTelemetry(t *testing.T) {
 		"mcp.auth.mode":           authModeNone,
 		"client.address":          "198.51.100.9",
 		"user_agent.original":     "claude-code/2.1.133 (cli)",
-		otelpkg.MCPSessionIDKey:   "mcp-session-e2e",
 	} {
 		got, ok := spanAttrValue(httpAttrs, key)
 		require.True(t, ok, "missing span attr %s", key)
 		require.Equal(t, want, got.AsString(), "span attr %s", key)
 	}
+	_, hasSessionSpanAttr := spanAttrValue(httpAttrs, attribute.Key("mcp.session.id"))
+	require.False(t, hasSessionSpanAttr, "incoming session header must not be attached to spans")
 }
 
 func firstTextContent(t *testing.T, content []mcp.Content) string {

--- a/internal/mcp-server/server.go
+++ b/internal/mcp-server/server.go
@@ -1,12 +1,9 @@
 package mcp_server
 
 import (
-	"bytes"
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
 	"log/slog"
 	"net/http"
 	"os"
@@ -25,6 +22,7 @@ import (
 	logpkg "github.com/SigNoz/signoz-mcp-server/pkg/log"
 	otelpkg "github.com/SigNoz/signoz-mcp-server/pkg/otel"
 	"github.com/SigNoz/signoz-mcp-server/pkg/prompts"
+	"github.com/SigNoz/signoz-mcp-server/pkg/toolerrors"
 	"github.com/SigNoz/signoz-mcp-server/pkg/util"
 	"github.com/SigNoz/signoz-mcp-server/pkg/version"
 	"github.com/mark3labs/mcp-go/mcp"
@@ -38,7 +36,6 @@ import (
 )
 
 const (
-	defaultMethodSpanBodyMaxSize = 1 << 20
 	// methodObsTombstoneTTL is how long an expired method observation lingers
 	// in methodObs so a late OnError hook can detect the race and skip its
 	// fallback (preventing double-count). Finish deletes the entry immediately;
@@ -54,36 +51,22 @@ const (
 	// Requires mcp-go >= v0.44.1, which routes empty ping replies to HTTP 202
 	// instead of the sampling-response path (mark3labs/mcp-go#740).
 	streamableHTTPHeartbeatInterval = 20 * time.Second
+	unknownToolName                 = "unknown"
 )
 
 type MCPServer struct {
-	logger                 *slog.Logger
-	handler                *tools.Handler
-	config                 *config.Config
-	analytics              analytics.Analytics
-	meters                 *otelpkg.Meters
-	methodObs              sync.Map
-	maxMethodSpanBodyBytes int64
-	methodObsTombstoneTTL  time.Duration
+	logger                *slog.Logger
+	handler               *tools.Handler
+	config                *config.Config
+	analytics             analytics.Analytics
+	meters                *otelpkg.Meters
+	methodObs             sync.Map
+	methodObsTombstoneTTL time.Duration
 	// httpServer is published via atomic.Pointer so Shutdown (on the main
 	// goroutine) can safely race Run's publication (on the errgroup
 	// goroutine) when SIGTERM lands mid-startup.
 	httpServer  atomic.Pointer[http.Server]
 	analyticsWG sync.WaitGroup
-}
-
-// attachClientInfo copies the MCP client name/version onto an analytics property
-// map. The server is stateless, so there is no session to correlate later tool
-// calls against — this is populated only from the InitializeRequest's ClientInfo
-// on the session_registered event, where the client identity is carried directly.
-func attachClientInfo(props map[string]any, info mcp.Implementation) {
-	if info.Name == "" {
-		return
-	}
-	props[analytics.AttrClientName] = info.Name
-	if info.Version != "" {
-		props[analytics.AttrClientVersion] = info.Version
-	}
 }
 
 // attachCallerCorrelation copies caller-correlation values from ctx onto an
@@ -149,23 +132,6 @@ func (m *MCPServer) resolveIdentity(ctx context.Context) (*signozclient.Analytic
 	return client.GetAnalyticsIdentity(ctx)
 }
 
-func (m *MCPServer) identifyAsync(ctx context.Context, traits map[string]any) {
-	if !m.analyticsEnabled() {
-		return
-	}
-
-	traits = cloneAttrs(traits)
-	m.dispatchAnalytics(ctx, func(detachedCtx context.Context) {
-		identity, err := m.resolveIdentity(detachedCtx)
-		if err != nil {
-			m.logger.WarnContext(detachedCtx, "analytics identity resolution failed; skipping identify", logpkg.ErrAttr(err))
-			return
-		}
-
-		m.analytics.IdentifyUser(detachedCtx, identity.OrgID, identity.UserID, m.mergeIdentityAttrs(identity, traits))
-	})
-}
-
 func (m *MCPServer) trackEventAsync(ctx context.Context, event string, properties map[string]any) {
 	if !m.analyticsEnabled() {
 		return
@@ -181,29 +147,6 @@ func (m *MCPServer) trackEventAsync(ctx context.Context, event string, propertie
 			return
 		}
 
-		m.analytics.TrackUser(detachedCtx, identity.OrgID, identity.UserID, event, m.mergeIdentityAttrs(identity, properties))
-	})
-}
-
-// identifyAndTrackAsync resolves identity once and emits both calls under
-// the same goroutine to avoid a second /me roundtrip.
-func (m *MCPServer) identifyAndTrackAsync(ctx context.Context, event string, traits map[string]any, properties map[string]any) {
-	if !m.analyticsEnabled() {
-		return
-	}
-
-	traits = cloneAttrs(traits)
-	properties = cloneAttrs(properties)
-	m.dispatchAnalytics(ctx, func(detachedCtx context.Context) {
-		identity, err := m.resolveIdentity(detachedCtx)
-		if err != nil {
-			m.logger.WarnContext(detachedCtx, "analytics identity resolution failed; skipping identify+track",
-				slog.String("event", event),
-				logpkg.ErrAttr(err))
-			return
-		}
-
-		m.analytics.IdentifyUser(detachedCtx, identity.OrgID, identity.UserID, m.mergeIdentityAttrs(identity, traits))
 		m.analytics.TrackUser(detachedCtx, identity.OrgID, identity.UserID, event, m.mergeIdentityAttrs(identity, properties))
 	})
 }
@@ -245,9 +188,6 @@ func (m *MCPServer) detachedAnalyticsContext(parent context.Context) (context.Co
 	if searchContext, ok := util.GetSearchContext(parent); ok && searchContext != "" {
 		ctx = util.SetSearchContext(ctx, searchContext)
 	}
-	if sessionID, ok := util.GetSessionID(parent); ok && sessionID != "" {
-		ctx = util.SetSessionID(ctx, sessionID)
-	}
 	if clientSource, ok := util.GetClientSource(parent); ok && clientSource != "" {
 		ctx = util.SetClientSource(ctx, clientSource)
 	}
@@ -279,13 +219,12 @@ func NewMCPServer(log *slog.Logger, handler *tools.Handler, cfg *config.Config, 
 		handler.SetMeters(meters)
 	}
 	return &MCPServer{
-		logger:                 log,
-		handler:                handler,
-		config:                 cfg,
-		analytics:              a,
-		meters:                 meters,
-		maxMethodSpanBodyBytes: defaultMethodSpanBodyMaxSize,
-		methodObsTombstoneTTL:  methodObsTombstoneTTL,
+		logger:                log,
+		handler:               handler,
+		config:                cfg,
+		analytics:             a,
+		meters:                meters,
+		methodObsTombstoneTTL: methodObsTombstoneTTL,
 	}
 }
 
@@ -422,6 +361,7 @@ func (m *MCPServer) newSDKServer() *server.MCPServer {
 		server.WithInstructions(instructions.ServerInstructions),
 		server.WithHooks(m.buildHooks()),
 		server.WithToolHandlerMiddleware(m.loggingMiddleware()),
+		server.WithTracer(otelpkg.NewMCPTracer(otel.Tracer("signoz-mcp-server"))),
 		server.WithRecovery(),
 	)
 }
@@ -464,9 +404,10 @@ type methodObservation struct {
 	cleanupStop func() bool
 	// completed is the exactly-once guard. CAS'd by finishMethodObservation
 	// (the hook path) or expireMethodObservation (the ctx-cancel path); whichever
-	// wins emits the metric and ends the span. The loser skips emission but the
-	// entry stays in methodObs so the loser can still detect "we were beaten by
-	// a race" vs "observation was never stored at all" (unmarshal-failure path).
+	// wins emits the metric and decorates the SDK-owned span. The loser skips
+	// emission, but the entry stays in methodObs so the loser can still detect
+	// "we were beaten by a race" vs "observation was never stored at all"
+	// (unmarshal-failure path).
 	completed atomic.Bool
 }
 
@@ -488,24 +429,6 @@ func shouldObserveMethod(method mcp.MCPMethod) bool {
 	return method != mcp.MethodToolsCall && !strings.HasPrefix(string(method), "notifications/")
 }
 
-func isKnownRequestMethod(method mcp.MCPMethod) bool {
-	switch method {
-	case mcp.MethodInitialize,
-		mcp.MethodPing,
-		mcp.MethodSetLogLevel,
-		mcp.MethodResourcesList,
-		mcp.MethodResourcesTemplatesList,
-		mcp.MethodResourcesRead,
-		mcp.MethodPromptsList,
-		mcp.MethodPromptsGet,
-		mcp.MethodToolsList,
-		mcp.MethodToolsCall:
-		return true
-	default:
-		return false
-	}
-}
-
 func methodErrorType(err error) string {
 	if err == nil {
 		return ""
@@ -513,6 +436,10 @@ func methodErrorType(err error) string {
 
 	var unparsable *server.UnparsableMessageError
 	switch {
+	case errors.Is(err, context.DeadlineExceeded):
+		return "timeout"
+	case errors.Is(err, context.Canceled):
+		return "cancelled"
 	case errors.As(err, &unparsable):
 		return "parse"
 	case errors.Is(err, server.ErrUnsupported):
@@ -551,7 +478,7 @@ func (m *MCPServer) beginMethodObservation(ctx context.Context, id any, method m
 // unmarshal-path fallback. Returns false only when no observation was ever
 // stored for this key — that's the "OnError without BeforeAny" path (e.g.,
 // mcp-go unmarshal failures in request_handler.go), where the caller SHOULD
-// fallback to synthesize a one-shot emission so the method span gets ended.
+// fallback to synthesize a one-shot metric emission.
 func (m *MCPServer) finishMethodObservation(ctx context.Context, id any, method mcp.MCPMethod, message any, err error) bool {
 	if !shouldObserveMethod(method) {
 		return false
@@ -598,14 +525,14 @@ func (m *MCPServer) expireMethodObservation(key string) {
 	}
 
 	ctxErr := observation.ctx.Err()
-	expireErr := errors.New("request context ended before success/error hook")
-	if ctxErr != nil {
-		expireErr = fmt.Errorf("%w: %v", expireErr, ctxErr)
+	expireErr := error(ctxErr)
+	if expireErr == nil {
+		expireErr = errors.New("request context ended before success/error hook")
 	}
 	m.completeMethodObservation(observation, expireErr)
 
 	logCtx := context.WithoutCancel(observation.ctx)
-	attrs := []any{slog.String("mcp.method.name", string(observation.method))}
+	attrs := []any{slog.String("mcp.method.name", otelpkg.NormalizeMCPMethod(string(observation.method)))}
 	if ctxErr != nil {
 		attrs = append(attrs, slog.String("context_error", ctxErr.Error()))
 	}
@@ -626,8 +553,7 @@ func (m *MCPServer) expireMethodObservation(key string) {
 // paths where BeforeAny never fired (mcp-go unmarshal-failure OnError invocations
 // and "notification channel blocked" operational errors — see mcp-go
 // request_handler.go and session.go). Without this, the method span started in
-// methodSpanMiddleware would leak and the error would be invisible in
-// mcp.method.calls.
+// mcp.method.calls would otherwise miss the failure.
 func (m *MCPServer) completeMethodObservationFallback(ctx context.Context, method mcp.MCPMethod, err error) {
 	observation := &methodObservation{
 		ctx:     ctx,
@@ -648,9 +574,6 @@ func (m *MCPServer) completeMethodObservation(observation *methodObservation, er
 	ctx := context.WithoutCancel(observation.ctx)
 	span := trace.SpanFromContext(ctx)
 	spanAttrs := []attribute.KeyValue{}
-	if session := server.ClientSessionFromContext(ctx); session != nil && session.SessionID() != "" {
-		spanAttrs = append(spanAttrs, otelpkg.MCPSessionIDKey.String(session.SessionID()))
-	}
 	spanAttrs = otelpkg.AppendTenantURL(ctx, spanAttrs)
 	spanAttrs = otelpkg.AppendCallerCorrelation(ctx, spanAttrs)
 
@@ -664,7 +587,7 @@ func (m *MCPServer) completeMethodObservation(observation *methodObservation, er
 
 	if m.meters != nil {
 		metricAttrs := []attribute.KeyValue{
-			attribute.String("mcp.method.name", string(observation.method)),
+			attribute.String("mcp.method.name", otelpkg.NormalizeMCPMethod(string(observation.method))),
 		}
 		metricAttrs = otelpkg.AppendTenantURL(ctx, metricAttrs)
 		metricAttrs = otelpkg.AppendClientSource(ctx, metricAttrs)
@@ -676,112 +599,14 @@ func (m *MCPServer) completeMethodObservation(observation *methodObservation, er
 		m.meters.MethodCalls.Add(ctx, 1, opts)
 		m.meters.MethodDuration.Record(ctx, float64(time.Since(observation.started))/float64(time.Millisecond), opts)
 	}
-
-	span.End()
-}
-
-func (m *MCPServer) startMethodSpan(ctx context.Context, method mcp.MCPMethod) (context.Context, trace.Span) {
-	attrs := []attribute.KeyValue{
-		otelpkg.MCPMethodKey.String(string(method)),
-	}
-	if signozURL, ok := util.GetSigNozURL(ctx); ok && signozURL != "" {
-		attrs = append(attrs, otelpkg.MCPTenantURLKey.String(signozURL))
-	}
-	attrs = otelpkg.AppendCallerCorrelation(ctx, attrs)
-
-	return otel.Tracer("signoz-mcp-server").Start(ctx, "MCP "+string(method),
-		trace.WithSpanKind(trace.SpanKindServer),
-		trace.WithAttributes(attrs...),
-	)
-}
-
-func methodFromJSONRPCMessage(message []byte) (mcp.MCPMethod, bool) {
-	var envelope struct {
-		JSONRPC string        `json:"jsonrpc"`
-		Method  mcp.MCPMethod `json:"method"`
-		ID      any           `json:"id,omitempty"`
-		Result  any           `json:"result,omitempty"`
-	}
-
-	if err := json.Unmarshal(message, &envelope); err != nil {
-		return "", false
-	}
-	if envelope.JSONRPC != mcp.JSONRPC_VERSION || envelope.ID == nil || envelope.Result != nil {
-		return "", false
-	}
-	if !isKnownRequestMethod(envelope.Method) {
-		return "", false
-	}
-	if !shouldObserveMethod(envelope.Method) {
-		return "", false
-	}
-
-	return envelope.Method, true
-}
-
-type delegatedReadCloser struct {
-	io.Reader
-	io.Closer
-}
-
-func (m *MCPServer) peekMethodSpanBody(body io.ReadCloser) ([]byte, io.ReadCloser, bool, error) {
-	if body == nil {
-		return nil, nil, false, nil
-	}
-
-	limited := &io.LimitedReader{R: body, N: m.maxMethodSpanBodyBytes + 1}
-	prefix, err := io.ReadAll(limited)
-	reconstructed := delegatedReadCloser{
-		Reader: io.MultiReader(bytes.NewReader(prefix), body),
-		Closer: body,
-	}
-	if err != nil {
-		return nil, reconstructed, false, err
-	}
-	if int64(len(prefix)) > m.maxMethodSpanBodyBytes {
-		return nil, reconstructed, true, nil
-	}
-	return prefix, reconstructed, false, nil
-}
-
-func (m *MCPServer) methodSpanMiddleware(next http.Handler) http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != http.MethodPost || r.Body == nil {
-			next.ServeHTTP(w, r)
-			return
-		}
-
-		body, reconstructed, oversized, err := m.peekMethodSpanBody(r.Body)
-		if reconstructed != nil {
-			r.Body = reconstructed
-		}
-		if err != nil {
-			next.ServeHTTP(w, r)
-			return
-		}
-		if oversized {
-			next.ServeHTTP(w, r)
-			return
-		}
-
-		method, ok := methodFromJSONRPCMessage(body)
-		if !ok {
-			next.ServeHTTP(w, r)
-			return
-		}
-
-		ctx, _ := m.startMethodSpan(r.Context(), method)
-		next.ServeHTTP(w, r.WithContext(ctx))
-	})
 }
 
 // maxBytesMiddleware bounds an inbound /mcp request body (config.MaxRequestBytes,
 // default 4 MiB; env MCP_MAX_REQUEST_BYTES) so one oversized POST can't OOM the
 // shared pod: a declared over-cap Content-Length is rejected early with 413,
 // otherwise MaxBytesReader bounds the (possibly chunked) stream and an over-cap
-// read surfaces downstream as mcp-go's JSON-RPC parse error. Outermost /mcp
-// middleware, so the cap also covers the methodSpanMiddleware peek. The limit<=0
-// guard is defensive for directly-constructed configs (e.g. tests).
+// read surfaces downstream as mcp-go's JSON-RPC parse error. The limit<=0 guard
+// is defensive for directly-constructed configs (e.g. tests).
 func (m *MCPServer) maxBytesMiddleware(next http.Handler) http.Handler {
 	limit := int64(m.config.MaxRequestBytes)
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -805,29 +630,37 @@ func (m *MCPServer) buildHooks() *server.Hooks {
 		m.beginMethodObservation(ctx, id, method, message)
 		span := trace.SpanFromContext(ctx)
 		spanAttrs := []attribute.KeyValue{}
-		if session := server.ClientSessionFromContext(ctx); session != nil && session.SessionID() != "" {
-			spanAttrs = append(spanAttrs, otelpkg.MCPSessionIDKey.String(session.SessionID()))
+		if method == mcp.MethodToolsCall {
+			span.SetName(string(mcp.MethodToolsCall))
+			spanAttrs = append(spanAttrs,
+				otelpkg.MCPMethodKey.String(string(mcp.MethodToolsCall)),
+				otelpkg.GenAIOperationNameKey.String("execute_tool"),
+			)
 		}
 		spanAttrs = otelpkg.AppendTenantURL(ctx, spanAttrs)
 		spanAttrs = otelpkg.AppendCallerCorrelation(ctx, spanAttrs)
 		if len(spanAttrs) > 0 {
 			span.SetAttributes(spanAttrs...)
 		}
-		m.logger.DebugContext(ctx, "mcp request", slog.String("mcp.method.name", string(method)))
+		m.logger.DebugContext(ctx, "mcp request", slog.String("mcp.method.name", otelpkg.NormalizeMCPMethod(string(method))))
 	})
 	hooks.AddOnSuccess(func(ctx context.Context, id any, method mcp.MCPMethod, message any, result any) {
-		if !m.finishMethodObservation(ctx, id, method, message, nil) && shouldObserveMethod(method) {
-			trace.SpanFromContext(ctx).End()
+		if method == mcp.MethodToolsCall {
+			m.completeUnobservedToolCall(ctx, result, nil)
+			return
 		}
+		m.finishMethodObservation(ctx, id, method, message, nil)
 	})
 	hooks.AddOnError(func(ctx context.Context, id any, method mcp.MCPMethod, message any, err error) {
-		if shouldObserveMethod(method) {
+		if method == mcp.MethodToolsCall {
+			m.completeUnobservedToolCall(ctx, nil, err)
+		} else if shouldObserveMethod(method) {
 			// finish returns true iff a matching observation existed (even if
 			// expireMethodObservation already emitted on the race path — the
 			// tombstone prevents double-count). It returns false only when
 			// BeforeAny never stored one (mcp-go unmarshal-failure paths), in
-			// which case we synthesize a one-shot emission so the method span
-			// gets ended and mcp.method.calls records the failure.
+			// which case we synthesize a one-shot emission so
+			// mcp.method.calls records the failure.
 			if !m.finishMethodObservation(ctx, id, method, message, err) {
 				m.completeMethodObservationFallback(ctx, method, err)
 			}
@@ -840,66 +673,39 @@ func (m *MCPServer) buildHooks() *server.Hooks {
 			span.SetStatus(codes.Error, err.Error())
 		}
 		m.logger.ErrorContext(ctx, "mcp error",
-			slog.String("mcp.method.name", string(method)),
+			slog.String("mcp.method.name", otelpkg.NormalizeMCPMethod(string(method))),
 			logpkg.ErrAttr(err))
 	})
-	// Analytics: track session registration after successful initialize.
-	// Uses AfterInitialize (not BeforeAny) so failed initializations are not counted.
 	hooks.AddAfterInitialize(func(ctx context.Context, id any, message *mcp.InitializeRequest, result *mcp.InitializeResult) {
-		if m.meters != nil {
-			attrs := otelpkg.AppendTenantURL(ctx, nil)
-			attrs = otelpkg.AppendClientSource(ctx, attrs)
-			m.meters.SessionRegistered.Add(ctx, 1, metric.WithAttributes(attrs...))
+		signozURL, ok := util.GetSigNozURL(ctx)
+		if !ok || signozURL == "" {
+			return
 		}
 
-		var sessionID string
-		if session := server.ClientSessionFromContext(ctx); session != nil {
-			sessionID = session.SessionID()
+		props := map[string]any{
+			analytics.AttrTenantURL: signozURL,
 		}
-
-		if signozURL, ok := util.GetSigNozURL(ctx); ok && signozURL != "" {
-			traits := map[string]any{
-				analytics.AttrTenantURL: signozURL,
+		if message != nil {
+			if name := message.Params.ClientInfo.Name; name != "" {
+				props[analytics.AttrClientName] = name
 			}
-			props := map[string]any{
-				analytics.AttrTenantURL: signozURL,
+			if clientVersion := message.Params.ClientInfo.Version; clientVersion != "" {
+				props[analytics.AttrClientVersion] = clientVersion
 			}
-			if sessionID != "" {
-				props[analytics.AttrSessionID] = sessionID
-			}
-			if message != nil && message.Params.ProtocolVersion != "" {
-				props[analytics.AttrProtocolVersion] = message.Params.ProtocolVersion
-				traits[analytics.AttrProtocolVersion] = message.Params.ProtocolVersion
-			}
-			if message != nil {
-				attachClientInfo(traits, message.Params.ClientInfo)
-				attachClientInfo(props, message.Params.ClientInfo)
-			}
-			attachCallerCorrelation(ctx, props)
-			m.identifyAndTrackAsync(ctx, analytics.EventSessionRegistered, traits, props)
 		}
-	})
-	hooks.AddOnRegisterSession(func(ctx context.Context, _ server.ClientSession) {
-		m.logger.InfoContext(ctx, "mcp session registered")
-
-		if signozURL, ok := util.GetSigNozURL(ctx); ok && signozURL != "" {
-			traits := map[string]any{
-				analytics.AttrTenantURL: signozURL,
-			}
-			m.identifyAsync(ctx, traits)
+		if result != nil && result.ProtocolVersion != "" {
+			props[analytics.AttrProtocolVersion] = result.ProtocolVersion
+		} else if message != nil && message.Params.ProtocolVersion != "" {
+			props[analytics.AttrProtocolVersion] = message.Params.ProtocolVersion
 		}
-	})
-	hooks.AddOnUnregisterSession(func(ctx context.Context, _ server.ClientSession) {
-		m.logger.InfoContext(ctx, "mcp session unregistered")
+		attachCallerCorrelation(ctx, props)
+		m.trackEventAsync(ctx, analytics.EventClientInitialized, props)
 	})
 	hooks.AddAfterGetPrompt(func(ctx context.Context, id any, message *mcp.GetPromptRequest, result *mcp.GetPromptResult) {
 		if signozURL, ok := util.GetSigNozURL(ctx); ok && signozURL != "" {
 			props := map[string]any{
 				analytics.AttrTenantURL:  signozURL,
 				analytics.AttrPromptName: message.Params.Name,
-			}
-			if session := server.ClientSessionFromContext(ctx); session != nil && session.SessionID() != "" {
-				props[analytics.AttrSessionID] = session.SessionID()
 			}
 			attachCallerCorrelation(ctx, props)
 			m.trackEventAsync(ctx, analytics.EventPromptFetched, props)
@@ -911,9 +717,6 @@ func (m *MCPServer) buildHooks() *server.Hooks {
 				analytics.AttrTenantURL:   signozURL,
 				analytics.AttrResourceURI: message.Params.URI,
 			}
-			if session := server.ClientSessionFromContext(ctx); session != nil && session.SessionID() != "" {
-				props[analytics.AttrSessionID] = session.SessionID()
-			}
 			attachCallerCorrelation(ctx, props)
 			m.trackEventAsync(ctx, analytics.EventResourceFetched, props)
 		}
@@ -922,18 +725,13 @@ func (m *MCPServer) buildHooks() *server.Hooks {
 }
 
 // loggingMiddleware returns a tool handler middleware that logs tool call
-// start/finish with duration, tool name, session ID, and search context.
-// It also creates an OTel span with GenAI semantic convention attributes.
+// start/finish with duration, tool name, and search context. It decorates the
+// request span created by mcp-go with MCP and GenAI semantic attributes.
 func (m *MCPServer) loggingMiddleware() server.ToolHandlerMiddleware {
-	tracer := otel.Tracer("signoz-mcp-server")
 	return func(next server.ToolHandlerFunc) server.ToolHandlerFunc {
 		return func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 			start := time.Now()
-
-			// Extract session ID from mcp-go client session.
-			if session := server.ClientSessionFromContext(ctx); session != nil {
-				ctx = util.SetSessionID(ctx, session.SessionID())
-			}
+			otelpkg.MarkMCPToolHandlerObserved(ctx)
 
 			// Extract searchContext from tool arguments (LLM-provided).
 			if args, ok := req.Params.Arguments.(map[string]any); ok {
@@ -944,22 +742,17 @@ func (m *MCPServer) loggingMiddleware() server.ToolHandlerMiddleware {
 
 			ctx = util.SetToolName(ctx, req.Params.Name)
 
-			// Create a span for this tool call with GenAI semantic attributes.
-			ctx, span := tracer.Start(ctx, "execute_tool",
-				trace.WithSpanKind(trace.SpanKindServer),
-				trace.WithAttributes(
-					otelpkg.GenAIOperationNameKey.String("execute_tool"),
-					otelpkg.GenAIToolNameKey.String(req.Params.Name),
-				))
-			defer span.End()
-
-			// Use the span's own span ID as the tool call ID.
-			span.SetAttributes(otelpkg.GenAIToolCallIDKey.String(span.SpanContext().SpanID().String()))
+			// mcp-go owns the request span lifetime. Decorate that MCP server span
+			// with the low-cardinality tool target and GenAI compatibility attrs.
+			span := trace.SpanFromContext(ctx)
+			span.SetName("tools/call " + req.Params.Name)
+			span.SetAttributes(
+				otelpkg.MCPMethodKey.String(string(mcp.MethodToolsCall)),
+				otelpkg.GenAIOperationNameKey.String("execute_tool"),
+				otelpkg.GenAIToolNameKey.String(req.Params.Name),
+			)
 
 			extraAttrs := []attribute.KeyValue{}
-			if sid, ok := util.GetSessionID(ctx); ok && sid != "" {
-				extraAttrs = append(extraAttrs, otelpkg.MCPSessionIDKey.String(sid))
-			}
 			if sc, ok := util.GetSearchContext(ctx); ok && sc != "" {
 				extraAttrs = append(extraAttrs, otelpkg.MCPSearchContextKey.String(sc))
 			}
@@ -974,7 +767,15 @@ func (m *MCPServer) loggingMiddleware() server.ToolHandlerMiddleware {
 
 			// Determine error status: either a Go error or an MCP tool result error.
 			isErr := err != nil || (result != nil && result.IsError)
+			errorType := toolOTelErrorType(err, result)
+			errorCode := toolerrors.Code(result)
 			span.SetAttributes(otelpkg.MCPToolIsErrorKey.Bool(isErr))
+			if errorType != "" {
+				span.SetAttributes(attribute.String("error.type", errorType))
+			}
+			if errorCode != "" {
+				span.SetAttributes(otelpkg.MCPToolErrorCodeKey.String(errorCode))
+			}
 			// Always emit the result size — even zero — so it matches the log
 			// field and downstream aggregations (avg, histogram) don't drop
 			// empty-result tool calls as nulls.
@@ -1011,39 +812,119 @@ func (m *MCPServer) loggingMiddleware() server.ToolHandlerMiddleware {
 					sizeAttr)
 			}
 
-			if m.meters != nil {
-				attrKVs := []attribute.KeyValue{
-					attribute.String("gen_ai.tool.name", req.Params.Name),
-					attribute.Bool("mcp.tool.is_error", isErr),
-				}
-				attrKVs = otelpkg.AppendTenantURL(ctx, attrKVs)
-				attrKVs = otelpkg.AppendClientSource(ctx, attrKVs)
-				attrs := metric.WithAttributes(attrKVs...)
-				m.meters.ToolCalls.Add(ctx, 1, attrs)
-				m.meters.ToolCallDuration.Record(ctx, float64(duration)/float64(time.Millisecond), attrs)
-			}
-
-			// Analytics: track tool call
-			if signozURL, ok := util.GetSigNozURL(ctx); ok && signozURL != "" {
-				props := map[string]any{
-					analytics.AttrTenantURL:   signozURL,
-					analytics.AttrToolName:    req.Params.Name,
-					analytics.AttrToolIsError: isErr,
-					analytics.AttrDurationMs:  time.Since(start).Milliseconds(),
-				}
-				if sid, ok := util.GetSessionID(ctx); ok && sid != "" {
-					props[analytics.AttrSessionID] = sid
-				}
-				if errorType := toolErrorType(err, result); errorType != "" {
-					props[analytics.AttrErrorType] = errorType
-				}
-				attachCallerCorrelation(ctx, props)
-				m.trackEventAsync(ctx, analytics.EventToolCalled, props)
-			}
+			m.recordToolMetrics(ctx, req.Params.Name, isErr, errorType, errorCode, duration)
+			m.trackToolCall(ctx, req.Params.Name, isErr, duration, toolErrorType(err, result))
 
 			return result, err
 		}
 	}
+}
+
+// completeUnobservedToolCall covers SDK rejections that occur before the
+// registered tool middleware can run, such as unknown or filtered tool names.
+func (m *MCPServer) completeUnobservedToolCall(ctx context.Context, rawResult any, err error) {
+	started, handlerObserved, ok := otelpkg.MCPToolRequestObservation(ctx)
+	if !ok || handlerObserved {
+		return
+	}
+
+	result, _ := rawResult.(*mcp.CallToolResult)
+	isErr := err != nil || (result != nil && result.IsError)
+	errorType := methodErrorType(err)
+	if err == nil {
+		errorType = toolOTelErrorType(nil, result)
+	}
+	errorCode := toolerrors.Code(result)
+	resultBytes := approxResultBytes(result)
+
+	span := trace.SpanFromContext(ctx)
+	span.SetName(string(mcp.MethodToolsCall))
+	spanAttrs := []attribute.KeyValue{
+		otelpkg.MCPMethodKey.String(string(mcp.MethodToolsCall)),
+		otelpkg.GenAIOperationNameKey.String("execute_tool"),
+		otelpkg.GenAIToolNameKey.String(unknownToolName),
+		otelpkg.MCPToolIsErrorKey.Bool(isErr),
+		otelpkg.MCPToolResultBytesKey.Int64(resultBytes),
+	}
+	if errorType != "" {
+		spanAttrs = append(spanAttrs, attribute.String("error.type", errorType))
+	}
+	if errorCode != "" {
+		spanAttrs = append(spanAttrs, otelpkg.MCPToolErrorCodeKey.String(errorCode))
+	}
+	span.SetAttributes(spanAttrs...)
+	if err != nil {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, err.Error())
+	} else if result != nil && result.IsError {
+		errMsg := extractToolErrorMessage(result)
+		span.RecordError(errors.New(errMsg))
+		span.SetStatus(codes.Error, errMsg)
+	}
+
+	duration := time.Since(started)
+	m.recordToolMetrics(ctx, unknownToolName, isErr, errorType, errorCode, duration)
+	analyticsErrorType := errorType
+	if err == nil {
+		analyticsErrorType = toolErrorType(nil, result)
+	}
+	m.trackToolCall(ctx, unknownToolName, isErr, duration, analyticsErrorType)
+}
+
+func (m *MCPServer) recordToolMetrics(ctx context.Context, toolName string, isErr bool, errorType, errorCode string, duration time.Duration) {
+	if m.meters == nil {
+		return
+	}
+	attrKVs := []attribute.KeyValue{
+		otelpkg.GenAIToolNameKey.String(toolName),
+		otelpkg.MCPToolIsErrorKey.Bool(isErr),
+	}
+	if errorType != "" {
+		attrKVs = append(attrKVs, attribute.String("error.type", errorType))
+	}
+	if errorCode != "" {
+		attrKVs = append(attrKVs, otelpkg.MCPToolErrorCodeKey.String(errorCode))
+	}
+	attrKVs = otelpkg.AppendTenantURL(ctx, attrKVs)
+	attrKVs = otelpkg.AppendClientSource(ctx, attrKVs)
+	opts := metric.WithAttributes(attrKVs...)
+	m.meters.ToolCalls.Add(ctx, 1, opts)
+	m.meters.ToolCallDuration.Record(ctx, float64(duration)/float64(time.Millisecond), opts)
+}
+
+func (m *MCPServer) trackToolCall(ctx context.Context, toolName string, isErr bool, duration time.Duration, errorType string) {
+	signozURL, ok := util.GetSigNozURL(ctx)
+	if !ok || signozURL == "" {
+		return
+	}
+	props := map[string]any{
+		analytics.AttrTenantURL:   signozURL,
+		analytics.AttrToolName:    toolName,
+		analytics.AttrToolIsError: isErr,
+		analytics.AttrDurationMs:  duration.Milliseconds(),
+	}
+	if errorType != "" {
+		props[analytics.AttrErrorType] = errorType
+	}
+	attachCallerCorrelation(ctx, props)
+	m.trackEventAsync(ctx, analytics.EventToolCalled, props)
+}
+
+func toolOTelErrorType(err error, result *mcp.CallToolResult) string {
+	if err != nil {
+		switch {
+		case errors.Is(err, context.DeadlineExceeded):
+			return "timeout"
+		case errors.Is(err, context.Canceled):
+			return "cancelled"
+		default:
+			return "internal"
+		}
+	}
+	if result != nil && result.IsError {
+		return "tool_error"
+	}
+	return ""
 }
 
 // extractToolErrorMessage returns the text from the first Content entry of an
@@ -1061,6 +942,7 @@ func extractToolErrorMessage(result *mcp.CallToolResult) string {
 
 // toolErrorType classifies a tool-call failure into a small, bounded set of
 // categories so dashboards can split errors without exploding cardinality.
+// Structured result codes are authoritative; display text is never parsed.
 // Returns "" when there is no error.
 func toolErrorType(err error, result *mcp.CallToolResult) string {
 	if err != nil {
@@ -1075,20 +957,10 @@ func toolErrorType(err error, result *mcp.CallToolResult) string {
 	if result == nil || !result.IsError {
 		return ""
 	}
-
-	msg := strings.ToLower(extractToolErrorMessage(result))
-	switch {
-	case strings.Contains(msg, "timeout") || strings.Contains(msg, "deadline exceeded"):
-		return "timeout"
-	case strings.Contains(msg, "unauthorized") || strings.Contains(msg, "status 401") || strings.Contains(msg, "status 403"):
-		return "unauthorized"
-	case strings.Contains(msg, "status 4"):
-		return "upstream_4xx"
-	case strings.Contains(msg, "status 5"):
-		return "upstream_5xx"
-	default:
-		return "tool_error"
+	if code := toolerrors.Code(result); code != "" {
+		return strings.ToLower(code)
 	}
+	return "tool_error"
 }
 
 // approxResultBytes sums the length of text content entries in a tool result.
@@ -1189,9 +1061,6 @@ func httpRequestSpanAttrs(r *http.Request) []attribute.KeyValue {
 	if userAgent := util.HTTPUserAgent(r); userAgent != "" {
 		attrs = append(attrs, attribute.String("user_agent.original", userAgent))
 	}
-	if sessionID := util.HTTPSessionID(r); sessionID != "" {
-		attrs = append(attrs, otelpkg.MCPSessionIDKey.String(sessionID))
-	}
 	return attrs
 }
 
@@ -1234,7 +1103,7 @@ func (m *MCPServer) logAuthFailure(ctx context.Context, r *http.Request, status 
 		slog.String("mcp.auth.failure_reason", reason),
 		slog.String("mcp.auth.mode", authMode),
 	}
-	logAttrs = append(logAttrs, logpkg.MCPHTTPRequestAttrs(r)...)
+	logAttrs = append(logAttrs, logpkg.HTTPRequestAttrs(r)...)
 	logAttrs = append(logAttrs, attrs...)
 	level := slog.LevelWarn
 	if reason == authFailureExpiredOAuthToken || reason == authFailureMissingCredential {
@@ -1471,7 +1340,7 @@ func (m *MCPServer) buildHTTP(s *server.MCPServer) *http.Server {
 	// WithHeartbeatInterval is kept: clients may still open a GET listening stream
 	// and the heartbeat keeps it alive through proxies.
 	mcpHandler := server.NewStreamableHTTPServer(s, m.streamableHTTPOptions()...)
-	mux.Handle("/mcp", m.maxBytesMiddleware(m.authMiddleware(m.methodSpanMiddleware(mcpHandler))))
+	mux.Handle("/mcp", m.maxBytesMiddleware(m.authMiddleware(mcpHandler)))
 
 	m.logger.Info("Listening for MCP clients",
 		slog.String("addr", addr),

--- a/internal/mcp-server/server_test.go
+++ b/internal/mcp-server/server_test.go
@@ -199,6 +199,13 @@ func spanAttrValue(attrs []attribute.KeyValue, key attribute.Key) (attribute.Val
 	return attribute.Value{}, false
 }
 
+func startTestMCPSpan(ctx context.Context, method mcp.MCPMethod) (context.Context, trace.Span) {
+	return otel.Tracer("signoz-mcp-server").Start(ctx, string(method),
+		trace.WithSpanKind(trace.SpanKindServer),
+		trace.WithAttributes(otelpkg.MCPMethodKey.String(string(method))),
+	)
+}
+
 func singleHook[T any](t *testing.T, hooks []T, name string) T {
 	t.Helper()
 	if len(hooks) != 1 {
@@ -695,7 +702,7 @@ func TestAuthMiddlewareLogsAndSpansAuthFailureTelemetry(t *testing.T) {
 	req.RemoteAddr = "203.0.113.10:54321"
 	req.Header.Set("X-Forwarded-For", "198.51.100.7, 10.0.0.2")
 	req.Header.Set("User-Agent", "claude-code/2.1.133 (cli)")
-	req.Header.Set(util.HeaderMCPSessionID, "mcp-session-test")
+	req.Header.Set("Mcp-Session-Id", "mcp-session-test")
 	rr := httptest.NewRecorder()
 
 	server.authMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -739,8 +746,8 @@ func TestAuthMiddlewareLogsAndSpansAuthFailureTelemetry(t *testing.T) {
 	if rec["user_agent.original"] != "claude-code/2.1.133 (cli)" {
 		t.Fatalf("user_agent.original = %v, want claude-code user agent", rec["user_agent.original"])
 	}
-	if rec["mcp.session.id"] != "mcp-session-test" {
-		t.Fatalf("mcp.session.id = %v, want mcp-session-test", rec["mcp.session.id"])
+	if _, ok := rec["mcp.session.id"]; ok {
+		t.Fatalf("mcp.session.id must not be logged in stateless mode: %#v", rec)
 	}
 	if rec["mcp.client_source"] != util.ClientSourceUserClient {
 		t.Fatalf("mcp.client_source = %v, want %s", rec["mcp.client_source"], util.ClientSourceUserClient)
@@ -759,7 +766,6 @@ func TestAuthMiddlewareLogsAndSpansAuthFailureTelemetry(t *testing.T) {
 		"server.address":          "mcp.us.signoz.cloud",
 		"client.address":          "198.51.100.7",
 		"user_agent.original":     "claude-code/2.1.133 (cli)",
-		otelpkg.MCPSessionIDKey:   "mcp-session-test",
 	} {
 		got, ok := spanAttrValue(attrs, key)
 		if !ok {
@@ -768,6 +774,9 @@ func TestAuthMiddlewareLogsAndSpansAuthFailureTelemetry(t *testing.T) {
 		if got.AsString() != want {
 			t.Fatalf("span attr %s = %q, want %q", key, got.AsString(), want)
 		}
+	}
+	if _, ok := spanAttrValue(attrs, attribute.Key("mcp.session.id")); ok {
+		t.Fatal("mcp.session.id must not be attached from an incoming header")
 	}
 	gotStatus, ok := spanAttrValue(attrs, "http.response.status_code")
 	if !ok {
@@ -1056,7 +1065,7 @@ func TestAuthMiddlewareMissingCredentialsLogsDebugAndRecordsAuthFailureMetric(t 
 	}
 }
 
-func TestBuildHooks_APIKeyAnalyticsUseServiceAccountIdentity(t *testing.T) {
+func TestToolAnalyticsUseServiceAccountIdentity(t *testing.T) {
 	var requests atomic.Int32
 	sigNoz := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requests.Add(1)
@@ -1080,39 +1089,38 @@ func TestBuildHooks_APIKeyAnalyticsUseServiceAccountIdentity(t *testing.T) {
 	handler := tools.NewHandler(logpkg.New("error"), cfg)
 	spy := &spyAnalytics{enabled: true}
 	mcpServer := NewMCPServer(logpkg.New("error"), handler, cfg, spy, nil)
-	hooks := mcpServer.buildHooks()
 
 	ctx := context.Background()
 	ctx = util.SetAPIKey(ctx, "test-api-key")
 	ctx = util.SetAuthHeader(ctx, "SIGNOZ-API-KEY")
 	ctx = util.SetSigNozURL(ctx, sigNoz.URL)
 
-	session := fakeSession{id: "sess-api", ch: make(chan mcp.JSONRPCNotification, 1)}
-	hooks.RegisterSession(ctx, session)
-	hooks.UnregisterSession(ctx, session)
+	_, err := mcpServer.loggingMiddleware()(func(context.Context, mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		return &mcp.CallToolResult{}, nil
+	})(ctx, mcp.CallToolRequest{Params: mcp.CallToolParams{Name: "signoz_list_services"}})
+	if err != nil {
+		t.Fatalf("middleware error = %v", err)
+	}
 
 	waitForCondition(t, time.Second, func() bool {
 		identifyCalls, trackCalls := spy.snapshot()
-		// RegisterSession fires one Identify; UnregisterSession is a no-op
-		// for analytics so trackCalls stays empty.
-		return requests.Load() >= 1 && len(identifyCalls) == 1 && len(trackCalls) == 0
+		return requests.Load() >= 1 && len(identifyCalls) == 0 && len(trackCalls) == 1
 	}, "timed out waiting for async API-key analytics")
 
 	identifyCalls, trackCalls := spy.snapshot()
-
-	if len(trackCalls) != 0 {
-		t.Fatalf("expected no track calls on UnregisterSession, got %d", len(trackCalls))
+	if len(identifyCalls) != 0 {
+		t.Fatalf("expected no session-derived identify calls, got %d", len(identifyCalls))
 	}
 
-	identify := identifyCalls[0]
-	if identify.groupID != "org-456" || identify.userID != "sa-123" {
-		t.Fatalf("identify user args = (%q, %q), want (%q, %q)", identify.groupID, identify.userID, "org-456", "sa-123")
+	toolCall := trackCalls[0]
+	if toolCall.groupID != "org-456" || toolCall.userID != "sa-123" {
+		t.Fatalf("track user args = (%q, %q), want (%q, %q)", toolCall.groupID, toolCall.userID, "org-456", "sa-123")
 	}
-	if identify.attrs[analytics.AttrOrgID] != "org-456" || identify.attrs[analytics.AttrPrincipal] != "service_account" || identify.attrs[analytics.AttrEmail] != "service@example.com" {
-		t.Fatalf("identify attrs = %#v, want orgId, principal, and email", identify.attrs)
+	if toolCall.attrs[analytics.AttrOrgID] != "org-456" || toolCall.attrs[analytics.AttrPrincipal] != "service_account" || toolCall.attrs[analytics.AttrEmail] != "service@example.com" {
+		t.Fatalf("tool attrs = %#v, want orgId, principal, and email", toolCall.attrs)
 	}
-	if identify.attrs[analytics.AttrName] != "ingest-bot" {
-		t.Fatalf("identify name = %v, want ingest-bot", identify.attrs[analytics.AttrName])
+	if toolCall.attrs[analytics.AttrName] != "ingest-bot" {
+		t.Fatalf("tool name = %v, want ingest-bot", toolCall.attrs[analytics.AttrName])
 	}
 }
 
@@ -1139,7 +1147,6 @@ func TestUserScopedAnalyticsUseJWTIdentity(t *testing.T) {
 	handler := tools.NewHandler(logpkg.New("error"), cfg)
 	spy := &spyAnalytics{enabled: true}
 	mcpServer := NewMCPServer(logpkg.New("error"), handler, cfg, spy, nil)
-	hooks := mcpServer.buildHooks()
 
 	ctx := context.Background()
 	ctx = util.SetAPIKey(ctx, "Bearer jwt-token")
@@ -1149,8 +1156,6 @@ func TestUserScopedAnalyticsUseJWTIdentity(t *testing.T) {
 	ctx = util.SetClientSource(ctx, "ai-assistant")
 	ctx = util.SetAssistantThreadID(ctx, "thread-abc")
 	ctx = util.SetAssistantExecutionID(ctx, "exec-xyz")
-
-	singleHook(t, hooks.OnAfterInitialize, "OnAfterInitialize")(ctx, nil, &mcp.InitializeRequest{}, &mcp.InitializeResult{})
 
 	middleware := mcpServer.loggingMiddleware()
 	_, err := middleware(func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
@@ -1169,40 +1174,15 @@ func TestUserScopedAnalyticsUseJWTIdentity(t *testing.T) {
 
 	waitForCondition(t, time.Second, func() bool {
 		identifyCalls, trackCalls := spy.snapshot()
-		return requests.Load() >= 1 && len(identifyCalls) == 1 && len(trackCalls) == 2
+		return requests.Load() >= 1 && len(identifyCalls) == 0 && len(trackCalls) == 1
 	}, "timed out waiting for async JWT analytics")
 
 	identifyCalls, trackCalls := spy.snapshot()
-
-	identify := identifyCalls[0]
-	if identify.groupID != "org-123" || identify.userID != "user-123" {
-		t.Fatalf("identify user args = (%q, %q), want (%q, %q)", identify.groupID, identify.userID, "org-123", "user-123")
-	}
-	if identify.attrs[analytics.AttrOrgID] != "org-123" || identify.attrs[analytics.AttrPrincipal] != "user" || identify.attrs[analytics.AttrEmail] != "user@example.com" {
-		t.Fatalf("identify attrs = %#v, want orgId, principal, and email", identify.attrs)
-	}
-	if identify.attrs[analytics.AttrName] != "Ada Lovelace" {
-		t.Fatalf("identify name = %v, want Ada Lovelace", identify.attrs[analytics.AttrName])
+	if len(identifyCalls) != 0 {
+		t.Fatalf("expected no session-derived identify calls, got %d", len(identifyCalls))
 	}
 
-	var registered analyticsCall
-	var toolCall analyticsCall
-	for _, call := range trackCalls {
-		switch call.event {
-		case analytics.EventSessionRegistered:
-			registered = call
-		case analytics.EventToolCalled:
-			toolCall = call
-		}
-	}
-
-	if registered.event != analytics.EventSessionRegistered || registered.groupID != "org-123" || registered.userID != "user-123" {
-		t.Fatalf("registered track call = (%q, %q, %q), want (%q, %q, %q)", registered.groupID, registered.userID, registered.event, "org-123", "user-123", analytics.EventSessionRegistered)
-	}
-	if registered.attrs[analytics.AttrSessionID] != "sess-jwt" {
-		t.Fatalf("registered session attr = %v, want %q", registered.attrs[analytics.AttrSessionID], "sess-jwt")
-	}
-
+	toolCall := trackCalls[0]
 	if toolCall.event != analytics.EventToolCalled || toolCall.groupID != "org-123" || toolCall.userID != "user-123" {
 		t.Fatalf("tool track call = (%q, %q, %q), want (%q, %q, %q)", toolCall.groupID, toolCall.userID, toolCall.event, "org-123", "user-123", analytics.EventToolCalled)
 	}
@@ -1223,15 +1203,6 @@ func TestUserScopedAnalyticsUseJWTIdentity(t *testing.T) {
 	}
 	if toolCall.attrs[analytics.AttrAssistantExecutionID] != "exec-xyz" {
 		t.Fatalf("tool assistantExecutionId attr = %v, want %q", toolCall.attrs[analytics.AttrAssistantExecutionID], "exec-xyz")
-	}
-	if registered.attrs[analytics.AttrClientSource] != "ai-assistant" {
-		t.Fatalf("registered clientSource attr = %v, want %q", registered.attrs[analytics.AttrClientSource], "ai-assistant")
-	}
-	if registered.attrs[analytics.AttrAssistantThreadID] != "thread-abc" {
-		t.Fatalf("registered assistantThreadId attr = %v, want %q", registered.attrs[analytics.AttrAssistantThreadID], "thread-abc")
-	}
-	if registered.attrs[analytics.AttrAssistantExecutionID] != "exec-xyz" {
-		t.Fatalf("registered assistantExecutionId attr = %v, want %q", registered.attrs[analytics.AttrAssistantExecutionID], "exec-xyz")
 	}
 	if toolCall.attrs[analytics.AttrOrgID] != "org-123" || toolCall.attrs[analytics.AttrPrincipal] != "user" || toolCall.attrs[analytics.AttrEmail] != "user@example.com" {
 		t.Fatalf("tool attrs = %#v, want orgId, principal, and email", toolCall.attrs)
@@ -1263,7 +1234,11 @@ func TestAnalyticsDisabledSkipsIdentityLookup(t *testing.T) {
 	ctx = util.SetSigNozURL(ctx, sigNoz.URL)
 	ctx = newAnalyticsTestContext(ctx, "sess-disabled")
 
-	singleHook(t, hooks.OnAfterInitialize, "OnAfterInitialize")(ctx, nil, &mcp.InitializeRequest{}, &mcp.InitializeResult{})
+	singleHook(t, hooks.OnAfterInitialize, "OnAfterInitialize")(ctx, nil, &mcp.InitializeRequest{
+		Params: mcp.InitializeParams{
+			ClientInfo: mcp.Implementation{Name: "test-client", Version: "1.0.0"},
+		},
+	}, &mcp.InitializeResult{ProtocolVersion: "2025-11-25"})
 
 	middleware := mcpServer.loggingMiddleware()
 	_, err := middleware(func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
@@ -1378,11 +1353,7 @@ func meEndpointServer(t *testing.T) *httptest.Server {
 	}))
 }
 
-// TestClientInfoAttachesToSessionRegisteredEvent verifies that under the stateless
-// transport the MCP client name/version land on the session_registered event
-// (taken directly from the InitializeRequest's ClientInfo), but NOT on per-tool-call
-// events — there is no session to correlate later calls against.
-func TestClientInfoAttachesToSessionRegisteredEvent(t *testing.T) {
+func TestClientInitializedEventCarriesClientInfo(t *testing.T) {
 	sigNoz := meEndpointServer(t)
 	defer sigNoz.Close()
 
@@ -1401,55 +1372,47 @@ func TestClientInfoAttachesToSessionRegisteredEvent(t *testing.T) {
 	ctx = util.SetAPIKey(ctx, "test-key")
 	ctx = util.SetAuthHeader(ctx, "SIGNOZ-API-KEY")
 	ctx = util.SetSigNozURL(ctx, sigNoz.URL)
-	ctx = newAnalyticsTestContext(ctx, "sess-client")
+	ctx = util.SetClientSource(ctx, "user-client")
 
 	singleHook(t, hooks.OnAfterInitialize, "OnAfterInitialize")(ctx, nil, &mcp.InitializeRequest{
 		Params: mcp.InitializeParams{
-			ClientInfo: mcp.Implementation{Name: "claude-desktop", Version: "1.2.3"},
+			ProtocolVersion: "2025-06-18",
+			ClientInfo: mcp.Implementation{
+				Name:    "claude-desktop",
+				Version: "1.2.3",
+			},
 		},
-	}, &mcp.InitializeResult{})
-
-	middleware := mcpServer.loggingMiddleware()
-	_, err := middleware(func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-		return &mcp.CallToolResult{}, nil
-	})(ctx, mcp.CallToolRequest{
-		Params: mcp.CallToolParams{Name: "signoz_list_services"},
-	})
-	if err != nil {
-		t.Fatalf("middleware error = %v", err)
-	}
+	}, &mcp.InitializeResult{ProtocolVersion: "2025-11-25"})
 
 	waitForCondition(t, time.Second, func() bool {
-		_, trackCalls := spy.snapshot()
-		return len(trackCalls) == 2
-	}, "timed out waiting for analytics")
+		identifyCalls, trackCalls := spy.snapshot()
+		return len(identifyCalls) == 0 && len(trackCalls) == 1
+	}, "timed out waiting for client-initialized event")
 
-	_, trackCalls := spy.snapshot()
-	var registered, toolCall analyticsCall
-	for _, c := range trackCalls {
-		switch c.event {
-		case analytics.EventSessionRegistered:
-			registered = c
-		case analytics.EventToolCalled:
-			toolCall = c
+	identifyCalls, trackCalls := spy.snapshot()
+	if len(identifyCalls) != 0 {
+		t.Fatalf("identify calls = %d, want 0", len(identifyCalls))
+	}
+	event := trackCalls[0]
+	if event.event != analytics.EventClientInitialized {
+		t.Fatalf("event = %q, want %q", event.event, analytics.EventClientInitialized)
+	}
+	if event.groupID != "org-1" || event.userID != "sa-1" {
+		t.Fatalf("identity = (%q, %q), want (org-1, sa-1)", event.groupID, event.userID)
+	}
+	for key, want := range map[string]any{
+		analytics.AttrClientName:      "claude-desktop",
+		analytics.AttrClientVersion:   "1.2.3",
+		analytics.AttrProtocolVersion: "2025-11-25",
+		analytics.AttrTenantURL:       sigNoz.URL,
+		analytics.AttrClientSource:    "user-client",
+	} {
+		if got := event.attrs[key]; got != want {
+			t.Fatalf("%s = %v, want %v", key, got, want)
 		}
 	}
-
-	// Client identity is attached to session_registered, sourced directly from
-	// the InitializeRequest's ClientInfo.
-	if registered.attrs[analytics.AttrClientName] != "claude-desktop" {
-		t.Fatalf("registered clientName = %v, want claude-desktop", registered.attrs[analytics.AttrClientName])
-	}
-	if registered.attrs[analytics.AttrClientVersion] != "1.2.3" {
-		t.Fatalf("registered clientVersion = %v, want 1.2.3", registered.attrs[analytics.AttrClientVersion])
-	}
-
-	// Stateless: no session correlation, so per-tool-call events carry no client identity.
-	if _, ok := toolCall.attrs[analytics.AttrClientName]; ok {
-		t.Fatalf("tool-call event should not carry clientName in stateless mode; got %v", toolCall.attrs[analytics.AttrClientName])
-	}
-	if _, ok := toolCall.attrs[analytics.AttrClientVersion]; ok {
-		t.Fatalf("tool-call event should not carry clientVersion in stateless mode; got %v", toolCall.attrs[analytics.AttrClientVersion])
+	if _, ok := event.attrs["sessionId"]; ok {
+		t.Fatal("client-initialized event must not contain sessionId")
 	}
 }
 
@@ -1488,7 +1451,7 @@ func TestBuildHooks_NonToolMethodsRecordSpanAndMetrics(t *testing.T) {
 	ctx := context.Background()
 	ctx = util.SetSigNozURL(ctx, "https://tenant.example.com")
 	ctx = newAnalyticsTestContext(ctx, "sess-init")
-	ctx, span := mcpServer.startMethodSpan(ctx, mcp.MethodInitialize)
+	ctx, span := startTestMCPSpan(ctx, mcp.MethodInitialize)
 
 	req := &mcp.InitializeRequest{}
 	result := &mcp.InitializeResult{}
@@ -1535,14 +1498,11 @@ func TestBuildHooks_NonToolMethodsRecordSpanAndMetrics(t *testing.T) {
 	if len(spans) != 1 {
 		t.Fatalf("span count = %d, want 1", len(spans))
 	}
-	if spans[0].Name != "MCP initialize" {
-		t.Fatalf("span name = %q, want %q", spans[0].Name, "MCP initialize")
+	if spans[0].Name != "initialize" {
+		t.Fatalf("span name = %q, want %q", spans[0].Name, "initialize")
 	}
 	if attr, ok := spanAttrValue(spans[0].Attributes, otelpkg.MCPMethodKey); !ok || attr.AsString() != string(mcp.MethodInitialize) {
 		t.Fatalf("span mcp.method.name = %v, want %q", attr, mcp.MethodInitialize)
-	}
-	if attr, ok := spanAttrValue(spans[0].Attributes, otelpkg.MCPSessionIDKey); !ok || attr.AsString() != "sess-init" {
-		t.Fatalf("span mcp.session.id = %v, want %q", attr, "sess-init")
 	}
 	if attr, ok := spanAttrValue(spans[0].Attributes, otelpkg.MCPTenantURLKey); !ok || attr.AsString() != "https://tenant.example.com" {
 		t.Fatalf("span mcp.tenant_url = %v, want tenant URL", attr)
@@ -1597,7 +1557,7 @@ func TestBuildHooks_NonToolMethodErrorsRecordErrorType(t *testing.T) {
 	hooks := mcpServer.buildHooks()
 
 	ctx := newAnalyticsTestContext(util.SetSigNozURL(context.Background(), "https://tenant.example.com"), "sess-err")
-	ctx, span := mcpServer.startMethodSpan(ctx, mcp.MethodResourcesRead)
+	ctx, span := startTestMCPSpan(ctx, mcp.MethodResourcesRead)
 	req := &mcp.ReadResourceRequest{}
 	methodErr := fmt.Errorf("resources %w", mcpgoserver.ErrUnsupported)
 
@@ -1647,7 +1607,7 @@ func TestBuildHooks_NonToolMethodErrorsRecordErrorType(t *testing.T) {
 	}
 }
 
-func TestBuildHooks_NonToolMethodSuccessEndsSpanWithoutMeters(t *testing.T) {
+func TestBuildHooks_NonToolMethodSuccessDoesNotEndSDKOwnedSpan(t *testing.T) {
 	traceExporter := tracetest.NewInMemoryExporter()
 	traceProvider := sdktrace.NewTracerProvider(sdktrace.WithSyncer(traceExporter))
 	prevTracerProvider := otel.GetTracerProvider()
@@ -1666,19 +1626,22 @@ func TestBuildHooks_NonToolMethodSuccessEndsSpanWithoutMeters(t *testing.T) {
 	hooks := mcpServer.buildHooks()
 
 	ctx := newAnalyticsTestContext(util.SetSigNozURL(context.Background(), "https://tenant.example.com"), "sess-no-meters")
-	ctx, span := mcpServer.startMethodSpan(ctx, mcp.MethodInitialize)
+	ctx, span := startTestMCPSpan(ctx, mcp.MethodInitialize)
 	req := &mcp.InitializeRequest{}
 
 	singleHook(t, hooks.OnBeforeAny, "OnBeforeAny")(ctx, "req-no-meters", mcp.MethodInitialize, req)
 	singleHook(t, hooks.OnSuccess, "OnSuccess")(ctx, "req-no-meters", mcp.MethodInitialize, req, &mcp.InitializeResult{})
+	if got := len(traceExporter.GetSpans()); got != 0 {
+		t.Fatalf("exported spans before SDK-owned End = %d, want 0", got)
+	}
 	span.End()
 
 	spans := traceExporter.GetSpans()
 	if len(spans) != 1 {
 		t.Fatalf("span count = %d, want 1", len(spans))
 	}
-	if spans[0].Name != "MCP initialize" {
-		t.Fatalf("span name = %q, want %q", spans[0].Name, "MCP initialize")
+	if spans[0].Name != "initialize" {
+		t.Fatalf("span name = %q, want %q", spans[0].Name, "initialize")
 	}
 }
 
@@ -1719,7 +1682,7 @@ func TestBuildHooks_NonToolMethodObservationContextCleanupCleansUp(t *testing.T)
 	baseCtx, cancel := context.WithCancel(newAnalyticsTestContext(util.SetSigNozURL(context.Background(), "https://tenant.example.com"), "sess-context-cleanup"))
 	defer cancel()
 	ctx := baseCtx
-	ctx, span := mcpServer.startMethodSpan(ctx, mcp.MethodInitialize)
+	ctx, span := startTestMCPSpan(ctx, mcp.MethodInitialize)
 	req := &mcp.InitializeRequest{}
 	key := methodObservationKey(ctx, "req-context-cleanup", mcp.MethodInitialize, req)
 
@@ -1764,8 +1727,8 @@ func TestBuildHooks_NonToolMethodObservationContextCleanupCleansUp(t *testing.T)
 	if len(methodCalls.DataPoints) != 1 {
 		t.Fatalf("mcp.method.calls datapoints = %d, want 1", len(methodCalls.DataPoints))
 	}
-	if attr, ok := methodCalls.DataPoints[0].Attributes.Value(attribute.Key("error.type")); !ok || attr.AsString() != "internal" {
-		t.Fatalf("error.type = %v, want internal", attr)
+	if attr, ok := methodCalls.DataPoints[0].Attributes.Value(attribute.Key("error.type")); !ok || attr.AsString() != "cancelled" {
+		t.Fatalf("error.type = %v, want cancelled", attr)
 	}
 
 	spans := traceExporter.GetSpans()
@@ -1781,11 +1744,11 @@ func TestBuildHooks_NonToolMethodObservationContextCleanupCleansUp(t *testing.T)
 	if spans[0].Events[0].Name != "exception" {
 		t.Fatalf("span event name = %q, want %q", spans[0].Events[0].Name, "exception")
 	}
-	if attr, ok := spanAttrValue(spans[0].Events[0].Attributes, attribute.Key("exception.message")); !ok || !strings.Contains(attr.AsString(), "request context ended before success/error hook") {
-		t.Fatalf("exception.message = %v, want context cleanup message", attr)
+	if attr, ok := spanAttrValue(spans[0].Events[0].Attributes, attribute.Key("exception.message")); !ok || !strings.Contains(attr.AsString(), context.Canceled.Error()) {
+		t.Fatalf("exception.message = %v, want context cancellation", attr)
 	}
-	if attr, ok := spanAttrValue(spans[0].Attributes, attribute.Key("error.type")); !ok || attr.AsString() != "internal" {
-		t.Fatalf("span error.type = %v, want internal", attr)
+	if attr, ok := spanAttrValue(spans[0].Attributes, attribute.Key("error.type")); !ok || attr.AsString() != "cancelled" {
+		t.Fatalf("span error.type = %v, want cancelled", attr)
 	}
 
 	records := parseJSONLogLines(t, &logBuf)
@@ -1835,7 +1798,7 @@ func TestMethodObservationLateExpireNoOpsAfterFinish(t *testing.T) {
 	hooks := mcpServer.buildHooks()
 
 	ctx := newAnalyticsTestContext(util.SetSigNozURL(context.Background(), "https://tenant.example.com"), "sess-race-finish")
-	ctx, span := mcpServer.startMethodSpan(ctx, mcp.MethodInitialize)
+	ctx, span := startTestMCPSpan(ctx, mcp.MethodInitialize)
 	req := &mcp.InitializeRequest{}
 	key := methodObservationKey(ctx, "req-race-finish", mcp.MethodInitialize, req)
 
@@ -1902,7 +1865,7 @@ func TestMethodObservationLateFinishNoOpsAfterExpire(t *testing.T) {
 	hooks := mcpServer.buildHooks()
 
 	ctx := newAnalyticsTestContext(util.SetSigNozURL(context.Background(), "https://tenant.example.com"), "sess-race-expire")
-	ctx, span := mcpServer.startMethodSpan(ctx, mcp.MethodInitialize)
+	ctx, span := startTestMCPSpan(ctx, mcp.MethodInitialize)
 	req := &mcp.InitializeRequest{}
 	key := methodObservationKey(ctx, "req-race-expire", mcp.MethodInitialize, req)
 
@@ -1978,7 +1941,7 @@ func TestMethodObservationLateOnErrorNoOpsAfterExpire(t *testing.T) {
 	hooks := mcpServer.buildHooks()
 
 	ctx := newAnalyticsTestContext(util.SetSigNozURL(context.Background(), "https://tenant.example.com"), "sess-race-error")
-	ctx, span := mcpServer.startMethodSpan(ctx, mcp.MethodInitialize)
+	ctx, span := startTestMCPSpan(ctx, mcp.MethodInitialize)
 	req := &mcp.InitializeRequest{}
 	key := methodObservationKey(ctx, "req-race-error", mcp.MethodInitialize, req)
 
@@ -2050,7 +2013,7 @@ func TestMethodObservationConcurrentFinishAndExpireDedupes(t *testing.T) {
 	hooks := mcpServer.buildHooks()
 
 	ctx := newAnalyticsTestContext(util.SetSigNozURL(context.Background(), "https://tenant.example.com"), "sess-race-concurrent")
-	ctx, span := mcpServer.startMethodSpan(ctx, mcp.MethodInitialize)
+	ctx, span := startTestMCPSpan(ctx, mcp.MethodInitialize)
 	req := &mcp.InitializeRequest{}
 	key := methodObservationKey(ctx, "req-race-concurrent", mcp.MethodInitialize, req)
 	onSuccess := singleHook(t, hooks.OnSuccess, "OnSuccess")
@@ -2097,312 +2060,6 @@ func TestMethodObservationConcurrentFinishAndExpireDedupes(t *testing.T) {
 	}
 	if len(spans[0].Events) > 1 {
 		t.Fatalf("span events = %d, want <= 1", len(spans[0].Events))
-	}
-}
-
-func TestMethodSpanMiddleware_PropagatesMethodSpanToRequestContext(t *testing.T) {
-	traceExporter := tracetest.NewInMemoryExporter()
-	traceProvider := sdktrace.NewTracerProvider(sdktrace.WithSyncer(traceExporter))
-	prevTracerProvider := otel.GetTracerProvider()
-	otel.SetTracerProvider(traceProvider)
-	defer func() {
-		otel.SetTracerProvider(prevTracerProvider)
-	}()
-	defer func() {
-		if err := traceProvider.Shutdown(context.Background()); err != nil {
-			t.Fatalf("shutdown tracer provider: %v", err)
-		}
-	}()
-
-	mcpServer := NewMCPServer(logpkg.New("error"), nil, &config.Config{}, noopanalytics.New(), nil)
-	var seenSpan trace.SpanContext
-
-	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		seenSpan = trace.SpanFromContext(r.Context()).SpanContext()
-		trace.SpanFromContext(r.Context()).End()
-		w.WriteHeader(http.StatusOK)
-	})
-
-	req := httptest.NewRequest(http.MethodPost, "/mcp", strings.NewReader(`{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}`))
-	req = req.WithContext(util.SetSigNozURL(req.Context(), "https://tenant.example.com"))
-	rr := httptest.NewRecorder()
-
-	mcpServer.methodSpanMiddleware(next).ServeHTTP(rr, req)
-
-	if rr.Code != http.StatusOK {
-		t.Fatalf("status = %d, want %d", rr.Code, http.StatusOK)
-	}
-	if !seenSpan.IsValid() {
-		t.Fatal("expected request context to carry a valid method span")
-	}
-
-	spans := traceExporter.GetSpans()
-	if len(spans) != 1 {
-		t.Fatalf("span count = %d, want 1", len(spans))
-	}
-	if spans[0].SpanContext.SpanID() != seenSpan.SpanID() {
-		t.Fatalf("request context span ID = %s, exported span ID = %s", seenSpan.SpanID(), spans[0].SpanContext.SpanID())
-	}
-	if spans[0].Name != "MCP initialize" {
-		t.Fatalf("span name = %q, want %q", spans[0].Name, "MCP initialize")
-	}
-}
-
-func TestMethodSpanMiddleware_SkipsUnknownMethodNames(t *testing.T) {
-	traceExporter := tracetest.NewInMemoryExporter()
-	traceProvider := sdktrace.NewTracerProvider(sdktrace.WithSyncer(traceExporter))
-	prevTracerProvider := otel.GetTracerProvider()
-	otel.SetTracerProvider(traceProvider)
-	defer func() {
-		otel.SetTracerProvider(prevTracerProvider)
-	}()
-	defer func() {
-		if err := traceProvider.Shutdown(context.Background()); err != nil {
-			t.Fatalf("shutdown tracer provider: %v", err)
-		}
-	}()
-
-	mcpServer := NewMCPServer(logpkg.New("error"), nil, &config.Config{}, noopanalytics.New(), nil)
-	var sawValidSpan bool
-
-	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		sawValidSpan = trace.SpanFromContext(r.Context()).SpanContext().IsValid()
-		w.WriteHeader(http.StatusOK)
-	})
-
-	req := httptest.NewRequest(http.MethodPost, "/mcp", strings.NewReader(`{"jsonrpc":"2.0","id":1,"method":"attacker/custom-cardinality","params":{}}`))
-	rr := httptest.NewRecorder()
-
-	mcpServer.methodSpanMiddleware(next).ServeHTTP(rr, req)
-
-	if rr.Code != http.StatusOK {
-		t.Fatalf("status = %d, want %d", rr.Code, http.StatusOK)
-	}
-	if sawValidSpan {
-		t.Fatal("did not expect a span for an unknown method")
-	}
-	if spans := traceExporter.GetSpans(); len(spans) != 0 {
-		t.Fatalf("span count = %d, want 0", len(spans))
-	}
-}
-
-func TestMethodSpanMiddleware_RequestContextCleanupEndsMethodSpan(t *testing.T) {
-	var logBuf lockedBuffer
-	traceExporter := tracetest.NewInMemoryExporter()
-	traceProvider := sdktrace.NewTracerProvider(sdktrace.WithSyncer(traceExporter))
-	prevTracerProvider := otel.GetTracerProvider()
-	otel.SetTracerProvider(traceProvider)
-	defer func() {
-		otel.SetTracerProvider(prevTracerProvider)
-	}()
-	defer func() {
-		if err := traceProvider.Shutdown(context.Background()); err != nil {
-			t.Fatalf("shutdown tracer provider: %v", err)
-		}
-	}()
-
-	reader := sdkmetric.NewManualReader()
-	meterProvider := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
-	defer func() {
-		if err := meterProvider.Shutdown(context.Background()); err != nil {
-			t.Fatalf("shutdown meter provider: %v", err)
-		}
-	}()
-
-	meters, err := otelpkg.NewMeters(meterProvider)
-	if err != nil {
-		t.Fatalf("new meters: %v", err)
-	}
-
-	cfg := &config.Config{ClientCacheSize: 1, ClientCacheTTL: time.Minute}
-	logger := newBufferedLogger(&logBuf, slog.LevelDebug)
-	mcpServer := NewMCPServer(logger, tools.NewHandler(logger, cfg), cfg, noopanalytics.New(), meters)
-	hooks := mcpServer.buildHooks()
-
-	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		req := &mcp.InitializeRequest{}
-		singleHook(t, hooks.OnBeforeAny, "OnBeforeAny")(r.Context(), "req-timeout-http", mcp.MethodInitialize, req)
-		w.WriteHeader(http.StatusOK)
-	})
-
-	baseCtx, cancel := context.WithCancel(util.SetSigNozURL(context.Background(), "https://tenant.example.com"))
-	defer cancel()
-	req := httptest.NewRequest(http.MethodPost, "/mcp", strings.NewReader(`{"jsonrpc":"2.0","id":"req-timeout-http","method":"initialize","params":{}}`))
-	req = req.WithContext(baseCtx)
-	rr := httptest.NewRecorder()
-
-	mcpServer.methodSpanMiddleware(next).ServeHTTP(rr, req)
-	cancel()
-
-	if rr.Code != http.StatusOK {
-		t.Fatalf("status = %d, want %d", rr.Code, http.StatusOK)
-	}
-
-	var metrics metricdata.ResourceMetrics
-	waitForCondition(t, time.Second, func() bool {
-		metrics = metricdata.ResourceMetrics{}
-		if err := reader.Collect(context.Background(), &metrics); err != nil {
-			t.Fatalf("collect metrics: %v", err)
-		}
-
-		methodCalls, found := oteltest.FindInt64SumMetric(metrics, "mcp.method.calls")
-		if !found || len(methodCalls.DataPoints) != 1 {
-			return false
-		}
-
-		for _, rec := range parseJSONLogLines(t, &logBuf) {
-			if rec["msg"] == "mcp method observation ended without success/error hook" {
-				return true
-			}
-		}
-
-		return false
-	}, "timed out waiting for HTTP-backed method observation context cleanup")
-
-	methodCalls, found := oteltest.FindInt64SumMetric(metrics, "mcp.method.calls")
-	if !found {
-		t.Fatal("mcp.method.calls metric not found")
-	}
-	if attr, ok := methodCalls.DataPoints[0].Attributes.Value(attribute.Key("error.type")); !ok || attr.AsString() != "internal" {
-		t.Fatalf("error.type = %v, want internal", attr)
-	}
-
-	spans := traceExporter.GetSpans()
-	if len(spans) != 1 {
-		t.Fatalf("span count = %d, want 1", len(spans))
-	}
-	if spans[0].Status.Code != codes.Error {
-		t.Fatalf("span status code = %v, want Error", spans[0].Status.Code)
-	}
-	if attr, ok := spanAttrValue(spans[0].Attributes, attribute.Key("error.type")); !ok || attr.AsString() != "internal" {
-		t.Fatalf("span error.type = %v, want internal", attr)
-	}
-}
-
-func TestMethodSpanMiddleware_OnErrorWithoutBeforeAnyStillEndsSpan(t *testing.T) {
-	traceExporter := tracetest.NewInMemoryExporter()
-	traceProvider := sdktrace.NewTracerProvider(sdktrace.WithSyncer(traceExporter))
-	prevTracerProvider := otel.GetTracerProvider()
-	otel.SetTracerProvider(traceProvider)
-	defer func() {
-		otel.SetTracerProvider(prevTracerProvider)
-	}()
-	defer func() {
-		if err := traceProvider.Shutdown(context.Background()); err != nil {
-			t.Fatalf("shutdown tracer provider: %v", err)
-		}
-	}()
-
-	reader := sdkmetric.NewManualReader()
-	meterProvider := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
-	defer func() {
-		if err := meterProvider.Shutdown(context.Background()); err != nil {
-			t.Fatalf("shutdown meter provider: %v", err)
-		}
-	}()
-
-	meters, err := otelpkg.NewMeters(meterProvider)
-	if err != nil {
-		t.Fatalf("new meters: %v", err)
-	}
-
-	cfg := &config.Config{ClientCacheSize: 1, ClientCacheTTL: time.Minute}
-	mcpServer := NewMCPServer(logpkg.New("error"), tools.NewHandler(logpkg.New("error"), cfg), cfg, noopanalytics.New(), meters)
-	hooks := mcpServer.buildHooks()
-	methodErr := fmt.Errorf("initialize %w", mcpgoserver.ErrUnsupported)
-
-	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		singleHook(t, hooks.OnError, "OnError")(r.Context(), "req-unmarshal", mcp.MethodInitialize, &mcp.InitializeRequest{}, methodErr)
-		w.WriteHeader(http.StatusBadRequest)
-	})
-
-	req := httptest.NewRequest(http.MethodPost, "/mcp", strings.NewReader(`{"jsonrpc":"2.0","id":"req-unmarshal","method":"initialize","params":{}}`))
-	req = req.WithContext(util.SetSigNozURL(req.Context(), "https://tenant.example.com"))
-	rr := httptest.NewRecorder()
-
-	mcpServer.methodSpanMiddleware(next).ServeHTTP(rr, req)
-
-	if rr.Code != http.StatusBadRequest {
-		t.Fatalf("status = %d, want %d", rr.Code, http.StatusBadRequest)
-	}
-
-	var metrics metricdata.ResourceMetrics
-	if err := reader.Collect(context.Background(), &metrics); err != nil {
-		t.Fatalf("collect metrics: %v", err)
-	}
-
-	methodCalls, found := oteltest.FindInt64SumMetric(metrics, "mcp.method.calls")
-	if !found {
-		t.Fatal("mcp.method.calls metric not found")
-	}
-	if len(methodCalls.DataPoints) != 1 {
-		t.Fatalf("mcp.method.calls datapoints = %d, want 1", len(methodCalls.DataPoints))
-	}
-	if attr, ok := methodCalls.DataPoints[0].Attributes.Value(attribute.Key("error.type")); !ok || attr.AsString() != "unsupported" {
-		t.Fatalf("error.type = %v, want unsupported", attr)
-	}
-
-	spans := traceExporter.GetSpans()
-	if len(spans) != 1 {
-		t.Fatalf("span count = %d, want 1", len(spans))
-	}
-	if spans[0].Status.Code != codes.Error {
-		t.Fatalf("span status code = %v, want Error", spans[0].Status.Code)
-	}
-	if attr, ok := spanAttrValue(spans[0].Attributes, attribute.Key("error.type")); !ok || attr.AsString() != "unsupported" {
-		t.Fatalf("span error.type = %v, want unsupported", attr)
-	}
-}
-
-func TestMethodSpanMiddleware_SkipsOversizedBodyAndPassesThrough(t *testing.T) {
-	mcpServer := NewMCPServer(logpkg.New("error"), nil, &config.Config{}, noopanalytics.New(), nil)
-	mcpServer.maxMethodSpanBodyBytes = 32
-	traceExporter := tracetest.NewInMemoryExporter()
-	traceProvider := sdktrace.NewTracerProvider(sdktrace.WithSyncer(traceExporter))
-	prevTracerProvider := otel.GetTracerProvider()
-	otel.SetTracerProvider(traceProvider)
-	defer func() {
-		otel.SetTracerProvider(prevTracerProvider)
-	}()
-	defer func() {
-		if err := traceProvider.Shutdown(context.Background()); err != nil {
-			t.Fatalf("shutdown tracer provider: %v", err)
-		}
-	}()
-
-	var nextCalled bool
-	var seenBody string
-
-	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		nextCalled = true
-		body, err := io.ReadAll(r.Body)
-		if err != nil {
-			t.Fatalf("read forwarded body: %v", err)
-		}
-		seenBody = string(body)
-		if trace.SpanFromContext(r.Context()).SpanContext().IsValid() {
-			t.Fatal("did not expect a method span for oversized body")
-		}
-		w.WriteHeader(http.StatusOK)
-	})
-
-	payload := `{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"payload":"this body is much larger than 32 bytes"}}`
-	req := httptest.NewRequest(http.MethodPost, "/mcp", strings.NewReader(payload))
-	rr := httptest.NewRecorder()
-
-	mcpServer.methodSpanMiddleware(next).ServeHTTP(rr, req)
-
-	if rr.Code != http.StatusOK {
-		t.Fatalf("status = %d, want %d", rr.Code, http.StatusOK)
-	}
-	if !nextCalled {
-		t.Fatal("expected next handler to be called for oversized body")
-	}
-	if seenBody != payload {
-		t.Fatalf("forwarded body = %q, want original payload", seenBody)
-	}
-	if spans := traceExporter.GetSpans(); len(spans) != 0 {
-		t.Fatalf("span count = %d, want 0", len(spans))
 	}
 }
 
@@ -2594,12 +2251,14 @@ func TestLoggingMiddleware_PanicPathRecordsErrorMetricAndSpan(t *testing.T) {
 	}
 	chain := mcpServer.loggingMiddleware()(recovery(panicTool))
 
-	_, err = chain(context.Background(), mcp.CallToolRequest{
+	ctx, span := startTestMCPSpan(context.Background(), mcp.MethodToolsCall)
+	_, err = chain(ctx, mcp.CallToolRequest{
 		Params: mcp.CallToolParams{
 			Name:      "panic_tool",
 			Arguments: map[string]any{},
 		},
 	})
+	span.End()
 	if err == nil {
 		t.Fatal("expected recovered panic to surface as error")
 	}
@@ -2634,6 +2293,10 @@ func TestLoggingMiddleware_PanicPathRecordsErrorMetricAndSpan(t *testing.T) {
 	if got := toolIsError.AsBool(); !got {
 		t.Fatalf("mcp.tool.is_error = %t, want true", got)
 	}
+	metricErrorType, ok := dataPoint.Attributes.Value(attribute.Key("error.type"))
+	if !ok || metricErrorType.AsString() != "internal" {
+		t.Fatalf("error.type = %v, want internal", metricErrorType)
+	}
 
 	spans := traceExporter.GetSpans()
 	if len(spans) != 1 {
@@ -2641,6 +2304,10 @@ func TestLoggingMiddleware_PanicPathRecordsErrorMetricAndSpan(t *testing.T) {
 	}
 	if spans[0].Status.Code != codes.Error {
 		t.Fatalf("span status code = %v, want %v", spans[0].Status.Code, codes.Error)
+	}
+	spanErrorType, ok := spanAttrValue(spans[0].Attributes, attribute.Key("error.type"))
+	if !ok || spanErrorType.AsString() != "internal" {
+		t.Fatalf("span error.type = %v, want internal", spanErrorType)
 	}
 }
 
@@ -2754,9 +2421,6 @@ func TestPromptFetchedEvent(t *testing.T) {
 	if call.attrs[analytics.AttrPromptName] != "rca" {
 		t.Fatalf("promptName attr = %v, want rca", call.attrs[analytics.AttrPromptName])
 	}
-	if call.attrs[analytics.AttrSessionID] != "sess-prompt" {
-		t.Fatalf("sessionId attr = %v, want sess-prompt", call.attrs[analytics.AttrSessionID])
-	}
 }
 
 func TestResourceFetchedEvent(t *testing.T) {
@@ -2861,52 +2525,6 @@ func TestRun_HTTPCanceledBeforeListen(t *testing.T) {
 	}
 }
 
-// TestRegisteredEventHasProtocolVersion verifies MCP Registered carries the
-// protocolVersion attribute — needed to track which clients are on which
-// MCP protocol revision as the spec evolves.
-func TestRegisteredEventHasProtocolVersion(t *testing.T) {
-	sigNoz := meEndpointServer(t)
-	defer sigNoz.Close()
-
-	cfg := &config.Config{
-		URL:             sigNoz.URL,
-		APIKey:          "test-key",
-		ClientCacheSize: 1,
-		ClientCacheTTL:  time.Minute,
-	}
-	handler := tools.NewHandler(logpkg.New("error"), cfg)
-	spy := &spyAnalytics{enabled: true}
-	mcpServer := NewMCPServer(logpkg.New("error"), handler, cfg, spy, nil)
-	hooks := mcpServer.buildHooks()
-
-	ctx := context.Background()
-	ctx = util.SetAPIKey(ctx, "test-key")
-	ctx = util.SetAuthHeader(ctx, "SIGNOZ-API-KEY")
-	ctx = util.SetSigNozURL(ctx, sigNoz.URL)
-	ctx = newAnalyticsTestContext(ctx, "sess-registered")
-
-	singleHook(t, hooks.OnAfterInitialize, "OnAfterInitialize")(ctx, nil, &mcp.InitializeRequest{
-		Params: mcp.InitializeParams{
-			ProtocolVersion: "2025-06-18",
-			ClientInfo:      mcp.Implementation{Name: "claude-desktop", Version: "1.2.3"},
-		},
-	}, &mcp.InitializeResult{})
-
-	waitForCondition(t, time.Second, func() bool {
-		_, trackCalls := spy.snapshot()
-		return len(trackCalls) == 1
-	}, "timed out waiting for registered event")
-
-	_, trackCalls := spy.snapshot()
-	ev := trackCalls[0]
-	if ev.event != analytics.EventSessionRegistered {
-		t.Fatalf("event = %q, want %q", ev.event, analytics.EventSessionRegistered)
-	}
-	if ev.attrs[analytics.AttrProtocolVersion] != "2025-06-18" {
-		t.Fatalf("protocolVersion = %v, want 2025-06-18", ev.attrs[analytics.AttrProtocolVersion])
-	}
-}
-
 // TestToolCallEventHasErrorType verifies error categorization lands on the
 // analytics event (analytics scope). resultBytes is not an analytics field
 // — see TestToolCallSpanHasResultBytes for the span + log coverage.
@@ -2933,8 +2551,9 @@ func TestToolCallEventHasErrorType(t *testing.T) {
 	middleware := mcpServer.loggingMiddleware()
 	_, err := middleware(func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 		return &mcp.CallToolResult{
-			IsError: true,
-			Content: []mcp.Content{mcp.TextContent{Type: "text", Text: "unexpected status 502 from upstream"}},
+			IsError:           true,
+			Content:           []mcp.Content{mcp.TextContent{Type: "text", Text: "access rejected"}},
+			StructuredContent: map[string]any{"code": tools.CodePermissionDenied},
 		}, nil
 	})(ctx, mcp.CallToolRequest{
 		Params: mcp.CallToolParams{Name: "signoz_list_services"},
@@ -2953,8 +2572,8 @@ func TestToolCallEventHasErrorType(t *testing.T) {
 	if ev.event != analytics.EventToolCalled {
 		t.Fatalf("event = %q, want %q", ev.event, analytics.EventToolCalled)
 	}
-	if ev.attrs[analytics.AttrErrorType] != "upstream_5xx" {
-		t.Fatalf("errorType = %v, want upstream_5xx", ev.attrs[analytics.AttrErrorType])
+	if ev.attrs[analytics.AttrErrorType] != "permission_denied" {
+		t.Fatalf("errorType = %v, want permission_denied", ev.attrs[analytics.AttrErrorType])
 	}
 }
 
@@ -2980,14 +2599,16 @@ func TestToolCallSpanHasResultBytes(t *testing.T) {
 	mcpServer := NewMCPServer(logpkg.New("error"), handler, cfg, noopanalytics.New(), nil)
 
 	body := strings.Repeat("x", 512)
+	ctx, span := startTestMCPSpan(context.Background(), mcp.MethodToolsCall)
 	middleware := mcpServer.loggingMiddleware()
 	_, err := middleware(func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 		return &mcp.CallToolResult{
 			Content: []mcp.Content{mcp.TextContent{Type: "text", Text: body}},
 		}, nil
-	})(context.Background(), mcp.CallToolRequest{
+	})(ctx, mcp.CallToolRequest{
 		Params: mcp.CallToolParams{Name: "signoz_list_services"},
 	})
+	span.End()
 	if err != nil {
 		t.Fatalf("middleware error = %v", err)
 	}
@@ -2995,6 +2616,25 @@ func TestToolCallSpanHasResultBytes(t *testing.T) {
 	spans := traceExporter.GetSpans()
 	if len(spans) != 1 {
 		t.Fatalf("span count = %d, want 1", len(spans))
+	}
+	if spans[0].Name != "tools/call signoz_list_services" {
+		t.Fatalf("span name = %q, want %q", spans[0].Name, "tools/call signoz_list_services")
+	}
+	if spans[0].SpanKind != trace.SpanKindServer {
+		t.Fatalf("span kind = %v, want SERVER", spans[0].SpanKind)
+	}
+	for key, want := range map[attribute.Key]string{
+		otelpkg.MCPMethodKey:          "tools/call",
+		otelpkg.GenAIOperationNameKey: "execute_tool",
+		otelpkg.GenAIToolNameKey:      "signoz_list_services",
+	} {
+		got, ok := spanAttrValue(spans[0].Attributes, key)
+		if !ok || got.AsString() != want {
+			t.Fatalf("%s = %v, want %q", key, got, want)
+		}
+	}
+	if _, ok := spanAttrValue(spans[0].Attributes, attribute.Key("gen_ai.tool.call.id")); ok {
+		t.Fatal("span must not contain fabricated gen_ai.tool.call.id")
 	}
 	size, ok := spanAttrValue(spans[0].Attributes, otelpkg.MCPToolResultBytesKey)
 	if !ok {
@@ -3026,12 +2666,14 @@ func TestToolCallSpanEmitsZeroResultBytes(t *testing.T) {
 	handler := tools.NewHandler(logpkg.New("error"), cfg)
 	mcpServer := NewMCPServer(logpkg.New("error"), handler, cfg, noopanalytics.New(), nil)
 
+	ctx, span := startTestMCPSpan(context.Background(), mcp.MethodToolsCall)
 	middleware := mcpServer.loggingMiddleware()
 	_, err := middleware(func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 		return &mcp.CallToolResult{}, nil
-	})(context.Background(), mcp.CallToolRequest{
+	})(ctx, mcp.CallToolRequest{
 		Params: mcp.CallToolParams{Name: "signoz_list_services"},
 	})
+	span.End()
 	if err != nil {
 		t.Fatalf("middleware error = %v", err)
 	}
@@ -3049,6 +2691,186 @@ func TestToolCallSpanEmitsZeroResultBytes(t *testing.T) {
 	}
 }
 
+func TestToolCallStructuredErrorTelemetry(t *testing.T) {
+	traceExporter := tracetest.NewInMemoryExporter()
+	traceProvider := sdktrace.NewTracerProvider(sdktrace.WithSyncer(traceExporter))
+	prevTracerProvider := otel.GetTracerProvider()
+	otel.SetTracerProvider(traceProvider)
+	defer func() {
+		otel.SetTracerProvider(prevTracerProvider)
+		if err := traceProvider.Shutdown(context.Background()); err != nil {
+			t.Fatalf("shutdown tracer provider: %v", err)
+		}
+	}()
+
+	reader := sdkmetric.NewManualReader()
+	meterProvider := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+	defer func() {
+		if err := meterProvider.Shutdown(context.Background()); err != nil {
+			t.Fatalf("shutdown meter provider: %v", err)
+		}
+	}()
+	meters, err := otelpkg.NewMeters(meterProvider)
+	if err != nil {
+		t.Fatalf("new meters: %v", err)
+	}
+
+	cfg := &config.Config{ClientCacheSize: 1, ClientCacheTTL: time.Minute}
+	handler := tools.NewHandler(logpkg.New("error"), cfg)
+	mcpServer := NewMCPServer(logpkg.New("error"), handler, cfg, noopanalytics.New(), meters)
+
+	ctx, span := startTestMCPSpan(context.Background(), mcp.MethodToolsCall)
+	_, err = mcpServer.loggingMiddleware()(func(context.Context, mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		return &mcp.CallToolResult{
+			IsError:           true,
+			Content:           []mcp.Content{mcp.TextContent{Text: "display text is not telemetry"}},
+			StructuredContent: map[string]any{"code": tools.CodePermissionDenied},
+		}, nil
+	})(ctx, mcp.CallToolRequest{Params: mcp.CallToolParams{Name: "signoz_query_logs"}})
+	span.End()
+	if err != nil {
+		t.Fatalf("middleware error = %v", err)
+	}
+
+	spans := traceExporter.GetSpans()
+	if len(spans) != 1 {
+		t.Fatalf("span count = %d, want 1", len(spans))
+	}
+	for key, want := range map[attribute.Key]string{
+		attribute.Key("error.type"): "tool_error",
+		otelpkg.MCPToolErrorCodeKey: tools.CodePermissionDenied,
+	} {
+		got, ok := spanAttrValue(spans[0].Attributes, key)
+		if !ok || got.AsString() != want {
+			t.Fatalf("span %s = %v, want %q", key, got, want)
+		}
+	}
+
+	var metrics metricdata.ResourceMetrics
+	if err := reader.Collect(context.Background(), &metrics); err != nil {
+		t.Fatalf("collect metrics: %v", err)
+	}
+	toolCalls, found := oteltest.FindInt64SumMetric(metrics, "mcp.tool.calls")
+	if !found || len(toolCalls.DataPoints) != 1 {
+		t.Fatalf("mcp.tool.calls datapoints = %d, found=%t; want 1", len(toolCalls.DataPoints), found)
+	}
+	toolDuration, found := oteltest.FindFloat64HistogramMetric(metrics, "mcp.tool.call.duration")
+	if !found || len(toolDuration.DataPoints) != 1 {
+		t.Fatalf("mcp.tool.call.duration datapoints = %d, found=%t; want 1", len(toolDuration.DataPoints), found)
+	}
+	for metricName, attrs := range map[string]attribute.Set{
+		"mcp.tool.calls":         toolCalls.DataPoints[0].Attributes,
+		"mcp.tool.call.duration": toolDuration.DataPoints[0].Attributes,
+	} {
+		for key, want := range map[attribute.Key]string{
+			attribute.Key("error.type"): "tool_error",
+			otelpkg.MCPToolErrorCodeKey: tools.CodePermissionDenied,
+		} {
+			got, ok := attrs.Value(key)
+			if !ok || got.AsString() != want {
+				t.Fatalf("%s %s = %v, want %q", metricName, key, got, want)
+			}
+		}
+	}
+}
+
+func TestUnknownToolCallRecordsBoundedFallbackTelemetry(t *testing.T) {
+	traceExporter := tracetest.NewInMemoryExporter()
+	traceProvider := sdktrace.NewTracerProvider(sdktrace.WithSyncer(traceExporter))
+	previousTracerProvider := otel.GetTracerProvider()
+	otel.SetTracerProvider(traceProvider)
+	t.Cleanup(func() {
+		otel.SetTracerProvider(previousTracerProvider)
+		_ = traceProvider.Shutdown(context.Background())
+	})
+
+	reader := sdkmetric.NewManualReader()
+	meterProvider := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+	t.Cleanup(func() { _ = meterProvider.Shutdown(context.Background()) })
+	meters, err := otelpkg.NewMeters(meterProvider)
+	if err != nil {
+		t.Fatalf("new meters: %v", err)
+	}
+
+	cfg := &config.Config{ClientCacheSize: 1, ClientCacheTTL: time.Minute}
+	mcpServer := NewMCPServer(logpkg.New("error"), tools.NewHandler(logpkg.New("error"), cfg), cfg, noopanalytics.New(), meters)
+	sdkServer := mcpServer.newSDKServer()
+	const requestedName = "attacker-generated-tool-name"
+	response := sdkServer.HandleMessage(context.Background(), json.RawMessage(`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"`+requestedName+`","arguments":{}}}`))
+	encoded, err := json.Marshal(response)
+	if err != nil {
+		t.Fatalf("marshal response: %v", err)
+	}
+	if !bytes.Contains(encoded, []byte("not found")) {
+		t.Fatalf("response = %s, want tool-not-found error", encoded)
+	}
+
+	var metrics metricdata.ResourceMetrics
+	if err := reader.Collect(context.Background(), &metrics); err != nil {
+		t.Fatalf("collect metrics: %v", err)
+	}
+	toolCalls, found := oteltest.FindInt64SumMetric(metrics, "mcp.tool.calls")
+	if !found || len(toolCalls.DataPoints) != 1 || toolCalls.DataPoints[0].Value != 1 {
+		t.Fatalf("mcp.tool.calls = %#v, found=%t; want one call", toolCalls.DataPoints, found)
+	}
+	for key, want := range map[attribute.Key]string{
+		otelpkg.GenAIToolNameKey:    unknownToolName,
+		attribute.Key("error.type"): "not_found",
+	} {
+		got, ok := toolCalls.DataPoints[0].Attributes.Value(key)
+		if !ok || got.AsString() != want {
+			t.Fatalf("metric %s = %v, want %q", key, got, want)
+		}
+	}
+
+	spans := traceExporter.GetSpans()
+	if len(spans) != 1 {
+		t.Fatalf("span count = %d, want 1", len(spans))
+	}
+	if spans[0].Name != string(mcp.MethodToolsCall) {
+		t.Fatalf("span name = %q, want %q", spans[0].Name, mcp.MethodToolsCall)
+	}
+	for key, want := range map[attribute.Key]string{
+		otelpkg.MCPMethodKey:          string(mcp.MethodToolsCall),
+		otelpkg.GenAIOperationNameKey: "execute_tool",
+		otelpkg.GenAIToolNameKey:      unknownToolName,
+		attribute.Key("error.type"):   "not_found",
+	} {
+		got, ok := spanAttrValue(spans[0].Attributes, key)
+		if !ok || got.AsString() != want {
+			t.Fatalf("span %s = %v, want %q", key, got, want)
+		}
+	}
+	if strings.Contains(spans[0].Name, requestedName) {
+		t.Fatalf("span name contains unvalidated tool name: %q", spans[0].Name)
+	}
+}
+
+func TestUnknownMethodUsesBoundedSpanName(t *testing.T) {
+	traceExporter := tracetest.NewInMemoryExporter()
+	traceProvider := sdktrace.NewTracerProvider(sdktrace.WithSyncer(traceExporter))
+	previousTracerProvider := otel.GetTracerProvider()
+	otel.SetTracerProvider(traceProvider)
+	t.Cleanup(func() {
+		otel.SetTracerProvider(previousTracerProvider)
+		_ = traceProvider.Shutdown(context.Background())
+	})
+
+	cfg := &config.Config{ClientCacheSize: 1, ClientCacheTTL: time.Minute}
+	mcpServer := NewMCPServer(logpkg.New("error"), tools.NewHandler(logpkg.New("error"), cfg), cfg, noopanalytics.New(), nil)
+	const requestedMethod = "attacker/generated-method"
+	mcpServer.newSDKServer().HandleMessage(context.Background(), json.RawMessage(`{"jsonrpc":"2.0","id":1,"method":"`+requestedMethod+`","params":{}}`))
+
+	spans := traceExporter.GetSpans()
+	if len(spans) != 1 || spans[0].Name != otelpkg.UnknownMCPMethod {
+		t.Fatalf("spans = %#v, want one %q span", spans, otelpkg.UnknownMCPMethod)
+	}
+	methodAttr, ok := spanAttrValue(spans[0].Attributes, otelpkg.MCPMethodKey)
+	if !ok || methodAttr.AsString() != otelpkg.UnknownMCPMethod {
+		t.Fatalf("span method = %v, want %q", methodAttr, otelpkg.UnknownMCPMethod)
+	}
+}
+
 func TestToolErrorType(t *testing.T) {
 	tests := []struct {
 		name   string
@@ -3061,19 +2883,24 @@ func TestToolErrorType(t *testing.T) {
 		{name: "cancelled", err: context.Canceled, want: "cancelled"},
 		{name: "generic go error", err: errors.New("boom"), want: "internal"},
 		{
-			name:   "result error 401",
-			result: &mcp.CallToolResult{IsError: true, Content: []mcp.Content{mcp.TextContent{Text: "unexpected status 401"}}},
-			want:   "unauthorized",
+			name: "structured permission denied",
+			result: &mcp.CallToolResult{IsError: true,
+				Content:           []mcp.Content{mcp.TextContent{Text: "arbitrary display text"}},
+				StructuredContent: map[string]any{"code": tools.CodePermissionDenied}},
+			want: "permission_denied",
 		},
 		{
-			name:   "result error 404",
-			result: &mcp.CallToolResult{IsError: true, Content: []mcp.Content{mcp.TextContent{Text: "unexpected status 404 not found"}}},
-			want:   "upstream_4xx",
+			name: "structured rate limited",
+			result: &mcp.CallToolResult{IsError: true,
+				Content:           []mcp.Content{mcp.TextContent{Text: "not a rate-limit phrase"}},
+				StructuredContent: map[string]any{"code": tools.CodeRateLimited}},
+			want: "rate_limited",
 		},
 		{
-			name:   "result error 503",
-			result: &mcp.CallToolResult{IsError: true, Content: []mcp.Content{mcp.TextContent{Text: "unexpected status 503 upstream"}}},
-			want:   "upstream_5xx",
+			name: "display text is not classified",
+			result: &mcp.CallToolResult{IsError: true,
+				Content: []mcp.Content{mcp.TextContent{Text: "unexpected status 503 upstream"}}},
+			want: "tool_error",
 		},
 		{
 			name:   "result error generic",
@@ -3092,6 +2919,25 @@ func TestToolErrorType(t *testing.T) {
 			got := toolErrorType(tt.err, tt.result)
 			if got != tt.want {
 				t.Errorf("toolErrorType = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestMethodErrorTypeCancellationAndDeadline(t *testing.T) {
+	for _, tt := range []struct {
+		name string
+		err  error
+		want string
+	}{
+		{name: "cancelled", err: context.Canceled, want: "cancelled"},
+		{name: "wrapped cancelled", err: fmt.Errorf("request stopped: %w", context.Canceled), want: "cancelled"},
+		{name: "deadline", err: context.DeadlineExceeded, want: "timeout"},
+		{name: "wrapped deadline", err: fmt.Errorf("request stopped: %w", context.DeadlineExceeded), want: "timeout"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := methodErrorType(tt.err); got != tt.want {
+				t.Fatalf("methodErrorType() = %q, want %q", got, tt.want)
 			}
 		})
 	}

--- a/internal/oauth/static/authorize.html
+++ b/internal/oauth/static/authorize.html
@@ -467,7 +467,7 @@
               <a href="https://signoz.io/docs/manage/administrator-guide/iam/service-accounts/#create-a-service-account"
                 target="_blank" rel="noopener" aria-describedby="api-key-help-tooltip">How to get your API key?</a>
               <span id="api-key-help-tooltip" class="api-key-tooltip" role="tooltip">Go to Settings → Service Accounts in
-                SigNoz, create a service account, and generate an API key (requires Admin role). Click for
+                SigNoz, create a service account, and generate an API key. Click for
                 details.</span>
             </span>
           </div>

--- a/pkg/analytics/events.go
+++ b/pkg/analytics/events.go
@@ -4,7 +4,7 @@ package analytics
 // distinct from main-app SigNoz events in shared destinations. IDs go in
 // attributes, never in the event name — cardinality stays bounded.
 const (
-	EventSessionRegistered           = "MCP Session: Registered"
+	EventClientInitialized           = "MCP Client: Initialized"
 	EventToolCalled                  = "MCP Tool: Called"
 	EventPromptFetched               = "MCP Prompt: Fetched"
 	EventResourceFetched             = "MCP Resource: Fetched"
@@ -20,16 +20,15 @@ const (
 	AttrName                 = "name"
 	AttrEmail                = "email"
 	AttrTenantURL            = "tenantUrl"
-	AttrSessionID            = "sessionId"
 	AttrClientName           = "clientName"
 	AttrClientVersion        = "clientVersion"
+	AttrProtocolVersion      = "protocolVersion"
 	AttrToolName             = "toolName"
 	AttrToolIsError          = "toolIsError"
 	AttrDurationMs           = "durationMs"
 	AttrPromptName           = "promptName"
 	AttrResourceURI          = "resourceUri"
 	AttrGrantType            = "grantType"
-	AttrProtocolVersion      = "protocolVersion"
 	AttrErrorType            = "errorType"
 	AttrClientSource         = "clientSource"
 	AttrAssistantThreadID    = "assistantThreadId"

--- a/pkg/log/handler.go
+++ b/pkg/log/handler.go
@@ -42,9 +42,6 @@ func (h *ContextHandler) Handle(ctx context.Context, r slog.Record) error {
 	if signozURL, ok := util.GetSigNozURL(ctx); ok && signozURL != "" {
 		r.AddAttrs(slog.String("mcp.tenant_url", signozURL))
 	}
-	if sessionID, ok := util.GetSessionID(ctx); ok && sessionID != "" {
-		r.AddAttrs(slog.String("mcp.session.id", sessionID))
-	}
 	if searchContext, ok := util.GetSearchContext(ctx); ok && searchContext != "" {
 		r.AddAttrs(slog.String("mcp.search_context", searchContext))
 	}

--- a/pkg/log/handler_test.go
+++ b/pkg/log/handler_test.go
@@ -20,13 +20,12 @@ func newTestLogger(buf *bytes.Buffer) *slog.Logger {
 	return slog.New(NewContextHandler(base))
 }
 
-func TestContextHandler_InjectsTenantSessionSearchContext(t *testing.T) {
+func TestContextHandler_InjectsTenantAndSearchContext(t *testing.T) {
 	var buf bytes.Buffer
 	logger := newTestLogger(&buf)
 
 	ctx := context.Background()
 	ctx = util.SetSigNozURL(ctx, "https://tenant.example.com")
-	ctx = util.SetSessionID(ctx, "sess-42")
 	ctx = util.SetSearchContext(ctx, "root-cause")
 
 	logger.InfoContext(ctx, "ping")
@@ -37,9 +36,6 @@ func TestContextHandler_InjectsTenantSessionSearchContext(t *testing.T) {
 	}
 	if got := rec["mcp.tenant_url"]; got != "https://tenant.example.com" {
 		t.Fatalf("mcp.tenant_url = %v, want tenant url", got)
-	}
-	if got := rec["mcp.session.id"]; got != "sess-42" {
-		t.Fatalf("mcp.session.id = %v, want sess-42", got)
 	}
 	if got := rec["mcp.search_context"]; got != "root-cause" {
 		t.Fatalf("mcp.search_context = %v, want root-cause", got)

--- a/pkg/log/http.go
+++ b/pkg/log/http.go
@@ -10,16 +10,10 @@ import (
 // HTTPRequestAttrs returns stable request metadata for logs. It intentionally
 // excludes query strings and auth material.
 func HTTPRequestAttrs(r *http.Request) []slog.Attr {
-	return httpRequestAttrs(r, false)
+	return httpRequestAttrs(r)
 }
 
-// MCPHTTPRequestAttrs returns stable request metadata plus the MCP session
-// header. Use it only on /mcp-scoped request logs.
-func MCPHTTPRequestAttrs(r *http.Request) []slog.Attr {
-	return httpRequestAttrs(r, true)
-}
-
-func httpRequestAttrs(r *http.Request, includeMCPSession bool) []slog.Attr {
+func httpRequestAttrs(r *http.Request) []slog.Attr {
 	if r == nil {
 		return nil
 	}
@@ -38,9 +32,6 @@ func httpRequestAttrs(r *http.Request, includeMCPSession bool) []slog.Attr {
 	}
 	if userAgent := util.HTTPUserAgent(r); userAgent != "" {
 		attrs = append(attrs, slog.String("user_agent.original", userAgent))
-	}
-	if sessionID := util.HTTPSessionID(r); includeMCPSession && sessionID != "" {
-		attrs = append(attrs, slog.String("mcp.session.id", sessionID))
 	}
 	return attrs
 }

--- a/pkg/otel/attr.go
+++ b/pkg/otel/attr.go
@@ -15,23 +15,23 @@ import (
 const (
 	GenAIOperationNameKey = attribute.Key("gen_ai.operation.name")
 	GenAIToolNameKey      = attribute.Key("gen_ai.tool.name")
-	GenAIToolCallIDKey    = attribute.Key("gen_ai.tool.call.id")
 )
 
 // MCP semantic convention attribute keys.
 // Spec: https://opentelemetry.io/docs/specs/semconv/registry/attributes/mcp/
 //
-// MCPMethodKey, MCPSessionIDKey match the registry exactly. The other keys
-// (search_context, tenant_url, tool.is_error, query.payload) are custom
+// MCPMethodKey and MCPProtocolVersionKey match the registry exactly. The other
+// keys (search_context, tenant_url, tool.*, query.payload) are custom
 // extensions this server uses for multi-tenant attribution and are not
 // defined by the spec.
 const (
-	MCPMethodKey        = attribute.Key("mcp.method.name")
-	MCPSessionIDKey     = attribute.Key("mcp.session.id")
-	MCPSearchContextKey = attribute.Key("mcp.search_context")
-	MCPTenantURLKey     = attribute.Key("mcp.tenant_url")
-	MCPToolIsErrorKey   = attribute.Key("mcp.tool.is_error")
-	MCPQueryPayloadKey  = attribute.Key("mcp.query.payload")
+	MCPMethodKey          = attribute.Key("mcp.method.name")
+	MCPProtocolVersionKey = attribute.Key("mcp.protocol.version")
+	MCPSearchContextKey   = attribute.Key("mcp.search_context")
+	MCPTenantURLKey       = attribute.Key("mcp.tenant_url")
+	MCPToolIsErrorKey     = attribute.Key("mcp.tool.is_error")
+	MCPToolErrorCodeKey   = attribute.Key("mcp.tool.error.code")
+	MCPQueryPayloadKey    = attribute.Key("mcp.query.payload")
 	// MCPToolResultBytes approximates the size, in bytes, of the text content
 	// returned by a tool call — sum of `len(Text)` across TextContent entries.
 	// Non-standard (the registry has no equivalent today); scoped under the

--- a/pkg/otel/mcp.go
+++ b/pkg/otel/mcp.go
@@ -1,0 +1,211 @@
+package otel
+
+import (
+	"context"
+	"strings"
+	"sync/atomic"
+	"time"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	mcptracing "github.com/mark3labs/mcp-go/tracing"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/trace"
+)
+
+const (
+	mcpSDKMethodAttr          = "mcp.method"
+	mcpSDKToolNameAttr        = "mcp.tool.name"
+	mcpSDKSessionIDAttr       = "mcp.session.id"
+	mcpSDKProtocolVersionAttr = "mcp.protocol.version"
+	UnknownMCPMethod          = "unknown"
+)
+
+type mcpToolRequestStateKey struct{}
+
+type mcpToolRequestState struct {
+	started         time.Time
+	handlerObserved atomic.Bool
+}
+
+// NewMCPTracer adapts an OpenTelemetry tracer to mcp-go while normalizing the
+// SDK's generic tracing names and attributes to the MCP semantic conventions.
+func NewMCPTracer(tracer trace.Tracer) mcptracing.Tracer {
+	return &mcpTracer{tracer: tracer}
+}
+
+type mcpTracer struct {
+	tracer trace.Tracer
+}
+
+func (t *mcpTracer) Start(ctx context.Context, name string, kind mcptracing.SpanKind, attrs ...mcptracing.Attribute) (context.Context, mcptracing.Span) {
+	// mcp-go also starts an internal tool.<name> span. The enclosing MCP
+	// tools/call server span already covers execution, so suppress the duplicate.
+	if kind == mcptracing.SpanKindInternal && strings.HasPrefix(name, "tool.") {
+		return ctx, noopMCPSpan{}
+	}
+	if mcpMethodAttribute(attrs) == string(mcp.MethodToolsCall) {
+		ctx = context.WithValue(ctx, mcpToolRequestStateKey{}, &mcpToolRequestState{started: time.Now()})
+	}
+	if t == nil || t.tracer == nil {
+		return ctx, noopMCPSpan{}
+	}
+
+	ctx, span := t.tracer.Start(ctx, mcpSpanName(name),
+		trace.WithSpanKind(mcpSpanKind(kind)),
+		trace.WithAttributes(mcpAttributes(attrs...)...),
+	)
+	wrapped := &mcpSpan{span: span}
+	ctx = mcptracing.ContextWithSpan(ctx, wrapped)
+	return ctx, wrapped
+}
+
+func mcpSpanName(name string) string {
+	if method, ok := strings.CutPrefix(name, "mcp."); ok {
+		return NormalizeMCPMethod(method)
+	}
+	return name
+}
+
+// NormalizeMCPMethod bounds client-controlled JSON-RPC method values to the
+// methods supported by this MCP SDK version. Unknown values share one bucket.
+func NormalizeMCPMethod(method string) string {
+	switch mcp.MCPMethod(method) {
+	case mcp.MethodInitialize,
+		mcp.MethodPing,
+		mcp.MethodResourcesList,
+		mcp.MethodResourcesTemplatesList,
+		mcp.MethodResourcesRead,
+		mcp.MethodResourcesSubscribe,
+		mcp.MethodResourcesUnsubscribe,
+		mcp.MethodPromptsList,
+		mcp.MethodPromptsGet,
+		mcp.MethodToolsList,
+		mcp.MethodToolsCall,
+		mcp.MethodSetLogLevel,
+		mcp.MethodElicitationCreate,
+		mcp.MethodNotificationElicitationComplete,
+		mcp.MethodListRoots,
+		mcp.MethodTasksGet,
+		mcp.MethodTasksList,
+		mcp.MethodTasksResult,
+		mcp.MethodTasksCancel,
+		mcp.MethodNotificationInitialized,
+		mcp.MethodNotificationCancelled,
+		mcp.MethodNotificationProgress,
+		mcp.MethodNotificationMessage,
+		mcp.MethodNotificationResourcesListChanged,
+		mcp.MethodNotificationResourceUpdated,
+		mcp.MethodNotificationPromptsListChanged,
+		mcp.MethodNotificationToolsListChanged,
+		mcp.MethodNotificationRootsListChanged,
+		mcp.MethodNotificationTasksStatus,
+		mcp.MethodCompletionComplete,
+		mcp.MethodSamplingCreateMessage:
+		return method
+	default:
+		return UnknownMCPMethod
+	}
+}
+
+func mcpMethodAttribute(attrs []mcptracing.Attribute) string {
+	for _, attr := range attrs {
+		if attr.Key == mcpSDKMethodAttr {
+			return attr.Value
+		}
+	}
+	return ""
+}
+
+// MarkMCPToolHandlerObserved records that registered tool middleware handled
+// the request, so the lifecycle hook does not emit fallback telemetry too.
+func MarkMCPToolHandlerObserved(ctx context.Context) {
+	if state, ok := ctx.Value(mcpToolRequestStateKey{}).(*mcpToolRequestState); ok {
+		state.handlerObserved.Store(true)
+	}
+}
+
+// MCPToolRequestObservation returns request-span state used to observe
+// tools/call failures that occur before registered tool middleware runs.
+func MCPToolRequestObservation(ctx context.Context) (started time.Time, handlerObserved bool, ok bool) {
+	state, ok := ctx.Value(mcpToolRequestStateKey{}).(*mcpToolRequestState)
+	if !ok || state == nil {
+		return time.Time{}, false, false
+	}
+	return state.started, state.handlerObserved.Load(), true
+}
+
+func mcpSpanKind(kind mcptracing.SpanKind) trace.SpanKind {
+	switch kind {
+	case mcptracing.SpanKindServer:
+		return trace.SpanKindServer
+	case mcptracing.SpanKindClient:
+		return trace.SpanKindClient
+	case mcptracing.SpanKindInternal:
+		return trace.SpanKindInternal
+	default:
+		return trace.SpanKindUnspecified
+	}
+}
+
+func mcpAttributes(attrs ...mcptracing.Attribute) []attribute.KeyValue {
+	converted := make([]attribute.KeyValue, 0, len(attrs))
+	for _, attr := range attrs {
+		switch attr.Key {
+		case mcpSDKMethodAttr:
+			converted = append(converted, MCPMethodKey.String(NormalizeMCPMethod(attr.Value)))
+		case mcpSDKToolNameAttr:
+			converted = append(converted, GenAIToolNameKey.String(attr.Value))
+		case mcpSDKProtocolVersionAttr:
+			converted = append(converted, MCPProtocolVersionKey.String(attr.Value))
+		case mcpSDKSessionIDAttr:
+			// Session telemetry is deliberately omitted by this stateless server.
+		default:
+			converted = append(converted, attribute.String(attr.Key, attr.Value))
+		}
+	}
+	return converted
+}
+
+type mcpSpan struct {
+	span trace.Span
+}
+
+func (s *mcpSpan) SetAttributes(attrs ...mcptracing.Attribute) {
+	if s != nil && s.span != nil {
+		s.span.SetAttributes(mcpAttributes(attrs...)...)
+	}
+}
+
+func (s *mcpSpan) RecordError(err error) {
+	if s != nil && s.span != nil && err != nil {
+		s.span.RecordError(err)
+	}
+}
+
+func (s *mcpSpan) SetStatus(code mcptracing.StatusCode, description string) {
+	if s == nil || s.span == nil {
+		return
+	}
+	switch code {
+	case mcptracing.StatusOK:
+		s.span.SetStatus(codes.Ok, description)
+	case mcptracing.StatusError:
+		s.span.SetStatus(codes.Error, description)
+	default:
+		s.span.SetStatus(codes.Unset, description)
+	}
+}
+
+func (s *mcpSpan) End() {
+	if s != nil && s.span != nil {
+		s.span.End()
+	}
+}
+
+type noopMCPSpan struct{}
+
+func (noopMCPSpan) SetAttributes(...mcptracing.Attribute)   {}
+func (noopMCPSpan) RecordError(error)                       {}
+func (noopMCPSpan) SetStatus(mcptracing.StatusCode, string) {}
+func (noopMCPSpan) End()                                    {}

--- a/pkg/otel/mcp_test.go
+++ b/pkg/otel/mcp_test.go
@@ -1,0 +1,155 @@
+package otel
+
+import (
+	"context"
+	"testing"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	mcptracing "github.com/mark3labs/mcp-go/tracing"
+	"go.opentelemetry.io/otel/attribute"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+	"go.opentelemetry.io/otel/trace"
+)
+
+func TestMCPTracerNormalizesRequestSpan(t *testing.T) {
+	exporter := tracetest.NewInMemoryExporter()
+	provider := sdktrace.NewTracerProvider(sdktrace.WithSyncer(exporter))
+	defer func() {
+		if err := provider.Shutdown(context.Background()); err != nil {
+			t.Fatalf("shutdown tracer provider: %v", err)
+		}
+	}()
+
+	baseTracer := provider.Tracer("test")
+	transportCtx, transportSpan := baseTracer.Start(context.Background(), "HTTP POST",
+		trace.WithSpanKind(trace.SpanKindServer))
+
+	mcpTracer := NewMCPTracer(baseTracer)
+	mcpCtx, mcpSpan := mcpTracer.Start(transportCtx, "mcp.tools/list", mcptracing.SpanKindServer,
+		mcptracing.String(mcpSDKMethodAttr, "tools/list"),
+		mcptracing.String(mcpSDKProtocolVersionAttr, "2025-11-25"),
+		mcptracing.String(mcpSDKSessionIDAttr, "caller-controlled"),
+	)
+	mcptracing.SpanFromContext(mcpCtx).SetAttributes(mcptracing.String("custom", "value"))
+	mcpSpan.End()
+	transportSpan.End()
+
+	spans := exporter.GetSpans()
+	if len(spans) != 2 {
+		t.Fatalf("span count = %d, want 2", len(spans))
+	}
+
+	var requestSpan *tracetest.SpanStub
+	for i := range spans {
+		if spans[i].Name == "tools/list" {
+			requestSpan = &spans[i]
+			break
+		}
+	}
+	if requestSpan == nil {
+		t.Fatal("normalized MCP request span not found")
+	}
+	if requestSpan.SpanKind != trace.SpanKindServer {
+		t.Fatalf("span kind = %v, want SERVER", requestSpan.SpanKind)
+	}
+	if requestSpan.Parent.SpanID() != transportSpan.SpanContext().SpanID() {
+		t.Fatalf("parent span ID = %s, want transport span %s",
+			requestSpan.Parent.SpanID(), transportSpan.SpanContext().SpanID())
+	}
+	if len(requestSpan.Links) != 0 {
+		t.Fatalf("links = %d, want 0", len(requestSpan.Links))
+	}
+
+	attrs := make(map[attribute.Key]attribute.Value)
+	for _, attr := range requestSpan.Attributes {
+		attrs[attr.Key] = attr.Value
+	}
+	if got := attrs[MCPMethodKey].AsString(); got != "tools/list" {
+		t.Fatalf("%s = %q, want tools/list", MCPMethodKey, got)
+	}
+	if got := attrs[MCPProtocolVersionKey].AsString(); got != "2025-11-25" {
+		t.Fatalf("%s = %q, want 2025-11-25", MCPProtocolVersionKey, got)
+	}
+	if got := attrs[attribute.Key("custom")].AsString(); got != "value" {
+		t.Fatalf("custom = %q, want value", got)
+	}
+	if _, ok := attrs[attribute.Key(mcpSDKSessionIDAttr)]; ok {
+		t.Fatal("MCP session ID must not be emitted")
+	}
+}
+
+func TestMCPTracerSuppressesDuplicateInternalToolSpan(t *testing.T) {
+	exporter := tracetest.NewInMemoryExporter()
+	provider := sdktrace.NewTracerProvider(sdktrace.WithSyncer(exporter))
+	defer func() {
+		if err := provider.Shutdown(context.Background()); err != nil {
+			t.Fatalf("shutdown tracer provider: %v", err)
+		}
+	}()
+
+	tracer := NewMCPTracer(provider.Tracer("test"))
+	inputCtx := context.Background()
+	ctx, span := tracer.Start(inputCtx, "tool.signoz_query", mcptracing.SpanKindInternal,
+		mcptracing.String(mcpSDKToolNameAttr, "signoz_query"),
+	)
+	span.End()
+
+	if got := len(exporter.GetSpans()); got != 0 {
+		t.Fatalf("span count = %d, want 0", got)
+	}
+	if ctx != inputCtx {
+		t.Fatal("suppressed tool span changed the context")
+	}
+}
+
+func TestMCPTracerBoundsUnknownMethodTelemetry(t *testing.T) {
+	exporter := tracetest.NewInMemoryExporter()
+	provider := sdktrace.NewTracerProvider(sdktrace.WithSyncer(exporter))
+	t.Cleanup(func() { _ = provider.Shutdown(context.Background()) })
+
+	tracer := NewMCPTracer(provider.Tracer("test"))
+	_, span := tracer.Start(context.Background(), "mcp.attacker/generated-method", mcptracing.SpanKindServer,
+		mcptracing.String(mcpSDKMethodAttr, "attacker/generated-method"),
+	)
+	span.End()
+
+	spans := exporter.GetSpans()
+	if len(spans) != 1 {
+		t.Fatalf("span count = %d, want 1", len(spans))
+	}
+	if spans[0].Name != UnknownMCPMethod {
+		t.Fatalf("span name = %q, want %q", spans[0].Name, UnknownMCPMethod)
+	}
+	attrs := make(map[attribute.Key]attribute.Value)
+	for _, attr := range spans[0].Attributes {
+		attrs[attr.Key] = attr.Value
+	}
+	if got := attrs[MCPMethodKey].AsString(); got != UnknownMCPMethod {
+		t.Fatalf("%s = %q, want %q", MCPMethodKey, got, UnknownMCPMethod)
+	}
+}
+
+func TestMCPTracerTracksWhetherToolMiddlewareRan(t *testing.T) {
+	tracer := NewMCPTracer(nil)
+	ctx, span := tracer.Start(context.Background(), "mcp.tools/call", mcptracing.SpanKindServer,
+		mcptracing.String(mcpSDKMethodAttr, "tools/call"),
+	)
+	defer span.End()
+
+	started, observed, ok := MCPToolRequestObservation(ctx)
+	if !ok || started.IsZero() || observed {
+		t.Fatalf("initial observation = (%v, %t, %t), want started/unobserved/present", started, observed, ok)
+	}
+	MarkMCPToolHandlerObserved(ctx)
+	_, observed, ok = MCPToolRequestObservation(ctx)
+	if !ok || !observed {
+		t.Fatalf("marked observation = (%t, %t), want observed/present", observed, ok)
+	}
+}
+
+func TestNormalizeMCPMethodPreservesKnownNotifications(t *testing.T) {
+	if got := NormalizeMCPMethod(mcp.MethodNotificationToolsListChanged); got != mcp.MethodNotificationToolsListChanged {
+		t.Fatalf("NormalizeMCPMethod() = %q, want %q", got, mcp.MethodNotificationToolsListChanged)
+	}
+}

--- a/pkg/otel/metrics.go
+++ b/pkg/otel/metrics.go
@@ -9,7 +9,6 @@ type Meters struct {
 	ToolCallDuration                   metric.Float64Histogram
 	MethodCalls                        metric.Int64Counter
 	MethodDuration                     metric.Float64Histogram
-	SessionRegistered                  metric.Int64Counter
 	AuthFailures                       metric.Int64Counter
 	OAuthEvents                        metric.Int64Counter
 	OAuthFailures                      metric.Int64Counter
@@ -20,11 +19,9 @@ type Meters struct {
 	DocsFetches                        metric.Int64Counter
 	DocsRefreshes                      metric.Int64Counter
 	DocsRefreshDuration                metric.Float64Histogram
-	DocsIndexAge                       metric.Float64Gauge
 	DocsIndexSizeBytes                 metric.Int64Gauge
 	DocsIndexDocCount                  metric.Int64Gauge
 	DocsIndexGeneration                metric.Int64Gauge
-	DocsFetcherRetries                 metric.Int64Counter
 	DocsSitemapFailures                metric.Int64Counter
 	ToolValidationMismatches           metric.Int64Counter
 	ToolSchemaCompileFailures          metric.Int64Counter
@@ -63,14 +60,6 @@ func NewMeters(mp metric.MeterProvider) (*Meters, error) {
 		"mcp.method.duration",
 		metric.WithDescription("Duration of non-tool MCP method calls"),
 		metric.WithUnit("ms"),
-	)
-	if err != nil {
-		return nil, err
-	}
-
-	sessionRegistered, err := meter.Int64Counter(
-		"mcp.session.registered",
-		metric.WithDescription("Count of MCP sessions successfully registered"),
 	)
 	if err != nil {
 		return nil, err
@@ -120,7 +109,12 @@ func NewMeters(mp metric.MeterProvider) (*Meters, error) {
 	if err != nil {
 		return nil, err
 	}
-	docsSearchDuration, err := meter.Float64Histogram("signoz_docs_search_duration_seconds", metric.WithDescription("Duration of SigNoz docs searches"), metric.WithUnit("s"))
+	docsSearchDuration, err := meter.Float64Histogram(
+		"signoz_docs_search_duration_seconds",
+		metric.WithDescription("Duration of SigNoz docs searches"),
+		metric.WithUnit("s"),
+		metric.WithExplicitBucketBoundaries(.005, .01, .025, .05, .1, .25, .5, 1, 2.5, 5, 10),
+	)
 	if err != nil {
 		return nil, err
 	}
@@ -132,11 +126,12 @@ func NewMeters(mp metric.MeterProvider) (*Meters, error) {
 	if err != nil {
 		return nil, err
 	}
-	docsRefreshDuration, err := meter.Float64Histogram("signoz_docs_refresh_duration_seconds", metric.WithDescription("Duration of SigNoz docs refreshes"), metric.WithUnit("s"))
-	if err != nil {
-		return nil, err
-	}
-	docsIndexAge, err := meter.Float64Gauge("signoz_docs_index_age_seconds", metric.WithDescription("Age of the active SigNoz docs index"), metric.WithUnit("s"))
+	docsRefreshDuration, err := meter.Float64Histogram(
+		"signoz_docs_refresh_duration_seconds",
+		metric.WithDescription("Duration of SigNoz docs refreshes"),
+		metric.WithUnit("s"),
+		metric.WithExplicitBucketBoundaries(.1, .5, 1, 2.5, 5, 10, 30, 60, 120, 300),
+	)
 	if err != nil {
 		return nil, err
 	}
@@ -149,10 +144,6 @@ func NewMeters(mp metric.MeterProvider) (*Meters, error) {
 		return nil, err
 	}
 	docsIndexGeneration, err := meter.Int64Gauge("signoz_docs_index_generation", metric.WithDescription("Active SigNoz docs index generation"))
-	if err != nil {
-		return nil, err
-	}
-	docsFetcherRetries, err := meter.Int64Counter("signoz_docs_fetcher_retries_total", metric.WithDescription("Count of SigNoz docs fetcher retries"))
 	if err != nil {
 		return nil, err
 	}
@@ -186,7 +177,6 @@ func NewMeters(mp metric.MeterProvider) (*Meters, error) {
 		ToolCallDuration:                   toolCallDuration,
 		MethodCalls:                        methodCalls,
 		MethodDuration:                     methodDuration,
-		SessionRegistered:                  sessionRegistered,
 		AuthFailures:                       authFailures,
 		OAuthEvents:                        oauthEvents,
 		OAuthFailures:                      oauthFailures,
@@ -197,11 +187,9 @@ func NewMeters(mp metric.MeterProvider) (*Meters, error) {
 		DocsFetches:                        docsFetches,
 		DocsRefreshes:                      docsRefreshes,
 		DocsRefreshDuration:                docsRefreshDuration,
-		DocsIndexAge:                       docsIndexAge,
 		DocsIndexSizeBytes:                 docsIndexSizeBytes,
 		DocsIndexDocCount:                  docsIndexDocCount,
 		DocsIndexGeneration:                docsIndexGeneration,
-		DocsFetcherRetries:                 docsFetcherRetries,
 		DocsSitemapFailures:                docsSitemapFailures,
 		ToolValidationMismatches:           toolValidationMismatches,
 		ToolSchemaCompileFailures:          toolSchemaCompileFailures,

--- a/pkg/otel/metrics_test.go
+++ b/pkg/otel/metrics_test.go
@@ -1,0 +1,51 @@
+package otel
+
+import (
+	"context"
+	"slices"
+	"testing"
+
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+)
+
+func TestDocsDurationHistogramsUseSecondScaleBuckets(t *testing.T) {
+	reader := sdkmetric.NewManualReader()
+	provider := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+	t.Cleanup(func() { _ = provider.Shutdown(context.Background()) })
+	meters, err := NewMeters(provider)
+	if err != nil {
+		t.Fatalf("NewMeters() error = %v", err)
+	}
+
+	meters.DocsSearchDuration.Record(context.Background(), .05)
+	meters.DocsRefreshDuration.Record(context.Background(), 30)
+	var collected metricdata.ResourceMetrics
+	if err := reader.Collect(context.Background(), &collected); err != nil {
+		t.Fatalf("Collect() error = %v", err)
+	}
+
+	wants := map[string][]float64{
+		"signoz_docs_search_duration_seconds":  {.005, .01, .025, .05, .1, .25, .5, 1, 2.5, 5, 10},
+		"signoz_docs_refresh_duration_seconds": {.1, .5, 1, 2.5, 5, 10, 30, 60, 120, 300},
+	}
+	for _, scope := range collected.ScopeMetrics {
+		for _, metric := range scope.Metrics {
+			want, ok := wants[metric.Name]
+			if !ok {
+				continue
+			}
+			histogram, ok := metric.Data.(metricdata.Histogram[float64])
+			if !ok || len(histogram.DataPoints) != 1 {
+				t.Fatalf("%s data = %T with %d points, want one float64 histogram", metric.Name, metric.Data, len(histogram.DataPoints))
+			}
+			if !slices.Equal(histogram.DataPoints[0].Bounds, want) {
+				t.Fatalf("%s bounds = %v, want %v", metric.Name, histogram.DataPoints[0].Bounds, want)
+			}
+			delete(wants, metric.Name)
+		}
+	}
+	if len(wants) != 0 {
+		t.Fatalf("duration histograms not collected: %v", wants)
+	}
+}

--- a/pkg/toolerrors/errors.go
+++ b/pkg/toolerrors/errors.go
@@ -1,0 +1,58 @@
+// Package toolerrors defines the stable error-code taxonomy shared by MCP
+// tool result producers and telemetry consumers.
+package toolerrors
+
+import "github.com/mark3labs/mcp-go/mcp"
+
+const (
+	CodeValidationFailed   = "VALIDATION_FAILED"
+	CodeUpstreamError      = "UPSTREAM_ERROR"
+	CodeUnauthorized       = "UNAUTHORIZED"
+	CodePermissionDenied   = "PERMISSION_DENIED"
+	CodeNotFound           = "NOT_FOUND"
+	CodeConflict           = "CONFLICT"
+	CodeRateLimited        = "RATE_LIMITED"
+	CodeUnsupported        = "UNSUPPORTED"
+	CodeLicenseUnavailable = "LICENSE_UNAVAILABLE"
+	CodeCanceled           = "CANCELED"
+	CodeTimeout            = "TIMEOUT"
+
+	CodeOutOfScopeURL  = "OUT_OF_SCOPE_URL"
+	CodeDocNotFound    = "DOC_NOT_FOUND"
+	CodeHeadingMissing = "HEADING_NOT_FOUND"
+	CodeIndexNotReady  = "INDEX_NOT_READY"
+)
+
+var knownCodes = map[string]struct{}{
+	CodeValidationFailed:   {},
+	CodeUpstreamError:      {},
+	CodeUnauthorized:       {},
+	CodePermissionDenied:   {},
+	CodeNotFound:           {},
+	CodeConflict:           {},
+	CodeRateLimited:        {},
+	CodeUnsupported:        {},
+	CodeLicenseUnavailable: {},
+	CodeCanceled:           {},
+	CodeTimeout:            {},
+	CodeOutOfScopeURL:      {},
+	CodeDocNotFound:        {},
+	CodeHeadingMissing:     {},
+	CodeIndexNotReady:      {},
+}
+
+// Code extracts a known structured code from an MCP tool error result.
+func Code(result *mcp.CallToolResult) string {
+	if result == nil || !result.IsError {
+		return ""
+	}
+	content, ok := result.StructuredContent.(map[string]any)
+	if !ok {
+		return ""
+	}
+	code, _ := content["code"].(string)
+	if _, ok := knownCodes[code]; !ok {
+		return ""
+	}
+	return code
+}

--- a/pkg/toolerrors/errors_test.go
+++ b/pkg/toolerrors/errors_test.go
@@ -1,0 +1,30 @@
+package toolerrors
+
+import (
+	"testing"
+
+	"github.com/mark3labs/mcp-go/mcp"
+)
+
+func TestCode(t *testing.T) {
+	tests := []struct {
+		name   string
+		result *mcp.CallToolResult
+		want   string
+	}{
+		{name: "nil"},
+		{name: "success", result: &mcp.CallToolResult{StructuredContent: map[string]any{"code": CodeTimeout}}},
+		{name: "unknown", result: &mcp.CallToolResult{IsError: true, StructuredContent: map[string]any{"code": "CALLER_VALUE"}}},
+		{name: "wrong shape", result: &mcp.CallToolResult{IsError: true, StructuredContent: []string{CodeTimeout}}},
+		{name: "handler code", result: &mcp.CallToolResult{IsError: true, StructuredContent: map[string]any{"code": CodePermissionDenied}}, want: CodePermissionDenied},
+		{name: "docs code", result: &mcp.CallToolResult{IsError: true, StructuredContent: map[string]any{"code": CodeIndexNotReady}}, want: CodeIndexNotReady},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := Code(tt.result); got != tt.want {
+				t.Fatalf("Code() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/util/context.go
+++ b/pkg/util/context.go
@@ -14,7 +14,6 @@ const (
 	authHeaderContextKey           contextKey = "auth_header"
 	signozURLContextKey            contextKey = "signoz_url"
 	searchContextContextKey        contextKey = "search_context"
-	sessionIDContextKey            contextKey = "session_id"
 	toolNameContextKey             contextKey = "tool_name"
 	clientSourceContextKey         contextKey = "client_source"
 	assistantThreadIDContextKey    contextKey = "assistant_thread_id"
@@ -90,17 +89,6 @@ func SetSearchContext(ctx context.Context, text string) context.Context {
 func GetSearchContext(ctx context.Context) (string, bool) {
 	text, ok := ctx.Value(searchContextContextKey).(string)
 	return text, ok
-}
-
-// SetSessionID stores the MCP session ID in the context.
-func SetSessionID(ctx context.Context, id string) context.Context {
-	return context.WithValue(ctx, sessionIDContextKey, id)
-}
-
-// GetSessionID retrieves the MCP session ID from the context.
-func GetSessionID(ctx context.Context) (string, bool) {
-	id, ok := ctx.Value(sessionIDContextKey).(string)
-	return id, ok
 }
 
 // SetToolName stores the MCP tool name in the context.

--- a/pkg/util/http.go
+++ b/pkg/util/http.go
@@ -7,8 +7,6 @@ import (
 	"strings"
 )
 
-const HeaderMCPSessionID = "Mcp-Session-Id"
-
 // HTTPClientAddress returns the best available client address for request
 // telemetry. It prefers forwarded headers because production traffic reaches
 // the server through ingress/proxy layers.
@@ -65,14 +63,6 @@ func HTTPUserAgent(r *http.Request) string {
 		return ""
 	}
 	return NormalizeCallerCorrelationValue(r.UserAgent())
-}
-
-// HTTPSessionID returns the MCP session ID header after basic normalization.
-func HTTPSessionID(r *http.Request) string {
-	if r == nil {
-		return ""
-	}
-	return NormalizeCallerCorrelationValue(r.Header.Get(HeaderMCPSessionID))
 }
 
 func normalizeClientAddress(s string) string {

--- a/plans/analytics.md
+++ b/plans/analytics.md
@@ -812,7 +812,7 @@ All event names are defined in [pkg/analytics/events.go](../pkg/analytics/events
 
 | Event | Fired at | Notable attributes |
 | --- | --- | --- |
-| `MCP Session: Registered` | `AddAfterInitialize` hook (successful initialize) | `tenantUrl`, `clientName`, `clientVersion`, `protocolVersion` |
+| `MCP Client: Initialized` | `AddAfterInitialize` hook (successful initialize) | `tenantUrl`, `clientName`, `clientVersion`, `protocolVersion`, `clientSource`, `assistantThreadId`/`assistantExecutionId` |
 | `MCP Tool: Called` | tool-handler middleware, post-return | `toolName`, `toolIsError`, `durationMs`, `errorType`, `tenantUrl`, `clientSource`, `assistantThreadId`/`assistantExecutionId` |
 | `MCP Prompt: Fetched` | `AddAfterGetPrompt` (success only) | `promptName`, `tenantUrl` |
 | `MCP Resource: Fetched` | `AddAfterReadResource` (success only) | `resourceUri`, `tenantUrl` |
@@ -823,11 +823,11 @@ Every event is enriched with identity attributes (`orgId`, `principal`, `name`, 
 
 ### Async dispatch
 
-All analytics emission runs on a detached goroutine via `trackEventAsync` / `identifyAsync` / `identifyAndTrackAsync` with a 5s budget and its own context carrying credentials, session/tenant context, and the OTel span context (so the identity HTTP request joins the originating tool-call trace). Tool-call latency is never blocked on analytics.
+All analytics emission runs on a detached goroutine via `trackEventAsync` with a 5s budget and its own context carrying credentials, tenant/caller context, and the OTel span context (so the identity HTTP request joins the originating tool-call trace). Tool-call latency is never blocked on analytics.
 
 ### Client attribution (stateless transport)
 
-The Streamable HTTP transport runs stateless (`WithStateLess(true)`; see [architecture.md](architecture.md)) — no `Mcp-Session-Id` is issued and there is no session to correlate requests across. Consequently MCP `ClientInfo` (Name, Version from `InitializeRequest.Params.ClientInfo`) is attached **only to `MCP Session: Registered`**, read directly from the initialize request in the `AfterInitialize` hook. Per-call events (`MCP Tool: Called`, `MCP Prompt: Fetched`, `MCP Resource: Fetched`) do **not** carry `clientName`/`clientVersion`, and `sessionId` is unset on all events. (The earlier per-session `expirable.LRU[string, mcp.Implementation]` cache that propagated client info onto later events was removed with the move to stateless.) `clientSource` and assistant correlation (`assistantThreadId`/`assistantExecutionId`) are unaffected — they are header-derived and attached per request via `attachCallerCorrelation`.
+The Streamable HTTP transport runs stateless (`WithStateLess(true)`; see [architecture.md](architecture.md)) — no `Mcp-Session-Id` is issued and there is no server-owned session lifecycle to report. The successful initialize request emits `MCP Client: Initialized`, sourcing `clientName`/`clientVersion` directly from its MCP `ClientInfo` and `protocolVersion` from the negotiated result. Those fields are not attached to later calls because stateless requests cannot be correlated through a durable session. `clientSource` and assistant correlation (`assistantThreadId`/`assistantExecutionId`) are header-derived and attached per request via `attachCallerCorrelation`.
 
 ### OAuth
 

--- a/plans/telemetry-semantics-cleanup.context.md
+++ b/plans/telemetry-semantics-cleanup.context.md
@@ -1,0 +1,58 @@
+# Feature: Telemetry Semantics Cleanup — Context & Discussion
+
+## Original Prompt
+> Review the telemetry audit decisions and implement the selected changes:
+> - Drop `MCP Session: Registered` instead of renaming it.
+> - Drop incoming `Mcp-Session-Id` from logs and spans.
+> - Fix MCP `_meta.traceparent` propagation.
+> - Explain and implement the correct OpenTelemetry semantics for tool spans.
+> - Fix tool error classification to use structured error codes and expose useful operational attributes.
+> - Drop `signoz_docs_fetcher_retries_total`.
+> - Drop `signoz_docs_index_age_seconds`.
+> - Classify MCP method cancellations and deadlines correctly.
+
+## Reference Links
+- [OpenTelemetry MCP semantic conventions](https://raw.githubusercontent.com/open-telemetry/semantic-conventions-genai/main/docs/gen-ai/mcp.md)
+- [SEP-414 request metadata trace propagation](https://modelcontextprotocol.io/seps/414-request-meta)
+- [mcp-go v0.56.0 server tracing source](https://github.com/mark3labs/mcp-go/blob/v0.56.0/server/tracing.go)
+
+## Key Decisions & Discussion Log
+
+### 2026-07-15 — Owner-selected telemetry cleanup
+- Drop the initialization-derived analytics event and counter; do not replace them with renamed client-initialization signals.
+- Drop session lifecycle hook logs and their analytics Identify side effect along with the event. Product events continue resolving identity independently before Track calls.
+- Stop treating the unvalidated incoming `Mcp-Session-Id` HTTP header as an observability correlation value. Actual SDK session context remains available where the transport genuinely has one.
+- Adopt MCP `_meta` W3C trace context as the remote parent for MCP server spans and link the ambient HTTP transport span when both exist.
+- Use one MCP `SERVER` span per request. Tool calls use span name `tools/call {gen_ai.tool.name}`, required `mcp.method.name=tools/call`, `gen_ai.operation.name=execute_tool`, and `gen_ai.tool.name`. Do not synthesize `gen_ai.tool.call.id`; the JSON-RPC request ID is a separate semantic field and is not exposed to the tool middleware.
+- For `CallToolResult{isError:true}`, keep semconv `error.type=tool_error` and add the bounded structured application code as custom `mcp.tool.error.code`. Product analytics uses the structured code instead of display-text parsing, with the legacy classifier only as fallback.
+- Remove the docs retry counter and index-age gauge entirely.
+- Preserve `context.Canceled` and `context.DeadlineExceeded` through method observation cleanup so they become `cancelled` and `timeout`, not `internal`.
+
+## Open Questions
+- [x] Rename the dropped session event/metric? → No; remove both.
+- [x] Keep the raw incoming session header under a diagnostic name? → No; drop it.
+- [x] What is the correct tool span? → One MCP `SERVER` span named `tools/call {tool}` with MCP and GenAI attributes; no fabricated tool-call ID.
+- [x] Keep the docs age/retry instruments? → No; remove them.
+
+### 2026-07-15 — Trace propagation excluded
+- The owner explicitly excluded extracting `traceparent` / `tracestate` from MCP `params._meta` from this change.
+- Keep the corrected MCP request/tool span naming and attributes, but preserve the existing transport-owned parent context and do not register an MCP metadata propagator.
+
+### 2026-07-15 — Structured tool errors are authoritative
+- Product analytics no longer infers an error category from user-facing text. Known structured result codes are authoritative; an error result without one is classified only as `tool_error`.
+
+### 2026-07-15 — Reason for excluding MCP metadata parenting
+- The owner noted that an instrumented agent may not export its telemetry to the same SigNoz Cloud tenant. Parenting MCP server spans to the agent's `_meta.traceparent` would then leave the ingested MCP trace without its remote root.
+- Preserve locally complete MCP traces. If cross-agent correlation is added later, evaluate an opt-in span link instead of unconditional remote parenting.
+
+### 2026-07-15 — Preserve initialization client metadata
+- The dropped registration event was the only Mixpanel event carrying MCP `ClientInfo` name/version.
+- Restore the successful-initialize Track event as `MCP Client: Initialized`. It reports client metadata without claiming that a durable session was registered.
+- Do not restore `mcp.session.registered`, session IDs, session lifecycle logs, or the profile-level Identify side effect.
+
+### 2026-07-15 — Multi-agent review remediation
+- Bound MCP method span names and `mcp.method.name` to the protocol's known method set; record unrecognized methods as `unknown` so client-controlled JSON-RPC methods cannot create unbounded telemetry cardinality.
+- Observe `tools/call` failures that occur before registered tool middleware runs, using the bounded tool name `unknown` and the same metrics, analytics, and span error semantics as handler-observed calls.
+- Remove manual `End` calls for spans owned by the mcp-go tracing lifecycle.
+- Move the known structured tool-error taxonomy and extraction into a shared package used by producers and telemetry consumers.
+- Add explicit second-based histogram buckets for docs search and refresh durations.

--- a/plans/telemetry-semantics-cleanup.plan.md
+++ b/plans/telemetry-semantics-cleanup.plan.md
@@ -1,0 +1,38 @@
+# Plan: Telemetry Semantics Cleanup
+
+## Status
+Done
+
+## Context
+Several analytics, log, metric, and trace signals either describe lifecycle state the stateless server does not own, expose unvalidated correlation values, or diverge from current MCP OpenTelemetry conventions. The owner selected the signals to remove and the correctness fixes to implement.
+
+## Approach
+1. Replace the misleading session-registration analytics event with a successful client-initialization event carrying `ClientInfo`; remove its session counter, lifecycle logs, Identify side effect, and session-specific fields.
+2. Remove incoming `Mcp-Session-Id` from HTTP log and span attributes.
+3. Replace the custom HTTP-only method-span ownership with mcp-go request tracing backed by a repository adapter that:
+   - preserves the transport-provided parent context and does not extract trace context from MCP `_meta`;
+   - emits semconv MCP server span names/attributes;
+   - suppresses mcp-go's redundant internal tool span.
+4. Decorate tool request spans as `tools/call {tool}`, omit synthetic tool-call IDs, and emit semconv `error.type` plus bounded structured `mcp.tool.error.code` on spans and metrics.
+5. Classify method deadlines/cancellations before generic internal failures and preserve the actual context error through observation expiry.
+6. Remove the docs index-age and fetcher-retry instruments and their tests.
+7. Apply multi-agent review findings: bound unknown method telemetry, observe pre-handler tool failures, remove stale span ownership, centralize structured error codes, and configure docs duration buckets in seconds.
+
+## Files to Modify
+- `internal/mcp-server/server.go` — server tracing ownership, event removals, session-header removal, and error classification.
+- `pkg/otel/mcp.go` — MCP tracer adapter.
+- `pkg/otel/attr.go` — corrected MCP/tool attributes.
+- `pkg/otel/metrics.go` — remove selected metrics.
+- `pkg/log/http.go`, `pkg/util/http.go` — remove incoming session-header telemetry.
+- `pkg/analytics/events.go` — define the client-initialized event and its client/protocol fields without session fields.
+- `internal/docs/metrics.go` — stop recording index age.
+- `pkg/toolerrors/errors.go` — shared structured tool-error taxonomy and extraction.
+- Focused tests under `internal/mcp-server`, `internal/docs`, `pkg/otel`, `pkg/log`, and `pkg/util`.
+
+## Verification
+- `gofmt` on changed Go files — passed.
+- Focused tests for client-initialization analytics, bounded span names/attributes, pre-handler tool failures, structured tool errors, method cancellation/timeout classification, docs histogram buckets, and removed metrics — passed.
+- `go test ./...` — passed.
+- `go vet ./...` — passed.
+- `go test -race ./internal/mcp-server ./pkg/otel ./pkg/toolerrors` — passed.
+- `git diff --check` — passed.


### PR DESCRIPTION
## Summary

- replace the misleading `MCP Session: Registered` analytics event with `MCP Client: Initialized`, preserving client name, client version, and negotiated protocol without claiming durable session state
- remove unvalidated session identifiers and session lifecycle signals from logs, spans, metrics, and analytics
- use the mcp-go request span as the single MCP server span, with bounded method names, MCP/GenAI tool attributes, and fallback telemetry for failures before tool middleware runs
- classify method cancellation, timeout, and structured tool errors consistently across spans, metrics, and analytics
- remove unused/stale docs retry and index-age metrics and add second-scale histogram buckets for docs durations
- correct the OAuth API-key tooltip so it no longer states that generating an API key requires the Admin role
- update architecture and analytics documentation and include the telemetry decision context/plan

## Why

The previous signals mixed stateless request behavior with session semantics, accepted caller-controlled correlation values, and emitted incomplete or misleading OpenTelemetry attributes. Some invalid tool calls also bypassed tool telemetry entirely, while docs duration histograms used buckets that did not match their seconds unit.

The OAuth tooltip also imposed an inaccurate Admin-role requirement on the service-account API-key flow.

This makes the telemetry bounded, operationally useful, and consistent with the server's actual lifecycle ownership while keeping the authorization guidance accurate.

## Compatibility

- MCP `params._meta.traceparent` / `tracestate` extraction remains intentionally disabled so SigNoz Cloud does not ingest orphaned child spans when the caller's root trace is exported elsewhere.
- No MCP tool or parameter contract changed, so the companion `SigNoz/agent-skills` repository does not need an update.

## Verification

- `go test ./...`
- `go vet ./...`
- `go test -race ./internal/mcp-server ./pkg/otel ./pkg/toolerrors`
- `go test ./internal/oauth`
- `git diff --check`
