### PR TITLE
fix: add distroless-safe MCP healthcheck

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -53,3 +53,5 @@ EXPOSE 8000
 
 # Run the application
 CMD ["./signoz-mcp-server"]
+
+HEALTHCHECK --interval=10s --timeout=2s --retries=5 CMD ["./signoz-mcp-server", "healthcheck"]

--- a/Dockerfile.multi-arch
+++ b/Dockerfile.multi-arch
@@ -10,4 +10,6 @@ ARG ARCH
 
 COPY ./target/${OS}-${ARCH}/signoz-mcp-server /usr/local/bin/signoz-mcp-server
 
+HEALTHCHECK --interval=10s --timeout=2s --retries=5 CMD ["/usr/local/bin/signoz-mcp-server", "healthcheck"]
+
 ENTRYPOINT ["/usr/local/bin/signoz-mcp-server"]

--- a/README.md
+++ b/README.md
@@ -310,6 +310,8 @@ MCP_SERVER_PORT=8000 \
 
 HTTP mode exposes unauthenticated probe endpoints. New Kubernetes deployments should use `/livez` for `livenessProbe` and `/readyz` for `readinessProbe`.
 
+The container image uses `signoz-mcp-server healthcheck` for its Docker healthcheck. This subcommand probes the local `/livez` endpoint directly, so it works in the distroless multi-architecture image without requiring `wget`, `curl`, or a shell.
+
 | Endpoint | Purpose |
 |----------|---------|
 | `/livez` | Shallow liveness probe. Returns `200 OK` when the server process can answer HTTP requests. It does not check dependencies. |

--- a/cmd/server/healthcheck.go
+++ b/cmd/server/healthcheck.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"time"
+)
+
+const healthcheckURL = "http://127.0.0.1:8000/livez"
+
+func runHealthcheck() error {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	return checkLiveness(ctx, http.DefaultClient, healthcheckURL)
+}
+
+func checkLiveness(ctx context.Context, client *http.Client, endpoint string) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return fmt.Errorf("create liveness request: %w", err)
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("request liveness endpoint: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("liveness endpoint returned %s", resp.Status)
+	}
+
+	return nil
+}

--- a/cmd/server/healthcheck_test.go
+++ b/cmd/server/healthcheck_test.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestCheckLiveness(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		statusCode int
+		wantErr    bool
+	}{
+		{name: "live server", statusCode: http.StatusOK},
+		{name: "not ready", statusCode: http.StatusServiceUnavailable, wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(tt.statusCode)
+			}))
+			t.Cleanup(server.Close)
+
+			ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+			t.Cleanup(cancel)
+
+			err := checkLiveness(ctx, server.Client(), server.URL)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("checkLiveness() error = %v, wantErr %t", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -27,6 +27,14 @@ import (
 )
 
 func main() {
+	if len(os.Args) == 2 && os.Args[1] == "healthcheck" {
+		if err := runHealthcheck(); err != nil {
+			fmt.Fprintf(os.Stderr, "Healthcheck failed: %v\n", err)
+			os.Exit(1)
+		}
+		return
+	}
+
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
 

--- a/plans/distroless-healthcheck.context.md
+++ b/plans/distroless-healthcheck.context.md
@@ -1,0 +1,34 @@
+# Feature: Distroless-safe MCP healthcheck — Context & Discussion
+
+## Original Prompt
+
+> Fix GitHub issue #246: the documented/Foundry Docker healthcheck runs `wget`
+> inside the distroless SigNoz MCP image, where neither `wget` nor a shell exists.
+
+## Reference Links
+
+- [SigNoz MCP issue #246](https://github.com/SigNoz/signoz-mcp-server/issues/246)
+- [Foundry compose template](https://github.com/SigNoz/foundry/blob/main/internal/casting/dockercomposecasting/templates/compose.yaml.gotmpl)
+
+## Key Decisions & Discussion Log
+
+### 2026-07-20 — Use the server binary as the probe
+
+- Add a `healthcheck` subcommand that performs a short HTTP request to the
+  existing local `/livez` endpoint and returns a process exit code.
+- This keeps the production image minimal and works in a distroless runtime.
+- Add the Docker healthcheck in both Dockerfiles. A companion Foundry template
+  update will replace its external `wget` probe with the binary subcommand.
+
+## Open Questions
+
+- [ ] Does Foundry accept the companion template update while the MCP release
+  containing this subcommand is pending?
+
+### 2026-07-20 — Validation completed
+
+- Added an integration check using the production `Dockerfile` with
+  `TRANSPORT_MODE=http`.
+- The container reported Docker health status `healthy`; the host-visible
+  `/livez` endpoint returned `ok`.
+- `go test ./cmd/server` and `go test ./...` both passed.

--- a/plans/distroless-healthcheck.plan.md
+++ b/plans/distroless-healthcheck.plan.md
@@ -1,0 +1,37 @@
+# Plan: Distroless-safe MCP healthcheck
+
+## Status
+
+Done
+
+## Context
+
+The MCP image has no shell or `wget`, so an in-container `wget` health probe
+always reports a healthy server as unhealthy.
+
+## Approach
+
+1. Add and test a native `healthcheck` binary subcommand that probes `/livez`.
+2. Use that subcommand in the single- and multi-architecture Dockerfiles.
+3. Update the Foundry compose template in a companion contribution.
+
+## Files to Modify
+
+- `cmd/server/healthcheck.go` — health probe implementation.
+- `cmd/server/healthcheck_test.go` — status and transport regression tests.
+- `cmd/server/main.go` — command dispatch before configuration startup.
+- `Dockerfile` and `Dockerfile.multi-arch` — distroless-safe healthcheck.
+- `README.md` — document container health behavior.
+
+## Verification
+
+- Run `go test ./cmd/server` and `go test ./...`.
+- Build the production Docker image, run it with HTTP transport, and verify both
+  Docker's native health status and the external `/livez` endpoint.
+
+## Results
+
+- `go test ./cmd/server` passed.
+- `go test ./...` passed.
+- The production Docker image reached Docker health status `healthy` with
+  `TRANSPORT_MODE=http`; an external request to `/livez` returned `ok`.


### PR DESCRIPTION
## Summary
- add a native `healthcheck` subcommand that probes the existing local `/livez` endpoint without loading normal server configuration
- configure both release Dockerfiles to use that subcommand, so the distroless image needs no `wget`, `curl`, or shell
- document the behaviour and cover 200/503 responses with regression tests

## Validation
- `go test ./cmd/server`
- `go test ./...`
- built the production Docker image, started it with `TRANSPORT_MODE=http`, and verified Docker health became `healthy` plus `/livez` returned `ok`

A companion Foundry template change will replace the external `wget` command that currently causes the failure.

Closes #246