### PR TITLE
fix(observability): propagate build version and user agent

### DIFF
--- a/.github/workflows/dockerbuildci.yaml
+++ b/.github/workflows/dockerbuildci.yaml
@@ -18,7 +18,7 @@ jobs:
       PRIMUS_REF: main
       GO_BUILD_CONTEXT: ./cmd/server
       GO_VERSION: 1.25
-      GO_BUILD_FLAGS: ""
+      GO_BUILD_FLAGS: "-ldflags=-X=github.com/SigNoz/signoz-mcp-server/pkg/version.Version=${{ github.ref_type == 'tag' && github.ref_name || github.sha }}"
       DOCKER_BASE_IMAGES: '{"distroless":"gcr.io/distroless/base:latest"}'
       DOCKER_DOCKERFILE_PATH: Dockerfile.multi-arch
       DOCKER_MANIFEST: true

--- a/.github/workflows/dockerbuildci.yaml
+++ b/.github/workflows/dockerbuildci.yaml
@@ -18,7 +18,7 @@ jobs:
       PRIMUS_REF: main
       GO_BUILD_CONTEXT: ./cmd/server
       GO_VERSION: 1.25
-      GO_BUILD_FLAGS: "-ldflags=-X=github.com/SigNoz/signoz-mcp-server/pkg/version.Version=${{ github.ref_type == 'tag' && github.ref_name || github.sha }}"
+      GO_BUILD_FLAGS: "-ldflags=-X=github.com/SigNoz/signoz-mcp-server/pkg/version.Version=$($MAKE info-version)"
       DOCKER_BASE_IMAGES: '{"distroless":"gcr.io/distroless/base:latest"}'
       DOCKER_DOCKERFILE_PATH: Dockerfile.multi-arch
       DOCKER_MANIFEST: true

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -13,7 +13,7 @@ builds:
     binary: bin/signoz-mcp-server
     main: ./cmd/server/
     ldflags:
-      - -s -w -X github.com/SigNoz/signoz-mcp-server/pkg/version.Version={{.Version}}
+      - -s -w -X github.com/SigNoz/signoz-mcp-server/pkg/version.Version={{.Tag}}
     goos:
       - linux
       - darwin

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,8 @@
 # Build stage
 FROM golang:1.25-alpine AS builder
 
+ARG VERSION=dev
+
 # Install git and ca-certificates for dependencies
 RUN apk --no-cache add git ca-certificates tzdata
 
@@ -17,7 +19,7 @@ COPY . .
 
 # Build the application with optimizations
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build \
-    -ldflags='-w -s -extldflags "-static"' \
+    -ldflags="-w -s -extldflags=-static -X github.com/SigNoz/signoz-mcp-server/pkg/version.Version=${VERSION}" \
     -a -installsuffix cgo \
     -o signoz-mcp-server \
     ./cmd/server/

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -22,11 +22,13 @@ import (
 	otelpkg "github.com/SigNoz/signoz-mcp-server/pkg/otel"
 	"github.com/SigNoz/signoz-mcp-server/pkg/types"
 	"github.com/SigNoz/signoz-mcp-server/pkg/util"
+	"github.com/SigNoz/signoz-mcp-server/pkg/version"
 )
 
 const (
 	SignozApiKey = "SIGNOZ-API-KEY"
 	ContentType  = "Content-Type"
+	UserAgent    = "User-Agent"
 
 	// DefaultQueryTimeout is used for read-only API calls.
 	DefaultQueryTimeout = 600 * time.Second
@@ -38,7 +40,10 @@ const (
 	analyticsIdentityCacheTTL = 10 * time.Minute
 )
 
-var ErrUnauthorized = errors.New("signoz credentials rejected")
+var (
+	ErrUnauthorized  = errors.New("signoz credentials rejected")
+	defaultUserAgent = version.UserAgent()
+)
 
 // HTTPStatusError preserves status and response details from a non-2xx SigNoz API response.
 type HTTPStatusError struct {
@@ -134,6 +139,29 @@ func (s *SigNoz) ensureTenantContext(ctx context.Context) context.Context {
 		return util.SetSigNozURL(ctx, s.baseURL)
 	}
 	return ctx
+}
+
+func (s *SigNoz) setRequestHeaders(ctx context.Context, req *http.Request, warnReserved bool) {
+	req.Header.Set(ContentType, "application/json")
+	req.Header.Set(s.authHeaderName, s.apiKey)
+	req.Header.Set(UserAgent, defaultUserAgent)
+
+	for name, value := range s.customHeaders {
+		if strings.EqualFold(name, UserAgent) {
+			if value = strings.TrimSpace(value); value != "" {
+				req.Header.Set(UserAgent, value+" "+defaultUserAgent)
+			}
+			continue
+		}
+		if strings.EqualFold(name, ContentType) || strings.EqualFold(name, s.authHeaderName) {
+			if warnReserved {
+				s.logger.WarnContext(ctx, "Custom header overrides a reserved header",
+					slog.String("header", name), slog.String("value", value))
+			}
+			continue
+		}
+		req.Header.Set(name, value)
+	}
 }
 
 // ValidateCredentials performs a lightweight authenticated request against the
@@ -281,14 +309,7 @@ func (s *SigNoz) doValidationRequest(ctx context.Context, reqURL string) (int, [
 		return 0, nil, fmt.Errorf("failed to create validation request: %w", err)
 	}
 
-	req.Header.Set(ContentType, "application/json")
-	req.Header.Set(s.authHeaderName, s.apiKey)
-
-	for k, v := range s.customHeaders {
-		if !strings.EqualFold(k, ContentType) && !strings.EqualFold(k, s.authHeaderName) {
-			req.Header.Set(k, v)
-		}
-	}
+	s.setRequestHeaders(ctx, req, false)
 
 	resp, err := s.httpClient.Do(req)
 	if err != nil {
@@ -369,18 +390,7 @@ func (s *SigNoz) doRequest(ctx context.Context, method, reqURL string, body io.R
 			return nil, fmt.Errorf("failed to create request: %w", err)
 		}
 
-		req.Header.Set(ContentType, "application/json")
-
-		req.Header.Set(s.authHeaderName, s.apiKey)
-
-		for k, v := range s.customHeaders {
-			if strings.EqualFold(k, ContentType) || strings.EqualFold(k, s.authHeaderName) {
-				s.logger.WarnContext(ctx, "Custom header overrides a reserved header",
-					slog.String("header", k), slog.String("value", v))
-				continue
-			}
-			req.Header.Set(k, v)
-		}
+		s.setRequestHeaders(ctx, req, true)
 
 		resp, err := s.httpClient.Do(req)
 		if err != nil {

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/SigNoz/signoz-mcp-server/pkg/types"
+	"github.com/SigNoz/signoz-mcp-server/pkg/version"
 )
 
 func newBufferedLogger(buf *bytes.Buffer, level slog.Level) *slog.Logger {
@@ -136,6 +137,7 @@ func TestListAlertRules(t *testing.T) {
 		assert.Equal(t, "", r.URL.RawQuery)
 		assert.Equal(t, "application/json", r.Header.Get("Content-Type"))
 		assert.Equal(t, "test-api-key", r.Header.Get("SIGNOZ-API-KEY"))
+		assert.Equal(t, version.UserAgent(), r.Header.Get("User-Agent"))
 
 		w.WriteHeader(http.StatusOK)
 		_, _ = w.Write([]byte(`{"status":"success","data":[{"id":"rule-1","alert":"High CPU","state":"inactive"}]}`))
@@ -216,6 +218,7 @@ func TestValidateCredentials(t *testing.T) {
 			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				assert.Equal(t, "application/json", r.Header.Get("Content-Type"))
 				assert.Equal(t, "test-api-key", r.Header.Get("SIGNOZ-API-KEY"))
+				assert.Equal(t, "custom-client/1.0 "+version.UserAgent(), r.Header.Get("User-Agent"))
 				assert.Equal(t, http.MethodGet, r.Method)
 
 				switch r.URL.Path {
@@ -234,7 +237,9 @@ func TestValidateCredentials(t *testing.T) {
 			defer server.Close()
 
 			logger := logpkg.New("debug")
-			client := NewClient(logger, server.URL, "test-api-key", "SIGNOZ-API-KEY", nil)
+			client := NewClient(logger, server.URL, "test-api-key", "SIGNOZ-API-KEY", map[string]string{
+				"User-Agent": "custom-client/1.0",
+			})
 
 			err := client.ValidateCredentials(context.Background())
 
@@ -1759,6 +1764,7 @@ func TestNewClient_ReservedHeadersSkipped(t *testing.T) {
 	customHeaders := map[string]string{
 		"Content-Type":        "text/plain",
 		"SIGNOZ-API-KEY":      "overridden-key",
+		"User-Agent":          "custom-client/1.0",
 		"CF-Access-Client-Id": "test-id",
 	}
 
@@ -1766,6 +1772,7 @@ func TestNewClient_ReservedHeadersSkipped(t *testing.T) {
 		// Reserved headers should NOT be overridden by custom headers
 		assert.Equal(t, "application/json", r.Header.Get("Content-Type"))
 		assert.Equal(t, "test-api-key", r.Header.Get("SIGNOZ-API-KEY"))
+		assert.Equal(t, "custom-client/1.0 "+version.UserAgent(), r.Header.Get("User-Agent"))
 
 		// Non-reserved custom headers should still be injected
 		assert.Equal(t, "test-id", r.Header.Get("CF-Access-Client-Id"))

--- a/internal/docs/fetcher.go
+++ b/internal/docs/fetcher.go
@@ -197,11 +197,7 @@ func retryAfter(raw string) time.Duration {
 }
 
 func defaultUserAgent() string {
-	ver := strings.TrimSpace(version.Version)
-	if ver == "" {
-		ver = "dev"
-	}
-	return fmt.Sprintf("signoz-mcp-server/%s (+https://github.com/SigNoz/signoz-mcp-server; docs-indexer)", ver)
+	return version.UserAgent() + " (+https://github.com/SigNoz/signoz-mcp-server; docs-indexer)"
 }
 
 func RemoteHost(remoteAddr string) string {

--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -5,6 +5,8 @@ import (
 	"log/slog"
 	"os"
 	"strings"
+
+	"github.com/SigNoz/signoz-mcp-server/pkg/version"
 )
 
 const (
@@ -41,7 +43,9 @@ func New(level string) *slog.Logger {
 		},
 	})
 
-	return slog.New(NewContextHandler(baseHandler))
+	return slog.New(NewContextHandler(baseHandler)).With(
+		slog.String("service.version", version.Version),
+	)
 }
 
 func ErrAttr(err error) slog.Attr {

--- a/pkg/log/log_test.go
+++ b/pkg/log/log_test.go
@@ -3,11 +3,14 @@ package log
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"io"
 	"log/slog"
 	"os"
 	"strings"
 	"testing"
+
+	"github.com/SigNoz/signoz-mcp-server/pkg/version"
 )
 
 func TestNew_WritesToStderr(t *testing.T) {
@@ -61,5 +64,13 @@ func TestNew_WritesToStderr(t *testing.T) {
 	}
 	if !strings.Contains(string(stderrBytes), "\"transport_mode\":\"stdio\"") {
 		t.Fatalf("expected structured stderr log output, got %q", string(stderrBytes))
+	}
+
+	var record map[string]any
+	if err := json.Unmarshal(stderrBytes, &record); err != nil {
+		t.Fatalf("parse stderr log record: %v", err)
+	}
+	if got := record["service.version"]; got != version.Version {
+		t.Fatalf("service.version = %v, want %q", got, version.Version)
 	}
 }

--- a/pkg/otel/metrics_test.go
+++ b/pkg/otel/metrics_test.go
@@ -5,9 +5,50 @@ import (
 	"slices"
 	"testing"
 
+	"github.com/SigNoz/signoz-mcp-server/pkg/version"
 	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
 	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+	semconv "go.opentelemetry.io/otel/semconv/v1.37.0"
 )
+
+func TestMetricsIncludeBuildVersionResource(t *testing.T) {
+	t.Setenv("OTEL_RESOURCE_ATTRIBUTES", "service.version=from-env")
+
+	ctx := context.Background()
+	res, err := NewResource(ctx, version.Version)
+	if err != nil {
+		t.Fatalf("NewResource() error = %v", err)
+	}
+
+	reader := sdkmetric.NewManualReader()
+	provider := sdkmetric.NewMeterProvider(
+		sdkmetric.WithReader(reader),
+		sdkmetric.WithResource(res),
+	)
+	t.Cleanup(func() { _ = provider.Shutdown(ctx) })
+
+	meters, err := NewMeters(provider)
+	if err != nil {
+		t.Fatalf("NewMeters() error = %v", err)
+	}
+	meters.DocsSearchDuration.Record(ctx, .05)
+
+	var collected metricdata.ResourceMetrics
+	if err := reader.Collect(ctx, &collected); err != nil {
+		t.Fatalf("Collect() error = %v", err)
+	}
+	if collected.Resource == nil {
+		t.Fatal("collected metrics have no resource")
+	}
+
+	got, ok := collected.Resource.Set().Value(semconv.ServiceVersionKey)
+	if !ok {
+		t.Fatal("collected metrics resource has no service.version")
+	}
+	if got.AsString() != version.Version {
+		t.Fatalf("service.version = %q, want %q", got.AsString(), version.Version)
+	}
+}
 
 func TestDocsDurationHistogramsUseSecondScaleBuckets(t *testing.T) {
 	reader := sdkmetric.NewManualReader()

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,4 +1,17 @@
 package version
 
+import "strings"
+
+const productName = "signoz-mcp-server"
+
 // Version is overridden at build time via ldflags.
 var Version = "dev"
+
+// UserAgent returns the RFC 9110 product identifier for this build.
+func UserAgent() string {
+	value := strings.TrimSpace(Version)
+	if value == "" {
+		value = "dev"
+	}
+	return productName + "/" + value
+}

--- a/pkg/version/version_test.go
+++ b/pkg/version/version_test.go
@@ -1,0 +1,28 @@
+package version
+
+import "testing"
+
+func TestUserAgent(t *testing.T) {
+	original := Version
+	t.Cleanup(func() { Version = original })
+
+	tests := []struct {
+		name    string
+		version string
+		want    string
+	}{
+		{name: "release", version: "v0.8.1", want: "signoz-mcp-server/v0.8.1"},
+		{name: "branch", version: "main-abcdef0", want: "signoz-mcp-server/main-abcdef0"},
+		{name: "trimmed", version: "  v0.8.1  ", want: "signoz-mcp-server/v0.8.1"},
+		{name: "blank fallback", version: " ", want: "signoz-mcp-server/dev"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			Version = tt.version
+			if got := UserAgent(); got != tt.want {
+				t.Fatalf("UserAgent() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/plans/observability-refactor.context.md
+++ b/plans/observability-refactor.context.md
@@ -160,3 +160,7 @@ GitHub issue #136 showed the "OTLP always on" decision was too sharp for self-ho
 
 ## Open Questions
 _(none — plan approved by Codex after 3 rounds; post-ship review findings addressed)_
+
+### 2026-07-15 — Docker image `service.version` parity
+- Follow-up review found that Make and GoReleaser injected `pkg/version.Version`, but the official Primus workflow passed empty `GO_BUILD_FLAGS` and the standalone Dockerfile had no version linker flag. Those images therefore exported the default `service.version=dev`.
+- Decision: tagged release builds inject the exact Git tag, which is also the published Docker tag; `main` builds inject the commit SHA so each deployment remains distinguishable. Standalone Docker builds accept an explicit `VERSION` build argument because an OCI image tag is not automatically available inside a Docker build.

--- a/plans/observability-refactor.context.md
+++ b/plans/observability-refactor.context.md
@@ -164,3 +164,14 @@ _(none — plan approved by Codex after 3 rounds; post-ship review findings addr
 ### 2026-07-15 — Docker image `service.version` parity
 - Follow-up review found that Make and GoReleaser injected `pkg/version.Version`, but the official Primus workflow passed empty `GO_BUILD_FLAGS` and the standalone Dockerfile had no version linker flag. Those images therefore exported the default `service.version=dev`.
 - Decision: tagged release builds inject the exact Git tag, which is also the published Docker tag; `main` builds inject the commit SHA so each deployment remains distinguishable. Standalone Docker builds accept an explicit `VERSION` build argument because an OCI image tag is not automatically available inside a Docker build.
+
+## Key Decisions & Discussion Log (continued)
+
+### 2026-07-15 — Independent review corrections
+- The initial workflow forwarded `github.ref_name` through `GO_BUILD_FLAGS`; Primus interpolates that input into a shell command, so flexible tag names could be interpreted as shell syntax. The workflow now passes only the repo-owned `$($MAKE info-version)` expression.
+- Primus's canonical `VERSION` is also the Docker image tag (`v0.8.1` for a release and `main-<shortsha>` for a main build), so injecting that value makes `service.version` match the image tag exactly.
+- GoReleaser now injects `{{.Tag}}` instead of `{{.Version}}`, preserving the leading `v` and keeping release binaries aligned with Docker images.
+
+### 2026-07-15 — `service.version` signal coverage
+- OpenTelemetry associates a `MeterProvider` resource with all metrics produced by its meters. The existing meter provider already receives the resource created with `semconv.ServiceVersion`, so metrics need regression coverage rather than an additional datapoint attribute.
+- Application logs are structured JSON on stderr, not records from an OpenTelemetry `LoggerProvider`. Decision: attach `version.Version` as the global `service.version` log field so every record carries the same build identity.

--- a/plans/observability-refactor.plan.md
+++ b/plans/observability-refactor.plan.md
@@ -1,7 +1,7 @@
 # Plan: Observability Refactor
 
 ## Status
-Done
+In Progress
 
 ## Context
 The MCP server's observability has three gaps relative to Zeus's pattern:
@@ -26,8 +26,11 @@ Single PR, three commits. Each commit compiles and tests green independently so 
 
 ### Post-ship follow-up — Docker `service.version` parity
 
-- The official Primus workflow passes the release Git tag into `pkg/version.Version` through `GO_BUILD_FLAGS`; branch builds use the commit SHA so deployment markers remain unique.
+- The official Primus workflow injects its canonical `VERSION` into `pkg/version.Version` through `GO_BUILD_FLAGS`, so `service.version` exactly matches the published image tag for both release and branch builds.
+- GoReleaser injects its full Git tag through the same linker variable so binaries from the same release use the same version representation as Docker images.
 - The standalone Dockerfile accepts `VERSION` as a build argument and injects it through the same linker variable. The image tag must be passed explicitly because OCI tags are not visible inside the build or running container.
+- Metrics retain `service.version` as an OpenTelemetry resource attribute through the shared `MeterProvider` resource; a manual-reader regression test verifies the exported `ResourceMetrics` value.
+- JSON stderr logs include `service.version` as a global structured field. They do not use an OpenTelemetry `LoggerProvider`, so they cannot inherit the SDK resource automatically.
 
 ### Commit 1 — OTel scaffolding + graceful lifecycle (no logger migration)
 
@@ -70,7 +73,7 @@ Introduce `pkg/otel`, `pkg/version`, and refactor the server for graceful shutdo
 - `server.NewMCPServer("SigNozMCP", version.Version, ...)` — replaces hard-coded `"0.0.1"` at [server.go:263](internal/mcp-server/server.go#L263).
 - Integration test still pins an expected version by reading `version.Version` at test time.
 - `Makefile` `build` target adds `-ldflags "-X github.com/SigNoz/signoz-mcp-server/pkg/version.Version=$(VERSION)"` (VERSION defaults to `git describe --tags --always --dirty 2>/dev/null || echo dev`).
-- `.goreleaser.yaml` — add `ldflags: -s -w -X github.com/SigNoz/signoz-mcp-server/pkg/version.Version={{.Version}}` under `builds[0]` (same convention Goreleaser uses; `{{.Version}}` is the tag without leading `v`).
+- `.goreleaser.yaml` — add `ldflags: -s -w -X github.com/SigNoz/signoz-mcp-server/pkg/version.Version={{.Tag}}` under `builds[0]` so release binaries preserve the exact Git/Docker tag.
 
 **Commit 1 compiles because:**
 - Zap is untouched.
@@ -164,9 +167,12 @@ Specifically:
 - `internal/client/client.go` — swap attr imports.
 - `internal/telemetry/telemetry.go` — thin shim delegating to `pkg/otel`; remove `genai.go` (moved).
 - `Makefile` — `-ldflags` on build target.
-- `.goreleaser.yaml` — `ldflags: -s -w -X .../pkg/version.Version={{.Version}}`.
-- `.github/workflows/dockerbuildci.yaml` — inject the release tag, or commit SHA for branch builds, into `pkg/version.Version`.
+- `.goreleaser.yaml` — `ldflags: -s -w -X .../pkg/version.Version={{.Tag}}`.
+- `.github/workflows/dockerbuildci.yaml` — inject Primus's canonical image `VERSION` into `pkg/version.Version`.
 - `Dockerfile` — accept a `VERSION` build argument and inject it into `pkg/version.Version` for standalone image builds.
+- `pkg/log/log.go` — attach `version.Version` to every JSON record as `service.version`.
+- `pkg/log/log_test.go` — verify the global log field is emitted.
+- `pkg/otel/metrics_test.go` — verify collected metrics carry the same version on their resource.
 
 ### Modified (commit 2)
 - All 14 files listed in commit 2 "Migration scope" — mechanical zap→slog.
@@ -195,6 +201,7 @@ Specifically:
 - Manual: send `SIGTERM` during a burst of tool calls — no OTLP "shutdown timed out" warnings; last batch reaches collector.
 - Manual: trigger a tool panic — verify `mcp.tool.calls{is_error=true}` increments and the span is marked `codes.Error`.
 - Build the standalone image with `--build-arg VERSION=v0.7.0` and confirm the compiled binary carries `v0.7.0` as `pkg/version.Version`.
+- Build with a test linker version and verify both collected metrics and emitted JSON logs report that exact `service.version`.
 
 ## Resolved Questions
 - [x] Stdout JSON vs OTLP log exporter → **stdout JSON**.
@@ -203,4 +210,4 @@ Specifically:
 - [x] `mcp.sessions.active` feasibility → **defer, use counter instead**.
 - [x] Shutdown ctx source → **fresh `context.Background()+timeout`, not cancelled signal ctx**.
 - [x] Middleware order for panic coverage → **`loggingMiddleware` appended before `WithRecovery()` in NewMCPServer options; mcp-go's reverse-slice wrap yields `logging(recovery(tool))` so recovery catches the panic and logging records metrics via the normal return path. No second `recover()` in logging middleware.**
-- [x] Version plumbing → **GoReleaser, Primus release builds, and standalone Docker builds inject `pkg/version.Version`; tagged images use the exact Git/Docker tag, while branch images use the commit SHA.**
+- [x] Version plumbing → **GoReleaser, Primus image builds, and standalone Docker builds inject `pkg/version.Version`; Primus builds use the exact published image tag, and GoReleaser uses the full Git tag.**

--- a/plans/observability-refactor.plan.md
+++ b/plans/observability-refactor.plan.md
@@ -24,6 +24,11 @@ Goal: match Zeus's shape — slog + ContextHandler + `pkg/otel` — so the MCP s
 
 Single PR, three commits. Each commit compiles and tests green independently so the PR is bisectable.
 
+### Post-ship follow-up — Docker `service.version` parity
+
+- The official Primus workflow passes the release Git tag into `pkg/version.Version` through `GO_BUILD_FLAGS`; branch builds use the commit SHA so deployment markers remain unique.
+- The standalone Dockerfile accepts `VERSION` as a build argument and injects it through the same linker variable. The image tag must be passed explicitly because OCI tags are not visible inside the build or running container.
+
 ### Commit 1 — OTel scaffolding + graceful lifecycle (no logger migration)
 
 Introduce `pkg/otel`, `pkg/version`, and refactor the server for graceful shutdown. **Zap stays.** No `pkg/log` yet.
@@ -160,6 +165,8 @@ Specifically:
 - `internal/telemetry/telemetry.go` — thin shim delegating to `pkg/otel`; remove `genai.go` (moved).
 - `Makefile` — `-ldflags` on build target.
 - `.goreleaser.yaml` — `ldflags: -s -w -X .../pkg/version.Version={{.Version}}`.
+- `.github/workflows/dockerbuildci.yaml` — inject the release tag, or commit SHA for branch builds, into `pkg/version.Version`.
+- `Dockerfile` — accept a `VERSION` build argument and inject it into `pkg/version.Version` for standalone image builds.
 
 ### Modified (commit 2)
 - All 14 files listed in commit 2 "Migration scope" — mechanical zap→slog.
@@ -187,6 +194,7 @@ Specifically:
 - Manual: run HTTP mode against staging SigNoz — confirm traces + metrics arrive, logs on stdout show trace_id/session/tenant.
 - Manual: send `SIGTERM` during a burst of tool calls — no OTLP "shutdown timed out" warnings; last batch reaches collector.
 - Manual: trigger a tool panic — verify `mcp.tool.calls{is_error=true}` increments and the span is marked `codes.Error`.
+- Build the standalone image with `--build-arg VERSION=v0.7.0` and confirm the compiled binary carries `v0.7.0` as `pkg/version.Version`.
 
 ## Resolved Questions
 - [x] Stdout JSON vs OTLP log exporter → **stdout JSON**.
@@ -195,4 +203,4 @@ Specifically:
 - [x] `mcp.sessions.active` feasibility → **defer, use counter instead**.
 - [x] Shutdown ctx source → **fresh `context.Background()+timeout`, not cancelled signal ctx**.
 - [x] Middleware order for panic coverage → **`loggingMiddleware` appended before `WithRecovery()` in NewMCPServer options; mcp-go's reverse-slice wrap yields `logging(recovery(tool))` so recovery catches the panic and logging records metrics via the normal return path. No second `recover()` in logging middleware.**
-- [x] Version plumbing → **goreleaser ldflags + version.Version in `NewMCPServer`**.
+- [x] Version plumbing → **GoReleaser, Primus release builds, and standalone Docker builds inject `pkg/version.Version`; tagged images use the exact Git/Docker tag, while branch images use the commit SHA.**

--- a/plans/signoz-backend-user-agent.context.md
+++ b/plans/signoz-backend-user-agent.context.md
@@ -1,0 +1,27 @@
+# Feature: SigNoz Backend User-Agent — Context & Discussion
+
+## Original Prompt
+> Can we also send user-agent in requests to SigNoz backend from mcp?
+> so when the mcp go-client makes an http call to signoz
+> it should send in the User Agent HTTP header to something like signoz/mcp-server? or whatever is the way to set right semantic user agents?
+
+## Reference Links
+- [RFC 9110, User-Agent](https://www.rfc-editor.org/rfc/rfc9110.html#name-user-agent)
+
+## Key Decisions & Discussion Log
+
+### 2026-07-15 — Product identifier and coverage
+- Use `signoz-mcp-server/<version>`: RFC 9110 defines each product identifier as `name[/version]`, so `signoz/mcp-server` would incorrectly identify `signoz` as the product and `mcp-server` as its version.
+- Use `pkg/version.Version` without stripping the leading `v`, keeping the outbound client identity aligned with `service.version` and the Docker image tag.
+- Set the header on both client request paths: normal SigNoz API calls and validation/identity requests.
+- Treat `User-Agent` as a reserved header so `SIGNOZ_CUSTOM_HEADERS` cannot replace the server's product identity.
+- Keep the identifier minimal; do not append Go runtime, OS, architecture, or other fingerprinting detail.
+
+### 2026-07-15 — Independent review corrections
+- Reuse review found that the docs indexer already built the same `signoz-mcp-server/<version>` product identifier with a blank-version fallback. Move that shared behavior into `pkg/version.UserAgent`; the docs indexer appends only its specific comment.
+- Efficiency review found that reserving and dropping an operator-configured `User-Agent` would break the documented `SIGNOZ_CUSTOM_HEADERS` behavior and could affect reverse-proxy routing. Preserve the configured value as the leading product/comment sequence and append the MCP product identifier.
+- Cache the process-static MCP product identifier once instead of rebuilding it for every request and retry attempt.
+
+## Open Questions
+- [x] Header form → `signoz-mcp-server/<version>`.
+- [x] Custom value → preserved first, with the MCP server product identifier appended.

--- a/plans/signoz-backend-user-agent.plan.md
+++ b/plans/signoz-backend-user-agent.plan.md
@@ -1,0 +1,28 @@
+# Plan: SigNoz Backend User-Agent
+
+## Status
+In Progress
+
+## Context
+Outbound requests currently rely on Go's generic HTTP user agent, so the SigNoz backend cannot identify traffic originating from a particular MCP server release.
+
+## Approach
+- Build one RFC 9110 product identifier in `pkg/version`: `signoz-mcp-server/<version>`, with `dev` as the blank-version fallback.
+- Set it on every request created by `doRequest` and `doValidationRequest`.
+- Preserve a configured custom `User-Agent` and append the MCP product identifier; continue protecting content-type and authentication headers from override.
+- Reuse the shared product identifier in the docs indexer and cache it for the backend client request path.
+- Add request-capture tests for normal API calls, credential validation, and custom-header override protection.
+
+## Files to Modify
+- `internal/client/client.go` — define and attach the canonical user agent.
+- `internal/client/client_test.go` — verify all outbound paths and override behavior.
+- `internal/docs/fetcher.go` — reuse the shared product identifier before its docs-indexer comment.
+- `pkg/version/version.go` — own the shared product identifier and blank-version fallback.
+- `pkg/version/version_test.go` — cover release, branch, whitespace, and blank versions.
+- `plans/signoz-backend-user-agent.context.md` — preserve decisions and discussion.
+- `plans/signoz-backend-user-agent.plan.md` — track implementation and verification.
+
+## Verification
+- Run focused client tests normally and with a linker-injected version.
+- Run the full Go test suite.
+- Run `git diff --check`.


### PR DESCRIPTION
## Summary

- inject Primus's canonical image `VERSION` into `pkg/version.Version` for official Docker builds
- preserve the exact release tag in GoReleaser and support explicit `VERSION` injection in standalone Docker builds
- propagate the embedded version as OpenTelemetry `service.version` on traces and metrics, and as a structured field on every JSON log
- send `User-Agent: signoz-mcp-server/<version>` on every MCP-to-SigNoz backend request, including credential validation and retries
- preserve an operator-configured `User-Agent` and append the MCP product identity
- reuse the same RFC 9110 product identifier for docs-indexer requests

## Why

The official Primus workflow and standalone Dockerfile did not inject `pkg/version.Version`, so affected images reported `service.version=dev` instead of the published image version. The build now embeds the canonical Primus version, which matches the official image tag, while GoReleaser preserves the full Git tag.

Backend requests also relied on Go's generic HTTP user agent, so the SigNoz backend could not attribute traffic to an MCP server release. Requests now carry the same build identity used by telemetry.

## Deployment impact

No Kubernetes manifest or deployment-workflow change is required when deploying an official image: the image version is embedded during the image build. Standalone Docker builds should pass `--build-arg VERSION=<image-tag>` so the binary and image tag remain aligned.

## Verification

- three independent review passes covering reuse, correctness/security, and efficiency/operations; all findings addressed
- `actionlint .github/workflows/dockerbuildci.yaml`
- YAML parsing for the workflow and GoReleaser configuration
- `go test ./...`
- `go test -race ./internal/client ./internal/docs ./pkg/version`
- linker-injected `v9.9.9-test` tests for logs, metrics, backend User-Agent, docs indexer, and version helper
- `go vet ./internal/client`
- `git diff --check`
- standalone Docker build and binary inspection with `VERSION=v9.9.9-test`

## Documentation and metadata

- updated the observability plan/context and added the backend User-Agent plan/context
- no README, `manifest.json`, or companion SigNoz/agent-skills changes are required because this PR does not change an MCP tool, resource, parameter, payload, or configuration contract
