### PR TITLE
feat(query-tools): add key-not-found recovery guidance and missingKeys error field

### DIFF
--- a/README.md
+++ b/README.md
@@ -429,6 +429,7 @@ Query metrics with smart aggregation defaults and validation. Automatically appl
   - `formulaQueries` (optional) - Array or JSON-encoded array string of additional named metric queries for formula. Each object supports `name`, `metricName`, `metricType`, `isMonotonic`, `temporality`, `timeAggregation`, `spaceAggregation`, `groupBy`, and `filter`; `name` and `metricName` are required.
   - `source` (optional) - Data-source filter. Use `"meter"` to query Cost Meter data; omit for the default metrics store
   - **Result bounds**: standalone generated metric queries and formula results use `limit: 100` with `__result desc`. Every query feeding a formula uses `limit: 10000`, because component limits are applied before formula evaluation and independent top-100 inputs can discard a high-ratio group. The response decisions note reports both bounds. Narrow the filters/grouping when formula-input cardinality can exceed 10000.
+  - **Key-not-found errors**: a filter referencing a key absent from this workspace's metrics metadata fails with recovery guidance in the error text plus a machine-readable `missingKeys` array in the structured error content
 
 #### `signoz_get_top_metrics`
 
@@ -657,8 +658,8 @@ Aggregate logs with count, average, sum, min, max, or percentiles, optionally gr
   - `aggregation` (required) - Aggregation function: count, count_distinct, avg, sum, min, max, p50, p75, p90, p95, p99, rate
   - `aggregateOn` (optional) - Field to aggregate on (required for all except count and rate)
   - `groupBy` (optional) - Comma-separated fields to group by (e.g., 'service.name, severity_text')
-  - `filter` (optional) - Filter expression using SigNoz search syntax. Combine conditions with AND, OR, and parentheses. Unknown keys hard-error; ambiguous keys default to resource context. See `signoz://logs/query-builder-guide`
-  - `service` (optional) - Shortcut filter for service name
+  - `filter` (optional) - Filter expression using SigNoz search syntax. Combine conditions with AND, OR, and parentheses. Unknown keys hard-error; ambiguous keys default to resource context. Log keys are workspace-specific — even `service.name` is only present when the log pipeline sets it. See `signoz://logs/query-builder-guide`
+  - `service` (optional) - Shortcut filter for service name (adds `service.name = '<value>'`; fails with `key service.name not found` when the workspace's logs lack that attribute)
   - `severity` (optional) - Shortcut filter for severity (DEBUG, INFO, WARN, ERROR, FATAL)
   - `orderBy` (optional) - Order expression and direction (e.g., 'count() desc')
   - `limit` (optional) - Maximum number of groups to return (default: 100, max: 10000; higher values are clamped to bound server memory)
@@ -667,14 +668,15 @@ Aggregate logs with count, average, sum, min, max, or percentiles, optionally gr
   - `requestType` (optional) - `scalar` (default — one aggregate value over the whole range) or `time_series` (one value per time bucket). Unknown values are rejected.
   - `stepInterval` (optional) - Time bucket size in seconds for `time_series` mode. Accepts a number or numeric string (backend auto-selects when omitted)
   - **Time-series ranking note**: the limit selects top groups over the whole requested window, not independently per bucket. Narrow the window or set a deliberate smaller/larger positive limit when a short-lived series could otherwise be hidden.
+  - **Key-not-found errors**: a filter referencing a key absent from this workspace's logs metadata fails with recovery guidance in the error text plus a machine-readable `missingKeys` array in the structured error content
 
 #### `signoz_search_logs`
 
 Search logs with flexible filtering across all services.
 
 - **Parameters**:
-  - `filter` (optional) - Filter expression using SigNoz search syntax. Combine conditions with AND, OR, and parentheses (e.g., "(severity_text = 'ERROR' OR body CONTAINS 'panic') AND service.name = 'payment-svc'"). Legacy `query` is still accepted for backward compatibility, but `filter` is canonical. See `signoz://logs/query-builder-guide`
-  - `service` (optional) - Service name to filter by
+  - `filter` (optional) - Filter expression using SigNoz search syntax. Combine conditions with AND, OR, and parentheses (e.g., "(severity_text = 'ERROR' OR body CONTAINS 'panic') AND service.name = 'payment-svc'"). Log keys are workspace-specific — even `service.name` is only present when the log pipeline sets it. Legacy `query` is still accepted for backward compatibility, but `filter` is canonical. See `signoz://logs/query-builder-guide`
+  - `service` (optional) - Service name to filter by (adds `service.name = '<value>'`; fails with `key service.name not found` when the workspace's logs lack that attribute)
   - `severity` (optional) - Severity filter (DEBUG, INFO, WARN, ERROR, FATAL)
   - `searchText` (optional) - Text to search for in log body (uses CONTAINS matching)
   - `timeRange` (optional) - Relative time range `<number><unit>` where unit is `m`/`h`/`d` (e.g. '30m', '1h', '6h', '24h', '7d'; default: '1h'; ignored when both `start` and `end` are provided)
@@ -683,6 +685,7 @@ Search logs with flexible filtering across all services.
   - `offset` (optional) - Offset for pagination (default: 0)
   - **Ordering**: generated raw log queries use `timestamp desc`, then `id desc`, so offset pagination is deterministic when multiple rows share a timestamp.
   - **Completeness note**: the response appends a note reporting `hasMore` (inferred from `returnedRows == limit`) and the `nextOffset` to fetch, so a truncated page is never mistaken for the full result set
+  - **Key-not-found errors**: a filter referencing a key absent from this workspace's logs metadata fails with recovery guidance in the error text plus a machine-readable `missingKeys` array in the structured error content
 
 #### `signoz_get_field_keys`
 
@@ -726,6 +729,7 @@ Search traces/spans with flexible filtering.
   - **Ordering**: generated raw trace queries use `timestamp desc`.
   - **Completeness note**: the response appends a note reporting `hasMore` (inferred from `returnedRows == limit`) and the `nextOffset` to fetch, so a truncated page is never mistaken for the full result set
   - **Output note**: raw result row keys follow canonical Query Builder field names (for example `trace_id`, `span_id`, `duration_nano`, `has_error`). Legacy caller-provided filters such as `hasError` still pass through to the backend alias layer, but new response parsers should read the canonical snake_case keys.
+  - **Key-not-found errors**: a filter referencing a key absent from this workspace's traces metadata fails with recovery guidance in the error text plus a machine-readable `missingKeys` array in the structured error content
 
 #### `signoz_aggregate_traces`
 
@@ -746,6 +750,7 @@ Aggregate trace statistics like count, average, sum, min, max, or percentiles ov
   - `requestType` (optional) - `scalar` (default — one aggregate value over the whole range) or `time_series` (one value per time bucket). Unknown values are rejected.
   - `stepInterval` (optional) - Time bucket size in seconds for `time_series` mode. Accepts a number or numeric string (backend auto-selects when omitted)
   - **Time-series ranking note**: the limit selects top groups over the whole requested window, not independently per bucket. Narrow the window or set a deliberate smaller/larger positive limit when a short-lived series could otherwise be hidden.
+  - **Key-not-found errors**: a filter referencing a key absent from this workspace's traces metadata fails with recovery guidance in the error text plus a machine-readable `missingKeys` array in the structured error content
 
 #### `signoz_get_trace_details`
 
@@ -850,6 +855,7 @@ Executes a SigNoz Query Builder v5 query as the raw escape hatch for shapes the 
 - **Guide routing**: read `signoz://logs/query-builder-guide` for logs, `signoz://traces/query-builder-guide` for traces, `signoz://metrics-aggregation-guide` for metrics/formulas, and `signoz://promql/instructions` for PromQL.
 - **Time-series ranking caveat**: top-N groups are ranked over the entire requested window. A short-lived spike can be omitted even when it dominates one bucket; narrow the window or choose a deliberate positive limit when that matters.
 - **Backend warnings**: non-fatal warnings the backend returns (e.g. ambiguous-key resolution) are surfaced as a note alongside the raw response and WARN-logged, matching the search/aggregate/query_metrics tools (previously the body was returned verbatim and warnings were dropped).
+- **Key-not-found errors**: a filter referencing a key absent from the workspace's metadata for the queried signal fails with recovery guidance in the error text plus a machine-readable `missingKeys` array in the structured error content
 - **Documentation**: See [SigNoz Query Builder v5 docs](https://signoz.io/docs/userguide/query-builder-v5/)
 
 </details>

--- a/internal/handler/tools/errs.go
+++ b/internal/handler/tools/errs.go
@@ -94,6 +94,14 @@ const statusClientClosedConnection = 499
 // into the surfaced upstream message; the body is upstream-controlled input.
 const maxUpstreamErrorDetails = 5
 
+// maxUpstreamErrorDetailsBytes bounds how large an error.errors[] payload is
+// decoded at all: json.Unmarshal materializes the whole array before the
+// per-detail cap applies, and a non-2xx body can be up to 64 MiB, so an
+// oversized detail array is skipped outright (fail open, like a drifted shape)
+// rather than decoded. 16 KiB is orders of magnitude more than the five
+// surfaced details ever need.
+const maxUpstreamErrorDetailsBytes = 16 << 10
+
 var assistantAuthEnvelopeCodes = map[string]struct{}{
 	"forbidden":       {},
 	"token_expired":   {},
@@ -501,12 +509,13 @@ func parseUpstreamErrorBody(body string) (upstreamCode, upstreamMessage, upstrea
 }
 
 // upstreamErrorDetails decodes error.errors[] best-effort: the documented shape is
-// [{"message": "..."}], with a plain []string fallback; any other shape yields nil
-// rather than an error, so a drifted detail array can never discard the main
-// error fields (they are decoded independently via json.RawMessage). Details are
-// trimmed, deduplicated (including against the main message), and capped.
+// [{"message": "..."}], with a plain []string fallback; any other shape — or a
+// payload over maxUpstreamErrorDetailsBytes — yields nil rather than an error, so
+// a drifted or oversized detail array can never discard the main error fields
+// (they are decoded independently via json.RawMessage). Details are trimmed,
+// deduplicated (including against the main message), and capped.
 func upstreamErrorDetails(raw json.RawMessage, mainMessage string) []string {
-	if len(raw) == 0 {
+	if len(raw) == 0 || len(raw) > maxUpstreamErrorDetailsBytes {
 		return nil
 	}
 	var messages []string

--- a/internal/handler/tools/errs.go
+++ b/internal/handler/tools/errs.go
@@ -94,13 +94,9 @@ const statusClientClosedConnection = 499
 // into the surfaced upstream message; the body is upstream-controlled input.
 const maxUpstreamErrorDetails = 5
 
-// maxUpstreamErrorDetailsBytes bounds how large an error object has its
-// error.errors[] detail array extracted at all: json.RawMessage copies the
-// field's bytes during Unmarshal and a non-2xx body can be up to 64 MiB, so
-// parseUpstreamErrorBody only names errors[] in a decode target when the whole
-// error object fits this bound (fail open, like a drifted shape — details
-// dropped, main fields kept). 16 KiB is orders of magnitude more than the five
-// surfaced details ever need.
+// maxUpstreamErrorDetailsBytes caps the error-object size for which errors[]
+// details are extracted: non-2xx bodies can reach 64 MiB and json.RawMessage
+// copies the field's bytes, so oversized objects skip extraction (fail open).
 const maxUpstreamErrorDetailsBytes = 16 << 10
 
 var assistantAuthEnvelopeCodes = map[string]struct{}{
@@ -233,22 +229,16 @@ func (h *Handler) logUpstreamFailure(ctx context.Context, msg string, err error,
 	h.logger.Log(ctx, level, msg, args...)
 }
 
-// keyNotFoundPattern matches the QB v5 key-resolution failure ("key `service.name`
-// not found") in a 400 body. The wording is stable across backend generations: older
-// releases inline it in error.message, newer ones carry it in error.errors[].message
-// — matching the raw body covers both. Contract-sensitive by design: if the backend
-// rewords it, detection fails open (no enrichment) and logQueryFailure's ERROR-level
-// fallback is the drift signal.
+// keyNotFoundPattern matches the QB v5 key-resolution failure in a 400 body;
+// the wording is stable across backend generations (inline in error.message or
+// in error.errors[].message). If the backend rewords it, detection fails open
+// and logQueryFailure's ERROR-level fallback is the drift signal.
 var keyNotFoundPattern = regexp.MustCompile("key `([^`]+)` not found")
 
-// The 400 body is upstream-controlled input (buffered up to 64 MiB), so everything
-// derived from it is bounded: only the first missingFilterKeyScanBytes are scanned
-// (FindAllStringSubmatch's match cap would not stop it walking the whole body, and
-// each failure is scanned by both logQueryFailure and upstreamQueryError), at most
-// missingFilterKeyScanLimit matches are examined, a captured key longer than
-// missingFilterKeyMaxLen is discarded as garbage, and at most
-// missingFilterKeysLimit distinct keys are surfaced. Real key-not-found bodies are
-// far smaller than the scan window; a phrase beyond it fails open (no enrichment).
+// Bounds on processing the upstream-controlled 400 body (up to 64 MiB): scan
+// only the first missingFilterKeyScanBytes (a match cap alone would still walk
+// the whole body), examine at most missingFilterKeyScanLimit matches, drop keys
+// longer than missingFilterKeyMaxLen, surface at most missingFilterKeysLimit.
 const (
 	missingFilterKeysLimit    = 10
 	missingFilterKeyScanLimit = 64
@@ -485,13 +475,9 @@ func parseUpstreamErrorBody(body string) (upstreamCode, upstreamMessage, upstrea
 			upstreamType = nested.Type
 			upstreamCode = nested.Code
 			upstreamMessage = nested.Message
-			// Newer backends put the per-term detail in error.errors[] and keep
-			// error.message as a bare summary ("Found N errors while parsing the
-			// search expression."); fold the details in so they reach the caller.
-			// Extracted in a separate size-gated pass: json.RawMessage copies the
-			// field's bytes during Unmarshal, so an oversized error object must
-			// never name errors[] in a decode target at all (fail open on the
-			// details; the main fields above are already decoded).
+			// Newer backends carry the per-term detail in error.errors[]; fold it
+			// in via a size-gated second decode — json.RawMessage copies the
+			// field's bytes, so oversized objects never decode errors[] at all.
 			if len(envelope.Error) <= maxUpstreamErrorDetailsBytes {
 				var withDetails struct {
 					Errors json.RawMessage `json:"errors"`
@@ -528,14 +514,10 @@ func parseUpstreamErrorBody(body string) (upstreamCode, upstreamMessage, upstrea
 	return upstreamCode, upstreamMessage, upstreamType, true
 }
 
-// upstreamErrorDetails decodes error.errors[] best-effort: the documented shape is
-// [{"message": "..."}], with a plain []string fallback; any other shape — or a
-// payload over maxUpstreamErrorDetailsBytes — yields nil rather than an error, so
-// a drifted or oversized detail array can never discard the main error fields
-// (they are decoded independently). The caller size-gates the whole error object
-// before raw is ever copied out of it, so the size check here is defense in
-// depth. Details are trimmed, deduplicated (including against the main message),
-// and capped.
+// upstreamErrorDetails decodes error.errors[] best-effort ([{"message":...}]
+// or []string); any other or oversized shape yields nil so a drifted detail
+// array never discards the main fields (the caller's size gate makes the check
+// here defense in depth). Details are trimmed, deduped, and capped.
 func upstreamErrorDetails(raw json.RawMessage, mainMessage string) []string {
 	if len(raw) == 0 || len(raw) > maxUpstreamErrorDetailsBytes {
 		return nil

--- a/internal/handler/tools/errs.go
+++ b/internal/handler/tools/errs.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"log/slog"
 	"net/http"
+	"regexp"
 	"strings"
 
 	"github.com/mark3labs/mcp-go/mcp"
@@ -88,6 +89,10 @@ const (
 )
 
 const statusClientClosedConnection = 499
+
+// maxUpstreamErrorDetails bounds how many error.errors[] detail messages are folded
+// into the surfaced upstream message; the body is upstream-controlled input.
+const maxUpstreamErrorDetails = 5
 
 var assistantAuthEnvelopeCodes = map[string]struct{}{
 	"forbidden":       {},
@@ -219,6 +224,135 @@ func (h *Handler) logUpstreamFailure(ctx context.Context, msg string, err error,
 	h.logger.Log(ctx, level, msg, args...)
 }
 
+// keyNotFoundPattern matches the QB v5 key-resolution failure ("key `service.name`
+// not found") in a 400 body. The wording is stable across backend generations: older
+// releases inline it in error.message, newer ones carry it in error.errors[].message
+// — matching the raw body covers both. Contract-sensitive by design: if the backend
+// rewords it, detection fails open (no enrichment) and logQueryFailure's ERROR-level
+// fallback is the drift signal.
+var keyNotFoundPattern = regexp.MustCompile("key `([^`]+)` not found")
+
+// The 400 body is upstream-controlled input, so everything derived from it is
+// bounded: at most missingFilterKeyScanLimit regex matches are examined, a
+// captured key longer than missingFilterKeyMaxLen is discarded as garbage, and at
+// most missingFilterKeysLimit distinct keys are surfaced.
+const (
+	missingFilterKeysLimit    = 10
+	missingFilterKeyScanLimit = 64
+	missingFilterKeyMaxLen    = 256
+)
+
+// missingFilterKeys extracts the filter keys a QB v5 400 reported as absent from
+// the workspace's field metadata. Returns nil for anything other than an HTTP 400
+// whose body carries the key-not-found wording.
+func missingFilterKeys(err error) []string {
+	var statusErr *signozclient.HTTPStatusError
+	if !errors.As(err, &statusErr) || statusErr.StatusCode != http.StatusBadRequest {
+		return nil
+	}
+	matches := keyNotFoundPattern.FindAllStringSubmatch(statusErr.Body, missingFilterKeyScanLimit)
+	if len(matches) == 0 {
+		return nil
+	}
+	seen := make(map[string]struct{}, missingFilterKeysLimit)
+	keys := make([]string, 0, missingFilterKeysLimit)
+	for _, m := range matches {
+		key := m[1]
+		if len(key) > missingFilterKeyMaxLen {
+			continue
+		}
+		if _, dup := seen[key]; dup {
+			continue
+		}
+		seen[key] = struct{}{}
+		keys = append(keys, key)
+		if len(keys) == missingFilterKeysLimit {
+			break
+		}
+	}
+	if len(keys) == 0 {
+		return nil
+	}
+	return keys
+}
+
+// missingKeyGuidance builds the recovery instructions appended to a key-not-found
+// error. Field keys are workspace- and signal-specific: logs carry no spec-mandated
+// resource attributes (even service.name is only present when the pipeline sets it),
+// so the guidance steers the agent to discover real keys instead of retrying blind.
+func missingKeyGuidance(keys []string, signal string) string {
+	quoted := make([]string, len(keys))
+	for i, key := range keys {
+		quoted[i] = "`" + key + "`"
+	}
+
+	var b strings.Builder
+	noun := "this workspace's data"
+	if signal != "" {
+		noun = "this workspace's " + signal + " data"
+	}
+	verb := "does"
+	if len(keys) > 1 {
+		verb = "do"
+	}
+	fmt.Fprintf(&b, "The filter references %s, which %s not exist in %s.", strings.Join(quoted, ", "), verb, noun)
+	if signal == "logs" {
+		b.WriteString(" Log attributes are workspace-specific: logs have no spec-mandated resource attributes, so even standard keys like service.name are only present when the log pipeline sets them.")
+	}
+	if signal != "" {
+		fmt.Fprintf(&b, ` Discover valid keys with signoz_get_field_keys (signal=%q; fieldContext="resource" for resource attributes), then retry with an existing key`, signal)
+	} else {
+		b.WriteString(` Discover valid keys with signoz_get_field_keys for the queried signal (fieldContext="resource" for resource attributes), then retry with an existing key`)
+	}
+	if signal == "logs" {
+		b.WriteString(" (for service scoping, workspaces without service.name often carry k8s.deployment.name or k8s.container.name)")
+	}
+	b.WriteString(", or remove the failing condition.")
+	return b.String()
+}
+
+// upstreamQueryError is upstreamError for the QB v5 passthrough tools: when the 400
+// reports filter keys missing from the workspace's field metadata, it appends
+// signal-aware recovery guidance to the text block and surfaces the keys as
+// `missingKeys` in StructuredContent so clients can branch without string-matching.
+// signal is "logs"/"traces", or "" when the tool spans signals (execute_builder_query).
+func upstreamQueryError(err error, signal string) *mcp.CallToolResult {
+	res := upstreamError(err)
+	keys := missingFilterKeys(err)
+	if len(keys) == 0 {
+		return res
+	}
+	if len(res.Content) == 1 {
+		if tc, ok := res.Content[0].(mcp.TextContent); ok {
+			tc.Text += "\n\n" + missingKeyGuidance(keys, signal)
+			res.Content[0] = tc
+		}
+	}
+	if structured, ok := res.StructuredContent.(map[string]any); ok {
+		structured["missingKeys"] = keys
+	}
+	return res
+}
+
+// logQueryFailure is the QB v5 tools' variant of logUpstreamFailure: a 400 whose
+// filter references keys absent from the workspace's metadata is an expected agent
+// mistake (the tool result carries the recovery guidance), so it logs at WARN with
+// the missing keys attached — still always emitted, never dropped. Everything else
+// keeps logUpstreamFailure's severity contract.
+func (h *Handler) logQueryFailure(ctx context.Context, msg string, err error, attrs ...slog.Attr) {
+	keys := missingFilterKeys(err)
+	if len(keys) == 0 {
+		h.logUpstreamFailure(ctx, msg, err, attrs...)
+		return
+	}
+	args := make([]any, 0, len(attrs)+2)
+	for _, attr := range attrs {
+		args = append(args, attr)
+	}
+	args = append(args, slog.Any("missingKeys", keys), logpkg.ErrAttr(err))
+	h.logger.Log(ctx, slog.LevelWarn, msg+" (filter references keys missing from workspace field metadata)", args...)
+}
+
 // upstreamError wraps a SigNoz backend client error with the uniform text prefix
 // and the most specific structured code we can derive from the HTTP response.
 func upstreamError(err error) *mcp.CallToolResult {
@@ -325,14 +459,25 @@ func parseUpstreamErrorBody(body string) (upstreamCode, upstreamMessage, upstrea
 	}
 	if len(envelope.Error) > 0 && string(envelope.Error) != "null" {
 		var nested struct {
-			Type    string `json:"type"`
-			Code    string `json:"code"`
-			Message string `json:"message"`
+			Type    string          `json:"type"`
+			Code    string          `json:"code"`
+			Message string          `json:"message"`
+			Errors  json.RawMessage `json:"errors"`
 		}
 		if err := json.Unmarshal(envelope.Error, &nested); err == nil {
 			upstreamType = nested.Type
 			upstreamCode = nested.Code
 			upstreamMessage = nested.Message
+			// Newer backends put the per-term detail in error.errors[] and keep
+			// error.message as a bare summary ("Found N errors while parsing the
+			// search expression."); fold the details in so they reach the caller.
+			switch details := upstreamErrorDetails(nested.Errors, upstreamMessage); {
+			case len(details) == 0:
+			case upstreamMessage == "":
+				upstreamMessage = strings.Join(details, "; ")
+			default:
+				upstreamMessage = upstreamMessage + " (" + strings.Join(details, "; ") + ")"
+			}
 		} else {
 			var message string
 			if err := json.Unmarshal(envelope.Error, &message); err == nil {
@@ -353,6 +498,47 @@ func parseUpstreamErrorBody(body string) (upstreamCode, upstreamMessage, upstrea
 		upstreamMessage = envelope.Message
 	}
 	return upstreamCode, upstreamMessage, upstreamType, true
+}
+
+// upstreamErrorDetails decodes error.errors[] best-effort: the documented shape is
+// [{"message": "..."}], with a plain []string fallback; any other shape yields nil
+// rather than an error, so a drifted detail array can never discard the main
+// error fields (they are decoded independently via json.RawMessage). Details are
+// trimmed, deduplicated (including against the main message), and capped.
+func upstreamErrorDetails(raw json.RawMessage, mainMessage string) []string {
+	if len(raw) == 0 {
+		return nil
+	}
+	var messages []string
+	var structured []struct {
+		Message string `json:"message"`
+	}
+	if err := json.Unmarshal(raw, &structured); err == nil {
+		messages = make([]string, 0, len(structured))
+		for _, additional := range structured {
+			messages = append(messages, additional.Message)
+		}
+	} else if err := json.Unmarshal(raw, &messages); err != nil {
+		return nil
+	}
+
+	seen := map[string]struct{}{mainMessage: {}}
+	details := make([]string, 0, maxUpstreamErrorDetails)
+	for _, message := range messages {
+		detail := strings.TrimSpace(message)
+		if detail == "" {
+			continue
+		}
+		if _, dup := seen[detail]; dup {
+			continue
+		}
+		seen[detail] = struct{}{}
+		details = append(details, detail)
+		if len(details) == maxUpstreamErrorDetails {
+			break
+		}
+	}
+	return details
 }
 
 // notFoundError marks a referenced resource that does not exist. The message is

--- a/internal/handler/tools/errs.go
+++ b/internal/handler/tools/errs.go
@@ -94,11 +94,12 @@ const statusClientClosedConnection = 499
 // into the surfaced upstream message; the body is upstream-controlled input.
 const maxUpstreamErrorDetails = 5
 
-// maxUpstreamErrorDetailsBytes bounds how large an error.errors[] payload is
-// decoded at all: json.Unmarshal materializes the whole array before the
-// per-detail cap applies, and a non-2xx body can be up to 64 MiB, so an
-// oversized detail array is skipped outright (fail open, like a drifted shape)
-// rather than decoded. 16 KiB is orders of magnitude more than the five
+// maxUpstreamErrorDetailsBytes bounds how large an error object has its
+// error.errors[] detail array extracted at all: json.RawMessage copies the
+// field's bytes during Unmarshal and a non-2xx body can be up to 64 MiB, so
+// parseUpstreamErrorBody only names errors[] in a decode target when the whole
+// error object fits this bound (fail open, like a drifted shape — details
+// dropped, main fields kept). 16 KiB is orders of magnitude more than the five
 // surfaced details ever need.
 const maxUpstreamErrorDetailsBytes = 16 << 10
 
@@ -240,14 +241,19 @@ func (h *Handler) logUpstreamFailure(ctx context.Context, msg string, err error,
 // fallback is the drift signal.
 var keyNotFoundPattern = regexp.MustCompile("key `([^`]+)` not found")
 
-// The 400 body is upstream-controlled input, so everything derived from it is
-// bounded: at most missingFilterKeyScanLimit regex matches are examined, a
-// captured key longer than missingFilterKeyMaxLen is discarded as garbage, and at
-// most missingFilterKeysLimit distinct keys are surfaced.
+// The 400 body is upstream-controlled input (buffered up to 64 MiB), so everything
+// derived from it is bounded: only the first missingFilterKeyScanBytes are scanned
+// (FindAllStringSubmatch's match cap would not stop it walking the whole body, and
+// each failure is scanned by both logQueryFailure and upstreamQueryError), at most
+// missingFilterKeyScanLimit matches are examined, a captured key longer than
+// missingFilterKeyMaxLen is discarded as garbage, and at most
+// missingFilterKeysLimit distinct keys are surfaced. Real key-not-found bodies are
+// far smaller than the scan window; a phrase beyond it fails open (no enrichment).
 const (
 	missingFilterKeysLimit    = 10
 	missingFilterKeyScanLimit = 64
 	missingFilterKeyMaxLen    = 256
+	missingFilterKeyScanBytes = 16 << 10
 )
 
 // missingFilterKeys extracts the filter keys a QB v5 400 reported as absent from
@@ -258,7 +264,11 @@ func missingFilterKeys(err error) []string {
 	if !errors.As(err, &statusErr) || statusErr.StatusCode != http.StatusBadRequest {
 		return nil
 	}
-	matches := keyNotFoundPattern.FindAllStringSubmatch(statusErr.Body, missingFilterKeyScanLimit)
+	body := statusErr.Body
+	if len(body) > missingFilterKeyScanBytes {
+		body = body[:missingFilterKeyScanBytes]
+	}
+	matches := keyNotFoundPattern.FindAllStringSubmatch(body, missingFilterKeyScanLimit)
 	if len(matches) == 0 {
 		return nil
 	}
@@ -467,10 +477,9 @@ func parseUpstreamErrorBody(body string) (upstreamCode, upstreamMessage, upstrea
 	}
 	if len(envelope.Error) > 0 && string(envelope.Error) != "null" {
 		var nested struct {
-			Type    string          `json:"type"`
-			Code    string          `json:"code"`
-			Message string          `json:"message"`
-			Errors  json.RawMessage `json:"errors"`
+			Type    string `json:"type"`
+			Code    string `json:"code"`
+			Message string `json:"message"`
 		}
 		if err := json.Unmarshal(envelope.Error, &nested); err == nil {
 			upstreamType = nested.Type
@@ -479,12 +488,23 @@ func parseUpstreamErrorBody(body string) (upstreamCode, upstreamMessage, upstrea
 			// Newer backends put the per-term detail in error.errors[] and keep
 			// error.message as a bare summary ("Found N errors while parsing the
 			// search expression."); fold the details in so they reach the caller.
-			switch details := upstreamErrorDetails(nested.Errors, upstreamMessage); {
-			case len(details) == 0:
-			case upstreamMessage == "":
-				upstreamMessage = strings.Join(details, "; ")
-			default:
-				upstreamMessage = upstreamMessage + " (" + strings.Join(details, "; ") + ")"
+			// Extracted in a separate size-gated pass: json.RawMessage copies the
+			// field's bytes during Unmarshal, so an oversized error object must
+			// never name errors[] in a decode target at all (fail open on the
+			// details; the main fields above are already decoded).
+			if len(envelope.Error) <= maxUpstreamErrorDetailsBytes {
+				var withDetails struct {
+					Errors json.RawMessage `json:"errors"`
+				}
+				if err := json.Unmarshal(envelope.Error, &withDetails); err == nil {
+					switch details := upstreamErrorDetails(withDetails.Errors, upstreamMessage); {
+					case len(details) == 0:
+					case upstreamMessage == "":
+						upstreamMessage = strings.Join(details, "; ")
+					default:
+						upstreamMessage = upstreamMessage + " (" + strings.Join(details, "; ") + ")"
+					}
+				}
 			}
 		} else {
 			var message string
@@ -512,8 +532,10 @@ func parseUpstreamErrorBody(body string) (upstreamCode, upstreamMessage, upstrea
 // [{"message": "..."}], with a plain []string fallback; any other shape — or a
 // payload over maxUpstreamErrorDetailsBytes — yields nil rather than an error, so
 // a drifted or oversized detail array can never discard the main error fields
-// (they are decoded independently via json.RawMessage). Details are trimmed,
-// deduplicated (including against the main message), and capped.
+// (they are decoded independently). The caller size-gates the whole error object
+// before raw is ever copied out of it, so the size check here is defense in
+// depth. Details are trimmed, deduplicated (including against the main message),
+// and capped.
 func upstreamErrorDetails(raw json.RawMessage, mainMessage string) []string {
 	if len(raw) == 0 || len(raw) > maxUpstreamErrorDetailsBytes {
 		return nil

--- a/internal/handler/tools/logs.go
+++ b/internal/handler/tools/logs.go
@@ -13,7 +13,7 @@ import (
 	"github.com/SigNoz/signoz-mcp-server/pkg/types"
 )
 
-const logsFilterParamDescription = "Filter expression using SigNoz search syntax (see signoz://logs/query-builder-guide). Combine conditions with AND, OR, and parentheses for precedence. Unknown keys hard-error; keys present in multiple contexts default to resource context. Disambiguate with attribute.<key> or resource.<key>. Discover valid keys with signoz_get_field_keys, then confirm values with signoz_get_field_values, before filtering. Examples: \"service.name = 'payment-svc' AND severity_text = 'ERROR'\", \"(severity_text = 'ERROR' OR body CONTAINS 'panic') AND k8s.namespace.name = 'prod'\", \"body.user.id = '123'\"."
+const logsFilterParamDescription = "Filter expression using SigNoz search syntax (see signoz://logs/query-builder-guide). Combine conditions with AND, OR, and parentheses for precedence. Unknown keys hard-error; keys present in multiple contexts default to resource context. Disambiguate with attribute.<key> or resource.<key>. Log keys are workspace-specific — logs have no spec-mandated resource attributes, so even service.name is only present when the log pipeline sets it. Discover valid keys with signoz_get_field_keys, then confirm values with signoz_get_field_values, before filtering. Examples: \"service.name = 'payment-svc' AND severity_text = 'ERROR'\", \"(severity_text = 'ERROR' OR body CONTAINS 'panic') AND k8s.namespace.name = 'prod'\", \"body.user.id = '123'\"."
 
 func (h *Handler) RegisterLogsHandlers(s *server.MCPServer) {
 	h.logger.Debug("Registering logs handlers")
@@ -30,7 +30,7 @@ func (h *Handler) RegisterLogsHandlers(s *server.MCPServer) {
 		mcp.WithString("aggregateOn", mcp.Description("Field name to aggregate on (e.g., 'response_time', 'duration'). Required for all aggregations except count and rate.")),
 		mcp.WithString("groupBy", mcp.Description("Comma-separated list of field names to group results by (e.g., 'service.name' or 'service.name, severity_text'). Leave empty for a single aggregate value.")),
 		mcp.WithString("filter", mcp.Description(logsFilterParamDescription+" Combined with service/severity params using AND.")),
-		mcp.WithString("service", mcp.Description("Shortcut filter for service name. Equivalent to adding service.name = '<value>' to filter.")),
+		mcp.WithString("service", mcp.Description("Shortcut filter for service name. Equivalent to adding service.name = '<value>' to filter. Fails with `key service.name not found` when this workspace's logs lack that attribute — then discover keys with signoz_get_field_keys(signal=\"logs\", fieldContext=\"resource\") and filter on an available key instead.")),
 		mcp.WithString("severity", mcp.Description("Shortcut filter for log severity (DEBUG, INFO, WARN, ERROR, FATAL). Equivalent to adding severity_text = '<value>' to filter.")),
 		mcp.WithString("orderBy", mcp.Description("How to order results. Format: '<expression> <direction>', e.g. 'count() desc' or 'avg(duration) asc'. Defaults to the aggregation expression descending.")),
 		mcp.WithString("limit", mcp.DefaultString(strconv.Itoa(types.DefaultAggregateQueryLimit)), intOrStringType(), mcp.Description("Maximum number of groups to return (default: 100, max: 10000; higher values are clamped). For time_series queries, groups are ranked across the entire time range, so a short-lived spike can fall outside the selected top groups.")),
@@ -54,7 +54,7 @@ func (h *Handler) RegisterLogsHandlers(s *server.MCPServer) {
 			"For logs filter syntax, field contexts, and body JSON examples, read signoz://logs/query-builder-guide. "+
 			"Defaults to last 1 hour if no time specified."),
 		mcp.WithString("filter", mcp.Description(logsFilterParamDescription)),
-		mcp.WithString("service", mcp.Description("Optional service name to filter by.")),
+		mcp.WithString("service", mcp.Description("Optional service name to filter by (adds service.name = '<value>'). Fails with `key service.name not found` when this workspace's logs lack that attribute — then discover keys with signoz_get_field_keys(signal=\"logs\", fieldContext=\"resource\") and filter on an available key instead.")),
 		mcp.WithString("severity", mcp.Description("Optional severity filter (DEBUG, INFO, WARN, ERROR, FATAL).")),
 		mcp.WithString("searchText", mcp.Description("Text to search for in log body (uses CONTAINS matching).")),
 		mcp.WithString("timeRange", mcp.DefaultString("1h"), mcp.Description(timeRangeDesc("Defaults to '1h'."))),
@@ -104,8 +104,8 @@ func (h *Handler) handleAggregateLogs(ctx context.Context, req mcp.CallToolReque
 	}
 	result, err := client.QueryBuilderV5(ctx, queryJSON)
 	if err != nil {
-		h.logUpstreamFailure(ctx, "Failed to aggregate logs", err)
-		return upstreamError(err), nil
+		h.logQueryFailure(ctx, "Failed to aggregate logs", err)
+		return upstreamQueryError(err, "logs"), nil
 	}
 
 	return aggregateResult(ctx, h.logger, "signoz_aggregate_logs", result, reqData.LimitClamped), nil
@@ -142,8 +142,8 @@ func (h *Handler) handleSearchLogs(ctx context.Context, req mcp.CallToolRequest)
 	}
 	result, err := client.QueryBuilderV5(ctx, queryJSON)
 	if err != nil {
-		h.logUpstreamFailure(ctx, "Failed to search logs", err)
-		return upstreamError(err), nil
+		h.logQueryFailure(ctx, "Failed to search logs", err)
+		return upstreamQueryError(err, "logs"), nil
 	}
 
 	return rawSearchResult(ctx, h.logger, "signoz_search_logs", result, reqData.Limit, reqData.Offset, reqData.LimitClamped), nil

--- a/internal/handler/tools/metrics_query.go
+++ b/internal/handler/tools/metrics_query.go
@@ -212,8 +212,8 @@ func (h *Handler) handleQueryMetrics(ctx context.Context, req mcp.CallToolReques
 
 	result, err := client.QueryBuilderV5(ctx, queryJSON)
 	if err != nil {
-		h.logUpstreamFailure(ctx, "Metrics query failed", err)
-		return upstreamError(err), nil
+		h.logQueryFailure(ctx, "Metrics query failed", err)
+		return upstreamQueryError(err, "metrics"), nil
 	}
 
 	// Extract backend-determined stepInterval from response if caller didn't provide one

--- a/internal/handler/tools/query_builder.go
+++ b/internal/handler/tools/query_builder.go
@@ -120,8 +120,8 @@ func (h *Handler) handleExecuteBuilderQuery(ctx context.Context, req mcp.CallToo
 	}
 	data, err := client.QueryBuilderV5(ctx, finalQueryJSON)
 	if err != nil {
-		h.logUpstreamFailure(ctx, "Failed to execute query builder v5", err)
-		return upstreamError(err), nil
+		h.logQueryFailure(ctx, "Failed to execute query builder v5", err)
+		return upstreamQueryError(err, ""), nil
 	}
 
 	h.logger.DebugContext(ctx, "Successfully executed query builder v5")

--- a/internal/handler/tools/traces.go
+++ b/internal/handler/tools/traces.go
@@ -125,8 +125,8 @@ func (h *Handler) handleAggregateTraces(ctx context.Context, req mcp.CallToolReq
 	}
 	result, err := client.QueryBuilderV5(ctx, queryJSON)
 	if err != nil {
-		h.logUpstreamFailure(ctx, "Failed to aggregate traces", err)
-		return upstreamError(err), nil
+		h.logQueryFailure(ctx, "Failed to aggregate traces", err)
+		return upstreamQueryError(err, "traces"), nil
 	}
 
 	return aggregateResult(ctx, h.logger, "signoz_aggregate_traces", result, reqData.LimitClamped), nil
@@ -160,8 +160,8 @@ func (h *Handler) handleSearchTraces(ctx context.Context, req mcp.CallToolReques
 	}
 	result, err := client.QueryBuilderV5(ctx, queryJSON)
 	if err != nil {
-		h.logUpstreamFailure(ctx, "Failed to search traces", err)
-		return upstreamError(err), nil
+		h.logQueryFailure(ctx, "Failed to search traces", err)
+		return upstreamQueryError(err, "traces"), nil
 	}
 
 	result = h.enrichSearchTracesWebURL(ctx, result)

--- a/internal/handler/tools/upstream_query_error_test.go
+++ b/internal/handler/tools/upstream_query_error_test.go
@@ -110,10 +110,8 @@ func TestMissingFilterKeys_DropsOversizedKeys(t *testing.T) {
 	}
 }
 
-// TestMissingFilterKeys_OversizedBodyScanBounded pins the byte bound on the
-// raw-body scan: the match cap alone would not stop FindAllStringSubmatch from
-// walking an arbitrarily large 400 body, so only the first
-// missingFilterKeyScanBytes are examined — a phrase beyond the window fails
+// Pins the byte bound on the raw-body scan: only the first
+// missingFilterKeyScanBytes are examined — a match beyond the window fails
 // open, one inside it is still detected.
 func TestMissingFilterKeys_OversizedBodyScanBounded(t *testing.T) {
 	padding := strings.Repeat("x", missingFilterKeyScanBytes)
@@ -223,11 +221,8 @@ func TestUpstreamError_AdditionalDetailsDedupAndCap(t *testing.T) {
 	}
 }
 
-// TestUpstreamError_OversizedDetailArraySkippedNotDecoded pins the input-size
-// bound: a non-2xx body can be up to 64 MiB and json.RawMessage copies the field
-// bytes during Unmarshal, so an error object beyond maxUpstreamErrorDetailsBytes
-// never has errors[] in a decode target — details are dropped (fail open) while
-// the independently parsed main fields survive.
+// Pins the input-size bound: an error object beyond maxUpstreamErrorDetailsBytes
+// never has errors[] decoded — details drop (fail open), main fields survive.
 func TestUpstreamError_OversizedDetailArraySkippedNotDecoded(t *testing.T) {
 	huge := `[{"message":"` + strings.Repeat("x", maxUpstreamErrorDetailsBytes) + `"}]`
 	body := `{"status":"error","error":{"type":"invalid-input","code":"invalid_input","message":"summary","errors":` + huge + `}}`

--- a/internal/handler/tools/upstream_query_error_test.go
+++ b/internal/handler/tools/upstream_query_error_test.go
@@ -207,6 +207,26 @@ func TestUpstreamError_AdditionalDetailsDedupAndCap(t *testing.T) {
 	}
 }
 
+// TestUpstreamError_OversizedDetailArraySkippedNotDecoded pins the input-size
+// bound: a non-2xx body can be up to 64 MiB, so an errors[] payload beyond
+// maxUpstreamErrorDetailsBytes is never json.Unmarshal-ed — details are dropped
+// (fail open) while the independently parsed main fields survive.
+func TestUpstreamError_OversizedDetailArraySkippedNotDecoded(t *testing.T) {
+	huge := `[{"message":"` + strings.Repeat("x", maxUpstreamErrorDetailsBytes) + `"}]`
+	body := `{"status":"error","error":{"type":"invalid-input","code":"invalid_input","message":"summary","errors":` + huge + `}}`
+
+	res := upstreamError(keyNotFound400(body))
+
+	text := resultText(t, res)
+	if !strings.Contains(text, "summary") || strings.Contains(text, "summary (") {
+		t.Fatalf("oversized details should be skipped, main message kept: %q", text[:min(len(text), 200)])
+	}
+	structured := resultStructuredMap(t, res)
+	if got := structured["upstreamCode"]; got != "invalid_input" {
+		t.Fatalf("upstreamCode = %v, want invalid_input preserved for oversized errors[]", got)
+	}
+}
+
 // TestUpstreamError_AlternativeErrorsShapesKeepMainFields pins the fail-open
 // contract of the errors[] decoding: a []string detail array still folds, and a
 // detail shape we don't recognize is ignored WITHOUT discarding the independently

--- a/internal/handler/tools/upstream_query_error_test.go
+++ b/internal/handler/tools/upstream_query_error_test.go
@@ -1,0 +1,360 @@
+package tools
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"log/slog"
+	"net/http"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/mark3labs/mcp-go/mcp"
+
+	signozclient "github.com/SigNoz/signoz-mcp-server/internal/client"
+	"github.com/SigNoz/signoz-mcp-server/pkg/types"
+)
+
+// Current-generation QB v5 envelope: bare summary in error.message, per-term
+// detail in error.errors[].
+const keyNotFoundEnvelopeBody = `{"status":"error","error":{"type":"invalid-input","code":"invalid_input","message":"Found 1 errors while parsing the search expression.","url":"https://signoz.io/docs/userguide/search-troubleshooting/","errors":[{"message":"key ` + "`service.name`" + ` not found","suggestions":[]}],"suggestions":[]}}`
+
+// Older-generation envelope: the detail is inlined in a string error field.
+const keyNotFoundLegacyBody = `{"status":"error","errorType":"invalid_input","error":"while parsing the search expression: key ` + "`service.name`" + ` not found"}`
+
+func keyNotFound400(body string) *signozclient.HTTPStatusError {
+	return &signozclient.HTTPStatusError{StatusCode: http.StatusBadRequest, Body: body}
+}
+
+func TestMissingFilterKeys(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want []string
+	}{
+		{
+			name: "new envelope with errors[] detail",
+			err:  keyNotFound400(keyNotFoundEnvelopeBody),
+			want: []string{"service.name"},
+		},
+		{
+			name: "legacy inline message",
+			err:  keyNotFound400(keyNotFoundLegacyBody),
+			want: []string{"service.name"},
+		},
+		{
+			name: "multiple keys deduped in order",
+			err: keyNotFound400("Found 3 errors while parsing the search expression: " +
+				"key `service.name` not found; key `env` not found; key `service.name` not found"),
+			want: []string{"service.name", "env"},
+		},
+		{
+			name: "wrapped error chain still detected",
+			err:  errWrap(keyNotFound400(keyNotFoundEnvelopeBody)),
+			want: []string{"service.name"},
+		},
+		{
+			name: "400 without the key-not-found wording",
+			err:  keyNotFound400(`{"status":"error","error":{"code":"invalid_input","message":"bad step interval"}}`),
+			want: nil,
+		},
+		{
+			name: "non-400 status is ignored",
+			err:  &signozclient.HTTPStatusError{StatusCode: http.StatusInternalServerError, Body: "key `service.name` not found"},
+			want: nil,
+		},
+		{
+			name: "non-HTTP error is ignored",
+			err:  errors.New("key `service.name` not found"),
+			want: nil,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := missingFilterKeys(tc.err); !reflect.DeepEqual(got, tc.want) {
+				t.Fatalf("missingFilterKeys = %#v, want %#v", got, tc.want)
+			}
+		})
+	}
+}
+
+func errWrap(err error) error {
+	return &upstreamFetchError{err: err}
+}
+
+func TestMissingFilterKeys_CapsSurfacedKeys(t *testing.T) {
+	var b strings.Builder
+	for r := 'a'; r < 'a'+20; r++ {
+		b.WriteString("key `" + string(r) + ".name` not found; ")
+	}
+	got := missingFilterKeys(keyNotFound400(b.String()))
+	if len(got) != missingFilterKeysLimit {
+		t.Fatalf("len(missingFilterKeys) = %d, want cap %d", len(got), missingFilterKeysLimit)
+	}
+}
+
+// TestMissingFilterKeys_DropsOversizedKeys pins the per-key length bound: the 400
+// body is upstream-controlled, so an enormous captured "key" must not flow into
+// guidance text or log attributes.
+func TestMissingFilterKeys_DropsOversizedKeys(t *testing.T) {
+	body := "key `" + strings.Repeat("x", missingFilterKeyMaxLen+1) + "` not found; key `service.name` not found"
+	got := missingFilterKeys(keyNotFound400(body))
+	if !reflect.DeepEqual(got, []string{"service.name"}) {
+		t.Fatalf("missingFilterKeys = %#v, want oversized key dropped", got)
+	}
+	if only := missingFilterKeys(keyNotFound400("key `" + strings.Repeat("x", missingFilterKeyMaxLen+1) + "` not found")); only != nil {
+		t.Fatalf("missingFilterKeys = %#v, want nil when every key is oversized", only)
+	}
+}
+
+func TestMissingKeyGuidance_PluralAgreement(t *testing.T) {
+	if got := missingKeyGuidance([]string{"a", "b"}, "logs"); !strings.Contains(got, "which do not exist") {
+		t.Fatalf("plural guidance = %q, want 'which do not exist'", got)
+	}
+	if got := missingKeyGuidance([]string{"a"}, "logs"); !strings.Contains(got, "which does not exist") {
+		t.Fatalf("singular guidance = %q, want 'which does not exist'", got)
+	}
+}
+
+func TestUpstreamQueryError_LogsGuidanceAndStructuredKeys(t *testing.T) {
+	res := upstreamQueryError(keyNotFound400(keyNotFoundEnvelopeBody), "logs")
+
+	text := resultText(t, res)
+	if !strings.HasPrefix(text, "SigNoz API error: unexpected status 400: Found 1 errors while parsing the search expression. (key `service.name` not found)") {
+		t.Fatalf("text should keep the upstream message with folded detail, got %q", text)
+	}
+	for _, want := range []string{
+		"`service.name`, which does not exist in this workspace's logs data",
+		"no spec-mandated resource attributes",
+		`signoz_get_field_keys (signal="logs"`,
+		"k8s.deployment.name",
+		"remove the failing condition",
+	} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("guidance missing %q in %q", want, text)
+		}
+	}
+
+	structured := resultStructuredMap(t, res)
+	if got := structured["code"]; got != CodeValidationFailed {
+		t.Fatalf("code = %v, want %s", got, CodeValidationFailed)
+	}
+	if got := structured["missingKeys"]; !reflect.DeepEqual(got, []string{"service.name"}) {
+		t.Fatalf("missingKeys = %#v, want [service.name]", got)
+	}
+}
+
+func TestUpstreamQueryError_TracesAndGenericSignalWording(t *testing.T) {
+	tracesText := resultText(t, upstreamQueryError(keyNotFound400(keyNotFoundLegacyBody), "traces"))
+	if !strings.Contains(tracesText, "this workspace's traces data") {
+		t.Fatalf("traces guidance missing signal noun: %q", tracesText)
+	}
+	if strings.Contains(tracesText, "spec-mandated") || strings.Contains(tracesText, "k8s.deployment.name") {
+		t.Fatalf("traces guidance leaked logs-specific wording: %q", tracesText)
+	}
+
+	genericText := resultText(t, upstreamQueryError(keyNotFound400(keyNotFoundLegacyBody), ""))
+	if !strings.Contains(genericText, "signoz_get_field_keys for the queried signal") {
+		t.Fatalf("generic guidance missing signal-agnostic discovery hint: %q", genericText)
+	}
+}
+
+func TestUpstreamQueryError_NoMissingKeyIsPlainUpstreamError(t *testing.T) {
+	err := keyNotFound400(`{"status":"error","error":{"code":"invalid_input","message":"bad step interval"}}`)
+
+	got := upstreamQueryError(err, "logs")
+	want := upstreamError(err)
+
+	if resultText(t, got) != resultText(t, want) {
+		t.Fatalf("text diverged without a missing key: %q vs %q", resultText(t, got), resultText(t, want))
+	}
+	if _, ok := resultStructuredMap(t, got)["missingKeys"]; ok {
+		t.Fatalf("unexpected missingKeys without a key-not-found body")
+	}
+}
+
+// TestUpstreamError_FoldsAdditionalErrorDetails pins the envelope-parsing fix:
+// newer backends put per-term details in error.errors[] and keep error.message a
+// bare summary, so the details must be folded into the surfaced message for every
+// tool using upstreamError, not just the QB wrappers.
+func TestUpstreamError_FoldsAdditionalErrorDetails(t *testing.T) {
+	res := upstreamError(keyNotFound400(keyNotFoundEnvelopeBody))
+
+	text := resultText(t, res)
+	if !strings.Contains(text, "Found 1 errors while parsing the search expression. (key `service.name` not found)") {
+		t.Fatalf("additional error detail not folded into text: %q", text)
+	}
+	structured := resultStructuredMap(t, res)
+	if got, ok := structured["upstreamMessage"].(string); !ok || !strings.Contains(got, "key `service.name` not found") {
+		t.Fatalf("upstreamMessage missing folded detail: %#v", structured["upstreamMessage"])
+	}
+}
+
+func TestUpstreamError_AdditionalDetailsDedupAndCap(t *testing.T) {
+	body := `{"status":"error","error":{"code":"invalid_input","message":"summary","errors":[` +
+		`{"message":"summary"},{"message":""},{"message":"d1"},{"message":"d1"},{"message":"d2"},{"message":"d3"},{"message":"d4"},{"message":"d5"},{"message":"d6"}]}}`
+	res := upstreamError(keyNotFound400(body))
+
+	text := resultText(t, res)
+	if !strings.Contains(text, "summary (d1; d2; d3; d4; d5)") {
+		t.Fatalf("details not deduped/capped as expected: %q", text)
+	}
+	if strings.Contains(text, "d6") {
+		t.Fatalf("detail cap exceeded: %q", text)
+	}
+}
+
+// TestUpstreamError_AlternativeErrorsShapesKeepMainFields pins the fail-open
+// contract of the errors[] decoding: a []string detail array still folds, and a
+// detail shape we don't recognize is ignored WITHOUT discarding the independently
+// parsed type/code/message (the pre-hardening struct decode failed wholesale).
+func TestUpstreamError_AlternativeErrorsShapesKeepMainFields(t *testing.T) {
+	stringDetails := `{"status":"error","error":{"code":"invalid_input","message":"summary","errors":["key ` + "`env`" + ` not found"]}}`
+	res := upstreamError(keyNotFound400(stringDetails))
+	if text := resultText(t, res); !strings.Contains(text, "summary (key `env` not found)") {
+		t.Fatalf("[]string details not folded: %q", text)
+	}
+
+	malformed := `{"status":"error","error":{"type":"invalid-input","code":"invalid_input","message":"summary","errors":{"weird":"object"}}}`
+	res = upstreamError(keyNotFound400(malformed))
+	if text := resultText(t, res); !strings.Contains(text, "summary") {
+		t.Fatalf("main message lost on malformed errors shape: %q", text)
+	}
+	structured := resultStructuredMap(t, res)
+	if got := structured["upstreamCode"]; got != "invalid_input" {
+		t.Fatalf("upstreamCode = %v, want invalid_input preserved despite malformed errors[]", got)
+	}
+	if got := structured["upstreamMessage"]; got != "summary" {
+		t.Fatalf("upstreamMessage = %v, want summary preserved despite malformed errors[]", got)
+	}
+}
+
+// TestQueryBuilderV5Handlers_KeyNotFoundGuidance pins, end to end through each
+// handler, that every QueryBuilderV5 caller routes its error path through
+// upstreamQueryError with its signal: the enriched guidance and the structured
+// missingKeys field must survive the real handler plumbing, not just the helpers.
+func TestQueryBuilderV5Handlers_KeyNotFoundGuidance(t *testing.T) {
+	failing := &signozclient.MockClient{
+		QueryBuilderV5Fn: func(ctx context.Context, body []byte) (json.RawMessage, error) {
+			return nil, keyNotFound400(keyNotFoundEnvelopeBody)
+		},
+	}
+	h := newTestHandler(failing)
+
+	var builderQuery map[string]any
+	payloadJSON, err := json.Marshal(types.BuildLogsQueryPayload(1711123200000, 1711130400000, "service.name = 'checkout'", 10, 0))
+	if err != nil {
+		t.Fatalf("marshal builder payload: %v", err)
+	}
+	if err := json.Unmarshal(payloadJSON, &builderQuery); err != nil {
+		t.Fatalf("unmarshal builder payload: %v", err)
+	}
+
+	cases := []struct {
+		tool     string
+		wantNoun string
+		run      func() (*mcp.CallToolResult, error)
+	}{
+		{"signoz_search_logs", "this workspace's logs data", func() (*mcp.CallToolResult, error) {
+			return h.handleSearchLogs(testCtx(), makeToolRequest("signoz_search_logs", map[string]any{"service": "checkout"}))
+		}},
+		{"signoz_aggregate_logs", "this workspace's logs data", func() (*mcp.CallToolResult, error) {
+			return h.handleAggregateLogs(testCtx(), makeToolRequest("signoz_aggregate_logs", map[string]any{"aggregation": "count", "service": "checkout"}))
+		}},
+		{"signoz_search_traces", "this workspace's traces data", func() (*mcp.CallToolResult, error) {
+			return h.handleSearchTraces(testCtx(), makeToolRequest("signoz_search_traces", map[string]any{"service": "checkout"}))
+		}},
+		{"signoz_aggregate_traces", "this workspace's traces data", func() (*mcp.CallToolResult, error) {
+			return h.handleAggregateTraces(testCtx(), makeToolRequest("signoz_aggregate_traces", map[string]any{"aggregation": "count", "service": "checkout"}))
+		}},
+		{"signoz_query_metrics", "this workspace's metrics data", func() (*mcp.CallToolResult, error) {
+			return h.handleQueryMetrics(testCtx(), makeToolRequest("signoz_query_metrics", map[string]any{"metricName": "system.cpu.time", "metricType": "gauge"}))
+		}},
+		{"signoz_execute_builder_query", "this workspace's data", func() (*mcp.CallToolResult, error) {
+			return h.handleExecuteBuilderQuery(testCtx(), makeToolRequest("signoz_execute_builder_query", map[string]any{"query": builderQuery}))
+		}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.tool, func(t *testing.T) {
+			result, err := tc.run()
+			if err != nil {
+				t.Fatalf("unexpected transport error: %v", err)
+			}
+			if !result.IsError {
+				t.Fatalf("expected error result, got success: %v", result.Content)
+			}
+			text := resultText(t, result)
+			if !strings.Contains(text, tc.wantNoun) {
+				t.Fatalf("guidance noun %q missing in %q", tc.wantNoun, text)
+			}
+			if !strings.Contains(text, "signoz_get_field_keys") {
+				t.Fatalf("recovery guidance missing in %q", text)
+			}
+			structured := resultStructuredMap(t, result)
+			if got := structured["missingKeys"]; !reflect.DeepEqual(got, []string{"service.name"}) {
+				t.Fatalf("missingKeys = %#v, want [service.name]", got)
+			}
+		})
+	}
+}
+
+// TestLogQueryFailureLevels pins the severity contract of the QB tools' failure
+// logger: key-not-found 400s are expected agent mistakes and log at WARN with the
+// missing keys attached — still always emitted — while everything else keeps the
+// shared logUpstreamFailure behavior.
+func TestLogQueryFailureLevels(t *testing.T) {
+	tests := []struct {
+		name            string
+		err             error
+		wantLevel       string
+		wantMsg         string
+		wantMissingKeys bool
+	}{
+		{
+			name:            "missing filter key logs warn with keys",
+			err:             keyNotFound400(keyNotFoundEnvelopeBody),
+			wantLevel:       "WARN",
+			wantMsg:         "Failed to search logs (filter references keys missing from workspace field metadata)",
+			wantMissingKeys: true,
+		},
+		{
+			name:      "other 400 stays error",
+			err:       keyNotFound400(`{"status":"error","error":{"code":"invalid_input","message":"bad step interval"}}`),
+			wantLevel: "ERROR",
+			wantMsg:   "Failed to search logs",
+		},
+		{
+			name:      "cancellation keeps debug demotion",
+			err:       context.Canceled,
+			wantLevel: "DEBUG",
+			wantMsg:   "Failed to search logs (request cancelled by client)",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			h := &Handler{logger: slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))}
+
+			h.logQueryFailure(context.Background(), "Failed to search logs", tc.err)
+
+			var rec map[string]any
+			if err := json.Unmarshal(buf.Bytes(), &rec); err != nil {
+				t.Fatalf("expected exactly one emitted log record, got %q: %v", buf.String(), err)
+			}
+			if rec["level"] != tc.wantLevel {
+				t.Fatalf("level = %v, want %s", rec["level"], tc.wantLevel)
+			}
+			if rec["msg"] != tc.wantMsg {
+				t.Fatalf("msg = %v, want %s", rec["msg"], tc.wantMsg)
+			}
+			if _, ok := rec["missingKeys"]; ok != tc.wantMissingKeys {
+				t.Fatalf("missingKeys present = %v, want %v (record: %v)", ok, tc.wantMissingKeys, rec)
+			}
+		})
+	}
+}

--- a/internal/handler/tools/upstream_query_error_test.go
+++ b/internal/handler/tools/upstream_query_error_test.go
@@ -110,6 +110,22 @@ func TestMissingFilterKeys_DropsOversizedKeys(t *testing.T) {
 	}
 }
 
+// TestMissingFilterKeys_OversizedBodyScanBounded pins the byte bound on the
+// raw-body scan: the match cap alone would not stop FindAllStringSubmatch from
+// walking an arbitrarily large 400 body, so only the first
+// missingFilterKeyScanBytes are examined — a phrase beyond the window fails
+// open, one inside it is still detected.
+func TestMissingFilterKeys_OversizedBodyScanBounded(t *testing.T) {
+	padding := strings.Repeat("x", missingFilterKeyScanBytes)
+	if got := missingFilterKeys(keyNotFound400(padding + "key `service.name` not found")); got != nil {
+		t.Fatalf("missingFilterKeys = %#v, want nil for a match beyond the scan window", got)
+	}
+	got := missingFilterKeys(keyNotFound400("key `service.name` not found" + padding))
+	if !reflect.DeepEqual(got, []string{"service.name"}) {
+		t.Fatalf("missingFilterKeys = %#v, want detection inside the scan window of an oversized body", got)
+	}
+}
+
 func TestMissingKeyGuidance_PluralAgreement(t *testing.T) {
 	if got := missingKeyGuidance([]string{"a", "b"}, "logs"); !strings.Contains(got, "which do not exist") {
 		t.Fatalf("plural guidance = %q, want 'which do not exist'", got)
@@ -208,9 +224,10 @@ func TestUpstreamError_AdditionalDetailsDedupAndCap(t *testing.T) {
 }
 
 // TestUpstreamError_OversizedDetailArraySkippedNotDecoded pins the input-size
-// bound: a non-2xx body can be up to 64 MiB, so an errors[] payload beyond
-// maxUpstreamErrorDetailsBytes is never json.Unmarshal-ed — details are dropped
-// (fail open) while the independently parsed main fields survive.
+// bound: a non-2xx body can be up to 64 MiB and json.RawMessage copies the field
+// bytes during Unmarshal, so an error object beyond maxUpstreamErrorDetailsBytes
+// never has errors[] in a decode target — details are dropped (fail open) while
+// the independently parsed main fields survive.
 func TestUpstreamError_OversizedDetailArraySkippedNotDecoded(t *testing.T) {
 	huge := `[{"message":"` + strings.Repeat("x", maxUpstreamErrorDetailsBytes) + `"}]`
 	body := `{"status":"error","error":{"type":"invalid-input","code":"invalid_input","message":"summary","errors":` + huge + `}}`

--- a/pkg/instructions/instructions.go
+++ b/pkg/instructions/instructions.go
@@ -13,6 +13,7 @@ const ServerInstructions = `# SigNoz MCP Server — Instructions
    b. Optionally call signoz_get_field_values to suggest concrete values for those attributes.
    c. Ask the user to pick a resource attribute filter before running the query.
    If the user already provides resource attributes, proceed directly without extra prompting.
+   **Caveat:** field keys are workspace- and signal-specific. Logs have no spec-mandated resource attributes — even service.name is only present when the log pipeline sets it (traces almost always carry it). If a query fails with ` + "`key ... not found`" + `, call signoz_get_field_keys for that signal to discover valid keys, then retry with an existing key or drop the failing condition — do not retry the same filter.
 
 3. **Clarify the signal before querying.** If it is not clear which signal to use, ask the user whether to start with metrics, traces, or logs.
 

--- a/pkg/prompts/prompts.go
+++ b/pkg/prompts/prompts.go
@@ -63,7 +63,7 @@ func handleDebugServiceErrors(_ context.Context, req mcp.GetPromptRequest) (*mcp
 					Type: "text",
 					Text: fmt.Sprintf(`Investigate errors for the service "%s" over the last %s. Follow these steps:
 
-1. Use signoz_search_logs with service="%s" and severity="ERROR" and timeRange="%s" to find recent error logs.
+1. Use signoz_search_logs with service="%s" and severity="ERROR" and timeRange="%s" to find recent error logs. If this fails with `+"`key service.name not found`"+`, this workspace's logs don't carry that attribute — call signoz_get_field_keys(signal="logs", fieldContext="resource") to discover available keys, pick a suitable one (e.g. k8s.deployment.name), confirm the matching value with signoz_get_field_values, and retry — or search without a service filter.
 2. Use signoz_aggregate_traces with error="true", service="%s", aggregation="count", groupBy="name", timeRange="%s" to see which operations are failing.
 3. Use signoz_get_service_top_operations with service="%s" to understand the service's operation landscape.
 4. Summarize: what errors are occurring, which operations are affected, and what the likely root cause is.`, service, timeRange, service, timeRange, service, timeRange, service),

--- a/pkg/querybuilder/logs_guide.go
+++ b/pkg/querybuilder/logs_guide.go
@@ -7,7 +7,7 @@ const LogsQueryBuilderGuide = `
 
 Filters are a STRING expression in filter.expression - NOT a structured {op, items} object.
 
-CORRECT:   "filter": {"expression": "severity_text = 'ERROR' AND service.name = 'checkout'"}
+CORRECT:   "filter": {"expression": "severity_text = 'ERROR' AND body CONTAINS 'timeout'"}
 INCORRECT: "filter": {"op": "AND", "items": [...]}
 
 Operators: =  !=  >  >=  <  <=  IN  NOT IN  LIKE  NOT LIKE  ILIKE  NOT ILIKE  CONTAINS  NOT CONTAINS  REGEXP  NOT REGEXP  BETWEEN  NOT BETWEEN  EXISTS  NOT EXISTS
@@ -16,7 +16,7 @@ Combine:   AND  OR  (use parentheses for precedence)
 Examples:
   severity_text = 'ERROR'
   body CONTAINS 'timeout'
-  service.name = 'checkout' AND severity_text IN ('ERROR', 'FATAL')
+  service.name = 'checkout' AND severity_text IN ('ERROR', 'FATAL')   <- only if this workspace's logs carry service.name (see FIELD NAMES AND CONTEXTS)
   body.user.id = '12345'
   body.error.message ILIKE '%connection refused%'
   trace_id = 'abc123def456'
@@ -28,6 +28,11 @@ Unknown keys hard-error. Do not guess field names. If unsure, call:
   signoz_get_field_keys(signal="logs", fieldContext="resource")
   signoz_get_field_keys(signal="logs", fieldContext="attribute")
   signoz_get_field_values(signal="logs", name="<field>")
+
+Log keys are workspace-specific: logs have no spec-mandated resource attributes, so even
+service.name exists only when the log pipeline sets it. A filter on a key this workspace's
+logs never carried fails with "key ... not found" — discover valid keys as above and use
+an existing one (e.g. k8s.deployment.name) instead of retrying the same filter.
 
 If a key matches BOTH the resource and attribute contexts, SigNoz defaults to the resource context (and warns). For other multi-context matches, every matching context is ORed together.
 Disambiguate explicitly in filter expressions with resource.<key> or attribute.<key> (scope.<key> also exists).

--- a/plans/key-not-found-guidance.context.md
+++ b/plans/key-not-found-guidance.context.md
@@ -47,6 +47,16 @@
 - PR was accidentally cut from local `main` carrying PR #243's unmerged oauth commit; rebased onto `origin/main` (`git rebase --onto`) and force-pushed — #243 and #244 are independent, zero file overlap.
 - Codex GitHub bot P2 on `upstreamErrorDetails` (r3600212141) judged **valid**: `json.Unmarshal` materialized the whole `error.errors[]` array before the 5-detail cap, and non-2xx bodies can reach 64 MiB (`client.go` `maxResponseBytes`); pre-change the field was unknown and never allocated. Fixed with `maxUpstreamErrorDetailsBytes` (16 KiB): oversized detail payloads are skipped outright (fail open, main fields preserved), matching the PR's bounded-extraction rule. Regression test added.
 
+### 2026-07-17 — PR #244 bot review finding #2 (valid): unbounded regex scan
+- Codex bot P2 (r3600488141) judged **valid**: `missingFilterKeys` ran `FindAllStringSubmatch` over the full 400 body — the 64-match cap bounds returned matches, not bytes walked, so a matchless (or few-match) body up to 64 MiB was fully scanned, twice per failure (`logQueryFailure` + `upstreamQueryError`), contradicting the "everything derived is bounded" comment.
+- Fixed with `missingFilterKeyScanBytes` (16 KiB, matching `maxUpstreamErrorDetailsBytes`): the scan examines only the body's prefix. Prefix-scan rather than skip-outright (the errors[] remedy) because a regex can safely scan a truncated string while JSON cannot be partially decoded — enrichment survives for any realistic body; a phrase beyond the window fails open. The double scan is left in place: two 16 KiB scans are negligible, so no cross-function caching complexity.
+- Regression test pins both sides of the window (match beyond → nil; match inside an oversized body → detected).
+
+### 2026-07-17 — Codex review of the scan-bound fix (gpt-5.6-sol, high) — clean, plus 1 should-fix on the earlier errors[] fix
+- Scan-bound fix cleared: no blocker; mid-UTF-8-rune and mid-match slicing confirmed safe (regexp tolerates invalid trailing bytes; a boundary-straddling match is omitted = documented fail-open); new test judged meaningful.
+- Should-fix found in the *first* bot-comment fix: `json.RawMessage` copies the field's bytes during `Unmarshal` (`*m = append((*m)[0:0], data...)`), so `json.Unmarshal(envelope.Error, &nested)` still materialized a near-64 MiB `errors[]` copy before `upstreamErrorDetails`' size check ran — the check was too late, and the oversized-details test's "never json.Unmarshal-ed" claim was false.
+- Fixed by removing `Errors` from the main nested decode target and extracting it in a second, size-gated pass (only when `len(envelope.Error) <= maxUpstreamErrorDetailsBytes`). Semantics shift slightly: the gate is now the whole error object's size, not the errors[] field's — anomalous-but-fine, fail open. The double decode of a ≤16 KiB object is negligible. `upstreamErrorDetails` keeps its own size check as defense in depth. Test comments corrected.
+
 ## Open Questions
 - [x] Should traces get the same description caveat as logs? — No; traces effectively guarantee `service.name` via SDKs. Traces still get the error-path enrichment (10 + 8 rows in the 7d evidence), with generic wording.
 - [x] Does manifest.json need updating? — No; it stores only tool name + top-level description, and only parameter descriptions/error text change. README parameter references do get updated.

--- a/plans/key-not-found-guidance.context.md
+++ b/plans/key-not-found-guidance.context.md
@@ -43,6 +43,10 @@
 - Logs guide's first canonical example now uses guaranteed built-ins; the service.name example is annotated as conditional on discovery. README documents the `missingKeys` structured error field on all six QB tools.
 - Nits fixed: general detail dedup (not just vs summary), singular/plural agreement in guidance.
 
+### 2026-07-17 — PR #244 bot review finding (valid) + branch hygiene
+- PR was accidentally cut from local `main` carrying PR #243's unmerged oauth commit; rebased onto `origin/main` (`git rebase --onto`) and force-pushed — #243 and #244 are independent, zero file overlap.
+- Codex GitHub bot P2 on `upstreamErrorDetails` (r3600212141) judged **valid**: `json.Unmarshal` materialized the whole `error.errors[]` array before the 5-detail cap, and non-2xx bodies can reach 64 MiB (`client.go` `maxResponseBytes`); pre-change the field was unknown and never allocated. Fixed with `maxUpstreamErrorDetailsBytes` (16 KiB): oversized detail payloads are skipped outright (fail open, main fields preserved), matching the PR's bounded-extraction rule. Regression test added.
+
 ## Open Questions
 - [x] Should traces get the same description caveat as logs? — No; traces effectively guarantee `service.name` via SDKs. Traces still get the error-path enrichment (10 + 8 rows in the 7d evidence), with generic wording.
 - [x] Does manifest.json need updating? — No; it stores only tool name + top-level description, and only parameter descriptions/error text change. README parameter references do get updated.

--- a/plans/key-not-found-guidance.context.md
+++ b/plans/key-not-found-guidance.context.md
@@ -1,0 +1,49 @@
+# Feature: Key-Not-Found Guidance — Context & Discussion
+
+## Original Prompt
+> Investigate this: https://github.com/SigNoz/nerve-pod/issues/148
+> [after investigation] Actually, the reason behind this issue is that the agents assume there's a service.name present in logs, but which may not be the case every time, because it's not spec-compulsory and logs are kind of wild-west. Compared to traces which are much more spec, and logs are generally parsed, so it's also possible that logs are not parsed. And there are multiple reasons behind this issue, so there cannot be any backend fix for this. Obviously, the MCP can be updated to ensure we guide the agents better.
+> Let's work on it, then run /codex 5.6 sol high review before creating PR
+
+## Reference Links
+- [nerve-pod#148 — key service.name not found spike on search_logs](https://github.com/SigNoz/nerve-pod/issues/148)
+- [SigNoz search troubleshooting — key not found](https://signoz.io/docs/userguide/search-troubleshooting/)
+
+## Key Decisions & Discussion Log
+
+### 2026-07-17 — Investigation findings (Claude + Codex gpt-5.6-sol cross-verified)
+- The MCP server does **no** field-context mapping on filter expressions; they pass verbatim to `/api/v5/query_range` (`logs_helper.go` → `pkg/types/querybuilder.go` → `QueryBuilderV5`).
+- The ``key `X` not found`` error originates in the SigNoz backend's QB v5 key resolution (`pkg/querybuilder/key_resolution.go` upstream): the key is absent from the tenant's per-signal field metadata.
+- Backend asymmetry (verified in the signoz repo at HEAD f24102c0): traces **synthesize** unknown keys and continue with a warning (`telemetrytraces/condition_builder.go`); logs **hard-error** unless the key is body-context (`telemetrylogs/condition_builder.go:400`). Same tenant state → 400 only on logs.
+- The MCP server pushes agents into the failure: the `service` shortcut silently injects `service.name = '...'` (`logs_helper.go:76`), the `debug_service_errors` prompt hard-codes `search_logs service="..."` as step 1 (`pkg/prompts/prompts.go:66`), tool descriptions use `service.name` as the canonical logs example, and server-instructions rule 2 says "always prefer resource attributes".
+- Newer backend error envelope (`errors.JSON`) carries the per-term detail in `error.errors[].message` (main message is just "Found N errors while parsing the search expression."); our `parseUpstreamErrorBody` only reads `error.message`, so on newer backends the actionable detail is dropped from tool error output.
+
+### 2026-07-17 — Root cause per user (decision)
+- Root cause: agents assume `service.name` exists on logs. It is not spec-compulsory for logs (unlike traces where SDKs mandate it); log pipelines may be unparsed or enrich with other attributes (`k8s.*`). Multiple tenant-side reasons → **no backend fix**; MCP must guide agents better.
+- Issue #148 title/description updated to reflect this.
+- Decision: implement MCP-side guidance only. Backend synthesis-for-logs recommendation dropped.
+
+### 2026-07-17 — Implementation decisions
+- Detect missing keys by regex ``key `X` not found`` over the raw 400 body — version-agnostic across old ("while parsing the search expression: key ... not found") and new ("Found N errors..." + `error.errors[]`) backend formats. Fail-open: no match → plain `upstreamError`, no enrichment.
+- Enrichment lives in a signal-aware wrapper (`upstreamQueryError`) used by the five QB v5 passthrough tools (search/aggregate logs/traces, execute_builder_query); guidance text is signal-specific for logs.
+- Missing keys surfaced in StructuredContent as `missingKeys` so clients can branch without string-matching.
+- Also extract `error.errors[].message` in `parseUpstreamErrorBody` so the per-term detail reaches the error text on newer backends (benefits all tools, not just QB).
+- Key-not-found 400s on QB tools log at WARN (with tool + missingKeys attrs), not ERROR — they are expected agent mistakes, consistent with #242's noise-reduction precedent; still always logged (fail open, never silent).
+- Per CLAUDE.md contract-testing rules: the regex is contract-sensitive pattern matching on an upstream message; the WARN log doubles as the drift signal, and fixture tests cover both envelope generations.
+
+### 2026-07-17 — query_metrics included
+- `metrics_query.go` is the sixth QueryBuilderV5 caller (per the sibling-caller comment in `query_builder.go`); metric label filters can hit the same key-not-found. Included with signal "metrics" for uniform behavior even though the 7d evidence had no query_metrics rows. Zero-risk when the pattern is absent (identical to `upstreamError`).
+
+### 2026-07-17 — Codex review (gpt-5.6-sol, high) — 0 blockers, 5 should-fix, 2 nits; all applied
+- **Correction to the 2026-07-17 skills-check entry above:** `missingKeys` IS an additive output-contract change (new StructuredContent field on error results), so "payload shapes unchanged" was inaccurate. The no-skills-change conclusion still holds, but the correct rationale is that `signoz-generating-queries` already teaches signal-specific key discovery and defers error-shape detail to the MCP server; an additive error field doesn't alter the contract the skills teach.
+- Envelope hardening: `error.errors[]` is now decoded best-effort via `json.RawMessage` (documented `[{"message"}]` shape + `[]string` fallback; anything else ignored), so a drifted detail array can never discard the independently parsed type/code/message. Regression-tested.
+- Bounded extraction: regex scan capped at 64 matches, per-key length capped at 256 bytes, 10 distinct keys surfaced — the 400 body is upstream-controlled input.
+- Prompt no longer implies a discovered key (e.g. k8s.deployment.name) takes the same value as the service name; it now routes through signoz_get_field_values.
+- Handler-level table test added covering all six QueryBuilderV5 callers end to end (guidance noun + missingKeys per signal).
+- Logs guide's first canonical example now uses guaranteed built-ins; the service.name example is annotated as conditional on discovery. README documents the `missingKeys` structured error field on all six QB tools.
+- Nits fixed: general detail dedup (not just vs summary), singular/plural agreement in guidance.
+
+## Open Questions
+- [x] Should traces get the same description caveat as logs? — No; traces effectively guarantee `service.name` via SDKs. Traces still get the error-path enrichment (10 + 8 rows in the 7d evidence), with generic wording.
+- [x] Does manifest.json need updating? — No; it stores only tool name + top-level description, and only parameter descriptions/error text change. README parameter references do get updated.
+- [x] agent-skills impact? — None; the tool contract (names, params, payload shapes) is unchanged — this is additive error guidance + description wording. Outcome stated in PR summary.

--- a/plans/key-not-found-guidance.plan.md
+++ b/plans/key-not-found-guidance.plan.md
@@ -1,0 +1,46 @@
+# Plan: Key-Not-Found Guidance
+
+## Status
+Done
+
+## Context
+nerve-pod#148: 162+ rows/7d of 400 `invalid_input` ``key `service.name` not found`` errors, concentrated on search_logs. Root cause: agents assume `service.name` exists on logs, but logs attributes are workspace-specific — the key is not spec-compulsory for logs, and pipelines may be unparsed. The backend hard-errors unknown keys for logs (while traces synthesize them), and the MCP server's own shortcut params, prompt, descriptions, and instructions steer agents into the failing filter. No backend fix is possible (legitimate tenant states); the MCP layer must guide agents to recover.
+
+## Approach
+
+1. **Error enrichment** (`internal/handler/tools/errs.go`):
+   - `missingFilterKeys(err) []string` — on an HTTP 400 `HTTPStatusError`, regex ``key `X` not found`` over the raw body; dedup, cap. Fail-open.
+   - `upstreamQueryError(err, signal) *mcp.CallToolResult` — wraps `upstreamError`; when missing keys are found, appends signal-aware guidance (discover keys via `signoz_get_field_keys`, logs-specific caveat that even `service.name` is not guaranteed, suggest `k8s.*` alternates or dropping the condition) and adds `missingKeys` to StructuredContent.
+   - `parseUpstreamErrorBody` additionally collects `error.errors[].message` (new envelope) and appends them to the displayed detail so newer backends don't hide the per-term errors behind "Found N errors while parsing the search expression."
+   - `logQueryFailure(ctx, msg, err)` on Handler — WARN with `missingKeys` attr when detected (expected agent mistake), else defer to `logUpstreamFailure`.
+
+2. **Handlers**: `logs.go` (search/aggregate → signal "logs"), `traces.go` (search/aggregate → "traces"), `metrics_query.go` (query_metrics → "metrics"), `query_builder.go` (execute_builder_query → "" generic): swap `upstreamError`/`logUpstreamFailure` for the new pair on the QueryBuilderV5 error path — all six QueryBuilderV5 callers behave uniformly.
+
+3. **Descriptions** (`logs.go`): `logsFilterParamDescription` + both `service` param descriptions state that log keys are workspace-specific and `service.name` is not guaranteed on logs; on key-not-found, discover keys and retry.
+
+4. **Prompt** (`pkg/prompts/prompts.go`): `debug_service_errors` step 1 gains a recovery clause for the key-not-found failure.
+
+5. **Instructions** (`pkg/instructions/instructions.go`): rule 2 gains the per-signal availability caveat + recovery guidance.
+
+6. **Logs guide** (`pkg/querybuilder/logs_guide.go`): availability caveat next to "Unknown keys hard-error".
+
+7. **Docs sync**: README updates — logs tools' `filter`/`service` parameter wording plus a **Key-not-found errors** bullet documenting the `missingKeys` structured error field on all six QB tools. manifest.json unchanged (only name + tool description stored; neither changes). agent-skills: `missingKeys` is an additive error-output field, and `signoz-generating-queries` already teaches signal-specific key discovery while deferring error-shape detail to the MCP server, so the contract the skills teach is unchanged — no skills PR needed; outcome stated in PR summary.
+
+## Files to Modify
+- `internal/handler/tools/errs.go` — detection, enrichment, envelope-additional extraction, WARN logging helper
+- `internal/handler/tools/logs.go` — descriptions + new error path
+- `internal/handler/tools/traces.go` — new error path
+- `internal/handler/tools/query_builder.go` — new error path
+- `internal/handler/tools/metrics_query.go` — new error path
+- `pkg/prompts/prompts.go` — debug prompt recovery clause
+- `pkg/instructions/instructions.go` — rule 2 caveat
+- `pkg/querybuilder/logs_guide.go` — availability caveat
+- `README.md` — logs tools parameter wording
+- `internal/handler/tools/upstream_query_error_test.go` (new) — fixtures for both envelope generations, enrichment, structured fields, WARN level, bounded extraction, six-handler end-to-end table test
+
+## Verification
+- `go test ./...` (green), `go vet`, `gofmt -l` clean.
+- Unit fixtures: old-format single message, new-format `error.errors[]`, `[]string` details fallback, malformed details shape (main fields preserved), multiple missing keys deduped, oversized keys dropped, scan/surface caps, non-400, non-key 400 (no enrichment), singular/plural guidance.
+- Handler-level table test driving all six QueryBuilderV5 callers (search/aggregate logs & traces, query_metrics, execute_builder_query) through a failing mock: per-signal guidance noun + `missingKeys` in StructuredContent.
+- Log-severity table test: key-not-found 400 → WARN with `missingKeys` attr; other 400s → ERROR; cancellation → DEBUG.
+- Codex (gpt-5.6-sol, high) review of the diff before PR — 0 blockers; 5 should-fixes + 2 nits applied (see context log).


### PR DESCRIPTION
## Summary

Addresses [SigNoz/nerve-pod#148](https://github.com/SigNoz/nerve-pod/issues/148): a 7-day spike of 400 `invalid_input` ``key `service.name` not found`` errors, 144 of 162 rows on `search_logs`.

**Root cause:** agents assume `service.name` exists on logs, but logs have no spec-mandated resource attributes (unlike traces, where SDKs effectively guarantee it) — log pipelines may be unparsed or enriched with `k8s.*` keys instead, so the key is legitimately absent from many workspaces' logs field metadata and the backend hard-errors. There is no backend fix; the MCP layer must guide agents to recover. Full investigation and decisions in `plans/key-not-found-guidance.{context,plan}.md`.

## Changes

- **Error enrichment (`errs.go`)** — all six QueryBuilderV5 tools (`search_logs`, `aggregate_logs`, `search_traces`, `aggregate_traces`, `query_metrics`, `execute_builder_query`) detect key-not-found 400s and append signal-aware recovery guidance (discover keys via `signoz_get_field_keys`, logs-specific caveat, `k8s.*` alternates, or drop the condition), plus a machine-readable `missingKeys` array in StructuredContent so clients can branch without string-matching. Extraction is bounded (64-match scan, 256-byte key cap, 10 keys surfaced) since the 400 body is upstream-controlled input, and fails open when the wording drifts.
- **Envelope detail folding (`errs.go`)** — newer backends carry per-term detail in `error.errors[].message` behind a bare summary; `parseUpstreamErrorBody` now folds those details into the surfaced message for every tool. Decoding is best-effort (`json.RawMessage`, documented shape + `[]string` fallback) so a drifted detail array can never discard the main error fields.
- **Log severity (`errs.go`)** — key-not-found 400s on QB tools log at WARN with a `missingKeys` attribute (expected agent mistake whose tool result carries the recovery path; still always emitted — fail open, never silent). Other failures keep the existing severity contract, including the DEBUG demotion for client cancellations.
- **Guidance surfaces** — `filter`/`service` param descriptions, the `debug_service_errors` prompt (recovery via `get_field_keys` + `get_field_values`), server-instructions rule 2, and the logs query-builder guide no longer imply `service.name` is guaranteed on logs.

## Docs & metadata sync

- **README**: updated logs tools' `filter`/`service` wording; added a **Key-not-found errors** bullet documenting `missingKeys` on all six QB tools.
- **manifest.json**: no change needed — it stores only tool names + top-level descriptions, neither of which changed.
- **agent-skills**: no companion PR needed. `missingKeys` is an additive error-output field, and `signoz-generating-queries` already teaches signal-specific key discovery while deferring error-shape detail to the MCP server, so the contract the skills teach is unchanged.
- **searchContext**: no tool schemas added or restructured.

## Verification

- `go test ./...`, `go vet`, `gofmt -l` all clean.
- New `upstream_query_error_test.go`: both upstream envelope generations (legacy inline message and `error.errors[]`), `[]string` details fallback, malformed detail shape preserving main fields, dedup/caps for keys and details, singular/plural guidance, a six-handler end-to-end table test (per-signal guidance + `missingKeys` through real handler plumbing), and a WARN/ERROR/DEBUG severity table for `logQueryFailure`.
- Peer-reviewed by Codex (gpt-5.6-sol, high effort): round 1 — 0 blockers, 5 should-fixes, 2 nits, all applied; round 2 — all findings confirmed resolved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)