### PR TITLE
fix(oauth): classify expired-workspace 404s as permanent instance-not-found errors

### DIFF
--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -41,8 +41,13 @@ const (
 )
 
 var (
-	ErrUnauthorized  = errors.New("signoz credentials rejected")
-	defaultUserAgent = version.UserAgent()
+	ErrUnauthorized = errors.New("signoz credentials rejected")
+	// ErrInstanceNotFound means the URL resolves but no SigNoz API answers
+	// there — e.g. an expired/deactivated cloud workspace whose ingress serves
+	// an HTML 404 page. A live SigNoz API replies to the validation endpoints
+	// with JSON, even on 404.
+	ErrInstanceNotFound = errors.New("no signoz instance found at URL")
+	defaultUserAgent    = version.UserAgent()
 )
 
 // HTTPStatusError preserves status and response details from a non-2xx SigNoz API response.
@@ -185,8 +190,11 @@ func (s *SigNoz) ValidateCredentials(ctx context.Context) error {
 		return fmt.Errorf("failed to reach SigNoz API: %w", err)
 	}
 
-	// 404 means the key is a service-account key; validate via service account endpoint.
-	if status == http.StatusNotFound {
+	// A JSON 404 means the key is a service-account key; validate via the
+	// service account endpoint. An HTML 404 is not a SigNoz API response at
+	// all (e.g. an expired cloud workspace's ingress page) — retrying the
+	// service-account endpoint would just hit the same page.
+	if status == http.StatusNotFound && !isHTMLBody(body) {
 		s.logger.DebugContext(ctx, "user/me returned non-user status, retrying with service_accounts/me",
 			slog.Int("status", status))
 		saURL := fmt.Sprintf("%s/api/v1/service_accounts/me", s.baseURL)
@@ -337,6 +345,13 @@ func (s *SigNoz) evaluateValidationResponse(ctx context.Context, status int, bod
 	case http.StatusUnauthorized, http.StatusForbidden:
 		s.logger.WarnContext(ctx, "SigNoz credential validation failed", slog.Int("status", status))
 		return fmt.Errorf("%w: status %d", ErrUnauthorized, status)
+	case http.StatusNotFound:
+		if isHTMLBody(body) {
+			s.logger.WarnContext(ctx, "no SigNoz API at instance URL (HTML 404)",
+				slog.String("response", logpkg.TruncBody(body)))
+			return fmt.Errorf("%w: status %d", ErrInstanceNotFound, status)
+		}
+		fallthrough
 	default:
 		truncatedBody := logpkg.TruncBody(body)
 		s.logger.WarnContext(ctx, "SigNoz credential validation returned unexpected status",
@@ -344,6 +359,16 @@ func (s *SigNoz) evaluateValidationResponse(ctx context.Context, status int, bod
 			slog.String("response", truncatedBody))
 		return fmt.Errorf("unexpected status %d: %s", status, truncatedBody)
 	}
+}
+
+// isHTMLBody reports whether a response body is a markup document (HTML/XML)
+// rather than a JSON API payload — the first non-whitespace byte of JSON is
+// never '<'. Empty and plain-text bodies conservatively count as non-HTML so
+// they keep the transient "try again" path.
+func isHTMLBody(body []byte) bool {
+	trimmed := bytes.TrimPrefix(body, []byte("\xef\xbb\xbf")) // UTF-8 BOM
+	trimmed = bytes.TrimLeft(trimmed, " \t\r\n")
+	return len(trimmed) > 0 && trimmed[0] == '<'
 }
 
 const (

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -152,11 +152,21 @@ func TestListAlertRules(t *testing.T) {
 	assert.Contains(t, string(result), `"id":"rule-1"`)
 }
 
+// expiredWorkspaceHTML mirrors the 404 page the SigNoz Cloud ingress serves
+// for expired/deactivated workspaces (captured from production logs).
+const expiredWorkspaceHTML = `<!DOCTYPE html>
+<html>
+<head><title>404 : This page does not exist :/</title></head>
+<body><p>Either the workspace has expired or the workspace does not exist.</p></body>
+</html>`
+
 func TestValidateCredentials(t *testing.T) {
 	tests := []struct {
 		name            string
-		userMeStatus    int // status for /api/v1/user/me (always hit first)
-		saStatus        int // status for /api/v1/service_accounts/me (only hit on user/me 502)
+		userMeStatus    int    // status for /api/v1/user/me (always hit first)
+		userMeBody      string // body for user/me; defaults to JSON
+		saStatus        int    // status for /api/v1/service_accounts/me (only hit on user/me JSON 404)
+		saBody          string // body for service_accounts/me; defaults to JSON
 		expectedError   bool
 		checkErr        func(t *testing.T, err error)
 		expectUserMeHit bool
@@ -208,6 +218,41 @@ func TestValidateCredentials(t *testing.T) {
 				assert.Contains(t, err.Error(), "unexpected status 500")
 			},
 		},
+		{
+			name:            "user/me HTML 404 means no instance, skips fallback",
+			userMeStatus:    http.StatusNotFound,
+			userMeBody:      expiredWorkspaceHTML,
+			expectedError:   true,
+			expectUserMeHit: true,
+			expectSAHit:     false,
+			checkErr: func(t *testing.T, err error) {
+				assert.ErrorIs(t, err, ErrInstanceNotFound)
+			},
+		},
+		{
+			name:            "user/me JSON 404 falls back, HTML 404 on service_accounts/me means no instance",
+			userMeStatus:    http.StatusNotFound,
+			saStatus:        http.StatusNotFound,
+			saBody:          expiredWorkspaceHTML,
+			expectedError:   true,
+			expectUserMeHit: true,
+			expectSAHit:     true,
+			checkErr: func(t *testing.T, err error) {
+				assert.ErrorIs(t, err, ErrInstanceNotFound)
+			},
+		},
+		{
+			name:            "JSON 404 on both endpoints stays a generic unexpected status",
+			userMeStatus:    http.StatusNotFound,
+			saStatus:        http.StatusNotFound,
+			expectedError:   true,
+			expectUserMeHit: true,
+			expectSAHit:     true,
+			checkErr: func(t *testing.T, err error) {
+				assert.NotErrorIs(t, err, ErrInstanceNotFound)
+				assert.Contains(t, err.Error(), "unexpected status 404")
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -221,18 +266,25 @@ func TestValidateCredentials(t *testing.T) {
 				assert.Equal(t, "custom-client/1.0 "+version.UserAgent(), r.Header.Get("User-Agent"))
 				assert.Equal(t, http.MethodGet, r.Method)
 
+				body := `{"status":"ok"}`
 				switch r.URL.Path {
 				case "/api/v1/user/me":
 					userMeRequests++
 					w.WriteHeader(tt.userMeStatus)
+					if tt.userMeBody != "" {
+						body = tt.userMeBody
+					}
 				case "/api/v1/service_accounts/me":
 					saRequests++
 					w.WriteHeader(tt.saStatus)
+					if tt.saBody != "" {
+						body = tt.saBody
+					}
 				default:
 					t.Fatalf("unexpected path %s", r.URL.Path)
 				}
 
-				_, _ = w.Write([]byte(`{"status":"ok"}`))
+				_, _ = w.Write([]byte(body))
 			}))
 			defer server.Close()
 

--- a/internal/oauth/handlers.go
+++ b/internal/oauth/handlers.go
@@ -65,6 +65,13 @@ type registerClientResponse struct {
 // allowlist rejections are alertable on the same mcp.auth.failure_reason.
 const authFailureDisallowedSignozURL = "disallowed_signoz_url"
 
+// Credential-validation failure subtypes, emitted as mcp.auth.failure_reason
+// so expired-workspace noise is separable from real connectivity incidents.
+const (
+	authFailureInstanceNotFound    = "instance_not_found"
+	authFailureInstanceUnreachable = "instance_unreachable"
+)
+
 type authorizeTemplateData struct {
 	ClientID            string
 	ClientName          string
@@ -231,11 +238,13 @@ func (h *Handler) HandleAuthorizeSubmit(w http.ResponseWriter, r *http.Request) 
 		})
 		return
 	}
+	// Seed the SigNoz URL (mcp.tenant_url) so every failure from here on —
+	// allowlist rejection, bad credentials, unreachable or missing instance —
+	// is attributed to the tenant in mcp.oauth.failures.
+	r = r.WithContext(util.SetSigNozURL(r.Context(), normalizedURL))
 	// Reject disallowed backends before probing them, so the server never
 	// dials — or issues a token for — a host it will not serve.
 	if !h.config.InstanceURLAllowlist.AllowsURL(normalizedURL) {
-		// Seed the SigNoz URL (mcp.tenant_url) so the rejection is attributed in mcp.oauth.failures.
-		r = r.WithContext(util.SetSigNozURL(r.Context(), normalizedURL))
 		h.renderAuthorizePage(w, r, http.StatusForbidden, authorizeTemplateData{
 			ClientID:            params.ClientID,
 			ClientName:          params.ClientName,
@@ -266,6 +275,20 @@ func (h *Handler) HandleAuthorizeSubmit(w http.ResponseWriter, r *http.Request) 
 				ErrorMessage:        "We couldn't sign in to that SigNoz instance. Check the URL and API key, then try again.",
 				ErrorCode:           "access_denied",
 			})
+		case errors.Is(err, client.ErrInstanceNotFound):
+			h.renderAuthorizePage(w, r, http.StatusNotFound, authorizeTemplateData{
+				ClientID:            params.ClientID,
+				ClientName:          params.ClientName,
+				RedirectURI:         params.RedirectURI,
+				State:               params.State,
+				CodeChallenge:       params.CodeChallenge,
+				CodeChallengeMethod: params.CodeChallengeMethod,
+				Scope:               params.Scope,
+				SignozURL:           normalizedURL,
+				ErrorMessage:        "We couldn't find a SigNoz workspace at that URL. If your trial or subscription has ended, the workspace may have been deactivated — check your workspace status or contact SigNoz support.",
+				ErrorCode:           "invalid_request",
+				FailureReason:       authFailureInstanceNotFound,
+			})
 		default:
 			h.renderAuthorizePage(w, r, http.StatusBadGateway, authorizeTemplateData{
 				ClientID:            params.ClientID,
@@ -278,6 +301,7 @@ func (h *Handler) HandleAuthorizeSubmit(w http.ResponseWriter, r *http.Request) 
 				SignozURL:           normalizedURL,
 				ErrorMessage:        "We couldn't reach that SigNoz instance. Check the URL and try again.",
 				ErrorCode:           "temporarily_unavailable",
+				FailureReason:       authFailureInstanceUnreachable,
 			})
 		}
 		return

--- a/internal/oauth/handlers_test.go
+++ b/internal/oauth/handlers_test.go
@@ -931,6 +931,230 @@ func TestAuthorizeSubmitUnauthorizedRecordsFailureMetric(t *testing.T) {
 	if !ok || statusAttr.AsInt64() != http.StatusUnauthorized {
 		t.Fatalf("http.response.status_code = %v, want %d", statusAttr, http.StatusUnauthorized)
 	}
+	tenantAttr, ok := dp.Attributes.Value(attribute.Key("mcp.tenant_url"))
+	if !ok || tenantAttr.AsString() != signozServer.URL {
+		t.Fatalf("mcp.tenant_url = %v, want %q", tenantAttr, signozServer.URL)
+	}
+}
+
+// TestAuthorizeSubmitExpiredWorkspaceRendersInstanceNotFound covers the
+// expired/deactivated cloud workspace case: the instance URL answers with the
+// ingress's HTML 404 page instead of a SigNoz API response. The user must get
+// a permanent error pointing at workspace status — not "try again" — and the
+// failure must be tagged instance_not_found with tenant attribution.
+func TestAuthorizeSubmitExpiredWorkspaceRendersInstanceNotFound(t *testing.T) {
+	signozServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`<!DOCTYPE html>
+<html><head><title>404 : This page does not exist :/</title></head>
+<body>Either the workspace has expired or the workspace does not exist.</body></html>`))
+	}))
+	defer signozServer.Close()
+
+	reader := sdkmetric.NewManualReader()
+	meterProvider := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+	defer func() {
+		if err := meterProvider.Shutdown(context.Background()); err != nil {
+			t.Fatalf("shutdown meter provider: %v", err)
+		}
+	}()
+
+	meters, err := otelpkg.NewMeters(meterProvider)
+	if err != nil {
+		t.Fatalf("new meters: %v", err)
+	}
+
+	cfg := &config.Config{
+		OAuthEnabled:     true,
+		OAuthTokenSecret: "0123456789abcdef0123456789abcdef",
+		OAuthIssuerURL:   "https://mcp.example.com",
+		AuthCodeTTL:      10 * time.Minute,
+	}
+
+	handler := NewHandler(logpkg.New("error"), cfg, nil, meters)
+	clientID, err := EncryptClientID([]string{"http://127.0.0.1:4567/callback"}, "Claude", time.Now().UTC(), []byte(cfg.OAuthTokenSecret))
+	if err != nil {
+		t.Fatalf("EncryptClientID() error = %v", err)
+	}
+
+	authorizeReq := httptest.NewRequest(
+		http.MethodGet,
+		"/oauth/authorize?response_type=code&client_id="+url.QueryEscape(clientID)+
+			"&redirect_uri="+url.QueryEscape("http://127.0.0.1:4567/callback")+
+			"&state=state-123&code_challenge=challenge&code_challenge_method=S256",
+		nil,
+	)
+	authorizeRR := httptest.NewRecorder()
+	handler.HandleAuthorizePage(authorizeRR, authorizeReq)
+
+	re := regexp.MustCompile(`name="csrf_token" value="([^"]+)"`)
+	matches := re.FindStringSubmatch(authorizeRR.Body.String())
+	if len(matches) != 2 {
+		t.Fatalf("csrf token not found in authorize page: %s", authorizeRR.Body.String())
+	}
+
+	form := url.Values{
+		"client_id":             {clientID},
+		"redirect_uri":          {"http://127.0.0.1:4567/callback"},
+		"state":                 {"state-123"},
+		"code_challenge":        {"challenge"},
+		"code_challenge_method": {"S256"},
+		"csrf_token":            {matches[1]},
+		"signoz_url":            {signozServer.URL},
+		"api_key":               {"some-api-key"},
+	}
+
+	submitReq := httptest.NewRequest(http.MethodPost, "/oauth/authorize", bytes.NewBufferString(form.Encode()))
+	submitReq.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	submitReq.AddCookie(authorizeRR.Result().Cookies()[0])
+	submitRR := httptest.NewRecorder()
+	handler.HandleAuthorizeSubmit(submitRR, submitReq)
+
+	if submitRR.Code != http.StatusNotFound {
+		t.Fatalf("authorize POST status = %d, want %d, body = %s", submitRR.Code, http.StatusNotFound, submitRR.Body.String())
+	}
+	if !strings.Contains(submitRR.Body.String(), "the workspace may have been deactivated") {
+		t.Fatalf("authorize POST body should point at workspace status, body = %s", submitRR.Body.String())
+	}
+	if strings.Contains(submitRR.Body.String(), "Check the URL and try again") {
+		t.Fatalf("authorize POST body should not suggest retrying, body = %s", submitRR.Body.String())
+	}
+
+	var metrics metricdata.ResourceMetrics
+	if err := reader.Collect(context.Background(), &metrics); err != nil {
+		t.Fatalf("collect metrics: %v", err)
+	}
+
+	failures, found := oteltest.FindInt64SumMetric(metrics, "mcp.oauth.failures")
+	if !found {
+		t.Fatal("mcp.oauth.failures metric not found")
+	}
+	if len(failures.DataPoints) != 1 {
+		t.Fatalf("mcp.oauth.failures datapoints = %d, want 1", len(failures.DataPoints))
+	}
+
+	dp := failures.DataPoints[0]
+	codeAttr, ok := dp.Attributes.Value(attribute.Key("oauth.error_code"))
+	if !ok || codeAttr.AsString() != "invalid_request" {
+		t.Fatalf("oauth.error_code = %v, want invalid_request", codeAttr)
+	}
+	statusAttr, ok := dp.Attributes.Value(attribute.Key("http.response.status_code"))
+	if !ok || statusAttr.AsInt64() != http.StatusNotFound {
+		t.Fatalf("http.response.status_code = %v, want %d", statusAttr, http.StatusNotFound)
+	}
+	reasonAttr, ok := dp.Attributes.Value(attribute.Key("mcp.auth.failure_reason"))
+	if !ok || reasonAttr.AsString() != "instance_not_found" {
+		t.Fatalf("mcp.auth.failure_reason = %v, want instance_not_found", reasonAttr)
+	}
+	tenantAttr, ok := dp.Attributes.Value(attribute.Key("mcp.tenant_url"))
+	if !ok || tenantAttr.AsString() != signozServer.URL {
+		t.Fatalf("mcp.tenant_url = %v, want %q", tenantAttr, signozServer.URL)
+	}
+}
+
+// TestAuthorizeSubmitTransientFailureStaysTemporarilyUnavailable pins the
+// transient path: a 503 from the instance keeps the retryable 502
+// temporarily_unavailable response, now tagged instance_unreachable.
+func TestAuthorizeSubmitTransientFailureStaysTemporarilyUnavailable(t *testing.T) {
+	signozServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+		_, _ = w.Write([]byte(`{"status":"error","message":"upgrade in progress"}`))
+	}))
+	defer signozServer.Close()
+
+	reader := sdkmetric.NewManualReader()
+	meterProvider := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+	defer func() {
+		if err := meterProvider.Shutdown(context.Background()); err != nil {
+			t.Fatalf("shutdown meter provider: %v", err)
+		}
+	}()
+
+	meters, err := otelpkg.NewMeters(meterProvider)
+	if err != nil {
+		t.Fatalf("new meters: %v", err)
+	}
+
+	cfg := &config.Config{
+		OAuthEnabled:     true,
+		OAuthTokenSecret: "0123456789abcdef0123456789abcdef",
+		OAuthIssuerURL:   "https://mcp.example.com",
+		AuthCodeTTL:      10 * time.Minute,
+	}
+
+	handler := NewHandler(logpkg.New("error"), cfg, nil, meters)
+	clientID, err := EncryptClientID([]string{"http://127.0.0.1:4567/callback"}, "Claude", time.Now().UTC(), []byte(cfg.OAuthTokenSecret))
+	if err != nil {
+		t.Fatalf("EncryptClientID() error = %v", err)
+	}
+
+	authorizeReq := httptest.NewRequest(
+		http.MethodGet,
+		"/oauth/authorize?response_type=code&client_id="+url.QueryEscape(clientID)+
+			"&redirect_uri="+url.QueryEscape("http://127.0.0.1:4567/callback")+
+			"&state=state-123&code_challenge=challenge&code_challenge_method=S256",
+		nil,
+	)
+	authorizeRR := httptest.NewRecorder()
+	handler.HandleAuthorizePage(authorizeRR, authorizeReq)
+
+	re := regexp.MustCompile(`name="csrf_token" value="([^"]+)"`)
+	matches := re.FindStringSubmatch(authorizeRR.Body.String())
+	if len(matches) != 2 {
+		t.Fatalf("csrf token not found in authorize page: %s", authorizeRR.Body.String())
+	}
+
+	form := url.Values{
+		"client_id":             {clientID},
+		"redirect_uri":          {"http://127.0.0.1:4567/callback"},
+		"state":                 {"state-123"},
+		"code_challenge":        {"challenge"},
+		"code_challenge_method": {"S256"},
+		"csrf_token":            {matches[1]},
+		"signoz_url":            {signozServer.URL},
+		"api_key":               {"some-api-key"},
+	}
+
+	submitReq := httptest.NewRequest(http.MethodPost, "/oauth/authorize", bytes.NewBufferString(form.Encode()))
+	submitReq.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	submitReq.AddCookie(authorizeRR.Result().Cookies()[0])
+	submitRR := httptest.NewRecorder()
+	handler.HandleAuthorizeSubmit(submitRR, submitReq)
+
+	if submitRR.Code != http.StatusBadGateway {
+		t.Fatalf("authorize POST status = %d, want %d, body = %s", submitRR.Code, http.StatusBadGateway, submitRR.Body.String())
+	}
+	if !strings.Contains(submitRR.Body.String(), "Check the URL and try again") {
+		t.Fatalf("authorize POST body should keep the retry guidance, body = %s", submitRR.Body.String())
+	}
+
+	var metrics metricdata.ResourceMetrics
+	if err := reader.Collect(context.Background(), &metrics); err != nil {
+		t.Fatalf("collect metrics: %v", err)
+	}
+
+	failures, found := oteltest.FindInt64SumMetric(metrics, "mcp.oauth.failures")
+	if !found {
+		t.Fatal("mcp.oauth.failures metric not found")
+	}
+	if len(failures.DataPoints) != 1 {
+		t.Fatalf("mcp.oauth.failures datapoints = %d, want 1", len(failures.DataPoints))
+	}
+
+	dp := failures.DataPoints[0]
+	codeAttr, ok := dp.Attributes.Value(attribute.Key("oauth.error_code"))
+	if !ok || codeAttr.AsString() != "temporarily_unavailable" {
+		t.Fatalf("oauth.error_code = %v, want temporarily_unavailable", codeAttr)
+	}
+	reasonAttr, ok := dp.Attributes.Value(attribute.Key("mcp.auth.failure_reason"))
+	if !ok || reasonAttr.AsString() != "instance_unreachable" {
+		t.Fatalf("mcp.auth.failure_reason = %v, want instance_unreachable", reasonAttr)
+	}
+	tenantAttr, ok := dp.Attributes.Value(attribute.Key("mcp.tenant_url"))
+	if !ok || tenantAttr.AsString() != signozServer.URL {
+		t.Fatalf("mcp.tenant_url = %v, want %q", tenantAttr, signozServer.URL)
+	}
 }
 
 func TestRefreshTokenGrantRejectsDisallowedInstanceURL(t *testing.T) {

--- a/plans/oauth-expired-workspace-errors.context.md
+++ b/plans/oauth-expired-workspace-errors.context.md
@@ -1,0 +1,62 @@
+# Feature: OAuth expired-workspace errors — Context & Discussion
+
+## Original Prompt
+> What to do here? https://github.com/SigNoz/nerve-pod/issues/155
+> Fix and then get codex 5.6 sol high review and then raise a PR
+
+## Reference Links
+- [nerve-pod#155 — OAuth authorize fails with `temporarily_unavailable` 502](https://github.com/SigNoz/nerve-pod/issues/155)
+
+## Key Decisions & Discussion Log
+### 2026-07-17 — Investigation (live telemetry)
+- Queried hosted MCP server logs (`service.name = 'signoz-mcp-server'`, last 7d):
+  23 WARN "SigNoz credential validation returned unexpected status" — 22× HTTP 404,
+  1× HTTP 503, across 8 distinct `*.signoz.cloud` tenant URLs.
+- The 404 bodies are the SigNoz Cloud ingress HTML page: "You have reached a
+  workspace that does not exist! Either the workspace has expired or the
+  workspace does not exist." — confirming the issue's hypothesis: these are
+  expired/deactivated cloud workspaces, not typos or transient outages. DNS
+  still resolves; the ingress serves the 404 page.
+- Found a telemetry gap: `mcp.oauth.failures` has an **empty `mcp.tenant_url`**
+  on the credential-validation failure path — the URL is only seeded into the
+  request context on the allowlist-rejection path (`handlers.go`).
+
+### 2026-07-17 — Design decisions
+- **Detection signal**: HTTP 404 whose body is not JSON (HTML page) from the
+  validation endpoints ⇒ no SigNoz API at that URL. A live SigNoz API always
+  answers `/api/v1/user/me` / `/api/v1/service_accounts/me` with JSON, even on
+  404. Detect via first non-whitespace byte `<` rather than matching page copy
+  (copy can change; content shape is stable).
+- New sentinel `client.ErrInstanceNotFound` returned from
+  `evaluateValidationResponse`; `ValidateCredentials` also skips the
+  service-account retry when the first 404 is HTML (the retry would just hit
+  the same ingress page).
+- **Handler mapping**: `ErrInstanceNotFound` ⇒ HTTP 404, OAuth error code
+  `invalid_request` (permanent, per issue ask), message pointing at
+  workspace/subscription status instead of "check the URL and try again".
+  Everything else non-401 keeps 502 `temporarily_unavailable`.
+- **Telemetry**: reuse existing `FailureReason` → `mcp.auth.failure_reason`
+  mechanism with `instance_not_found` / `instance_unreachable` so
+  expired-workspace noise is separable from real connectivity incidents.
+- Seed `util.SetSigNozURL` into the request context right after allowlist
+  check so every subsequent failure metric carries `mcp.tenant_url`.
+- 4xx failures log at WARN (existing `recordOAuthFailure` behavior), so the
+  reclassified expired-workspace failures also stop appearing as ERROR noise.
+
+### 2026-07-17 — Codex review (gpt-5.6-sol, reasoning=high, read-only)
+- Verdict: **APPROVE**, no blocker/major findings. Minors addressed:
+  - `isHTMLBody` now strips a UTF-8 BOM before sniffing; comment documents
+    that XML also classifies as "no SigNoz API here" and that empty/plain-text
+    404s conservatively stay on the transient path.
+  - Added the transient-path handler test (503 ⇒ 502 `temporarily_unavailable`
+    + `instance_unreachable` + tenant attribution) promised by the plan.
+  - Fixed a stale test comment ("user/me 502" → "user/me JSON 404").
+- Codex confirmed: no OAuth wire-level concern (ErrorCode on this rendered
+  form path is telemetry/display only, no redirect), and
+  `GetAnalyticsIdentity` sharing `evaluateValidationResponse` only changes
+  error identity/log text, not behavior.
+
+## Open Questions
+- [x] Are the failing URLs really expired deployments? — Yes; confirmed via
+  ingress 404 "workspace does not exist" HTML bodies in the hosted server's
+  own logs (see 2026-07-17 investigation entry).

--- a/plans/oauth-expired-workspace-errors.plan.md
+++ b/plans/oauth-expired-workspace-errors.plan.md
@@ -1,0 +1,56 @@
+# Plan: OAuth expired-workspace errors
+
+## Status
+In Progress
+
+## Context
+`/oauth/authorize` currently maps every non-401 credential-validation failure
+to 502 `temporarily_unavailable` with "We couldn't reach that SigNoz instance.
+Check the URL and try again." Live-telemetry investigation (nerve-pod#155)
+shows 22 of 23 such failures in the last 7 days were expired/deactivated
+SigNoz Cloud workspaces whose ingress returns an HTML 404 "workspace does not
+exist" page — a permanent condition. The current message sends users down the
+wrong recovery path, and the failures are not attributable per-tenant because
+`mcp.tenant_url` is empty on the metric for this path.
+
+## Approach
+1. **Classify the dead-workspace signature in the client**
+   (`internal/client/client.go`):
+   - New sentinel `ErrInstanceNotFound`.
+   - `evaluateValidationResponse`: status 404 with a non-JSON (HTML) body ⇒
+     `ErrInstanceNotFound`. JSON 404s keep the generic "unexpected status"
+     error (a real API 404 means service-account retry logic elsewhere).
+   - `ValidateCredentials`: skip the `/api/v1/service_accounts/me` retry when
+     `/api/v1/user/me` returned an HTML 404 — it is the ingress page, not a
+     "key is a service account" signal.
+2. **Branch in the OAuth handler** (`internal/oauth/handlers.go`):
+   - `errors.Is(err, client.ErrInstanceNotFound)` ⇒ HTTP 404, error code
+     `invalid_request`, message: "We couldn't find a SigNoz workspace at that
+     URL. If your trial or subscription has ended, the workspace may have been
+     deactivated — check your workspace status or contact SigNoz support."
+     `FailureReason: instance_not_found`.
+   - Remaining default case keeps 502 `temporarily_unavailable` but gains
+     `FailureReason: instance_unreachable`.
+3. **Fix tenant attribution**: seed `util.SetSigNozURL(r.Context(), normalizedURL)`
+   into the request context immediately after the allowlist check, so the
+   401, not-found, and unreachable failure metrics/logs all carry
+   `mcp.tenant_url` (today only the allowlist rejection seeds it).
+
+## Files to Modify
+- `internal/client/client.go` — `ErrInstanceNotFound`, HTML-404 classification,
+  skip pointless service-account retry on ingress 404.
+- `internal/client/client_test.go` — cases: HTML 404 on user/me (no retry,
+  `ErrInstanceNotFound`), JSON 404 → service-account retry preserved, HTML 404
+  on the retry ⇒ `ErrInstanceNotFound`.
+- `internal/oauth/handlers.go` — new branch + failure reasons + context
+  seeding.
+- `internal/oauth/handlers_test.go` — authorize-submit renders the permanent
+  error for `ErrInstanceNotFound`; transient path keeps `temporarily_unavailable`.
+- `plans/oauth-expired-workspace-errors.{context,plan}.md` — this pair.
+
+## Verification
+- `go test ./...`, `go vet`, lint.
+- Fixture for the classifier is the real ingress 404 HTML captured from
+  production logs (title "404 : This page does not exist :/").
+- Docs/metadata sync: no MCP tool contract change ⇒ README/manifest/agent-skills
+  unaffected; verified nothing under `docs/` references the old message.


### PR DESCRIPTION
Fixes SigNoz/nerve-pod#155

## Problem

`/oauth/authorize` mapped every non-401 credential-validation failure to 502 `temporarily_unavailable` with *"We couldn't reach that SigNoz instance. Check the URL and try again."* — 21+ occurrences in the last 7 days.

Live-telemetry investigation (see `plans/oauth-expired-workspace-errors.context.md`) confirmed the issue's hypothesis: **22 of 23** such failures were expired/deactivated SigNoz Cloud workspaces across 8 tenants. DNS still resolves; the cloud ingress serves an HTML 404 *"workspace does not exist / has expired"* page. The retry guidance sends users down a recovery path that can never succeed. Only 1 failure (a 503) was genuinely transient.

## Changes

- **`internal/client`**: new `ErrInstanceNotFound` sentinel. A 404 from the validation endpoints whose body is markup (HTML/XML, BOM-aware sniff) rather than JSON means no SigNoz API answers at that URL — a live SigNoz API always replies with JSON, even on 404. The service-account retry is skipped for HTML 404s (it would just hit the same ingress page); JSON 404s keep the existing service-account fallback. Empty/plain-text 404s conservatively stay on the transient path.
- **`internal/oauth`**: `ErrInstanceNotFound` renders a permanent HTTP 404 / `invalid_request` error: *"We couldn't find a SigNoz workspace at that URL. If your trial or subscription has ended, the workspace may have been deactivated — check your workspace status or contact SigNoz support."* Transient failures keep 502 `temporarily_unavailable` with the retry guidance.
- **Telemetry**: failures are tagged `mcp.auth.failure_reason=instance_not_found|instance_unreachable`, so expired-workspace noise is separable from real connectivity incidents (issue ask #3). Also fixes an attribution gap found during investigation: the tenant URL is now seeded into the request context right after allowlist checks, so `mcp.oauth.failures` carries `mcp.tenant_url` on the credential-validation failure paths (previously only allowlist rejections were attributed). As a side effect of the 502→404 reclassification, expired-workspace failures now log at WARN instead of ERROR.

## Review

Codex (gpt-5.6-sol, reasoning=high) reviewed the diff: **APPROVE**, no blocker/major findings; its minors (BOM handling, transient-path test, stale comment) are addressed. Log in the context file.

## Tests

- `internal/client`: HTML 404 on `user/me` short-circuits as `ErrInstanceNotFound` without the service-account retry; JSON 404 → HTML 404 on the retry also classifies; JSON 404 on both endpoints stays a generic unexpected-status error. Fixture mirrors the real ingress 404 page captured from production logs.
- `internal/oauth`: expired-workspace submit renders the permanent 404 with `instance_not_found` + `mcp.tenant_url` on the failure metric; a 503 keeps 502 `temporarily_unavailable` with `instance_unreachable`; the existing unauthorized-failure metric test now also asserts tenant attribution.
- `go test ./...`, `go vet ./...`, `gofmt` clean.

## Docs & metadata sync

No MCP tool contract change: `README.md`, `manifest.json`, and `docs/` have no references to the changed messages (verified by grep), and the companion **SigNoz/agent-skills** repo needs no change — this alters an OAuth error page, not any tool contract the skills teach. Plan/context pair committed per convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)