### PR TITLE
docs: streamline CLAUDE.md and extract plan templates

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,7 @@
 # CLAUDE.md — Development Conventions
 
+Consult `docs/` (architecture, MCP best practices) and `plans/` (per-feature context and plans) when you need background on a subsystem or an in-flight feature.
+
 ## Feature Planning Convention
 
 For every non-trivial feature, maintain a file pair in `plans/` and commit it alongside the feature PR:
@@ -16,12 +18,14 @@ plans/
 2. **After each brainstorm exchange**, append a dated entry to the discussion log in `.context.md`.
 3. **When the plan changes**, rewrite the relevant section in `.plan.md` and note the change with a dated entry in `.context.md`.
 4. **Mark open questions as resolved** (with the answer inline) when they are settled in discussion.
-5. **`.context.md` is append-only** — never rewrite or delete prior entries. It is the audit trail of why decisions were made.
+5. **The discussion log in `.context.md` is append-only** — never rewrite or delete prior log entries; it is the audit trail of why decisions were made. Only the Open Questions checklist may be updated in place (rule 4).
 6. **`.plan.md` is rewritten freely** — it always reflects current thinking, not history.
 7. Add a `## Status` line at the top of every `.plan.md`:
    - `Planning` — actively being designed
    - `In Progress` — implementation underway
    - `Done` — shipped
+
+File templates for both files live in `plans/TEMPLATES.md`.
 
 ## Git & PR
 
@@ -35,68 +39,36 @@ plans/
 
 - Avoid long inline code comments unless needed; keep comments concise and non-redundant.
 
+## Local Verification
+
+- Tests: `go test ./...` (`make test` runs them verbose).
+- Build: `go build ./cmd/server` (`make build` also rewrites formatting/imports).
+- Formatting/imports: `make fmt goimports`.
+
 ## MCP Contract Changes
 
 Changes to client-visible MCP surfaces must follow `docs/mcp-best-practices.md`
 and its section 11 review checklist. Deterministic budgets and CI mechanics stay
-in `guardrails/README.md`.
+in `guardrails/README.md`. The companion **SigNoz/agent-skills** repo depends on
+these contracts — audit it on every contract change (CMP-3; see the sync
+checklist below).
 
 ## Guardrail Changes
 
-- Follow `guardrails/README.md`; keep policy in `policy.go`, the sorted `TestGuardrail_*` inventory in `tests.txt`, and package-sensitive tests beside their packages.
+- Follow `guardrails/README.md`; keep policy in `guardrails/policy.go`, the sorted `TestGuardrail_*` inventory in `guardrails/tests.txt`, and package-sensitive tests beside their packages.
 - Never weaken a guardrail merely to pass CI. Document intentional relaxations in the feature context log and PR summary.
 - Run the workflow lint, focused guardrail suite, and full test suite documented in `guardrails/README.md` before handoff.
 
 ## Documentation & Metadata Sync Checklist
 
-When adding, renaming, or removing MCP tools/resources/configuration, update docs and metadata in the same PR.
+When adding, removing, renaming, or otherwise changing a client-visible MCP tool, resource, prompt, or configuration contract, update docs and metadata in the same PR.
 
 - Every MCP tool input schema must expose a top-level `searchContext` string with the user's original question/search text. Do not put `searchContext` in the JSON Schema `required` list or describe it as optional. For tools using `mcp.WithInputSchema[T]()`, put `SearchContext` on `T` itself because typed schemas replace earlier `mcp.WithString("searchContext", ...)` options.
 - Update `README.md` tool tables/parameter references to match current behavior.
 - Update `manifest.json` tool metadata (`tools`, descriptions, and related fields) to match registered handlers.
 - Review any user-facing docs under `docs/` for stale references.
-- Check whether the companion **SigNoz/agent-skills** repo needs a matching change. Skills (e.g. `signoz-creating-alerts`, `signoz-creating-dashboards`) deliberately defer field/schema detail to the MCP server, so they need updating only when a change alters the **tool contract they teach** — a renamed/removed tool or parameter, a changed payload shape, or changed documented behavior (as the `query`→`filter` rename did). Additive or internal changes that don't alter that contract (e.g. surfacing already-authored field descriptions) need no skills change. State the outcome of this check in the PR summary, and link the companion agent-skills PR when one is needed.
+- The companion **SigNoz/agent-skills** repo depends on this server's tool contracts. Apply CMP-3 in `docs/mcp-best-practices.md`: state in the PR summary whether agent-skills needs a companion change, and link that PR when needed. Changes to the contract skills teach (a renamed/removed tool or parameter, payload shape, documented behavior — like the `query`→`filter` rename) require a skills update; additive or internal changes do not.
 - Mention these doc updates explicitly in the PR summary.
-
-### File templates
-
-**`<feature>.context.md`**
-```markdown
-# Feature: <Name> — Context & Discussion
-
-## Original Prompt
-> <paste full user prompt here>
-
-## Reference Links
-- [Title](url)
-
-## Key Decisions & Discussion Log
-### YYYY-MM-DD — <topic>
-- <decision or note>
-
-## Open Questions
-- [ ] <question>
-```
-
-**`<feature>.plan.md`**
-```markdown
-# Plan: <Name>
-
-## Status
-Planning
-
-## Context
-<why this change is needed>
-
-## Approach
-<implementation details>
-
-## Files to Modify
-- `path/to/file.go` — what changes
-
-## Verification
-<how to test end-to-end>
-```
 
 ## End-to-End / Live Verification
 
@@ -104,11 +76,9 @@ Verifying against a live SigNoz instance — creating/reading/updating/deleting 
 
 ## Testing across external contracts
 
-This server sits between external parties: it consumes the SigNoz backend / query-builder (QB) API (upstream) and produces tool outputs that MCP clients and the AI assistant consume (downstream). Unit tests that assert behavior against hard-coded fixtures only prove our code matches our *assumption* of those contracts — they do not catch the contract drifting out from under us (a renamed field, a changed QB response envelope, a new route/output shape).
+This server consumes the SigNoz backend / query-builder (QB) API upstream and produces tool outputs that MCP clients consume downstream. Fixture-based unit tests only prove our code matches our *assumption* of those contracts — they do not catch upstream drift (a renamed field, a changed QB envelope, a new output shape). For any code that parses an upstream response or shapes a tool output:
 
-For any code that parses an upstream response or shapes a tool output:
-
-- **Pin the contract, and test against reality where you can.** Beyond fixture-based unit tests, add a periodic/integration test against a live SigNoz instance (or a recorded real response) so upstream drift fails a test, not a user. Per-PR fixture tests are necessary but not sufficient.
-- **When tests can't catch it, observability must.** If a break only manifests against real data, add a metric or WARN log that fires when the contract appears violated (e.g. a passthrough enrichment that found rows but could not locate the expected field). Silent degradation that no test and no signal can catch is the failure mode to design against.
-- **Do not hide global upstream failures inside partial item results.** Auth and permission failures such as SigNoz 401/403 must propagate through the shared coded error path (`upstreamError` for tools) so clients can re-authenticate or handle permissions.
-- **Fail open, but never fail silent.** Prefer fail-open behavior for cross-boundary parsing, but always pair it with a detectable signal so "fail-open" does not become "fail-silent."
+- **Test against reality where you can.** Beyond fixtures, add a periodic/integration test against a live SigNoz instance (or a recorded real response) so upstream drift fails a test, not a user.
+- **When tests can't catch it, observability must.** Add a metric or WARN log that fires when the contract appears violated. Silent degradation that no test and no signal can catch is the failure mode to design against.
+- **Do not hide global upstream failures inside partial item results.** SigNoz 401/403 must propagate through the shared coded error path (`upstreamError` for tools) so clients can re-authenticate or handle permissions.
+- **Fail open, but never fail silent.** Prefer fail-open cross-boundary parsing, always paired with a detectable signal.

--- a/plans/TEMPLATES.md
+++ b/plans/TEMPLATES.md
@@ -1,0 +1,42 @@
+# Plan File Templates
+
+Templates for the `plans/<feature>.context.md` + `plans/<feature>.plan.md` pair
+described in `CLAUDE.md` → Feature Planning Convention.
+
+**`<feature>.context.md`**
+```markdown
+# Feature: <Name> — Context & Discussion
+
+## Original Prompt
+> <paste full user prompt here>
+
+## Reference Links
+- [Title](url)
+
+## Key Decisions & Discussion Log
+### YYYY-MM-DD — <topic>
+- <decision or note>
+
+## Open Questions
+- [ ] <question>
+```
+
+**`<feature>.plan.md`**
+```markdown
+# Plan: <Name>
+
+## Status
+Planning
+
+## Context
+<why this change is needed>
+
+## Approach
+<implementation details>
+
+## Files to Modify
+- `path/to/file.go` — what changes
+
+## Verification
+<how to test end-to-end>
+```


### PR DESCRIPTION
## Summary

Best-practices pass over `CLAUDE.md` (loaded into every agent session, so it should stay lean, unambiguous, and self-sufficient for routine work).

- **Progressive disclosure**: top-of-file pointer to `docs/` and `plans/` for background; plan-file skeletons extracted to `plans/TEMPLATES.md` (referenced from the planning convention).
- **Resolved a contradiction**: rule 5 (".context.md is append-only") conflicted with rule 4 (mark open questions resolved inline). Append-only now scopes to the discussion log; the Open Questions checklist may be updated in place.
- **New Local Verification section**: `go test ./...` / `make test`, `go build ./cmd/server`, `make fmt goimports` — so agents don't rediscover the Makefile every session.
- **Sync-checklist trigger broadened**: now covers *any* change to a client-visible MCP tool/resource/prompt/configuration contract, not just add/rename/remove.
- **Guardrail paths disambiguated**: `guardrails/policy.go`, `guardrails/tests.txt`.
- **agent-skills dependency made explicit**: the MCP Contract Changes section now states that `SigNoz/agent-skills` depends on these contracts and must be audited on every contract change; the sync-checklist bullet is compressed to anchor on CMP-3 in `docs/mcp-best-practices.md` while keeping the decision rule inline.
- **Tightened** the testing-across-external-contracts section (same four rules, less prose).

## Doc/metadata sync check

Docs-only change — no MCP tool contract is altered, so no `README.md`/`manifest.json` updates and **no companion SigNoz/agent-skills change** is needed.

## Verification

Docs-only; verified all referenced paths exist (`cmd/server`, `guardrails/policy.go`, `guardrails/tests.txt`, CMP-3 in `docs/mcp-best-practices.md`) and Makefile targets match the documented commands.