### PR TITLE
fix(observability): stop logging expected subscribe rejections and client cancellations at ERROR

### DIFF
--- a/internal/handler/tools/alerts.go
+++ b/internal/handler/tools/alerts.go
@@ -206,7 +206,7 @@ func (h *Handler) handleListAlerts(ctx context.Context, req mcp.CallToolRequest)
 	}
 	alerts, err := client.ListAlerts(ctx, params)
 	if err != nil {
-		h.logger.ErrorContext(ctx, "Failed to list alerts", logpkg.ErrAttr(err))
+		h.logUpstreamFailure(ctx, "Failed to list alerts", err)
 		return upstreamError(err), nil
 	}
 
@@ -258,7 +258,7 @@ func (h *Handler) handleListAlertRules(ctx context.Context, req mcp.CallToolRequ
 	}
 	rules, err := client.ListAlertRules(ctx)
 	if err != nil {
-		h.logger.ErrorContext(ctx, "Failed to list alert rules", logpkg.ErrAttr(err))
+		h.logUpstreamFailure(ctx, "Failed to list alert rules", err)
 		return upstreamError(err), nil
 	}
 
@@ -331,7 +331,7 @@ func (h *Handler) handleGetAlert(ctx context.Context, req mcp.CallToolRequest) (
 	}
 	respJSON, err := client.GetAlertByRuleID(ctx, ruleID)
 	if err != nil {
-		h.logger.ErrorContext(ctx, "Failed to get alert", slog.String("ruleId", ruleID), logpkg.ErrAttr(err))
+		h.logUpstreamFailure(ctx, "Failed to get alert", err, slog.String("ruleId", ruleID))
 		return upstreamError(err), nil
 	}
 
@@ -449,9 +449,7 @@ func (h *Handler) handleGetAlertHistory(ctx context.Context, req mcp.CallToolReq
 	}
 	respJSON, err := client.GetAlertHistory(ctx, ruleID, historyReq)
 	if err != nil {
-		h.logger.ErrorContext(ctx, "Failed to get alert history",
-			slog.String("ruleId", ruleID),
-			logpkg.ErrAttr(err))
+		h.logUpstreamFailure(ctx, "Failed to get alert history", err, slog.String("ruleId", ruleID))
 		var statusErr *signozclient.HTTPStatusError
 		if errors.As(err, &statusErr) && statusErr.StatusCode == http.StatusNotFound {
 			result := upstreamError(err)
@@ -497,7 +495,7 @@ func (h *Handler) handleCreateAlert(ctx context.Context, req mcp.CallToolRequest
 
 	data, err := client.CreateAlertRule(ctx, cleanJSON)
 	if err != nil {
-		h.logger.ErrorContext(ctx, "Failed to create alert rule in SigNoz", logpkg.ErrAttr(err))
+		h.logUpstreamFailure(ctx, "Failed to create alert rule in SigNoz", err)
 		return upstreamError(err), nil
 	}
 
@@ -533,7 +531,7 @@ func (h *Handler) handleUpdateAlert(ctx context.Context, req mcp.CallToolRequest
 	}
 
 	if err := client.UpdateAlertRule(ctx, ruleID, cleanJSON); err != nil {
-		h.logger.ErrorContext(ctx, "Failed to update alert rule in SigNoz", slog.String("ruleId", ruleID), logpkg.ErrAttr(err))
+		h.logUpstreamFailure(ctx, "Failed to update alert rule in SigNoz", err, slog.String("ruleId", ruleID))
 		return upstreamError(err), nil
 	}
 
@@ -560,7 +558,7 @@ func (h *Handler) handleDeleteAlert(ctx context.Context, req mcp.CallToolRequest
 	}
 
 	if err := client.DeleteAlertRule(ctx, ruleID); err != nil {
-		h.logger.ErrorContext(ctx, "Failed to delete alert rule in SigNoz", slog.String("ruleId", ruleID), logpkg.ErrAttr(err))
+		h.logUpstreamFailure(ctx, "Failed to delete alert rule in SigNoz", err, slog.String("ruleId", ruleID))
 		return upstreamError(err), nil
 	}
 

--- a/internal/handler/tools/dashboards.go
+++ b/internal/handler/tools/dashboards.go
@@ -166,7 +166,7 @@ func (h *Handler) handleListDashboards(ctx context.Context, req mcp.CallToolRequ
 	}
 	result, err := client.ListDashboards(ctx)
 	if err != nil {
-		h.logger.ErrorContext(ctx, "Failed to list dashboards", logpkg.ErrAttr(err))
+		h.logUpstreamFailure(ctx, "Failed to list dashboards", err)
 		return upstreamError(err), nil
 	}
 
@@ -233,7 +233,7 @@ func (h *Handler) handleGetDashboard(ctx context.Context, req mcp.CallToolReques
 	}
 	data, err := client.GetDashboard(ctx, uuid)
 	if err != nil {
-		h.logger.ErrorContext(ctx, "Failed to get dashboard", slog.String("uuid", uuid), logpkg.ErrAttr(err))
+		h.logUpstreamFailure(ctx, "Failed to get dashboard", err, slog.String("uuid", uuid))
 		return upstreamError(err), nil
 	}
 	data = enrichDashboardWebURL(ctx, data, uuid)
@@ -272,7 +272,7 @@ func (h *Handler) handleCreateDashboard(ctx context.Context, req mcp.CallToolReq
 	data, err := client.CreateDashboardRaw(ctx, cleanJSON)
 
 	if err != nil {
-		h.logger.ErrorContext(ctx, "Failed to create dashboard in SigNoz", logpkg.ErrAttr(err))
+		h.logUpstreamFailure(ctx, "Failed to create dashboard in SigNoz", err)
 		return upstreamError(err), nil
 	}
 
@@ -297,7 +297,7 @@ func (h *Handler) handleImportDashboard(ctx context.Context, req mcp.CallToolReq
 
 	body, err := fetchTemplate(ctx, path)
 	if err != nil {
-		h.logger.ErrorContext(ctx, "Failed to fetch dashboard template", slog.String("path", path), logpkg.ErrAttr(err))
+		h.logUpstreamFailure(ctx, "Failed to fetch dashboard template", err, slog.String("path", path))
 		return mcp.NewToolResultError(fmt.Sprintf("Template fetch error: %s", err.Error())), nil
 	}
 
@@ -322,7 +322,7 @@ func (h *Handler) handleImportDashboard(ctx context.Context, req mcp.CallToolReq
 	}
 	data, err := client.CreateDashboardRaw(ctx, cleanJSON)
 	if err != nil {
-		h.logger.ErrorContext(ctx, "Failed to create dashboard from template", slog.String("path", path), logpkg.ErrAttr(err))
+		h.logUpstreamFailure(ctx, "Failed to create dashboard from template", err, slog.String("path", path))
 		return upstreamError(err), nil
 	}
 
@@ -407,7 +407,7 @@ func (h *Handler) handleUpdateDashboard(ctx context.Context, req mcp.CallToolReq
 	err = client.UpdateDashboardRaw(ctx, uuid, cleanJSON)
 
 	if err != nil {
-		h.logger.ErrorContext(ctx, "Failed to update dashboard in SigNoz", logpkg.ErrAttr(err))
+		h.logUpstreamFailure(ctx, "Failed to update dashboard in SigNoz", err)
 		return upstreamError(err), nil
 	}
 
@@ -432,7 +432,7 @@ func (h *Handler) handleDeleteDashboard(ctx context.Context, req mcp.CallToolReq
 	}
 	err = client.DeleteDashboard(ctx, uuid)
 	if err != nil {
-		h.logger.ErrorContext(ctx, "Failed to delete dashboard", slog.String("uuid", uuid), logpkg.ErrAttr(err))
+		h.logUpstreamFailure(ctx, "Failed to delete dashboard", err, slog.String("uuid", uuid))
 		return upstreamError(err), nil
 	}
 	return mcp.NewToolResultText("dashboard deleted"), nil

--- a/internal/handler/tools/errs.go
+++ b/internal/handler/tools/errs.go
@@ -2,10 +2,12 @@ package tools
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
+	"log/slog"
 	"net/http"
 	"strings"
 
@@ -196,6 +198,25 @@ func requireStringField(args map[string]any, key, requiredReason string) (string
 // notAConfigObjectError is the body-carrying-tool variant of the arguments guard.
 func notAConfigObjectError() *mcp.CallToolResult {
 	return errorWithCode(CodeValidationFailed, notAConfigObjectMessage)
+}
+
+// logUpstreamFailure logs a failed outbound call (SigNoz backend, template
+// fetch) at a severity derived from its cause: context.Canceled — the MCP
+// client disconnected or aborted the request mid-flight — logs at DEBUG with a
+// cancellation note, while everything else, including context.DeadlineExceeded
+// (a real operational signal), stays ERROR. The record is always emitted at
+// the chosen level, never dropped (fail open, never fail silent).
+func (h *Handler) logUpstreamFailure(ctx context.Context, msg string, err error, attrs ...slog.Attr) {
+	level := logpkg.LevelForError(err)
+	if level != slog.LevelError {
+		msg += " (request cancelled by client)"
+	}
+	args := make([]any, 0, len(attrs)+1)
+	for _, attr := range attrs {
+		args = append(args, attr)
+	}
+	args = append(args, logpkg.ErrAttr(err))
+	h.logger.Log(ctx, level, msg, args...)
 }
 
 // upstreamError wraps a SigNoz backend client error with the uniform text prefix

--- a/internal/handler/tools/fields.go
+++ b/internal/handler/tools/fields.go
@@ -6,8 +6,6 @@ import (
 
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
-
-	logpkg "github.com/SigNoz/signoz-mcp-server/pkg/log"
 )
 
 const fieldContextParamDesc = "Restrict results to a single field context (optional). Valid values: " +
@@ -78,7 +76,7 @@ func (h *Handler) handleGetFieldKeys(ctx context.Context, req mcp.CallToolReques
 	}
 	result, err := client.GetFieldKeys(ctx, signal, metricName, searchText, fieldContext, fieldDataType, source)
 	if err != nil {
-		h.logger.ErrorContext(ctx, "Failed to get field keys", slog.String("signal", signal), logpkg.ErrAttr(err))
+		h.logUpstreamFailure(ctx, "Failed to get field keys", err, slog.String("signal", signal))
 		return upstreamError(err), nil
 	}
 	return mcp.NewToolResultText(string(result)), nil
@@ -112,7 +110,7 @@ func (h *Handler) handleGetFieldValues(ctx context.Context, req mcp.CallToolRequ
 	}
 	result, err := client.GetFieldValues(ctx, signal, name, metricName, searchText, fieldContext, source)
 	if err != nil {
-		h.logger.ErrorContext(ctx, "Failed to get field values", slog.String("signal", signal), slog.String("name", name), logpkg.ErrAttr(err))
+		h.logUpstreamFailure(ctx, "Failed to get field values", err, slog.String("signal", signal), slog.String("name", name))
 		return upstreamError(err), nil
 	}
 	return mcp.NewToolResultText(string(result)), nil

--- a/internal/handler/tools/log_level_test.go
+++ b/internal/handler/tools/log_level_test.go
@@ -1,0 +1,68 @@
+package tools
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"testing"
+)
+
+// TestLogUpstreamFailureLevels pins the severity contract of the shared
+// upstream-failure log helper: client-driven cancellations (context.Canceled)
+// log at DEBUG — but are still emitted, never dropped — while
+// context.DeadlineExceeded (a real operational signal) and generic upstream
+// failures stay ERROR.
+func TestLogUpstreamFailureLevels(t *testing.T) {
+	tests := []struct {
+		name      string
+		err       error
+		wantLevel string
+		wantMsg   string
+	}{
+		{
+			name:      "canceled logs debug with cancellation note",
+			err:       fmt.Errorf(`Post "https://tenant.signoz.cloud/api/v5/query_range": %w`, context.Canceled),
+			wantLevel: "DEBUG",
+			wantMsg:   "Failed to search logs (request cancelled by client)",
+		},
+		{
+			name:      "deadline exceeded stays error",
+			err:       fmt.Errorf("query: %w", context.DeadlineExceeded),
+			wantLevel: "ERROR",
+			wantMsg:   "Failed to search logs",
+		},
+		{
+			name:      "generic upstream failure stays error",
+			err:       errors.New("boom"),
+			wantLevel: "ERROR",
+			wantMsg:   "Failed to search logs",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			h := &Handler{logger: slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))}
+
+			h.logUpstreamFailure(context.Background(), "Failed to search logs", tc.err, slog.String("filter", "x"))
+
+			// Fail open, never fail silent: the record must always be emitted.
+			var rec map[string]any
+			if err := json.Unmarshal(buf.Bytes(), &rec); err != nil {
+				t.Fatalf("expected exactly one emitted log record, got %q: %v", buf.String(), err)
+			}
+			if rec["level"] != tc.wantLevel {
+				t.Fatalf("level = %v, want %s", rec["level"], tc.wantLevel)
+			}
+			if rec["msg"] != tc.wantMsg {
+				t.Fatalf("msg = %v, want %q", rec["msg"], tc.wantMsg)
+			}
+			if rec["filter"] != "x" {
+				t.Fatalf("filter attr = %v, want %q (extra attrs must survive the helper)", rec["filter"], "x")
+			}
+		})
+	}
+}

--- a/internal/handler/tools/logs.go
+++ b/internal/handler/tools/logs.go
@@ -103,7 +103,7 @@ func (h *Handler) handleAggregateLogs(ctx context.Context, req mcp.CallToolReque
 	}
 	result, err := client.QueryBuilderV5(ctx, queryJSON)
 	if err != nil {
-		h.logger.ErrorContext(ctx, "Failed to aggregate logs", logpkg.ErrAttr(err))
+		h.logUpstreamFailure(ctx, "Failed to aggregate logs", err)
 		return upstreamError(err), nil
 	}
 
@@ -141,7 +141,7 @@ func (h *Handler) handleSearchLogs(ctx context.Context, req mcp.CallToolRequest)
 	}
 	result, err := client.QueryBuilderV5(ctx, queryJSON)
 	if err != nil {
-		h.logger.ErrorContext(ctx, "Failed to search logs", logpkg.ErrAttr(err))
+		h.logUpstreamFailure(ctx, "Failed to search logs", err)
 		return upstreamError(err), nil
 	}
 

--- a/internal/handler/tools/metric_cardinality.go
+++ b/internal/handler/tools/metric_cardinality.go
@@ -6,8 +6,6 @@ import (
 
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
-
-	logpkg "github.com/SigNoz/signoz-mcp-server/pkg/log"
 )
 
 func (h *Handler) RegisterMetricCardinalityHandlers(s *server.MCPServer) {
@@ -62,8 +60,7 @@ func (h *Handler) handleCheckMetricCardinality(ctx context.Context, req mcp.Call
 
 	result, err := client.GetMetricCardinality(ctx, metricName, startTime, endTime)
 	if err != nil {
-		h.logger.ErrorContext(ctx, "Failed to fetch metric cardinality",
-			slog.String("metricName", metricName), logpkg.ErrAttr(err))
+		h.logUpstreamFailure(ctx, "Failed to fetch metric cardinality", err, slog.String("metricName", metricName))
 		return upstreamError(err), nil
 	}
 

--- a/internal/handler/tools/metric_usage.go
+++ b/internal/handler/tools/metric_usage.go
@@ -9,8 +9,6 @@ import (
 	signozclient "github.com/SigNoz/signoz-mcp-server/internal/client"
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
-
-	logpkg "github.com/SigNoz/signoz-mcp-server/pkg/log"
 )
 
 func (h *Handler) RegisterMetricUsageHandlers(s *server.MCPServer) {
@@ -92,7 +90,7 @@ func (h *Handler) handleCheckMetricUsage(ctx context.Context, req mcp.CallToolRe
 
 	usage, err := client.CheckMetricUsage(ctx, names)
 	if err != nil {
-		h.logger.ErrorContext(ctx, "Failed to check metric usage", logpkg.ErrAttr(err))
+		h.logUpstreamFailure(ctx, "Failed to check metric usage", err)
 		return upstreamError(err), nil
 	}
 

--- a/internal/handler/tools/metrics.go
+++ b/internal/handler/tools/metrics.go
@@ -7,7 +7,6 @@ import (
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
 
-	logpkg "github.com/SigNoz/signoz-mcp-server/pkg/log"
 	"github.com/SigNoz/signoz-mcp-server/pkg/metricsrules"
 )
 
@@ -111,7 +110,7 @@ func (h *Handler) handleListMetrics(ctx context.Context, req mcp.CallToolRequest
 	}
 	result, err := client.ListMetrics(ctx, start, end, limit, searchText, source)
 	if err != nil {
-		h.logger.ErrorContext(ctx, "Failed to list metrics", slog.String("searchText", searchText), logpkg.ErrAttr(err))
+		h.logUpstreamFailure(ctx, "Failed to list metrics", err, slog.String("searchText", searchText))
 		return upstreamError(err), nil
 	}
 

--- a/internal/handler/tools/metrics_query.go
+++ b/internal/handler/tools/metrics_query.go
@@ -203,7 +203,7 @@ func (h *Handler) handleQueryMetrics(ctx context.Context, req mcp.CallToolReques
 
 	result, err := client.QueryBuilderV5(ctx, queryJSON)
 	if err != nil {
-		h.logger.ErrorContext(ctx, "Metrics query failed", logpkg.ErrAttr(err))
+		h.logUpstreamFailure(ctx, "Metrics query failed", err)
 		return upstreamError(err), nil
 	}
 

--- a/internal/handler/tools/metrics_top.go
+++ b/internal/handler/tools/metrics_top.go
@@ -7,8 +7,6 @@ import (
 
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
-
-	logpkg "github.com/SigNoz/signoz-mcp-server/pkg/log"
 )
 
 func (h *Handler) RegisterTopMetricsHandlers(s *server.MCPServer) {
@@ -53,7 +51,7 @@ func (h *Handler) handleGetTopMetrics(ctx context.Context, req mcp.CallToolReque
 	const topMetricsLimit = 100
 	result, err := client.GetTopMetrics(ctx, startTime, endTime, topMetricsLimit)
 	if err != nil {
-		h.logger.ErrorContext(ctx, "Failed to get top metrics", logpkg.ErrAttr(err))
+		h.logUpstreamFailure(ctx, "Failed to get top metrics", err)
 		return upstreamError(err), nil
 	}
 

--- a/internal/handler/tools/notification_channels.go
+++ b/internal/handler/tools/notification_channels.go
@@ -197,7 +197,7 @@ func (h *Handler) handleGetNotificationChannel(ctx context.Context, req mcp.Call
 
 	resp, err := client.GetNotificationChannel(ctx, id)
 	if err != nil {
-		h.logger.ErrorContext(ctx, "Failed to get notification channel", slog.String("id", id), logpkg.ErrAttr(err))
+		h.logUpstreamFailure(ctx, "Failed to get notification channel", err, slog.String("id", id))
 		return upstreamError(err), nil
 	}
 	return structuredResult(resp), nil
@@ -220,7 +220,7 @@ func (h *Handler) handleDeleteNotificationChannel(ctx context.Context, req mcp.C
 	}
 
 	if err := client.DeleteNotificationChannel(ctx, id); err != nil {
-		h.logger.ErrorContext(ctx, "Failed to delete notification channel", slog.String("id", id), logpkg.ErrAttr(err))
+		h.logUpstreamFailure(ctx, "Failed to delete notification channel", err, slog.String("id", id))
 		return upstreamError(err), nil
 	}
 	return structuredResult([]byte(fmt.Sprintf(`{"status":"success","id":%q}`, id))), nil
@@ -237,7 +237,7 @@ func (h *Handler) handleListNotificationChannels(ctx context.Context, req mcp.Ca
 
 	result, err := client.ListNotificationChannels(ctx)
 	if err != nil {
-		h.logger.ErrorContext(ctx, "Failed to list notification channels", logpkg.ErrAttr(err))
+		h.logUpstreamFailure(ctx, "Failed to list notification channels", err)
 		return upstreamError(err), nil
 	}
 
@@ -344,7 +344,7 @@ func (h *Handler) handleCreateNotificationChannel(ctx context.Context, req mcp.C
 	// Step 1: Create the channel
 	createResp, err := client.CreateNotificationChannel(ctx, receiverJSON)
 	if err != nil {
-		h.logger.ErrorContext(ctx, "Failed to create notification channel", slog.String("type", channelType), slog.String("name", name), logpkg.ErrAttr(err))
+		h.logUpstreamFailure(ctx, "Failed to create notification channel", err, slog.String("type", channelType), slog.String("name", name))
 		return upstreamError(err), nil
 	}
 
@@ -444,7 +444,7 @@ func (h *Handler) handleUpdateNotificationChannel(ctx context.Context, req mcp.C
 
 	// Step 1: Update the channel (204 No Content on success)
 	if err := client.UpdateNotificationChannel(ctx, id, receiverJSON); err != nil {
-		h.logger.ErrorContext(ctx, "Failed to update notification channel", slog.String("type", channelType), slog.String("name", name), slog.String("id", id), logpkg.ErrAttr(err))
+		h.logUpstreamFailure(ctx, "Failed to update notification channel", err, slog.String("type", channelType), slog.String("name", name), slog.String("id", id))
 		return upstreamError(err), nil
 	}
 

--- a/internal/handler/tools/query_builder.go
+++ b/internal/handler/tools/query_builder.go
@@ -117,7 +117,7 @@ func (h *Handler) handleExecuteBuilderQuery(ctx context.Context, req mcp.CallToo
 	}
 	data, err := client.QueryBuilderV5(ctx, finalQueryJSON)
 	if err != nil {
-		h.logger.ErrorContext(ctx, "Failed to execute query builder v5", logpkg.ErrAttr(err))
+		h.logUpstreamFailure(ctx, "Failed to execute query builder v5", err)
 		return upstreamError(err), nil
 	}
 

--- a/internal/handler/tools/services.go
+++ b/internal/handler/tools/services.go
@@ -66,7 +66,7 @@ func (h *Handler) handleListServices(ctx context.Context, req mcp.CallToolReques
 	}
 	result, err := client.ListServices(ctx, start, end)
 	if err != nil {
-		h.logger.ErrorContext(ctx, "Failed to list services", slog.String("start", start), slog.String("end", end), logpkg.ErrAttr(err))
+		h.logUpstreamFailure(ctx, "Failed to list services", err, slog.String("start", start), slog.String("end", end))
 		return upstreamError(err), nil
 	}
 
@@ -144,11 +144,7 @@ func (h *Handler) handleGetServiceTopOperations(ctx context.Context, req mcp.Cal
 	}
 	result, err := client.GetServiceTopOperations(ctx, start, end, service, tags)
 	if err != nil {
-		h.logger.ErrorContext(ctx, "Failed to get service top operations",
-			slog.String("start", start),
-			slog.String("end", end),
-			slog.String("service", service),
-			logpkg.ErrAttr(err))
+		h.logUpstreamFailure(ctx, "Failed to get service top operations", err, slog.String("start", start), slog.String("end", end), slog.String("service", service))
 		return upstreamError(err), nil
 	}
 	return mcp.NewToolResultText(string(result)), nil

--- a/internal/handler/tools/traces.go
+++ b/internal/handler/tools/traces.go
@@ -124,7 +124,7 @@ func (h *Handler) handleAggregateTraces(ctx context.Context, req mcp.CallToolReq
 	}
 	result, err := client.QueryBuilderV5(ctx, queryJSON)
 	if err != nil {
-		h.logger.ErrorContext(ctx, "Failed to aggregate traces", logpkg.ErrAttr(err))
+		h.logUpstreamFailure(ctx, "Failed to aggregate traces", err)
 		return upstreamError(err), nil
 	}
 
@@ -159,7 +159,7 @@ func (h *Handler) handleSearchTraces(ctx context.Context, req mcp.CallToolReques
 	}
 	result, err := client.QueryBuilderV5(ctx, queryJSON)
 	if err != nil {
-		h.logger.ErrorContext(ctx, "Failed to search traces", logpkg.ErrAttr(err))
+		h.logUpstreamFailure(ctx, "Failed to search traces", err)
 		return upstreamError(err), nil
 	}
 
@@ -209,7 +209,7 @@ func (h *Handler) handleGetTraceDetails(ctx context.Context, req mcp.CallToolReq
 	}
 	result, err := client.GetTraceDetails(ctx, traceID, includeSpans, startTime, endTime)
 	if err != nil {
-		h.logger.ErrorContext(ctx, "Failed to get trace details", slog.String("traceId", traceID), logpkg.ErrAttr(err))
+		h.logUpstreamFailure(ctx, "Failed to get trace details", err, slog.String("traceId", traceID))
 		return upstreamError(err), nil
 	}
 	result = enrichTraceWebURL(ctx, result, traceID)

--- a/internal/handler/tools/views.go
+++ b/internal/handler/tools/views.go
@@ -370,7 +370,7 @@ func (h *Handler) handleListViews(ctx context.Context, req mcp.CallToolRequest) 
 	}
 	result, err := client.ListViews(ctx, sourcePage, name, category)
 	if err != nil {
-		h.logger.ErrorContext(ctx, "Failed to list views", logpkg.ErrAttr(err))
+		h.logUpstreamFailure(ctx, "Failed to list views", err)
 		return upstreamError(err), nil
 	}
 
@@ -419,7 +419,7 @@ func (h *Handler) handleGetView(ctx context.Context, req mcp.CallToolRequest) (*
 	}
 	data, err := client.GetView(ctx, viewID)
 	if err != nil {
-		h.logger.ErrorContext(ctx, "Failed to get view", slog.String("viewId", viewID), logpkg.ErrAttr(err))
+		h.logUpstreamFailure(ctx, "Failed to get view", err, slog.String("viewId", viewID))
 		return upstreamError(err), nil
 	}
 	return structuredResult(data), nil
@@ -461,7 +461,7 @@ func (h *Handler) handleCreateView(ctx context.Context, req mcp.CallToolRequest)
 	}
 	data, err := client.CreateView(ctx, body)
 	if err != nil {
-		h.logger.ErrorContext(ctx, "Failed to create view", logpkg.ErrAttr(err))
+		h.logUpstreamFailure(ctx, "Failed to create view", err)
 		return upstreamError(err), nil
 	}
 	return mcp.NewToolResultText(string(data)), nil
@@ -548,7 +548,7 @@ func (h *Handler) handleUpdateView(ctx context.Context, req mcp.CallToolRequest)
 	}
 	data, err := client.UpdateView(ctx, viewID, body)
 	if err != nil {
-		h.logger.ErrorContext(ctx, "Failed to update view", slog.String("viewId", viewID), logpkg.ErrAttr(err))
+		h.logUpstreamFailure(ctx, "Failed to update view", err, slog.String("viewId", viewID))
 		return upstreamError(err), nil
 	}
 	return mcp.NewToolResultText(string(data)), nil
@@ -571,7 +571,7 @@ func (h *Handler) handleDeleteView(ctx context.Context, req mcp.CallToolRequest)
 	}
 	data, err := client.DeleteView(ctx, viewID)
 	if err != nil {
-		h.logger.ErrorContext(ctx, "Failed to delete view", slog.String("viewId", viewID), logpkg.ErrAttr(err))
+		h.logUpstreamFailure(ctx, "Failed to delete view", err, slog.String("viewId", viewID))
 		return upstreamError(err), nil
 	}
 	return mcp.NewToolResultText(string(data)), nil

--- a/internal/mcp-server/log_noise_test.go
+++ b/internal/mcp-server/log_noise_test.go
@@ -1,0 +1,141 @@
+package mcp_server
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	mcpgoserver "github.com/mark3labs/mcp-go/server"
+
+	"github.com/SigNoz/signoz-mcp-server/internal/config"
+	"github.com/SigNoz/signoz-mcp-server/internal/handler/tools"
+	"github.com/SigNoz/signoz-mcp-server/pkg/analytics/noopanalytics"
+	logpkg "github.com/SigNoz/signoz-mcp-server/pkg/log"
+)
+
+// TestInitializeDoesNotAdvertiseResourceSubscribe pins the capability
+// contract: this server registers resources but never implements
+// resources/subscribe, so the initialize result must not advertise
+// resources.subscribe — well-behaved clients should never attempt it.
+func TestInitializeDoesNotAdvertiseResourceSubscribe(t *testing.T) {
+	cfg := &config.Config{ClientCacheSize: 1, ClientCacheTTL: time.Minute}
+	handler := tools.NewHandler(logpkg.New("error"), cfg)
+	mcpServer := NewMCPServer(logpkg.New("error"), handler, cfg, noopanalytics.New(), nil)
+
+	s := mcpServer.newSDKServer()
+	// Register at least one resource so the resources capability is present
+	// at all — the load-bearing assertion is that subscribe stays unset even
+	// when resources are advertised.
+	handler.RegisterQueryBuilderV5Handlers(s)
+
+	ctx := newAnalyticsTestContext(context.Background(), "sess-init-cap")
+	resp := s.HandleMessage(ctx, json.RawMessage(`{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"cap-test","version":"0.0.1"}}}`))
+
+	raw, err := json.Marshal(resp)
+	if err != nil {
+		t.Fatalf("marshal initialize response: %v", err)
+	}
+
+	var envelope struct {
+		Result struct {
+			Capabilities struct {
+				Resources *struct {
+					Subscribe bool `json:"subscribe"`
+				} `json:"resources"`
+			} `json:"capabilities"`
+		} `json:"result"`
+	}
+	if err := json.Unmarshal(raw, &envelope); err != nil {
+		t.Fatalf("unmarshal initialize response %q: %v", raw, err)
+	}
+	if envelope.Result.Capabilities.Resources == nil {
+		t.Fatalf("resources capability missing from initialize result %q; expected it advertised (without subscribe) once resources are registered", raw)
+	}
+	if envelope.Result.Capabilities.Resources.Subscribe {
+		t.Fatalf("resources.subscribe advertised as true in %q; this server does not implement resources/subscribe", raw)
+	}
+	if strings.Contains(string(raw), `"subscribe":true`) {
+		t.Fatalf("initialize result advertises subscribe support: %q", raw)
+	}
+}
+
+// TestMethodErrorLogLevel pins the hook-level severity classification:
+// rejections of unadvertised optional capabilities (server.ErrUnsupported,
+// e.g. resources/subscribe) and client cancellations log at DEBUG, while
+// deadline-exceeded and generic errors stay ERROR.
+func TestMethodErrorLogLevel(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want slog.Level
+	}{
+		{"resources subscribe not supported", fmt.Errorf("resources subscribe %w", mcpgoserver.ErrUnsupported), slog.LevelDebug},
+		{"client canceled", fmt.Errorf(`Post "https://tenant.signoz.cloud/api/v5/query_range": %w`, context.Canceled), slog.LevelDebug},
+		{"deadline exceeded", fmt.Errorf("query: %w", context.DeadlineExceeded), slog.LevelError},
+		{"generic", errors.New("boom"), slog.LevelError},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := methodErrorLogLevel(tc.err); got != tc.want {
+				t.Fatalf("methodErrorLogLevel(%v) = %v, want %v", tc.err, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestBuildHooks_ErrorLogSeverityClassification exercises the OnError hook
+// end-to-end through a debug-level buffered logger and asserts that expected
+// protocol noise (resources/subscribe rejections, client cancellations) is
+// still emitted — fail open, never fail silent — but below ERROR, while
+// deadline-exceeded and generic failures remain ERROR.
+func TestBuildHooks_ErrorLogSeverityClassification(t *testing.T) {
+	var buf lockedBuffer
+	cfg := &config.Config{ClientCacheSize: 1, ClientCacheTTL: time.Minute}
+	handler := tools.NewHandler(logpkg.New("error"), cfg)
+	mcpServer := NewMCPServer(newBufferedLogger(&buf, slog.LevelDebug), handler, cfg, noopanalytics.New(), nil)
+	hooks := mcpServer.buildHooks()
+
+	fail := func(method mcp.MCPMethod, id string, err error) {
+		ctx := newAnalyticsTestContext(context.Background(), "sess-"+id)
+		req := &mcp.SubscribeRequest{}
+		singleHook(t, hooks.OnBeforeAny, "OnBeforeAny")(ctx, id, method, req)
+		singleHook(t, hooks.OnError, "OnError")(ctx, id, method, req, err)
+	}
+
+	fail(mcp.MethodResourcesSubscribe, "req-sub", fmt.Errorf("resources subscribe %w", mcpgoserver.ErrUnsupported))
+	fail(mcp.MethodResourcesRead, "req-cancel", fmt.Errorf("read: %w", context.Canceled))
+	fail(mcp.MethodResourcesList, "req-deadline", fmt.Errorf("list: %w", context.DeadlineExceeded))
+	fail(mcp.MethodPromptsList, "req-generic", errors.New("boom"))
+
+	levels := map[string]string{}
+	for _, rec := range parseJSONLogLines(t, &buf) {
+		if rec["msg"] != "mcp error" {
+			continue
+		}
+		method, _ := rec["mcp.method.name"].(string)
+		level, _ := rec["level"].(string)
+		levels[method] = level
+	}
+
+	want := map[string]string{
+		string(mcp.MethodResourcesSubscribe): "DEBUG",
+		string(mcp.MethodResourcesRead):      "DEBUG",
+		string(mcp.MethodResourcesList):      "ERROR",
+		string(mcp.MethodPromptsList):        "ERROR",
+	}
+	for method, wantLevel := range want {
+		got, ok := levels[method]
+		if !ok {
+			t.Fatalf("no 'mcp error' record emitted for %s — expected level was %s; downgraded logs must still be emitted", method, wantLevel)
+		}
+		if got != wantLevel {
+			t.Fatalf("'mcp error' level for %s = %s, want %s", method, got, wantLevel)
+		}
+	}
+}

--- a/internal/mcp-server/server.go
+++ b/internal/mcp-server/server.go
@@ -451,6 +451,20 @@ func methodErrorType(err error) string {
 	}
 }
 
+// methodErrorLogLevel maps a hook error to its log severity. Requests for
+// optional capabilities this server does not advertise (e.g. clients probing
+// resources/subscribe, rejected by mcp-go with server.ErrUnsupported) are
+// expected protocol negotiation, and context.Canceled means the client
+// disconnected or aborted the request — both log at DEBUG. Deadline-exceeded
+// and everything else stay ERROR. The record is always emitted at the
+// returned level, never dropped.
+func methodErrorLogLevel(err error) slog.Level {
+	if errors.Is(err, server.ErrUnsupported) {
+		return slog.LevelDebug
+	}
+	return logpkg.LevelForError(err)
+}
+
 func (m *MCPServer) beginMethodObservation(ctx context.Context, id any, method mcp.MCPMethod, message any) {
 	if !shouldObserveMethod(method) {
 		return
@@ -672,7 +686,7 @@ func (m *MCPServer) buildHooks() *server.Hooks {
 			span.RecordError(err)
 			span.SetStatus(codes.Error, err.Error())
 		}
-		m.logger.ErrorContext(ctx, "mcp error",
+		m.logger.Log(ctx, methodErrorLogLevel(err), "mcp error",
 			slog.String("mcp.method.name", otelpkg.NormalizeMCPMethod(string(method))),
 			logpkg.ErrAttr(err))
 	})
@@ -794,7 +808,9 @@ func (m *MCPServer) loggingMiddleware() server.ToolHandlerMiddleware {
 			sizeAttr := slog.Int64("mcp.tool.result.size_bytes", resultBytes)
 			switch {
 			case err != nil:
-				m.logger.ErrorContext(ctx, "tool call failed",
+				// Client-driven cancellations (context.Canceled) log at DEBUG;
+				// deadline-exceeded and real failures stay ERROR.
+				m.logger.Log(ctx, logpkg.LevelForError(err), "tool call failed",
 					slog.Duration("duration", duration),
 					slog.Bool("mcp.tool.is_error", isErr),
 					sizeAttr,

--- a/pkg/log/level_test.go
+++ b/pkg/log/level_test.go
@@ -1,0 +1,31 @@
+package log
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"testing"
+)
+
+func TestLevelForError(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want slog.Level
+	}{
+		{"canceled", context.Canceled, slog.LevelDebug},
+		{"wrapped canceled", fmt.Errorf(`Post "https://tenant.signoz.cloud/api/v5/query_range": %w`, context.Canceled), slog.LevelDebug},
+		{"deadline exceeded", context.DeadlineExceeded, slog.LevelError},
+		{"wrapped deadline exceeded", fmt.Errorf("query: %w", context.DeadlineExceeded), slog.LevelError},
+		{"generic", errors.New("boom"), slog.LevelError},
+		{"nil", nil, slog.LevelError},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := LevelForError(tc.err); got != tc.want {
+				t.Fatalf("LevelForError(%v) = %v, want %v", tc.err, got, tc.want)
+			}
+		})
+	}
+}

--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -1,7 +1,9 @@
 package log
 
 import (
+	"context"
 	"encoding/json"
+	"errors"
 	"log/slog"
 	"os"
 	"strings"
@@ -50,6 +52,20 @@ func New(level string) *slog.Logger {
 
 func ErrAttr(err error) slog.Attr {
 	return slog.Any("error", err)
+}
+
+// LevelForError maps an error to the severity it should be logged at.
+// context.Canceled means the caller (typically an MCP client) disconnected or
+// aborted the request mid-flight — expected behavior logged at DEBUG so it
+// does not pollute ERROR streams. context.DeadlineExceeded and every other
+// error stay ERROR: timeouts are real operational signals. Callers must still
+// emit the record at the returned level — never drop it (fail open, never
+// fail silent).
+func LevelForError(err error) slog.Level {
+	if errors.Is(err, context.Canceled) {
+		return slog.LevelDebug
+	}
+	return slog.LevelError
 }
 
 func TruncBody(b []byte) string {

--- a/plans/error-log-noise-reduction.context.md
+++ b/plans/error-log-noise-reduction.context.md
@@ -1,0 +1,27 @@
+# Feature: Error Log Noise Reduction — Context & Discussion
+
+## Original Prompt
+> Production error-log analysis found two log-noise problems accounting for ~28% of all ERROR logs:
+> 1. `request error: resources subscribe not supported` — 454 ERROR logs in 7 days. Clients call `resources/subscribe`; the server rejects it and the `buildHooks` error hook logs each rejection at ERROR. Ensure the capability advertisement does not declare subscribe support, and classify these rejections as expected protocol negotiation logged at DEBUG.
+> 2. Client cancellations logged at ERROR — 410 logs in 7 days. When an MCP client disconnects mid-request, upstream calls fail with `context canceled` and tool handlers log "Failed to search logs" etc. at ERROR. Fix centrally: `errors.Is(err, context.Canceled)` → DEBUG; `context.DeadlineExceeded` stays ERROR.
+
+## Reference Links
+- mcp-go v0.56.0 `server/server.go` — `handleSubscribe` rejects with `fmt.Errorf("resources subscribe %w", ErrUnsupported)`; initialize advertises `resources.subscribe` only via `WithResourceCapabilities`.
+
+## Key Decisions & Discussion Log
+### 2026-07-17 — capability advertisement finding
+- The server never calls `server.WithResourceCapabilities`. Registering resources via `AddResource` implicitly enables the resources capability with `subscribe: false` (omitted via `omitempty`). Advertisement was already correct; only the logging needed fixing. Pinned with a new initialize-result test so a future option change can't silently start advertising subscribe.
+
+### 2026-07-17 — classification signals
+- Subscribe rejection: matched on the typed sentinel `server.ErrUnsupported` (wrapped by mcp-go), not on message strings. This also covers `resources/unsubscribe` and any other unadvertised-capability rejection.
+- Cancellation: `errors.Is(err, context.Canceled)` in a single shared helper `logpkg.LevelForError`. `context.DeadlineExceeded` deliberately stays ERROR — timeouts are operational signals.
+
+### 2026-07-17 — where the classification lives
+- `pkg/log.LevelForError(err)` is the single severity classifier.
+- Hook path: `methodErrorLogLevel` (server.go) = `ErrUnsupported` → DEBUG, else `LevelForError`.
+- Tool handlers: per-callsite logging was scattered across ~39 sites, so a shared `(*Handler).logUpstreamFailure(ctx, msg, err, attrs...)` was added in `errs.go` and substituted at every site that logs a failed ctx-bearing outbound call (SigNoz client calls + dashboard template fetch). Local marshal/parse/pagination failures keep plain `ErrorContext` — they cannot be context-canceled.
+- The `loggingMiddleware` "tool call failed" branch also routes through `LevelForError` for handlers that return a Go error directly.
+- Fail open, never fail silent: downgraded records are still emitted (at DEBUG, with a "(request cancelled by client)" note on the tool path), never dropped; tests assert emission.
+
+## Open Questions
+- [x] Was subscribe support being advertised? — No. `WithResourceCapabilities` is never called; implicit resource registration advertises `subscribe: false`. Only the logging needed fixing.

--- a/plans/error-log-noise-reduction.plan.md
+++ b/plans/error-log-noise-reduction.plan.md
@@ -1,0 +1,28 @@
+# Plan: Error Log Noise Reduction
+
+## Status
+Done
+
+## Context
+Two expected client behaviors were logged at ERROR, together ~28% of production ERROR volume:
+1. `resources/subscribe` rejections (454/7d) — the server does not implement resource subscription (and correctly does not advertise it), but the `buildHooks` OnError hook logged every rejection at ERROR.
+2. Client cancellations (410/7d) — MCP client disconnects surface as `context canceled` from upstream SigNoz calls, and every tool handler logged them at ERROR.
+
+## Approach
+- `pkg/log.LevelForError(err)`: shared classifier — `context.Canceled` → DEBUG, everything else (including `context.DeadlineExceeded`) → ERROR.
+- Hook path (`internal/mcp-server/server.go`): `methodErrorLogLevel(err)` maps mcp-go's typed `server.ErrUnsupported` (wrapped by the subscribe/unsubscribe rejections) to DEBUG, otherwise defers to `LevelForError`; the OnError hook logs "mcp error" via `logger.Log(ctx, level, ...)`. The middleware "tool call failed" branch (Go-error path) also uses `LevelForError`.
+- Tool handlers (`internal/handler/tools`): new `(*Handler).logUpstreamFailure(ctx, msg, err, attrs...)` in `errs.go` picks the level via `LevelForError`, appends "(request cancelled by client)" on the DEBUG path, and always emits. Substituted at all 39 upstream-call ERROR sites; local marshal/parse failures unchanged.
+- Capability advertisement: already correct (no `WithResourceCapabilities`; implicit `subscribe: false`). Pinned with a test on the initialize result.
+
+## Files to Modify
+- `pkg/log/log.go` — add `LevelForError`.
+- `internal/mcp-server/server.go` — `methodErrorLogLevel`; OnError hook and "tool call failed" log level selection.
+- `internal/handler/tools/errs.go` — `logUpstreamFailure` helper.
+- `internal/handler/tools/{alerts,dashboards,fields,logs,metric_usage,metrics_query,metrics_top,metric_cardinality,notification_channels,query_builder,metrics,services,traces,views}.go` — route upstream-call failure logs through the helper.
+- `pkg/log/level_test.go`, `internal/handler/tools/log_level_test.go`, `internal/mcp-server/log_noise_test.go` — tests.
+
+## Verification
+- `go build ./...`, `go vet ./...`, `go test ./...` all pass.
+- `TestInitializeDoesNotAdvertiseResourceSubscribe` asserts the initialize result advertises resources without `subscribe: true`.
+- `TestBuildHooks_ErrorLogSeverityClassification` drives the OnError hook: subscribe-unsupported and canceled → DEBUG (and still emitted), deadline-exceeded and generic → ERROR.
+- `TestLogUpstreamFailureLevels` / `TestLevelForError` pin the helper contract.


### PR DESCRIPTION
## Summary

A 7-day analysis of the "MCP errors - Noz" logs view found that ~28% of the server's ERROR logs (864 of 3,112 rows) are benign protocol/cancellation noise, inflating the error signal:

- **`resources/subscribe not supported` — 454 rows.** Clients probe the standard MCP subscribe capability the server doesn't implement, and each rejection was logged at ERROR from the `buildHooks` OnError hook.
- **Client cancellations — 410 rows.** When a client disconnects mid-request, upstream calls fail with `context canceled` and were logged at ERROR across the tool handlers.

## Changes

**Subscribe rejections → DEBUG**
- mcp-go rejects `resources/subscribe` with a typed `server.ErrUnsupported` sentinel, so no string matching: new `methodErrorLogLevel(err)` in `internal/mcp-server/server.go` maps `errors.Is(err, server.ErrUnsupported)` → DEBUG (also covers unsubscribe / any unadvertised capability); the OnError hook logs at that level.
- Capability finding: the server already does **not** advertise subscribe (mcp-go enables resources implicitly with `subscribe` omitted). `TestInitializeDoesNotAdvertiseResourceSubscribe` pins that so a future option change can't silently start advertising it.

**Client cancellations → DEBUG**
- New central classifier `pkg/log.LevelForError(err)`: `context.Canceled` → DEBUG; everything else — explicitly including `context.DeadlineExceeded` — stays ERROR.
- New shared helper `logUpstreamFailure` in `internal/handler/tools/errs.go`, substituted at all 39 upstream-call ERROR sites across 14 handler files; also applied on the hook path and the `loggingMiddleware` "tool call failed" branch.
- The 23 local marshal/parse/pagination ERROR sites are deliberately unchanged — they can't be context-canceled.

Per the fail-open-never-silent rule, all these records are still emitted at DEBUG, not dropped.

## Tests

- `pkg/log/level_test.go` — classifier contract (canceled → DEBUG; deadline-exceeded/generic → ERROR).
- `internal/handler/tools/log_level_test.go` — `logUpstreamFailure` contract incl. attribute passthrough.
- `internal/mcp-server/log_noise_test.go` — initialize does not advertise subscribe; hook end-to-end (DEBUG records still emitted; deadline/generic stay ERROR).
- `go build ./...`, `go vet ./...`, `go test ./...` all green; `gofmt -l` clean.

## Docs & skills check

No mentions of resource subscription in `README.md`, `manifest.json`, or `docs/` — no doc updates needed. No tool contract changed, so no companion agent-skills change is required. `plans/error-log-noise-reduction.{context,plan}.md` included per the planning convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)