### PR TITLE
test(mcp): add Inspector protocol CI

### DIFF
--- a/.github/workflows/mcp-protocol.yaml
+++ b/.github/workflows/mcp-protocol.yaml
@@ -1,0 +1,42 @@
+name: protocol
+
+on:
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  inspector:
+    name: inspector
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout pull request
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.25"
+          cache: true
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+          cache: npm
+          cache-dependency-path: tools/mcp-ci/package-lock.json
+
+      - name: Install MCP Inspector CLI
+        working-directory: tools/mcp-ci
+        run: npm ci --ignore-scripts
+
+      - name: Parse protocol harness
+        run: bash -n scripts/test-mcp-protocol.sh
+
+      - name: Run MCP protocol checks
+        run: scripts/test-mcp-protocol.sh

--- a/.gitignore
+++ b/.gitignore
@@ -27,8 +27,9 @@ bundle/
 go.work
 go.work.sum
 
-# Local scripts (root-only; CI helpers under .github/scripts/ are tracked)
-/scripts/
+# Local scripts (root-only; explicitly reviewed CI helpers are tracked)
+/scripts/*
+!/scripts/test-mcp-protocol.sh
 
 # env file
 .env

--- a/README.md
+++ b/README.md
@@ -233,6 +233,8 @@ Add this to your MCP client config (`claude_desktop_config.json`, `.cursor/mcp.j
 
 ### HTTP Mode
 
+HTTP mode listens on all interfaces by default. Set `MCP_SERVER_HOST=127.0.0.1` when the server should accept loopback connections only.
+
 #### With OAuth (Multi-Tenant / Cloud)
 
 Start the server:
@@ -885,6 +887,7 @@ Runs a SigNoz Query Builder v5 request that the dedicated tools cannot express, 
 | `SIGNOZ_API_KEY`  | SigNoz API key (get from Settings → API Keys in the SigNoz UI) | Yes (stdio); Optional (http with OAuth) |
 | `LOG_LEVEL`       | Logging level: `info`(default), `debug`, `warn`, `error`                       | No                                  |
 | `TRANSPORT_MODE`  | MCP transport mode: `stdio`(default) or `http`                                 | No                                  |
+| `MCP_SERVER_HOST` | Host/interface for HTTP transport mode (default: empty, which listens on all interfaces). Set to `127.0.0.1` for loopback-only access. | No |
 | `MCP_SERVER_PORT` | Port for HTTP transport mode (default: `8000`)                                 | No |
 | `MCP_MAX_REQUEST_BYTES` | Max inbound MCP HTTP request body size in bytes (default: `4194304` / 4 MiB). Bounds memory from a single oversized request. | No |
 | `CLIENT_CACHE_SIZE` | Maximum cached tenant clients in multi-tenant HTTP mode (default: `256`) | No |

--- a/guardrails/README.md
+++ b/guardrails/README.md
@@ -9,6 +9,7 @@ access to unexported retry, registration, middleware, and server-composition hel
 - `policy.go` contains shared limits, official aliases, and explicitly grandfathered exceptions.
 - `tests.txt` is the exact inventory executed by the `guardrails / contract` GitHub check.
 - `.github/workflows/guardrails.yaml` verifies the inventory and runs the guarded tests.
+- `.github/workflows/mcp-protocol.yaml` runs the real-server Inspector compatibility check.
 - Package-local functions named `TestGuardrail_*` contain the enforcement logic.
 
 ## Invariants covered
@@ -26,6 +27,30 @@ growth through normal code and client compatibility review. This is separate fro
 arguments sent in a tool call: streamable HTTP request bodies retain the configurable
 `MCP_MAX_REQUEST_BYTES` limit (4 MiB by default), while that middleware does not apply
 to stdio.
+
+## Protocol compatibility
+
+The `protocol / inspector` check starts the production HTTP server on loopback and exercises initialization, tools, resources, resource templates, prompts, and logging through `@modelcontextprotocol/inspector-cli@1.0.0`. It runs on every pull request to `main` without credentials or a live SigNoz backend.
+
+Protocol policy is split across three review-sensitive files:
+
+- `tools/mcp-ci/package.json` and its lockfile pin the Inspector CLI.
+- `scripts/test-mcp-protocol.sh` owns the server lifecycle and selective response assertions.
+- `.github/workflows/mcp-protocol.yaml` owns the Node/Go toolchain and required check name.
+
+Keep assertions focused on usable protocol surfaces, stable identity, and non-empty result envelopes. Do not turn this check into a full catalog snapshot by pinning counts, ordering, descriptions, schemas, or ranked documentation content. `tests.txt` remains the inventory for Go `TestGuardrail_*` tests only.
+
+After the workflow succeeds once on the default branch, configure `protocol / inspector` as a required `main` branch check. Upgrade Inspector only in a reviewed dependency change that reruns the same assertions.
+
+Run the protocol lane on Ubuntu with:
+
+```bash
+npm ci --ignore-scripts --prefix tools/mcp-ci
+bash -n scripts/test-mcp-protocol.sh
+shellcheck scripts/test-mcp-protocol.sh
+actionlint .github/workflows/mcp-protocol.yaml
+scripts/test-mcp-protocol.sh
+```
 
 ## Changing a guardrail
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -16,6 +16,7 @@ type Config struct {
 	APIKey        string
 	LogLevel      string
 	TransportMode string
+	Host          string
 	Port          string
 
 	OAuthEnabled     bool
@@ -51,6 +52,7 @@ const (
 	SignozApiKey  = "SIGNOZ_API_KEY"
 	LogLevel      = "LOG_LEVEL"
 	TransportMode = "TRANSPORT_MODE"
+	MCPHost       = "MCP_SERVER_HOST"
 	MCPPort       = "MCP_SERVER_PORT"
 
 	SignozCustomHeaders     = "SIGNOZ_CUSTOM_HEADERS"
@@ -128,6 +130,7 @@ func LoadConfig() (*Config, error) {
 		APIKey:                  getEnv(SignozApiKey, ""),
 		LogLevel:                getEnv(LogLevel, "info"),
 		TransportMode:           getEnv(TransportMode, "stdio"),
+		Host:                    getEnv(MCPHost, ""),
 		Port:                    getEnv(MCPPort, "8000"),
 		OAuthEnabled:            getEnvBool(OAuthEnabledEnv, false),
 		OAuthTokenSecret:        getEnv(OAuthTokenSecretEnv, ""),

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -89,6 +89,22 @@ func TestValidateConfig_HTTPAllowsCredentialsFromHeaders(t *testing.T) {
 	require.NoError(t, cfg.ValidateConfig())
 }
 
+func TestLoadConfig_HTTPHostDefaultsToAllInterfaces(t *testing.T) {
+	t.Setenv(MCPHost, "")
+
+	cfg, err := LoadConfig()
+	require.NoError(t, err)
+	require.Empty(t, cfg.Host)
+}
+
+func TestLoadConfig_HTTPHostCanBeConfigured(t *testing.T) {
+	t.Setenv(MCPHost, "127.0.0.1")
+
+	cfg, err := LoadConfig()
+	require.NoError(t, err)
+	require.Equal(t, "127.0.0.1", cfg.Host)
+}
+
 func TestValidateConfig_StdioRequiresConfiguredCredentials(t *testing.T) {
 	cfg := &Config{
 		TransportMode: "stdio",

--- a/internal/mcp-server/docs_http_test.go
+++ b/internal/mcp-server/docs_http_test.go
@@ -103,6 +103,30 @@ func TestLivenessEndpointDoesNotRequireReadiness(t *testing.T) {
 	require.Equal(t, "ok", rr.Body.String())
 }
 
+func TestBuildHTTPListenAddress(t *testing.T) {
+	tests := []struct {
+		name string
+		host string
+		want string
+	}{
+		{name: "all interfaces by default", want: ":18080"},
+		{name: "configured loopback host", host: "127.0.0.1", want: "127.0.0.1:18080"},
+		{name: "configured IPv6 host", host: "::1", want: "[::1]:18080"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := &MCPServer{
+				logger: logpkg.New("error"),
+				config: &config.Config{Host: tt.host, Port: "18080"},
+			}
+			s := server.NewMCPServer("SigNozMCP", version.Version)
+
+			require.Equal(t, tt.want, m.buildHTTP(s).Addr)
+		})
+	}
+}
+
 func newDocsHTTPHandler(t *testing.T) (http.Handler, *MCPServer) {
 	t.Helper()
 	logger := logpkg.New("error")

--- a/internal/mcp-server/server.go
+++ b/internal/mcp-server/server.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"net"
 	"net/http"
 	"os"
 	"strings"
@@ -1301,7 +1302,7 @@ func (m *MCPServer) authMiddleware(next http.Handler) http.Handler {
 func (m *MCPServer) buildHTTP(s *server.MCPServer) *http.Server {
 	m.logger.Info("MCP Server running in HTTP mode")
 
-	addr := fmt.Sprintf(":%s", m.config.Port)
+	addr := net.JoinHostPort(m.config.Host, m.config.Port)
 
 	mux := http.NewServeMux()
 

--- a/plans/mcp-tier-2-protocol-client-lanes.context.md
+++ b/plans/mcp-tier-2-protocol-client-lanes.context.md
@@ -189,3 +189,7 @@
 - [x] Which repository/environment secrets and live SigNoz environment should Tranche D use? Resolved for Tier 2: move this decision to the linked live-upstream follow-up.
 - [x] Which conformance scenarios, if any, are legitimate expected failures with the pinned mcp-go version? Resolved for Tier 2: conformance is deferred until a stable release, so no baseline is created now.
 - [x] Who owns the weekly Devin marketplace check and where should its result be recorded? Resolved for Tier 2: move ownership and recording policy to the linked Devin follow-up.
+
+### 2026-07-21 — Streamable HTTP Accept header review
+- PR review correctly identified that the raw initialize POST advertised only `application/json`, while MCP 2025-11-25 requires clients to advertise both `application/json` and `text/event-stream`.
+- The harness now sends both media types and retains the server-specific JSON response assertion.

--- a/plans/mcp-tier-2-protocol-client-lanes.context.md
+++ b/plans/mcp-tier-2-protocol-client-lanes.context.md
@@ -1,0 +1,191 @@
+# Feature: MCP Tier 2 Protocol and Client Lanes — Context & Discussion
+
+## Original Prompt
+> Merged this PR, now let's move to tier 2, only create plan
+
+## Reference Links
+- [SigNoz/nerve-pod#34](https://github.com/SigNoz/nerve-pod/issues/34)
+- [Reconciled Tier 2 lanes](https://github.com/SigNoz/nerve-pod/issues/34#issuecomment-5010045025)
+- [Initialized-catalog and metadata best practices](https://github.com/SigNoz/nerve-pod/issues/34#issuecomment-5014863452)
+- [Merged Tier 1 PR #249](https://github.com/SigNoz/signoz-mcp-server/pull/249)
+- [MCP Inspector](https://github.com/modelcontextprotocol/inspector)
+- [MCP conformance suite](https://github.com/modelcontextprotocol/conformance)
+- [MCP protocol versioning](https://modelcontextprotocol.io/docs/learn/versioning)
+- [2026-07-28 release candidate](https://blog.modelcontextprotocol.io/posts/2026-07-28-release-candidate/)
+- [Cursor CLI MCP commands](https://docs.cursor.com/en/cli/reference/parameters)
+
+## Key Decisions & Discussion Log
+
+### 2026-07-19 — Tier 2 planning started
+- This is planning only. No production code, tests, workflows, commits, or pull requests are part of this step.
+- Tier 2 means the protocol and real-client compatibility lanes from the reconciled nerve-pod plan. The model-based reviewer agent remains a later tier.
+- The work will be delivered as small, independently reviewable tranches rather than one workflow containing every protocol, vendor, and live-environment dependency.
+- Tier 2 starts with a normalized in-process catalog snapshot, semantic comparison, and runtime/manifest parity. These form the stable oracle that Inspector and client lanes compare against and close the semantic snapshot gap deliberately deferred from Tier 1.
+- The remaining Tier 1 work on per-tool-class response budgets and exhaustive coded-error injection is orthogonal and remains outside this plan. Tier 2 must not silently mark those items complete.
+- Per-PR lanes must be deterministic, unprivileged, and secret-free. Paid or authenticated vendor clients and a live SigNoz instance run only from protected schedules or manual dispatches.
+- Client checks will assert machine-observed catalog data or receipt of a synthetic sentinel call. Asking a model to enumerate tools is not an acceptable compatibility oracle.
+
+### 2026-07-19 — Delivery sequence
+- Tranche A establishes one production-derived catalog, a canonical snapshot, semantic breaking-change classification, reviewed migration records, and `manifest.json` parity.
+- Tranche B adds blocking MCP Inspector and official conformance checks against a locally started server.
+- Tranche C adds protected nightly Cursor, Claude Code, and Codex lanes using pinned clients, plus nonblocking latest-version probes.
+- Tranche D adds the separately protected live-SigNoz contract lane, a manual Devin checklist, and a nonblocking next-protocol lane.
+
+### 2026-07-19 — External tool baseline
+- The planning baseline is Node.js 22, `@modelcontextprotocol/inspector@1.0.0`, and `@modelcontextprotocol/conformance@0.1.16`. Exact versions and their documented CLI behavior must be reverified when Tranche B begins, then pinned in a committed lockfile.
+- Cursor, Claude Code, and Codex versions will be pinned in one reviewed client-version policy file. A client version must pass the lane before it becomes the blocking pin; upgrades are explicit policy changes.
+- The current MCP protocol version is `2025-11-25`. The `2026-07-28` candidate remains nonblocking until the official versioning page marks it current and stable mcp-go and conformance support are available.
+
+### 2026-07-19 — Central review surfaces
+- Human-reviewed compatibility policy will live under `guardrails/`: the catalog snapshot, migration ledger, conformance expected-failure baseline, client pins, parser fixtures, and manual-lane documentation.
+- Workflows only execute this policy. A contributor must not be able to hide a semantic break by updating the snapshot alone: pull-request CI compares the base catalog with the head catalog and requires an exact reviewed migration entry for any allowed break.
+- GitHub CODEOWNERS changes are not part of this plan, consistent with the Tier 1 decision.
+
+### 2026-07-20 — Design interview opened after Tier 1 merge
+- Tier 1 PR #249 and the follow-up catalog-metadata PR #248 are merged on `main`.
+- The user asked to revisit Tier 2 through a dependency-ordered design interview, one question batch at a time. Existing Tier 2 choices remain draft until explicitly resolved during this interview.
+- Each question will include a recommended answer, counterpoints, and alternatives. Repository facts will be checked directly rather than asked back to the user.
+
+### 2026-07-20 — Tier 2 scope boundary resolved
+- Tier 2 covers three dependency-ordered areas: the production-derived catalog oracle, Inspector/conformance protocol checks, and protected Cursor/Claude Code/Codex compatibility lanes.
+- Live SigNoz upstream testing, the manual Devin marketplace check, and next-protocol probes remain valuable linked follow-ups, but are outside Tier 2 and cannot delay its completion.
+- This supersedes the earlier four-tranche delivery sequence. It keeps downstream MCP/client compatibility cohesive while separating work with different credentials, cleanup, ownership, or dependency-readiness constraints.
+
+### 2026-07-20 — Committed catalog snapshot rejected
+- The user chose to omit a committed catalog snapshot entirely.
+- `guardrails/catalog.snapshot.json` and snapshot generate/verify workflows are therefore out of scope. Earlier snapshot-specific planning is superseded.
+- The next dependency is to decide whether CI should compare catalogs generated from the pull request base and head revisions at runtime, or use narrower invariant/protocol checks without historical catalog comparison.
+
+### 2026-07-21 — Catalog branch removed from Tier 2
+- The user chose to skip the first Tier 2 area completely: no production/test registration refactor, catalog extractor, catalog normalization, historical comparison, migration ledger, or expanded manifest parity is part of Tier 2.
+- Tier 2 now contains only protocol checks and protected real-client compatibility lanes.
+- This accepts that Tier 2 will not detect semantic catalog removal or narrowing beyond the existing Tier 1 guardrails, integration tests, and manifest checks.
+
+### 2026-07-21 — Inspector V1 retained
+- The user chose to include MCP Inspector V1 now and upgrade to V2 when V2 is ready.
+- Pin Inspector `1.0.0` and Node.js `22.7.5` or newer within the Node 22 line. Keep the Inspector wrapper isolated so the V2 replacement does not require redesigning the server harness or assertions.
+- Inspector V1's CLI does not expose the initialize result. Use a minimal raw protocol probe for negotiated version, capabilities, server identity, and instructions; use Inspector for its supported list/read/call operations.
+- V2 promotion is a separate reviewed dependency update after a stable release passes the same required assertions.
+
+### 2026-07-21 — Conformance deferred
+- The user chose to omit the official MCP conformance suite until it becomes stable.
+- Tier 2 will not add the `0.1.16` package, expected-failure baseline, conformance workflow check, or branch-protection rule.
+- Reconsider conformance as a linked follow-up when the project publishes a stable release; its adoption must then be planned and reviewed separately.
+
+### 2026-07-21 — Real-client lanes deferred
+- The user chose to omit Cursor, Claude Code, and Codex compatibility lanes from Tier 2 for now.
+- Tier 2 will not add a sentinel server, client-version policy, vendor credentials, scheduled client workflow, parser fixtures, or model-driven invocation checks.
+- Real-client compatibility remains a linked follow-up. Active Tier 2 is now only the Inspector V1 protocol lane.
+
+### 2026-07-21 — Inspector covers all advertised surfaces shallowly
+- The user chose broad surface coverage rather than the minimal initialize/list/call path.
+- A raw protocol probe validates initialization metadata because Inspector V1 cannot emit it. Inspector validates `tools/list`, `resources/list`, resource-template listing, `prompts/list`, and one deterministic `signoz_search_docs` invocation backed by the embedded docs index.
+- Assertions cover successful, well-formed responses and capability usability. They do not pin exact catalog counts, descriptions, schemas, or ranked documentation text.
+
+### 2026-07-21 — Inspector runs on every pull request
+- The user chose to run the Inspector workflow on every pull request to `main` with no path filters.
+- Required-check status and any additional manual or scheduled trigger remain separate decisions.
+
+### 2026-07-21 — Inspector becomes required after bootstrap
+- The user chose to make `protocol / inspector` a required check for `main`.
+- First merge and run the workflow successfully on the default branch, then add its exact check name to branch protection as a separate administrative step.
+- Do not use `continue-on-error` or an expected-failure bypass.
+
+### 2026-07-21 — Inspector trigger policy resolved
+- The workflow runs on every pull request to `main` and supports `workflow_dispatch` for manual diagnostics.
+- It does not run on a schedule because the code and toolchain are pinned; recurring unchanged runs are not part of Tier 2.
+
+### 2026-07-21 — Inspector uses a separate workflow
+- The user chose a separate `.github/workflows/mcp-protocol.yaml` rather than adding Inspector to `.github/workflows/guardrails.yaml`.
+- The stable required-check name is `protocol / inspector`. Tier 1 stays a fast Go-only workflow, while Inspector owns its Node toolchain, server lifecycle, logs, and manual trigger.
+- Protocol policy and contributor guidance remain centralized under `guardrails/README.md`.
+
+### 2026-07-21 — Use a reusable Bash harness
+- The user chose a reusable Bash harness under `scripts/` around the real production binary rather than a Go harness, inline workflow commands, or an in-process server.
+- The harness builds and starts the binary on a fixed high default port with an environment override, supplies isolated test configuration, waits for `/readyz` with a bounded timeout, runs the raw initialize probe and Inspector commands, captures logs on failure, and always terminates the server through an exit trap.
+
+### 2026-07-21 — Use environment-provided test credentials
+- The user chose fixed test-only `SIGNOZ_URL` and `SIGNOZ_API_KEY` environment values rather than Inspector request headers or an authentication bypass.
+- OAuth and analytics are disabled. The Inspector lane exercises the production configured-credential fallback, while existing Go tests retain responsibility for other authentication branches.
+- The selected embedded-docs tool call must not contact the dummy SigNoz backend.
+
+### 2026-07-21 — Selective initialize contract
+- The user chose selective initialize assertions rather than success-only validation or a full-response snapshot.
+- Pin protocol version `2025-11-25`, server name `SigNozMCP`, expected tools/resources/prompts/logging capability presence, non-empty server version and instructions, and stateless operation without a required session ID.
+- Do not pin the exact server version or instruction text.
+
+### 2026-07-21 — Minimal discovery metadata assertions
+- The user chose non-empty collection and minimal identity validation for every Inspector list surface.
+- Require valid JSON; non-empty tools, resources, templates, and prompts; and non-empty item identity fields (`name`, plus resource `uri` or template URI as applicable).
+- Require `signoz_search_docs` to be present because the lane invokes it. Do not pin counts, complete inventories, descriptions, schemas, or ordering.
+
+### 2026-07-21 — Deterministic docs tool invocation
+- The user chose `signoz_search_docs` with `searchText: "docker"`, a fixed verbatim `searchContext`, and `limit: 1` for the Inspector tool call.
+- Require a successful result, non-empty structured `results`, and non-empty text content. Do not pin result URL, title, snippet, rank, or wording.
+- This intentionally overlaps the in-process docs test at a different boundary: the production binary, auth middleware, Streamable HTTP transport, and Inspector client.
+
+### 2026-07-21 — Raw initialize probe uses curl and jq
+- The user chose an explicit `curl` JSON-RPC initialize request plus `jq` assertions inside the Bash harness rather than another Node/Go program or relying only on Inspector's internal handshake.
+- Request an `application/json` response, require HTTP 200 and JSON content type, apply the selective initialize assertions, and verify that the stateless server does not return `Mcp-Session-Id`.
+
+### 2026-07-21 — Strict timeout and retry policy
+- The user chose a 10-minute workflow timeout, 30-second readiness deadline, and 60-second limit for each raw/Inspector command.
+- Only readiness polling repeats. Protocol commands are not retried, so intermittent compatibility failures remain visible.
+- Cleanup targets only the captured server PID: send TERM, wait up to five seconds, then force-stop that PID if necessary.
+
+### 2026-07-21 — Print failure logs only
+- The user rejected uploaded failure artifacts.
+- Successful runs print a concise summary. Failed runs print the failed phase, its relevant Inspector stderr/JSON, and a bounded tail of server logs directly in the job log.
+- Temporary files are always removed during cleanup; no workflow artifact is retained.
+
+### 2026-07-21 — Pin the CLI-only Inspector V1 package
+- The user chose `@modelcontextprotocol/inspector-cli@1.0.0` rather than the full Inspector package.
+- Commit an npm lockfile and install with `npm ci`. The full V1 web UI and proxy dependencies are not needed by this lane.
+- The isolated harness adapter owns the future migration to Inspector V2's consolidated package and changed CLI surface.
+
+### 2026-07-21 — Inspector connection and usable-surface coverage
+- The user chose direct Inspector CLI flags rather than a generated MCP configuration file.
+- The production binary binds to `127.0.0.1:18080` by default for the harness, supports a `MCP_PROTOCOL_PORT` override, and fails clearly before startup if the selected port is occupied.
+- In addition to initialize, list calls, and docs search, exercise `resources/read` for `signoz://docs/sitemap`, `prompts/get` for `debug_service_errors` with synthetic arguments, and `logging/setLevel`. Require successful, non-empty responses without pinning generated content.
+
+### 2026-07-21 — Bind-address correction
+- Code inspection found that the production HTTP server currently accepts only a port and listens on `:<port>` (all interfaces). Connecting to `127.0.0.1` does not make the listener loopback-only.
+- The prior discussion entry's loopback-binding statement is therefore corrected. Whether to add an explicit bind-host configuration remains unresolved.
+
+### 2026-07-21 — Bind host and runner portability resolved
+- The user chose an optional `MCP_SERVER_HOST` configuration. Existing empty/default behavior remains unchanged for deployments; the Inspector harness sets it to `127.0.0.1`.
+- The user chose Ubuntu GitHub runner support only. Local macOS portability is not a Tier 2 requirement, so the harness may use utilities and timeout behavior available on `ubuntu-latest`.
+- The Node major remains under discussion: distinguish the absolute latest Current release from the latest patch of a selected supported/LTS line.
+
+### 2026-07-21 — CI toolchain and bookkeeping finalized
+- The user chose the latest patch of the Node 24 LTS line, not the absolute latest Current Node major or an exact patch. Inspector's `>=22.7.5` engine requirement remains satisfied.
+- Follow repository convention with `actions/checkout@v4`, `actions/setup-go@v5`, and `actions/setup-node@v4`; enable Go and npm caches, with npm keyed by the committed Inspector lockfile.
+- Document the Inspector pin, workflow, update process, and local/CI commands in `guardrails/README.md`. Do not add the shell workflow to the Go-only `guardrails/tests.txt` inventory and do not create a second protocol inventory file.
+- Validate the harness and workflow with `bash -n`, ShellCheck, and actionlint, then run the focused Inspector lane and existing Go verification.
+- The Tier 2 design interview is complete; implementation has not started.
+
+### 2026-07-21 — Implementation started
+- The user approved implementation of the finalized Inspector V1 protocol lane.
+- Work is split across optional bind-host support, the pinned CLI-only Inspector harness, and the separate required workflow/policy surface. Scope exclusions agreed during planning remain unchanged.
+
+### 2026-07-21 — Protocol harness tracking
+- The repository ignores new root-level scripts by default. `.gitignore` now admits only `scripts/test-mcp-protocol.sh`, keeping the agreed reusable harness path without exposing unrelated local scripts.
+
+### 2026-07-21 — Implementation verified
+- The planned source areas had not drifted from the planning baseline before implementation.
+- Inspector 1.0.0 resolves package metadata relative to its working directory, so the isolated adapter runs the official CLI launcher from its package build directory.
+- Agent CI exposed two runner-image assumptions. The workflow now uses `bash -n` instead of assuming ShellCheck is installed, and the harness uses Node to preflight the exact loopback bind instead of assuming `ss` is installed. ShellCheck remains a documented maintainer check.
+- Agent CI passed both `guardrails / contract` and `protocol / inspector`; the protocol lane exercised every agreed surface against the production binary.
+- Focused guardrails, the full Go suite, vet, build, tidy diff, npm lockfile installation, Inspector version verification, ShellCheck, and actionlint passed locally. Two modified entries in the shared Go module cache were independently downloaded and verified in an isolated cache.
+- `README.md` documents `MCP_SERVER_HOST`. No `docs/`, `manifest.json`, or companion `SigNoz/agent-skills` change is needed because the stdio manifest and taught MCP tool contracts are unchanged.
+- Implementation is complete and remains `In Progress` until the change is delivered; the required branch-check setting is a post-merge administrative step.
+
+## Open Questions
+- [x] Without a committed snapshot, should pull-request CI generate and compare the base and head catalogs at runtime, or avoid historical catalog comparison entirely? Resolved: skip historical catalog comparison and the complete catalog branch.
+- [x] Should the official conformance suite run alongside Inspector V1, and when should it become a required check? Resolved: omit it until a stable release is available.
+- [x] Should `protocol / inspector` become a required branch check or remain advisory? Resolved: require it after its first successful default-branch run.
+- [x] In addition to every pull request, should the Inspector workflow support manual dispatch or a schedule? Resolved: support manual dispatch and omit scheduled runs.
+- [x] Which exact Cursor, Claude Code, and Codex versions should become the first blocking pins? Resolved for Tier 2: defer all three client lanes and decide versions in a linked follow-up.
+- [x] Which repository/environment secrets and live SigNoz environment should Tranche D use? Resolved for Tier 2: move this decision to the linked live-upstream follow-up.
+- [x] Which conformance scenarios, if any, are legitimate expected failures with the pinned mcp-go version? Resolved for Tier 2: conformance is deferred until a stable release, so no baseline is created now.
+- [x] Who owns the weekly Devin marketplace check and where should its result be recorded? Resolved for Tier 2: move ownership and recording policy to the linked Devin follow-up.

--- a/plans/mcp-tier-2-protocol-client-lanes.plan.md
+++ b/plans/mcp-tier-2-protocol-client-lanes.plan.md
@@ -1,0 +1,146 @@
+# Plan: MCP Tier 2 Inspector V1 Protocol Lane
+
+## Status
+In Progress
+
+## Planning Baseline
+- Priority: P1
+- Estimated effort: Medium, one pull request
+- Risk: Low-to-medium; the work adds one protocol CI lane without changing the public MCP contract
+- Planned from: `5fc09a9` (`refactor(mcp): clarify full catalog metadata (#248)`), 2026-07-20
+- Depends on: merged PRs #249 and #248
+
+Before implementing any tranche, confirm that relevant code has not drifted:
+
+`git diff --stat 5fc09a9..HEAD -- internal/mcp-server internal/handler/tools guardrails manifest.json .github/workflows tools scripts cmd plans/mcp-tier-2-protocol-client-lanes.*`
+
+If it has, update this plan and append the reason to the context file before coding.
+
+## Context
+Tier 1 makes selected wire budgets, duplicate registration, resource pointers, retry safety, and result serialization visible in blocking pull-request CI. Tier 2 now asks one narrower question: does the real HTTP server interoperate with Inspector V1 over Streamable HTTP?
+
+Tier 2 deliberately does not add a complete catalog oracle, snapshot, historical catalog comparison, migration ledger, registration-composition refactor, or expanded manifest parity.
+
+## Goals
+- Exercise Streamable HTTP with pinned MCP Inspector V1 on every pull request.
+
+## Non-goals
+- Building the later model-based reviewer agent.
+- Completing the remaining Tier 1 per-tool response budgets or exhaustive 401/403 coded-error matrix.
+- Adding a complete catalog oracle, snapshot, base/head comparison, migration ledger, registration-composition refactor, or expanded manifest parity.
+- Running the MCP conformance suite before it has a stable release.
+- Running protected Cursor, Claude Code, or Codex discovery/invocation lanes.
+- Changing tool names, schemas, prompts, resources, or product behavior merely to make a compatibility test pass.
+- Running paid/vendor-secret or live-SigNoz jobs on untrusted pull-request code.
+- Live SigNoz upstream-contract automation, manual Devin marketplace checks, or next-protocol probes; these are linked follow-ups with different ownership and trust boundaries.
+- Adding CODEOWNERS.
+
+## Current State to Preserve
+- `guardrails/tests.txt` is the exact Tier 1 guardrail inventory and `guardrails/README.md` is the central reviewer guide.
+- `.github/workflows/guardrails.yaml` is an unprivileged, secret-free pull-request workflow. Tier 2 per-PR jobs must retain that trust boundary.
+- The HTTP server exposes `/mcp` and `/readyz`. A local protocol job can use a dummy SigNoz URL/API key with OAuth and analytics disabled; no real SigNoz credential is needed for protocol checks.
+
+## Delivery Plan
+
+### Inspector V1 protocol lane
+
+#### 1. Pin the protocol toolchain
+- Add `tools/mcp-ci/package.json` and a committed lockfile.
+- Pin `@modelcontextprotocol/inspector-cli@1.0.0`, use the latest patch of the Node 24 LTS line, and install dependencies with `npm ci`.
+- Do not install the full V1 web UI/proxy package. Keep the CLI harness adapter isolated so Inspector V2's consolidated package can replace it without redesigning the server harness or assertions.
+- Do not use floating `latest` versions in blocking jobs.
+
+#### 2. Start the real HTTP server safely
+- Add one reusable Bash protocol harness under `scripts/` that:
+  - builds and starts the actual server in Streamable HTTP mode;
+  - uses port `18080` by default, supports a `MCP_PROTOCOL_PORT` override, and fails clearly before startup if the selected port is occupied;
+  - adds optional `MCP_SERVER_HOST` support with existing empty/default deployment behavior preserved, while the harness sets it to `127.0.0.1`;
+  - sets fixed test-only `SIGNOZ_URL` and `SIGNOZ_API_KEY` values, with OAuth and analytics disabled;
+  - waits for `/readyz` with a bounded timeout;
+  - prints the failed phase, relevant Inspector stderr/JSON, and a bounded server-log tail on failure;
+  - always terminates the process through a cleanup trap.
+- Bound readiness to 30 seconds and every raw/Inspector command to 60 seconds. Poll only readiness; do not retry protocol commands.
+- On cleanup, send TERM to the captured server PID, wait up to five seconds, then force-stop only that PID if still running.
+- Do not upload workflow artifacts. Print a concise summary on success and always remove temporary files during cleanup.
+- Keep this harness backend-independent. Use `signoz_search_docs` with the embedded docs index and assert its result envelope rather than exact ranked prose.
+- Do not configure Inspector request auth headers or add a test-only auth bypass; use the production configured-credential fallback.
+- Target `ubuntu-latest`; local macOS portability is not required for this harness.
+
+#### 3. Exercise MCP Inspector
+- Against `/mcp`, exercise `tools/list`, `resources/list`, resource-template listing, `prompts/list`, and one selected `tools/call`.
+- Pass the Streamable HTTP URL, transport, method, and arguments directly as CLI flags; do not generate an Inspector config file.
+- Require every list command to return valid JSON and a non-empty collection. Validate each item's minimal identity fields: tool/prompt `name`, resource `uri` and `name`, and template URI plus `name`.
+- Require `tools/list` to contain `signoz_search_docs`; do not pin counts, complete inventories, descriptions, schemas, or ordering.
+- Use `signoz_search_docs` for the deterministic tool call; it requires no live SigNoz backend or external network access after the embedded index is ready.
+- Call it with `searchText: "docker"`, `searchContext: "How do I send Docker logs to SigNoz?"`, and `limit: 1`.
+- Require `isError` to be absent or false, structured content with a non-empty `results` array, and non-empty text content. Do not pin the first result or any ranked content.
+- Read `signoz://docs/sitemap`, get `debug_service_errors` with synthetic `service`/`timeRange` arguments, and call `logging/setLevel`. Require successful, non-empty resource/prompt responses without pinning their generated content.
+- Require valid machine-readable results on every advertised surface and a successful tool result envelope. Do not pin exact catalog counts, descriptions, schemas, or ranked documentation text.
+- Do not claim semantic catalog compatibility or treat process exit alone as sufficient.
+- Use a minimal raw protocol probe for the initialize result because Inspector V1's CLI does not expose it. Assert negotiated version, capabilities, stable server identity, and instructions through that probe.
+- Implement the probe inside the Bash harness with `curl` and `jq`; do not add a separate Node or Go probe program.
+- Request `application/json`, require HTTP 200 plus JSON content type, and verify that no `Mcp-Session-Id` response header is issued.
+- Pin protocol version `2025-11-25` and server name `SigNozMCP`; require non-empty server version and instructions plus tools, resources, prompts, and logging capabilities.
+- Confirm the stateless server does not require a session ID. Do not pin the complete initialize response, exact server version, or instruction text.
+- Fail on malformed JSON, missing surfaces, protocol errors, or an unexpected result envelope.
+- Upgrade to Inspector V2 only through a separate reviewed dependency change after a stable V2 release passes the same assertions.
+
+#### 4. Add the workflow check
+- Add the separate `.github/workflows/mcp-protocol.yaml` on every `pull_request` targeting `main`, with no path filters, plus `workflow_dispatch` for manual diagnostics.
+- Set workflow name `protocol` and job name `inspector` so the stable check name is `protocol / inspector`.
+- Keep pull-request jobs unprivileged with `contents: read` and no secrets.
+- Set the job timeout to 10 minutes.
+- Use `actions/checkout@v4`, `actions/setup-go@v5` with Go `1.25` caching, and `actions/setup-node@v4` with Node `24` plus npm caching keyed by `tools/mcp-ci/package-lock.json`.
+- Keep Tier 1 in `.github/workflows/guardrails.yaml`; do not add the Node toolchain or Inspector lifecycle to that workflow.
+- Document Inspector policy and maintenance under `guardrails/README.md`.
+- After the workflow succeeds on the default branch, add the exact `protocol / inspector` check to `main` branch protection as a separate administrative step.
+- Do not use `continue-on-error` or an expected-failure bypass.
+- Do not add a scheduled trigger.
+
+## Linked Follow-ups Outside Tier 2
+- Add protected Cursor, Claude Code, and Codex discovery/invocation lanes with explicit version, credential, cost, and ownership policy.
+- Adopt the official MCP conformance suite after it publishes a stable release.
+- Live SigNoz upstream-contract automation, with dedicated credentials, representative query/CRUD coverage, and confirmed cleanup.
+- A manual Devin marketplace procedure with an explicit owner and recording location.
+- A nonblocking next-protocol probe once the draft is supported well enough to exercise meaningfully.
+
+These follow-ups must be tracked explicitly, but they do not block the Inspector V1 Tier 2 lane.
+
+## Expected Files
+- `internal/config/config.go` and tests — optional `MCP_SERVER_HOST`, preserving the existing default listener behavior.
+- `internal/mcp-server/server.go` and focused tests — apply the optional host when constructing the HTTP listen address.
+- `README.md` — document `MCP_SERVER_HOST` and its unchanged default behavior.
+- `guardrails/README.md` — Inspector pin, policy, required-check promotion, update procedure, and verification commands. `guardrails/tests.txt` does not change.
+- `tools/mcp-ci/package.json`, lockfile, and `.gitignore` — pinned Inspector V1 toolchain without vendored dependencies.
+- `scripts/test-mcp-protocol.sh` — bounded Ubuntu production-server and Inspector harness.
+- `.gitignore` — track the reviewed protocol harness while keeping other root scripts ignored.
+- `.github/workflows/mcp-protocol.yaml` — secret-free per-PR and manual Inspector lane; no schedule.
+- `plans/mcp-tier-2-protocol-client-lanes.*` — finalized design record committed with the implementation.
+
+## Verification
+
+### Inspector V1 lane
+- Run the local server harness from a clean checkout and prove it always exits.
+- Run the pinned Inspector list/call sequence and require valid machine-readable results.
+- Run `bash -n scripts/test-mcp-protocol.sh`.
+- Run ShellCheck on `scripts/test-mcp-protocol.sh`.
+- Run `actionlint .github/workflows/mcp-protocol.yaml`.
+- Run `npm ci` using only the committed lockfile and verify installed CLI versions equal the pins.
+
+### Final repository checks
+- `git diff --check`
+- `go test -count=1 -run '^TestGuardrail_' ./...`
+- `go test -count=1 ./...`
+- `go vet ./...`
+- `go build ./...`
+- `go mod tidy -diff`
+- `go mod verify`
+- Explicit PR-summary statement on `README.md`/`docs/`/`manifest.json` updates and whether `SigNoz/agent-skills` needs a companion change
+
+## Stop Conditions
+- Stop if the pinned Inspector cannot provide stable machine-readable output; document and design the smallest explicit probe instead of parsing prose.
+
+## Success Criteria
+- Inspector V1 exercises initialization, tool discovery/invocation, resource discovery/read, resource-template discovery, prompt discovery/get, and logging level against the real HTTP server without secrets.
+- `protocol / inspector` is required for pull requests targeting `main` after its successful bootstrap run.
+- Human reviewers can find the Inspector pin and protocol policy under `guardrails/`.

--- a/scripts/test-mcp-protocol.sh
+++ b/scripts/test-mcp-protocol.sh
@@ -1,0 +1,280 @@
+#!/usr/bin/env bash
+
+set -Eeuo pipefail
+
+ROOT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+MCP_PROTOCOL_PORT=${MCP_PROTOCOL_PORT:-18080}
+MCP_PROTOCOL_HOST=127.0.0.1
+MCP_URL="http://${MCP_PROTOCOL_HOST}:${MCP_PROTOCOL_PORT}/mcp"
+READY_URL="http://${MCP_PROTOCOL_HOST}:${MCP_PROTOCOL_PORT}/readyz"
+COMMAND_TIMEOUT_SECONDS=60
+READINESS_TIMEOUT_SECONDS=30
+INSPECTOR_VERSION=1.0.0
+
+PROTOCOL_TMP_DIR=""
+SERVER_PID=""
+CURRENT_PHASE="setup"
+CURRENT_STDOUT=""
+CURRENT_STDERR=""
+SERVER_LOG=""
+
+cleanup() {
+  local status=$?
+  trap - EXIT INT TERM
+
+  if [[ $status -ne 0 ]]; then
+    printf 'MCP protocol check failed during: %s\n' "$CURRENT_PHASE" >&2
+    if [[ -n "$CURRENT_STDOUT" && -s "$CURRENT_STDOUT" ]]; then
+      printf '%s\n' '--- command stdout ---' >&2
+      sed -n '1,240p' "$CURRENT_STDOUT" >&2
+    fi
+    if [[ -n "$CURRENT_STDERR" && -s "$CURRENT_STDERR" ]]; then
+      printf '%s\n' '--- command stderr ---' >&2
+      sed -n '1,240p' "$CURRENT_STDERR" >&2
+    fi
+    if [[ -n "$SERVER_LOG" && -s "$SERVER_LOG" ]]; then
+      printf '%s\n' '--- server log (last 120 lines) ---' >&2
+      tail -n 120 "$SERVER_LOG" >&2
+    fi
+  fi
+
+  if [[ -n "$SERVER_PID" ]] && kill -0 "$SERVER_PID" 2>/dev/null; then
+    kill -TERM "$SERVER_PID" 2>/dev/null || true
+    for _ in {1..5}; do
+      if ! kill -0 "$SERVER_PID" 2>/dev/null; then
+        break
+      fi
+      sleep 1
+    done
+    if kill -0 "$SERVER_PID" 2>/dev/null; then
+      kill -KILL "$SERVER_PID" 2>/dev/null || true
+    fi
+    wait "$SERVER_PID" 2>/dev/null || true
+  fi
+
+  if [[ -n "$PROTOCOL_TMP_DIR" && -d "$PROTOCOL_TMP_DIR" ]]; then
+    rm -r "$PROTOCOL_TMP_DIR"
+  fi
+
+  exit "$status"
+}
+
+trap cleanup EXIT
+trap 'exit 130' INT TERM
+
+fail() {
+  printf '%s\n' "$1" >"$CURRENT_STDERR"
+  return 1
+}
+
+run_timed() {
+  local phase=$1
+  local stdout_file=$2
+  local stderr_file=$3
+  shift 3
+
+  CURRENT_PHASE=$phase
+  CURRENT_STDOUT=$stdout_file
+  CURRENT_STDERR=$stderr_file
+  timeout --signal=TERM --kill-after=5s "${COMMAND_TIMEOUT_SECONDS}s" "$@" >"$stdout_file" 2>"$stderr_file"
+}
+
+run_inspector() {
+  local phase=$1
+  local output_file=$2
+  shift 2
+
+  local inspector_stderr="${output_file}.stderr"
+  CURRENT_PHASE=$phase
+  CURRENT_STDOUT=$output_file
+  CURRENT_STDERR=$inspector_stderr
+
+  # Inspector 1.0.0 resolves its package metadata from this working directory.
+  (
+    cd "$ROOT_DIR/tools/mcp-ci/node_modules/@modelcontextprotocol/inspector-cli/build"
+    timeout --signal=TERM --kill-after=5s "${COMMAND_TIMEOUT_SECONDS}s" \
+      ./cli.js --cli --transport http "$MCP_URL" "$@"
+  ) >"$output_file" 2>"$inspector_stderr"
+}
+
+assert_json() {
+  local phase=$1
+  local json_file=$2
+  local filter=$3
+
+  CURRENT_PHASE=$phase
+  CURRENT_STDOUT=$json_file
+  CURRENT_STDERR="${json_file}.assert.stderr"
+  if ! jq -e "$filter" "$json_file" >/dev/null 2>"$CURRENT_STDERR"; then
+    printf 'JSON assertion failed: %s\n' "$filter" >>"$CURRENT_STDERR"
+    return 1
+  fi
+}
+
+for dependency in curl go jq node timeout; do
+  if ! command -v "$dependency" >/dev/null 2>&1; then
+    printf 'Required command is unavailable: %s\n' "$dependency" >&2
+    exit 1
+  fi
+done
+
+if [[ ! "$MCP_PROTOCOL_PORT" =~ ^[0-9]+$ ]] || ((MCP_PROTOCOL_PORT < 1 || MCP_PROTOCOL_PORT > 65535)); then
+  printf 'MCP_PROTOCOL_PORT must be an integer between 1 and 65535\n' >&2
+  exit 1
+fi
+
+PROTOCOL_TMP_DIR=$(mktemp -d)
+SERVER_LOG="$PROTOCOL_TMP_DIR/server.log"
+CURRENT_STDOUT="$PROTOCOL_TMP_DIR/setup.stdout"
+CURRENT_STDERR="$PROTOCOL_TMP_DIR/setup.stderr"
+
+if ! node -e '
+  const net = require("node:net");
+  const server = net.createServer();
+  server.once("error", () => process.exit(1));
+  server.listen({host: process.argv[1], port: Number(process.argv[2])}, () => server.close());
+' "$MCP_PROTOCOL_HOST" "$MCP_PROTOCOL_PORT" >"$CURRENT_STDOUT" 2>"$CURRENT_STDERR"; then
+  fail "Port ${MCP_PROTOCOL_PORT} is already occupied"
+fi
+
+node -e '
+  const current = process.versions.node.split(".").map(Number);
+  const minimum = [22, 7, 5];
+  const supported = current.some((value, index) => value > minimum[index] && current.slice(0, index).every((part, i) => part === minimum[i])) || current.every((value, index) => value === minimum[index]);
+  if (!supported) {
+    console.error("Node >=" + minimum.join(".") + " is required; found " + process.versions.node);
+    process.exit(1);
+  }
+' >"$CURRENT_STDOUT" 2>"$CURRENT_STDERR"
+
+installed_inspector_version=$(node -p "require('$ROOT_DIR/tools/mcp-ci/node_modules/@modelcontextprotocol/inspector-cli/package.json').version")
+if [[ "$installed_inspector_version" != "$INSPECTOR_VERSION" ]]; then
+  fail "Inspector CLI ${INSPECTOR_VERSION} is required; found ${installed_inspector_version}"
+fi
+
+CURRENT_PHASE="build server"
+go build -o "$PROTOCOL_TMP_DIR/signoz-mcp-server" ./cmd/server >"$CURRENT_STDOUT" 2>"$CURRENT_STDERR"
+
+env \
+  TRANSPORT_MODE=http \
+  MCP_SERVER_HOST="$MCP_PROTOCOL_HOST" \
+  MCP_SERVER_PORT="$MCP_PROTOCOL_PORT" \
+  SIGNOZ_URL=https://example.invalid \
+  SIGNOZ_API_KEY=protocol-test-key \
+  OAUTH_ENABLED=false \
+  ANALYTICS_ENABLED=false \
+  OTEL_TRACES_EXPORTER=none \
+  OTEL_METRICS_EXPORTER=none \
+  "$PROTOCOL_TMP_DIR/signoz-mcp-server" >"$SERVER_LOG" 2>&1 &
+SERVER_PID=$!
+
+CURRENT_PHASE="server readiness"
+CURRENT_STDOUT="$PROTOCOL_TMP_DIR/readiness.stdout"
+CURRENT_STDERR="$PROTOCOL_TMP_DIR/readiness.stderr"
+readiness_deadline=$((SECONDS + READINESS_TIMEOUT_SECONDS))
+until curl --fail --silent --show-error --max-time 2 "$READY_URL" >"$CURRENT_STDOUT" 2>"$CURRENT_STDERR"; do
+  if ! kill -0 "$SERVER_PID" 2>/dev/null; then
+    fail "Server exited before becoming ready"
+  fi
+  if ((SECONDS >= readiness_deadline)); then
+    fail "Server did not become ready within ${READINESS_TIMEOUT_SECONDS} seconds"
+  fi
+  sleep 1
+done
+
+initialize_body="$PROTOCOL_TMP_DIR/initialize.json"
+initialize_headers="$PROTOCOL_TMP_DIR/initialize.headers"
+initialize_status="$PROTOCOL_TMP_DIR/initialize.status"
+run_timed "initialize request" "$initialize_status" "$PROTOCOL_TMP_DIR/initialize.stderr" \
+  curl --silent --show-error --max-time "$COMMAND_TIMEOUT_SECONDS" \
+  --output "$initialize_body" --dump-header "$initialize_headers" --write-out '%{http_code}' \
+  --header 'Content-Type: application/json' --header 'Accept: application/json' \
+  --data '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"signoz-protocol-ci","version":"1.0.0"}}}' \
+  "$MCP_URL"
+
+CURRENT_PHASE="initialize HTTP contract"
+CURRENT_STDOUT=$initialize_body
+CURRENT_STDERR="$PROTOCOL_TMP_DIR/initialize-contract.stderr"
+if [[ $(<"$initialize_status") != "200" ]]; then
+  fail "Initialize returned HTTP $(<"$initialize_status"), expected 200"
+fi
+if ! grep -Eiq '^content-type:[[:space:]]*application/json([[:space:]]*;|[[:space:]]*\r?$)' "$initialize_headers"; then
+  fail "Initialize response did not use an application/json content type"
+fi
+if grep -Eiq '^mcp-session-id:' "$initialize_headers"; then
+  fail "Stateless initialize unexpectedly returned Mcp-Session-Id"
+fi
+assert_json "initialize JSON contract" "$initialize_body" '
+  .jsonrpc == "2.0" and
+  .id == 1 and
+  .result.protocolVersion == "2025-11-25" and
+  .result.serverInfo.name == "SigNozMCP" and
+  (.result.serverInfo.version | type == "string" and length > 0) and
+  (.result.instructions | type == "string" and length > 0) and
+  (.result.capabilities | has("tools") and has("resources") and has("prompts") and has("logging"))
+'
+
+tools_json="$PROTOCOL_TMP_DIR/tools.json"
+run_inspector "Inspector tools/list" "$tools_json" --method tools/list
+assert_json "tools/list contract" "$tools_json" '
+  (.tools | type == "array" and length > 0) and
+  all(.tools[]; (.name | type == "string" and length > 0)) and
+  any(.tools[]; .name == "signoz_search_docs")
+'
+
+resources_json="$PROTOCOL_TMP_DIR/resources.json"
+run_inspector "Inspector resources/list" "$resources_json" --method resources/list
+assert_json "resources/list contract" "$resources_json" '
+  (.resources | type == "array" and length > 0) and
+  all(.resources[]; (.name | type == "string" and length > 0) and (.uri | type == "string" and length > 0))
+'
+
+templates_json="$PROTOCOL_TMP_DIR/resource-templates.json"
+run_inspector "Inspector resources/templates/list" "$templates_json" --method resources/templates/list
+assert_json "resources/templates/list contract" "$templates_json" '
+  (.resourceTemplates | type == "array" and length > 0) and
+  all(.resourceTemplates[]; (.name | type == "string" and length > 0) and (.uriTemplate | type == "string" and length > 0))
+'
+
+prompts_json="$PROTOCOL_TMP_DIR/prompts.json"
+run_inspector "Inspector prompts/list" "$prompts_json" --method prompts/list
+assert_json "prompts/list contract" "$prompts_json" '
+  (.prompts | type == "array" and length > 0) and
+  all(.prompts[]; (.name | type == "string" and length > 0))
+'
+
+tool_call_json="$PROTOCOL_TMP_DIR/tool-call.json"
+run_inspector "Inspector tools/call" "$tool_call_json" \
+  --method tools/call --tool-name signoz_search_docs \
+  --tool-arg searchText=docker \
+  --tool-arg 'searchContext=How do I send Docker logs to SigNoz?' \
+  --tool-arg limit=1
+assert_json "tools/call contract" "$tool_call_json" '
+  ((.isError // false) == false) and
+  (.structuredContent.results | type == "array" and length > 0) and
+  any(.content[]; .type == "text" and (.text | type == "string" and length > 0))
+'
+
+resource_read_json="$PROTOCOL_TMP_DIR/resource-read.json"
+run_inspector "Inspector resources/read" "$resource_read_json" \
+  --method resources/read --uri signoz://docs/sitemap
+assert_json "resources/read contract" "$resource_read_json" '
+  (.contents | type == "array" and length > 0) and
+  any(.contents[]; ((.text // .blob // "") | type == "string" and length > 0))
+'
+
+prompt_get_json="$PROTOCOL_TMP_DIR/prompt-get.json"
+run_inspector "Inspector prompts/get" "$prompt_get_json" \
+  --method prompts/get --prompt-name debug_service_errors \
+  --prompt-args service=checkout --prompt-args timeRange=1h
+assert_json "prompts/get contract" "$prompt_get_json" '
+  (.messages | type == "array" and length > 0) and
+  any(.messages[]; .content.type == "text" and (.content.text | type == "string" and length > 0))
+'
+
+logging_json="$PROTOCOL_TMP_DIR/logging.json"
+run_inspector "Inspector logging/setLevel" "$logging_json" \
+  --method logging/setLevel --log-level info
+assert_json "logging/setLevel contract" "$logging_json" 'type == "object"'
+
+printf '%s\n' 'MCP protocol check passed: initialize, tools, resources, templates, prompts, and logging'

--- a/scripts/test-mcp-protocol.sh
+++ b/scripts/test-mcp-protocol.sh
@@ -188,7 +188,7 @@ initialize_status="$PROTOCOL_TMP_DIR/initialize.status"
 run_timed "initialize request" "$initialize_status" "$PROTOCOL_TMP_DIR/initialize.stderr" \
   curl --silent --show-error --max-time "$COMMAND_TIMEOUT_SECONDS" \
   --output "$initialize_body" --dump-header "$initialize_headers" --write-out '%{http_code}' \
-  --header 'Content-Type: application/json' --header 'Accept: application/json' \
+  --header 'Content-Type: application/json' --header 'Accept: application/json, text/event-stream' \
   --data '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"signoz-protocol-ci","version":"1.0.0"}}}' \
   "$MCP_URL"
 

--- a/tools/mcp-ci/.gitignore
+++ b/tools/mcp-ci/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/tools/mcp-ci/package-lock.json
+++ b/tools/mcp-ci/package-lock.json
@@ -1,0 +1,1324 @@
+{
+  "name": "signoz-mcp-protocol-ci",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "signoz-mcp-protocol-ci",
+      "version": "1.0.0",
+      "devDependencies": {
+        "@modelcontextprotocol/inspector-cli": "1.0.0"
+      },
+      "engines": {
+        "node": ">=22.7.5"
+      }
+    },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.14",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
+      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
+    "node_modules/@modelcontextprotocol/inspector-cli": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/inspector-cli/-/inspector-cli-1.0.0.tgz",
+      "integrity": "sha512-Pz6KnRkqrDd7z3SKlTKf6fTiVZbW+N/TqhDdyq23kuUPHOUTNcL6ha07MIUYub4oHKHXPOTGHA+XV4SeyG3dlg==",
+      "dev": true,
+      "license": "SEE LICENSE IN LICENSE",
+      "dependencies": {
+        "@modelcontextprotocol/sdk": "^1.25.2",
+        "commander": "^13.1.0",
+        "express": "^5.2.1",
+        "spawn-rx": "^5.1.2"
+      },
+      "bin": {
+        "mcp-inspector-cli": "build/cli.js"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/body-parser": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
+      "integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^2.0.0",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.1",
+        "iconv-lite": "^0.7.2",
+        "on-finished": "^2.4.1",
+        "qs": "^6.15.2",
+        "raw-body": "^3.0.2",
+        "type-is": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/body-parser/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/commander": {
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-13.1.0.tgz",
+      "integrity": "sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.1.0.tgz",
+      "integrity": "sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.6.0.tgz",
+      "integrity": "sha512-XKJXDsASUOo0LLtFwW5hCcQGH0N4WQc/Rn8/Pvoia+TJFOkkFPvrtW9lZOeeNcxQJspvOIERMwiRLsVFlhHEkA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "ip-address": "^10.2.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/hono": {
+      "version": "4.12.31",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.31.tgz",
+      "integrity": "sha512-zJIHFrl6bq3RDd2YusFNCDlM8qUprxKswyi/OPzPyzKDdyBXDqWx8bZlZ7R+saTdSTatUmb3O7K4SspGPaEOQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.3.tgz",
+      "integrity": "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/jose": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
+      "integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "dev": true,
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
+      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.3.0.tgz",
+      "integrity": "sha512-hek2mFQpPuI4E1BBKrSto+BU3e3x4xuarsbiwr3+lf7p44juvFMV0XFWQAP3xUyqXA4RrXLIoaSUGbSt056ZMw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/rxjs": {
+      "version": "7.8.2",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
+      "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/spawn-rx": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/spawn-rx/-/spawn-rx-5.1.2.tgz",
+      "integrity": "sha512-/y7tJKALVZ1lPzeZZB9jYnmtrL7d0N2zkorii5a7r7dhHkWIuLTzZpZzMJLK1dmYRgX/NCc4iarTO3F7BS2c/A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.3.7",
+        "rxjs": "^7.8.1"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD"
+    },
+    "node_modules/type-is": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+      "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^2.0.0",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/type-is/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "dev": true,
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
+      }
+    }
+  }
+}

--- a/tools/mcp-ci/package.json
+++ b/tools/mcp-ci/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "signoz-mcp-protocol-ci",
+  "version": "1.0.0",
+  "private": true,
+  "engines": {
+    "node": ">=22.7.5"
+  },
+  "devDependencies": {
+    "@modelcontextprotocol/inspector-cli": "1.0.0"
+  }
+}


### PR DESCRIPTION
## Summary

- add a secret-free `protocol / inspector` workflow for every pull request to `main` and manual diagnostics
- pin `@modelcontextprotocol/inspector-cli@1.0.0` and exercise initialization, tools, resources, templates, prompts, and logging against the production HTTP server
- add optional `MCP_SERVER_HOST` configuration so CI can bind to loopback without changing the existing all-interface default
- document the centralized protocol policy, maintenance commands, and post-merge required-check step under `guardrails/`

## Why

The existing Go tests validate server behavior in process, but they do not prove that the production binary remains interoperable with a real MCP client over Streamable HTTP. This adds one deliberately shallow Inspector V1 lane without introducing catalog snapshots, conformance baselines, vendor-client jobs, live credentials, or CODEOWNERS.

## Impact

Pull requests now receive a deterministic compatibility signal covering every advertised MCP surface. HTTP deployments retain their current bind behavior unless `MCP_SERVER_HOST` is explicitly configured.

## Validation

- Agent CI: `guardrails / contract`
- Agent CI: `protocol / inspector`
- `go test -count=1 ./...`
- `actionlint .github/workflows/mcp-protocol.yaml`
- `bash -n scripts/test-mcp-protocol.sh`
- `shellcheck scripts/test-mcp-protocol.sh`
- clean `npm ci --ignore-scripts` with Inspector `1.0.0`
- independent agent review: no actionable findings

## Documentation and metadata

- updated `README.md` for `MCP_SERVER_HOST`
- updated `guardrails/README.md` with protocol review and maintenance guidance
- no `docs/` or `manifest.json` change is needed because the stdio manifest and MCP catalog are unchanged
- no companion `SigNoz/agent-skills` change is needed because no taught tool contract changed

After this workflow succeeds on `main`, configure the exact `protocol / inspector` check as required branch protection.
