### PR TITLE
docs(mcp): add best-practices guide

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,6 +35,12 @@ plans/
 
 - Avoid long inline code comments unless needed; keep comments concise and non-redundant.
 
+## MCP Contract Changes
+
+Changes to client-visible MCP surfaces must follow `docs/mcp-best-practices.md`
+and its section 11 review checklist. Deterministic budgets and CI mechanics stay
+in `guardrails/README.md`.
+
 ## Guardrail Changes
 
 - Follow `guardrails/README.md`; keep policy in `policy.go`, the sorted `TestGuardrail_*` inventory in `tests.txt`, and package-sensitive tests beside their packages.

--- a/docs/mcp-best-practices.md
+++ b/docs/mcp-best-practices.md
@@ -1,0 +1,317 @@
+# MCP Best Practices
+
+This guide is the authoring standard for every client-visible MCP surface this
+server exposes: tool names, input/output schemas, descriptions, annotations,
+results, errors, resources, resource templates, prompts, and server
+instructions. It governs qualitative design judgment — the things a reviewer
+must weigh against a diff. Deterministic, countable enforcement (byte budgets,
+schema-shape inventories, retry/replay rules, URI resolution, telemetry
+measurement) lives in [`guardrails/README.md`](../guardrails/README.md) and CI;
+this guide never duplicates those numbers or commands.
+
+**Normative language.** `MUST`/`MUST NOT` are binding: violating one requires a
+justified exception recorded in the feature context log or PR description.
+`SHOULD`/`SHOULD NOT` are strong defaults: deviate only with a stated reason in
+the PR. `MAY` marks an explicitly permitted option. Rules carry stable rubric
+IDs (e.g. `SUR-1`); the PR checklist in section 11 is derived from them and is
+the rubric source for the advisory reviewer.
+
+## 1. Scope and agent-first principles
+
+The consumer of every surface here is an AI agent acting for a user. Design for
+the agent's decision sequence: choose the right surface, make a valid first
+call, interpret the result, recover from failure, and survive contract
+evolution.
+
+- **[SUR-1] Delivery universality.** The more critical a piece of guidance is
+  to a *correct first call*, the more universal and inline its placement MUST
+  be. Tool descriptions and schemas are the most widely delivered surfaces;
+  fewer clients read resources, and none can be assumed to read external docs.
+  Correctness-critical rules go on the tool/parameter surface; depth goes in
+  resources.
+- **[SUR-2] Mis-calls are contract feedback.** A reasonable or recurring agent
+  mis-call SHOULD be treated as evidence that the advertised contract needs
+  improvement (clearer description, tighter schema, better error recovery).
+- **[SUR-3] Fewer, sharper surfaces.** Prefer improving an existing surface
+  over adding a new one. Measure real use before investing in new tools,
+  resources, or prompts, and before removing existing ones.
+
+## 2. Choosing, naming, and annotating MCP surfaces
+
+- **[SUR-4]** Add a tool for a distinct *agent task*, not for a distinct
+  backend endpoint. Before adding one, compare: a parameter on an existing
+  tool, a resource, or a prompt. A new tool MUST justify why the agent needs a
+  separately selectable action.
+- **[SUR-5]** Names and descriptions MUST use agent/domain vocabulary
+  (`signoz_search_logs`, `signoz_list_alert_rules`), not backend route or
+  implementation vocabulary. Unavoidable backend terminology (e.g. the query
+  builder, Alertmanager) SHOULD be briefly explained where it appears rather
+  than banned.
+- **[SUR-6] Nearest-neighbor boundaries.** Every tool whose scope could be
+  confused with another MUST state the selection boundary against its nearest
+  neighbor(s) — as `signoz_search_traces` does against `signoz_aggregate_traces`
+  and `signoz_get_trace_details`. An agent reading only the descriptions should
+  never face two tools that both plausibly claim the same request.
+- **[SUR-7] Annotations are behavior-backed safety claims.** The advertised
+  read-only/destructive/idempotent triple MUST match what the handler actually
+  does, including side effects beyond the primary write (an update that also
+  sends a live test notification is not idempotent). Annotations are hints for
+  client policy, never an authorization or trust boundary.
+- **[SUR-8]** Collapse predictable read round-trips where it removes a likely
+  follow-up call (return IDs, names, and `webUrl` handles together). Mutations
+  MUST stay atomic and observable: one tool call represents one coherent
+  user-intended mutation. Any additional side effect MUST be declared in the
+  description and annotations and reported accurately in the result.
+
+## 3. Surface placement
+
+| Content | Surface |
+|---|---|
+| What the tool does, when to pick it over its nearest neighbor, critical pre-call caveats, pointers to discovery tools/resources | Tool description |
+| Field-local format, units, accepted forms, defaults, constraints, inter-field dependencies, short examples | Parameter description / input schema |
+| Result shape, handles (IDs, `webUrl`), pagination and truncation metadata | Output schema / result envelope |
+| Read-only / destructive / idempotent behavior | Tool annotations |
+| Routing rules and policies shared across several tools | Server instructions |
+| Long grammars, full schemas, complete worked examples, workflows, catalogs | Resources (`signoz://…`) |
+| Live per-entity content addressed by ID | Resource templates (`signoz://alert/{id}/summary`) |
+| Reusable user-invoked multi-step workflows | Prompts |
+| Immediate correction and recognized backend guidance for a failed call | Error result (text + structured fields) |
+
+- **[SUR-9]** Correctness-critical first-call rules MUST be inline on the
+  tool/parameter surface. Resources provide progressive disclosure and MAY be
+  recommended pre-reading, but MUST NOT be the only route to immediate repair
+  of a failed call.
+- **[SUR-10]** Gate a tool call only on authentication, consent, or
+  confirmation of destructive action. A tool MUST NOT hard-require an optional
+  documentation or resource fetch before it will work.
+
+## 4. Input schemas and parameter behavior
+
+- **[SCH-1] Loose in representation, strict in meaning.** Accept equivalent
+  representations (number-as-string, boolean-as-string, single-value-as-list)
+  only when the JSON Schema honestly advertises them, for example with a union
+  type. Descriptions MAY clarify accepted forms but cannot substitute for the
+  schema. Normalizing a form the advertised schema rejects makes the contract
+  dishonest; advertising a form the handler rejects makes it broken. Both
+  MUST NOT happen.
+- **[SCH-2]** Unparseable, ambiguous, or semantically invalid values MUST be
+  rejected with field-specific recovery guidance. A supplied-but-invalid value
+  MUST NOT be silently replaced with a default — silent substitution answers a
+  question the agent didn't ask.
+- **[SCH-3] Parity.** Schema, handler validation, defaults, examples, and the
+  `required` list MUST agree with each other and with runtime behavior. Shared
+  definitions and parity tests are the preferred mechanism; do not introduce
+  code generation solely for documentation.
+- **[SCH-4] Enums.** Use a schema enum only for values this server owns and
+  keeps stable (e.g. `signal`, `requestType`). Workspace- or backend-evolving
+  vocabularies (field keys, metric names, channel types that track the backend)
+  MUST instead point to a discovery tool (`signoz_get_field_keys`,
+  `signoz_get_field_values`) or resource.
+- **[SCH-5] `searchContext`.** Every tool's input schema MUST expose a
+  top-level `searchContext` string carrying the user's original request
+  verbatim. It MUST NOT appear in the JSON Schema `required` list and MUST NOT
+  be described as optional. (Mechanics for typed schemas are in `CLAUDE.md`.)
+- **[SCH-6]** Inputs SHOULD be shaped for the agent's task (flat, task-named
+  parameters like `filter`, `limit`, `start`/`end`), not mirror the backend
+  payload structure, except for deliberate body-carrying tools (dashboard/alert
+  create and update) where the resource definition *is* the domain object.
+
+## 5. Tool descriptions and examples
+
+- **[DSC-1]** Optimize a description for correct selection plus a successful
+  first call — not for maximal detail, and not for minimum byte count. Byte
+  budgets are enforced deterministically; within them, spend words where they
+  change agent behavior.
+- **[DSC-2]** Lead with intent and result ("Use this when the user wants …; it
+  returns …"). Name only the nearest confusing alternative(s), include
+  pre-call caveats that commonly break first calls (default time window,
+  workspace-specific fields), and give exact discovery pointers
+  (tool name or `signoz://` URI), as the existing tool descriptions do.
+- **[DSC-3]** Field-local detail — format, units, constraints, dependencies,
+  defaults, short examples — belongs on the parameter/schema surface, not in
+  the tool description.
+- **[DSC-4] Examples.** Every non-trivial tool or workflow MUST have at least
+  one realistic, executable example somewhere the agent can reach it
+  (tool/parameter description or a linked `signoz://` resource);
+  the same applies to any grammar, filter syntax, or ambiguous parameter
+  format. Self-evident scalar fields do not need examples. Examples MUST use
+  real SigNoz shapes and stay valid against the current handler.
+- **[DSC-5]** Descriptions MUST NOT contain backend routes, implementation
+  history, volatile catalogs (current workspace values, version tables), or
+  guarantees the handler does not enforce.
+
+## 6. Resources, resource templates, and server instructions
+
+- **[RES-1]** Use resources for content too long or too structured for a
+  description: query grammars (`signoz://logs/query-builder-guide`), payload
+  schemas and worked examples (`signoz://dashboard/widgets-examples`),
+  multi-step workflows. Use resource templates only for genuinely parameterized
+  live content (`signoz://alert/{id}/summary`).
+- **[RES-2]** Resource names and descriptions MUST state what the content is,
+  when an agent should read it, and which tools/workflows it supports — they
+  are selection surfaces, like tool descriptions.
+- **[RES-3]** Advertised URIs MUST stay stable, resolve to non-empty content of
+  the declared MIME type, be bounded in size, and require the same
+  authentication as the data they expose.
+- **[RES-4]** Inside a resource, put purpose and warnings before detail. For
+  content that mirrors mutable external material, record provenance and
+  freshness so staleness is detectable.
+- **[RES-5]** Server instructions are for routing and policies that span
+  several tools (signal selection, filter-key discovery, timestamp handling,
+  `webUrl` usage). Per-tool detail MUST NOT migrate into server instructions.
+
+## 7. Results, pagination, and partial success
+
+- **[OUT-1]** Return predictable envelopes. Include reusable handles — IDs,
+  names, `webUrl` deep links — when they remove a likely follow-up lookup.
+  Clients are told to use `webUrl` verbatim, so it MUST be correct and
+  tenant-scoped.
+- **[OUT-2] Read–modify–write.** Where the domain supports it (alerts,
+  dashboards, channels, views), the shape a read tool returns MUST be writable
+  back through the corresponding update tool without undocumented reshaping.
+- **[OUT-3]** Clamps, truncation, pagination, and known-incomplete data MUST be
+  explicit in machine-readable result metadata with the next step attached
+  (`pagination.hasMore`/`nextOffset`, `data.nextCursor`), never silent. An
+  agent that cannot see truncation will present partial data as complete.
+- **[OUT-4] Partial success** is legitimate only for genuinely independent
+  per-item work (one panel of several failing enrichment). Global failures —
+  authentication, permission, upstream unavailability — MUST surface as
+  top-level coded errors, never folded into per-item results.
+- **[OUT-5]** Passthrough tools that return upstream JSON verbatim MUST NOT
+  silently reshape it into a misleading local contract; either pass it through
+  honestly or own the envelope completely. Cross-boundary parsing may fail
+  open, but MUST pair with a WARN log or metric (see `CLAUDE.md`, "Testing
+  across external contracts").
+
+## 8. Errors and recovery
+
+- **[ERR-1]** Every tool error result MUST carry a stable machine-readable
+  category in `StructuredContent` (`code`: `VALIDATION_FAILED`, `UNAUTHORIZED`,
+  `NOT_FOUND`, `UPSTREAM_ERROR`, …) plus concise agent-readable text. Other MCP
+  surfaces MUST use their protocol-appropriate error channel with equally
+  stable semantics. Keep the code set small, add codes deliberately, and treat
+  removals/renames as breaking changes (section 10).
+- **[ERR-2]** Agent-correctable validation errors MUST name the failing field
+  or operation, explain what is wrong, state the accepted forms or
+  alternatives, and give the smallest next action — the canonical shape is
+  `Parameter validation failed: "<field>" <reason>`. Extra structured fields
+  (e.g. `missingKeys`) SHOULD be added when clients would otherwise
+  string-match prose.
+- **[ERR-3]** Put the immediate correction inline in the error; link a
+  resource or discovery tool for deeper guidance. Resource retrieval MUST NOT
+  be the only recovery path.
+- **[ERR-4]** Upstream authentication and permission failures MUST propagate
+  through the shared top-level coded path so clients can re-authenticate or
+  handle permissions — never hidden inside partial results or converted to
+  empty successes.
+- **[ERR-5]** Distinguish expected agent mistakes (invalid filter key → WARN
+  with recovery guidance in the result) from server/upstream faults (ERROR).
+  Neither may be dropped: fail open, never fail silent.
+- **[ERR-6] Backend guidance fidelity.** When a recognized SigNoz error
+  envelope contains actionable guidance, the MCP layer MUST preserve its
+  message, documentation URL, top-level and detail suggestions, detail
+  messages, and retry hints faithfully. Stable MCP classification and
+  tool-specific recovery MAY supplement that guidance but MUST NOT paraphrase,
+  contradict, or replace it. Bound the preserved content and filter secrets or
+  unsafe markup; malformed or unrecognized bodies fall back to the local coded
+  error contract rather than raw passthrough.
+
+## 9. Safety and security
+
+- **[SEC-1]** Every request MUST be authenticated and resolve its instance and
+  tenant scope from the request itself — never from cached caller identity. A
+  cross-tenant identifier in the arguments MUST NOT leak another tenant's
+  data; it fails like any other not-found/forbidden reference.
+- **[SEC-2]** Destructive actions MUST be explicit, narrowly scoped single
+  tools (`signoz_delete_dashboard` deletes exactly one dashboard by ID), with
+  irreversibility stated in the description and side effects observable in the
+  result. No tool may perform an undisclosed destructive side effect.
+- **[SEC-3]** Retry eligibility MUST derive from actual handler idempotency —
+  what the call does end-to-end — not from HTTP method or annotation wording
+  alone. (Replay behavior is guardrail-enforced; classifying a new tool
+  correctly is a review judgment.)
+
+## 10. Contract evolution and synchronized documentation
+
+The surface advertised at initialization is a stable executable promise.
+
+- **[CMP-1]** These are breaking changes and MUST NOT ship silently: removing
+  or renaming a tool, parameter, resource URI, or prompt; narrowing an
+  accepted type or format; making an optional parameter required; removing an
+  enum value; changing an annotation safety claim; changing a result envelope
+  clients parse; removing or renaming an error code.
+- **[CMP-2]** An intentional break MUST ship with an explicit compatibility
+  path and a migration note in the PR. Compatibility aliases (e.g. a silently
+  accepted legacy parameter name) MUST be retained until an explicit,
+  evidence-backed deprecation/removal decision documents the migration risk
+  and path — they are not promised forever, and each alias is contract
+  complexity to be tracked, not accumulated freely.
+- **[CMP-3]** When contracts overlap, production registration, validators,
+  `README.md`, `manifest.json`, `docs/`, and tests MUST change in the same
+  server PR (see the `CLAUDE.md` sync checklist). When the tool contract taught
+  by the companion `SigNoz/agent-skills` repository changes, create and link
+  its companion PR; internal or additive changes need no skills update.
+
+## 11. Evaluation and PR review checklist
+
+Deterministic facts — counts, byte budgets, schema compilation, URI integrity,
+protocol compatibility — stay in CI (`guardrails/`, Inspector checks). This
+section governs the judgment layer.
+
+- **[EVL-1]** A change to selection- or recovery-critical guidance
+  (descriptions, boundary language, error results, server instructions) SHOULD
+  be evaluated with direct, indirect, and negative prompts using comparable
+  model/catalog sessions before and after. Check the affected behaviors among
+  tool choice, argument construction, clarification, abstention, and recovery
+  from representative failed calls.
+- **[EVL-2]** Substantive changes to broad guidance (this guide, server
+  instructions) MUST be backed by evidence: eval results, recurring real
+  failures, or production usage. Do not canonize dated usage statistics in
+  this document.
+- **[EVL-3] Reviewer output.** The advisory reviewer (human or model) judges
+  the diff against this rubric. Findings MUST be diff-local and cite: rubric
+  ID, changed line, evidence, client impact, concrete repair, and confidence.
+  Countable violations belong to CI, not findings. Report at most the three
+  highest-priority findings; "no findings" is a valid result. Findings are
+  advisory, not blocking.
+
+### PR checklist
+
+For any PR touching a client-visible MCP surface, review the applicable items:
+
+**Surface choice & placement**
+- [ ] New surface justified over extending an existing one; names use agent/domain vocabulary; boundary vs nearest neighbor stated (SUR-3, SUR-4, SUR-5, SUR-6)
+- [ ] First-call-critical guidance inline, not resource-only; no optional-doc gating (SUR-1, SUR-9, SUR-10)
+- [ ] Annotations match end-to-end behavior; mutations are atomic and disclose/report all side effects (SUR-7, SUR-8)
+
+**Schemas**
+- [ ] Accepted representations honestly advertised; invalid values rejected with recovery, never silently defaulted; inputs are task-shaped, not backend-mirrored (SCH-1, SCH-2, SCH-6)
+- [ ] Schema, validation, defaults, examples, required-list agree (SCH-3)
+- [ ] Enums only for server-owned stable values; evolving vocab → discovery (SCH-4)
+- [ ] Top-level `searchContext`, not required, not described optional (SCH-5)
+
+**Descriptions & examples**
+- [ ] Description leads with intent/result; caveats and discovery pointers present; field detail on params (DSC-2, DSC-3)
+- [ ] Realistic executable example for non-trivial tools and syntax-heavy params; examples still valid (DSC-4)
+- [ ] No routes, history, volatile catalogs, or unenforced guarantees (DSC-5)
+
+**Resources & instructions**
+- [ ] Resource metadata says what/when/for-which-workflows; content leads with purpose and warnings and records provenance; URIs stable, typed, bounded, authenticated (RES-2, RES-3, RES-4)
+- [ ] Server instructions contain only cross-tool routing and policy (RES-5)
+
+**Results**
+- [ ] Handles returned where they save a lookup; reads write back cleanly (OUT-1, OUT-2)
+- [ ] Truncation/pagination explicit with next step; partial success only for independent items (OUT-3, OUT-4)
+
+**Errors**
+- [ ] Stable tool-error `code`; validation text names field, problem, accepted forms, next action (ERR-1, ERR-2)
+- [ ] Inline correction first; recognized backend guidance preserved safely and faithfully; auth/permission failures top-level (ERR-3, ERR-4, ERR-6)
+- [ ] Passthroughs remain faithful; fail-open parsing emits a WARN/metric (OUT-5, ERR-5)
+
+**Safety & security**
+- [ ] Per-request auth + tenant scoping; no cross-tenant leakage (SEC-1)
+- [ ] Destructive actions explicit, narrow, observable; retry classification matches real idempotency (SEC-2, SEC-3)
+
+**Compatibility**
+- [ ] No silent breaking change; intentional breaks carry migration note; aliases tracked, not dropped or promised forever (CMP-1, CMP-2)
+- [ ] README/manifest/docs/tests sync done; companion agent-skills outcome stated and linked when needed (CMP-3)

--- a/plans/mcp-tier-3-best-practices.context.md
+++ b/plans/mcp-tier-3-best-practices.context.md
@@ -1,0 +1,83 @@
+# Feature: MCP Tier 3 Best-Practices Guide — Context & Discussion
+
+## Original Prompt
+> While tier 2 gets merged, let's work on tier 3.
+> I am planning to create a best-practices doc and then mention it in claude.md
+> Let's finalize what goes inside that best practices doc.
+>
+> It should have different sections covering different areas, eg: tool descriptions and resources section, etc
+> Based on [MCP Best practices](https://app.notion.com/p/signoz/MCP-Best-practices-38cfcc6bcd198071b904e3f2d911487d)
+>
+> Independently ask claude fable 5 as well
+
+## Reference Links
+- [Internal MCP Best practices](https://app.notion.com/p/signoz/MCP-Best-practices-38cfcc6bcd198071b904e3f2d911487d)
+- [SigNoz/nerve-pod#34](https://github.com/SigNoz/nerve-pod/issues/34)
+- [Reconciled Tier 3 reviewer plan](https://github.com/SigNoz/nerve-pod/issues/34#issuecomment-5010045025)
+- [Tool descriptions and resources best practices](https://github.com/SigNoz/nerve-pod/issues/34#issuecomment-5014863452)
+- [Tier 1 guardrail policy](../guardrails/README.md)
+
+## Key Decisions & Discussion Log
+
+### 2026-07-21 — Tier 3 planning started
+- Tier 3 starts with a repository-owned MCP best-practices guide and a concise `CLAUDE.md` pointer. The guide will later be the qualitative rubric source for the advisory reviewer agent described in nerve-pod#34.
+- This is documentation-governance planning while the Tier 2 Inspector PR is pending. No reviewer workflow, model call in CI, new runtime abstraction, or additional guardrail is part of this step.
+- Work moved to a branch based on `origin/main` so the pending Tier 2 PR is not modified or made a dependency of the documentation design.
+
+### 2026-07-21 — Source-page synthesis
+- The internal Notion source supplies the core agent-first principles: treat reasonable mis-calls as contract feedback; make errors recoverable; normalize equivalent input representations; provide reliable defaults and realistic examples; prefer fewer, sharper tools; collapse predictable read round-trips while keeping mutations atomic; use domain language; keep the advertised contract stable; and make the server teach its own map.
+- “Accept all and normalize internally” needs a safety qualification. The proposed rule is: accept equivalent representations when the schema advertises them, but reject ambiguous or semantically invalid values with an actionable error. Silent coercion or accepting values the schema rejects would make the contract less reliable, not more agent-friendly.
+- “Generate schema, docs, and examples from the same source” is treated as a parity invariant, not a requirement to introduce code generation. Existing tests and shared definitions may enforce parity more simply.
+
+### 2026-07-21 — Tier 3 issue additions
+- The live Tier 3 issue adds stable topics that are not explicit in the Notion page: delivery universality and surface placement, error escalation, annotations as tested safety claims, output truncation/pagination, narrow gating, external-content provenance, telemetry privacy, measure-before-investing, eval-gated guidance changes, schema evolution, retry/idempotency, partial success, authentication on every request, tenant isolation, and the companion agent-skills check.
+- Numeric budgets, exact client limits, guardrail inventories, and Inspector mechanics remain owned by `guardrails/`. The best-practices guide should link to that enforcement surface instead of copying values that can drift.
+- The eventual reviewer rubric should remain qualitative and diff-local. Countable facts belong in deterministic CI; model findings should cite a rubric ID, changed line, evidence, client impact, concrete repair, and confidence.
+
+### 2026-07-21 — Independent Claude Fable 5 review
+- One requested read-only Fable 5 pass independently recommended `docs/mcp-best-practices.md` as a normative, public-repository guide with a compact checklist. It agreed that the guide should name existing repository idioms instead of inventing a framework.
+- Fable independently recommended separating authoring guidance from `guardrails/README.md`, qualifying lenient input handling as “loose in representation, strict in value, honest in schema,” keeping mutations atomic, making truncation visible, treating aliases/error codes as contract decisions, and adding explicit anti-overengineering rules.
+- Fable proposed examples on every parameter and aliases forever. The current draft intentionally leaves those as owner decisions because the Tier 3 issue warns against blanket example/default requirements, and permanent aliases can themselves accumulate contract complexity.
+- Claude plan mode created a transient plan outside the repository despite the read-only prompt; it was removed after the review was captured. No repository file was changed by Claude.
+
+### 2026-07-21 — Guide governance and scope finalized
+- The owner approved all five recommendations as a batch.
+- The guide will be normative, using `MUST`, `SHOULD`, and `MAY`. A justified exception must be recorded in the feature context or PR rather than silently weakening the rule.
+- The compact PR checklist and stable rubric IDs will live in the guide itself, making it the source for the later advisory reviewer agent.
+- Compatibility aliases have no unconditional forever promise. They remain until an explicit, evidence-backed deprecation and removal decision documents the migration risk and path.
+- Realistic executable examples are required for non-trivial tools/workflows and syntax-heavy or ambiguous parameters, not every self-evident field.
+- The guide includes stable security and privacy principles for request authentication, tenant isolation, remote-content provenance, and sensitive telemetry. Organization-specific retention and deployment values remain elsewhere.
+
+### 2026-07-21 — Documentation tranche implemented
+- Created `docs/mcp-best-practices.md` following the finalized 11-section plan: normative `MUST`/`SHOULD`/`MAY` rules with stable rubric IDs (`SUR`/`SCH`/`DSC`/`RES`/`OUT`/`ERR`/`SEC`/`CMP`/`EVL`), a compact surface-placement table, and a one-screen PR checklist derived from the body rules.
+- Examples and terminology were verified against the current surface: tool names and boundary descriptions, `searchContext` invariant, the `StructuredContent` `code` taxonomy and `missingKeys` field, `signoz://` resource and template URIs, registered prompt names, annotation triples (including the non-idempotent channel update), and pagination metadata (`pagination.hasMore`/`nextOffset`, `data.nextCursor`).
+- The guide separates qualitative authoring judgment from deterministic enforcement: it links to `guardrails/README.md` and copies no numeric budgets, client-version tables, exception inventories, or CI commands. Finalized decisions preserved verbatim in the rules: aliases retained until an evidence-backed deprecation decision (CMP-2); examples required for non-trivial tools/workflows and syntax-heavy or ambiguous parameters only (DSC-4); representation leniency only when honestly advertised, with actionable rejection otherwise (SCH-1, SCH-2); stable security/privacy principles with organization-specific retention/deployment values kept elsewhere (SEC-5).
+- Added a concise `## MCP Contract Changes` pointer to `CLAUDE.md` requiring contract-touching changes to follow the guide and its checklist. Plan status moved to In Progress (not Done — not yet shipped). No runtime code, tests, guardrails, workflows, `README.md`, `manifest.json`, or companion-repo changes in this tranche.
+
+### 2026-07-21 — Post-implementation verification
+- Direct diff review corrected four precision issues without changing the approved scope: descriptions/schemas are the most widely delivered surfaces rather than literally visible to every client; accepted alternative representations must appear in JSON Schema rather than prose alone; atomic tools may have explicitly declared and observable secondary side effects; and a companion `SigNoz/agent-skills` change ships as a linked companion PR rather than inside the server PR.
+- The future advisory reviewer output is now explicitly capped at its three highest-priority findings, matching the reconciled Tier 3 design.
+- The `CLAUDE.md` pointer now says to review against the checklist rather than “run” it and remains three wrapped lines.
+
+### 2026-07-21 — Backend error fidelity considered
+- The owner proposed documenting that high-quality SigNoz backend errors, including documentation links, should reach the agent rather than being replaced by generic MCP prose.
+- Direct inspection shows the current MCP `upstreamError` path already preserves a bounded backend message plus upstream code/type and HTTP status, and Query Builder errors may add MCP-specific recovery context. The newer SigNoz backend error envelope also exposes `url`, top-level and per-detail `suggestions`, and `retry`; those fields are not currently carried through the MCP result.
+- The recommended rule is “faithful, not raw”: preserve recognized, safe, actionable backend fields verbatim and add the stable MCP classification around them. Bound size, redact secrets, reject unsafe markup/unrecognized payloads, and allow tool-specific recovery to supplement rather than rewrite backend guidance.
+- Adding this as a normative rule would expose a small runtime conformance gap. Keep the documentation decision in Tier 3 and handle URL/suggestion/retry passthrough in a separate focused implementation change rather than silently expanding this documentation-only tranche.
+
+### 2026-07-21 — Backend fidelity and owner edits reconciled
+- The owner approved adding backend-error fidelity to the guide. `ERR-6` now requires faithful, bounded preservation of recognized SigNoz messages, documentation URLs, suggestions, detail messages, and retry hints while retaining stable MCP codes and allowing additive tool-specific recovery.
+- The owner's manual simplification removed dedicated prompt-authoring, remote-fetch, telemetry, and code-generation rules. Those removals were preserved; the plan and section titles now match the narrower guide instead of restoring deleted material.
+- Section 11 and the PR checklist were repaired after those removals: stale `RES-6`, `SEC-4`, and `SEC-5` references were removed; selection evaluation now covers recovery-critical guidance; atomic mutation coverage was added; passthrough fidelity is explicit; and validation-only wording no longer overgeneralizes all errors.
+
+### 2026-07-21 — Final review finding addressed
+- The final Fable 5 review found one valid P3 checklist-coverage gap: `SUR-5`, `SCH-6`, and `RES-4` were defined in the guide but absent from the compact PR checklist.
+- The existing surface, schema, and resource checklist rows now cover agent/domain vocabulary, task-shaped inputs, and resource purpose/warnings/provenance. No rule or checklist row was added, and the review remains compact.
+
+## Open Questions
+- [x] Should the guide use normative `MUST`/`SHOULD`/`MAY` language, with exceptions recorded in the feature context/PR, or remain advisory prose? Resolved: normative, with justified exceptions documented in the feature context or PR.
+- [x] Should the compact PR checklist and stable rubric IDs live at the end of the same guide, making it the direct source for the later reviewer agent? Resolved: yes.
+- [x] Should compatibility aliases be indefinite by default, or require an explicit deprecation/removal policy based on usage and migration risk? Resolved: retain until an explicit, evidence-backed deprecation/removal decision; do not promise forever.
+- [x] Should realistic examples be required once per non-trivial tool/workflow and only on syntax-heavy parameters, or on every parameter? Resolved: require them for non-trivial tools/workflows and syntax-heavy or ambiguous parameters only.
+- [x] Should the guide govern security/privacy aspects of client-visible MCP behavior, including tenant isolation, remote-content provenance, and telemetry handling, while leaving organization-specific retention values elsewhere? Resolved initially: yes. Superseded by the owner's later edit: retain authentication, tenant isolation, destructive-action, and retry guidance; omit dedicated remote-fetch and telemetry rules from this tranche.
+- [x] Should the guide require faithful, bounded passthrough of recognized SigNoz backend error guidance (`message`, documentation URL, suggestions, detail messages, and retry hints) while retaining stable MCP codes and safety filtering? Resolved: yes; MCP classification and tool-specific recovery may supplement but not replace recognized backend guidance.

--- a/plans/mcp-tier-3-best-practices.plan.md
+++ b/plans/mcp-tier-3-best-practices.plan.md
@@ -1,0 +1,119 @@
+# Plan: MCP Tier 3 Best-Practices Guide
+
+## Status
+In Progress
+
+## Context
+Tier 1 puts deterministic contract invariants behind a central CI review surface. Tier 2 adds real-server Inspector compatibility. Tier 3 documents the qualitative design decisions that deterministic checks cannot judge: whether an agent can choose the right surface, make a valid first call, recover from errors, interpret results, and survive compatible contract evolution.
+
+The guide will be the repository's stable MCP authoring standard and the future source rubric for an advisory reviewer agent. It must be concrete enough to review against a diff without duplicating numeric guardrails, CI mechanics, or per-tool documentation.
+
+Use `MUST`, `SHOULD`, and `MAY` normatively. Record any justified exception in the feature context or PR. Keep stable rubric IDs and the compact checklist in this same guide so the later reviewer agent consumes the human-reviewed source directly.
+
+## Goals
+- Create one repository-owned guide for every client-visible MCP surface.
+- Turn the internal agent-first principles into concrete, reviewable rules.
+- Keep measurable enforcement in `guardrails/` and qualitative judgment in the guide.
+- End with a compact checklist and stable rubric identifiers reusable by the later reviewer agent.
+- Add only a concise pointer in `CLAUDE.md`.
+
+## Proposed Document Structure
+
+### 1. Scope and agent-first principles
+- Define which surfaces are governed: names, schemas, descriptions, annotations, results, errors, resources, resource templates, prompts, and server instructions.
+- State the delivery-universality rule: the more critical a rule is to a correct first call, the more universal and inline its placement must be.
+- Treat reasonable or recurring agent mis-calls as evidence that the advertised contract needs improvement, without promising to accept ambiguous or unsafe input.
+- Prefer fewer, sharper surfaces and measure real use before adding new ones.
+- Point to `guardrails/README.md` for numeric enforcement and workflow mechanics.
+
+### 2. Choosing, naming, and annotating MCP surfaces
+- Add a tool for a distinct agent task, not merely for a distinct backend endpoint; compare an existing-tool parameter, resource, or prompt first.
+- Use agent/domain vocabulary and explain unavoidable backend terminology instead of imposing a blanket jargon ban.
+- Require clear nearest-neighbor selection boundaries.
+- Treat annotations as behavior-backed safety claims, not authorization or trust boundaries.
+- Collapse predictable read round-trips where useful; keep mutations atomic, observable, and accurately classified for retry/idempotency.
+
+### 3. Surface placement
+- Include a compact table assigning content to tool descriptions, parameter descriptions/schema, output schemas/results, annotations, server instructions, resources, prompts/skills, and execution errors.
+- Keep correctness-critical first-call rules inline; resources provide progressive disclosure, never the only route to immediate repair.
+- Gate only for authentication, consent, or destructive action. Do not block a tool call on optional documentation fetches.
+
+### 4. Input schemas and parameter behavior
+- Be lenient across explicitly advertised equivalent representations and strict about meaning: normalize safe number/string, boolean/string, and similar forms only when the schema says they are accepted.
+- Reject unparseable, ambiguous, or semantically invalid values with field-specific recovery guidance; never silently replace an invalid supplied value with a default.
+- Keep schema, handler validation, defaults, examples, and requiredness aligned.
+- Distinguish MCP-owned stable enums from workspace- or backend-evolving values that should use discovery guidance.
+- Include the repository's `searchContext` invariant without duplicating implementation details unnecessarily.
+- Prefer agent-shaped flat inputs over exposing backend payload structure.
+
+### 5. Tool descriptions and examples
+- Optimize for correct selection and a successful first call, not maximal detail or minimum byte count.
+- Lead with intent/result; name only the nearest confusing alternative; include critical pre-call caveats and exact resource/discovery pointers.
+- Put field-local format, units, constraints, dependencies, defaults, and examples on the parameter/schema surface.
+- Require realistic, executable examples for every non-trivial tool/workflow and for grammars, filters, or ambiguous parameter formats; do not require an example on every self-evident field.
+- Do not include routes, implementation history, volatile catalogs, or guarantees the handler does not enforce.
+
+### 6. Resources, resource templates, and server instructions
+- Use resources for long grammars, schemas, workflows, catalogs, and complete examples; use templates only for genuinely parameterized content.
+- Make discovery metadata state what the surface contains, when to use it, and which workflows it supports.
+- Keep URIs stable, resolvable, authenticated where needed, correctly typed, non-empty, and bounded.
+- Put purpose and warnings before detail; record provenance/freshness for mutable content.
+- Use server instructions only for routing or policies shared across several tools.
+
+### 7. Results, pagination, and partial success
+- Return predictable envelopes and reusable handles such as IDs and web URLs when they remove a likely follow-up lookup.
+- Keep read results writable back without undocumented reshaping where the domain supports read-modify-write.
+- Make clamps, truncation, pagination, and incomplete data explicit in machine-readable metadata with the next step or cursor.
+- Define when per-item partial success is legitimate. Global authentication, permission, or upstream availability failures must remain top-level coded errors.
+- Do not silently reshape passthrough upstream results into a misleading local contract.
+
+### 8. Errors and recovery
+- Return stable machine-readable error categories and concise agent-readable text.
+- Name the failing field or operation, explain the problem, state accepted forms or alternatives, and give the smallest next action.
+- Put the immediate correction inline, then link a resource for deeper guidance; never make resource retrieval the only recovery path.
+- Propagate authentication and permission failures through the shared top-level path.
+- Preserve recognized SigNoz backend messages, documentation URLs, suggestions, detail messages, and retry hints faithfully in bounded, safe form. Stable MCP codes and tool-specific recovery supplement rather than replace that guidance.
+- Pair fail-open cross-boundary parsing with a WARN log or metric; distinguish expected agent mistakes from server/upstream faults without hiding either.
+
+### 9. Safety and security
+- Authenticate and resolve tenant scope on every request; do not rely on cached caller identity or allow cross-tenant identifiers to leak data.
+- Keep destructive actions explicit and narrowly scoped; make side effects observable.
+- Tie retry eligibility to actual idempotency, not merely HTTP method or annotation wording.
+
+### 10. Contract evolution and synchronized documentation
+- Treat the initialized advertised surface as a stable executable promise.
+- List breaking changes: removal/rename, type narrowing, optional-to-required, enum removal, annotation safety changes, result-envelope changes, and error-code changes.
+- Require an explicit compatibility path and migration note for intentional breaks. Retain compatibility aliases until an explicit, evidence-backed deprecation/removal decision documents the migration risk and path; do not promise aliases forever.
+- Keep production registration, validators, README, `manifest.json`, `docs/`, tests, and companion `SigNoz/agent-skills` teaching synchronized when their contracts overlap.
+
+### 11. Evaluation and PR review checklist
+- Keep deterministic counts, schema compilation, URI integrity, and protocol compatibility in CI.
+- Evaluate selection- or recovery-critical guidance changes with direct, indirect, and negative prompts; check the affected tool choice, arguments, clarification, abstention, and failed-call recovery behaviors using comparable model/catalog sessions.
+- Change broad guidance only with evidence from evals, recurring failures, or production use; do not canonize dated usage statistics in the guide.
+- End with a one-screen checklist grouped by stable rubric IDs: surface choice, schema, description, resources/instructions, results, errors, safety/security, and compatibility.
+- Future reviewer findings cite rubric ID, changed line, evidence, client impact, repair, and confidence; stay diff-local, cap noisy output, and allow “no findings.”
+
+## Explicit Non-goals
+- Copying numeric budgets, current client-version tables, exception inventories, or CI commands from `guardrails/`.
+- Building the reviewer workflow, running models in CI, or promoting model findings to blocking status.
+- Requiring a new abstraction, code generator, snapshot, completion surface, or guardrail merely because the guide mentions a principle.
+- Maintaining a per-tool catalog or duplicating README/manifest documentation.
+- Requiring examples/default prose on every parameter regardless of complexity.
+- Encoding organization-specific secret, retention, or deployment values in a public design guide.
+- Adding dedicated prompt-authoring, external-fetch provenance, or telemetry-retention policy beyond the placement and security rules retained in this tranche.
+
+## Expected Files
+- `docs/mcp-best-practices.md` — normative principles, area-specific rules, placement table, and compact review checklist.
+- `CLAUDE.md` — concise pointer requiring contract-touching changes to follow the guide and its checklist.
+- `plans/mcp-tier-3-best-practices.context.md` — append-only discussion and decision history.
+- `plans/mcp-tier-3-best-practices.plan.md` — current design and verification plan.
+
+No `guardrails/`, workflow, runtime code, `manifest.json`, or companion `SigNoz/agent-skills` change is expected from the documentation-only tranche.
+
+## Verification
+- Check every source principle and Tier 3 issue addition maps to one body section or an explicit non-goal.
+- Check every checklist item is directly traceable to a body rule and can be evaluated against a changed diff.
+- Verify all referenced repository paths, helper names, MCP URIs, and examples against the current initialized surface before committing the guide.
+- Run Markdown/link checks available in the repository and `git diff --check`.
+- Confirm the `CLAUDE.md` addition stays concise and does not duplicate the guide.
+- Record the README/`docs/`/`manifest.json` and companion agent-skills sync outcome in the PR summary.


### PR DESCRIPTION
## Summary

- add `docs/mcp-best-practices.md` as the normative authoring guide for client-visible MCP surfaces
- define stable rubric IDs and a compact PR checklist for qualitative review
- add a concise `CLAUDE.md` pointer and the required Tier 3 plan/context audit trail
- document faithful, bounded SigNoz backend error guidance; track the existing runtime passthrough gap in [SigNoz/nerve-pod#164](https://github.com/SigNoz/nerve-pod/issues/164)

## Why

Tier 1 owns deterministic contract guardrails and Tier 2 exercises protocol/client compatibility. This Tier 3 documentation tranche centralizes the qualitative decisions reviewers must make: whether agents can choose the right surface, form a valid first call, recover from errors, interpret results, and evolve with the contract without unnecessary abstractions.

The final review found that three defined rules were missing from the compact checklist. The existing rows now cover agent/domain vocabulary (`SUR-5`), task-shaped inputs (`SCH-6`), and resource purpose/warnings/provenance (`RES-4`) without adding checklist length.

## Documentation and metadata sync

- `docs/`: added the best-practices guide
- `README.md`: unchanged; no tool catalog or parameter contract changed
- `manifest.json`: unchanged; no registered surface changed
- tests/guardrails/workflows: unchanged; numeric budgets and CI mechanics remain in `guardrails/`
- companion `SigNoz/agent-skills`: reviewed; no change needed because this PR does not rename or reshape a tool contract taught by the skills

## Validation

- verified all 11 planned guide sections are present
- verified rubric IDs have no duplicates or undefined checklist references
- verified `SUR-5`, `SCH-6`, and `RES-4` are covered by the checklist
- verified local Markdown link targets
- ran `git diff --cached --check` before commit
- completed one final read-only Fable 5 review and addressed its valid P3 finding

Go tests were not run because this PR changes documentation and contributor guidance only.