### PR TITLE
feat(services): add signoz_get_service_map dependency graph tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -367,6 +367,7 @@ HTTP mode exposes unauthenticated probe endpoints. New Kubernetes deployments sh
 | `signoz_list_dashboard_templates` | List curated templates and discover an import path |
 | `signoz_list_services` | List APM services with trace activity in a time range |
 | `signoz_get_service_top_operations` | Get ranked operations for one traced service |
+| `signoz_get_service_map` | Get the service dependency graph (caller → callee edges with error rate and latency) |
 | `signoz_list_views` | List saved Explorer views for traces/logs/metrics/Cost Meter and discover UUIDs |
 | `signoz_get_view` | Get one saved Explorer view's complete definition by `id` |
 | `signoz_search_docs` | Find ranked official-doc matches when no exact page is selected |
@@ -375,7 +376,8 @@ HTTP mode exposes unauthenticated probe endpoints. New Kubernetes deployments sh
 | `signoz_update_view` | Fully replace a fetched saved view while preserving unrequested fields |
 | `signoz_delete_view` | Permanently delete a confirmed saved view by `id` |
 | `signoz_aggregate_logs` | Aggregate log statistics and grouped or top-N breakdowns |
-| `signoz_search_logs` | Return individual log records matching filters |
+| `signoz_search_logs` | Return individual log records
+ matching filters |
 | `signoz_aggregate_traces` | Aggregate span statistics and grouped or top-N breakdowns |
 | `signoz_search_traces` | Return individual span rows or discover trace IDs |
 | `signoz_get_trace_details` | Get one known trace with all spans and hierarchy |
@@ -597,6 +599,20 @@ Gets the built-in operation table for one traced service, ranked by p99 latency 
   - `start` (optional) - Start time in unix milliseconds (defaults to 6 hours ago).
   - `end` (optional) - End time in unix milliseconds (defaults to now)
   - `tags` (optional) - JSON-encoded `TagQueryParam` array passed as a string, for example `[{"key":"http.method","tagType":"SpanAttribute","operator":"In","stringValues":["GET"]}]`; omit for no tag filter
+
+#### `signoz_get_service_map`
+
+Returns the service dependency graph behind SigNoz's Service Map — one record per caller/callee edge with `parent`, `child`, `callCount`, `callRate`, `errorRate` (a percentage), and latency quantiles `p50`/`p75`/`p90`/`p95`/`p99` (in milliseconds). Filter to a single service with `service` plus `direction` to get just its callers or callees. Use `signoz_list_services` for the flat service list and `signoz_get_service_top_operations` for one service's operations. Edges come from a per-minute rollup table, so a very narrow window can legitimately return no edges — widen `timeRange` before concluding a dependency does not exist.
+
+- **Parameters**:
+  - `timeRange` (optional) - Relative time range `<number><unit>` where unit is `m`/`h`/`d` (e.g. '30m', '1h', '6h', '7d'; defaults to last 6 hours; ignored when both `start` and `end` are provided)
+  - `start` (optional) - Start time in unix milliseconds (defaults to 6 hours ago)
+  - `end` (optional) - End time in unix milliseconds (defaults to now)
+  - `service` (optional) - Exact service name to filter edges to, typically from `signoz_list_services`; omit for the full graph
+  - `direction` (optional) - Which edges to keep relative to `service`: `downstream` (services it calls), `upstream` (services that call it), or `both` (default). Requires `service`
+  - `limit` (optional) - Maximum edges per page (default: 50, max: 1000; higher values are clamped)
+  - `offset` (optional) - Number of edges to skip for pagination (default: 0)
+  - `tags` (optional) - JSON-encoded `TagQueryParam` array passed as a string, applied server-side before the graph is built, for example `[{"key":"deployment.environment","tagType":"ResourceAttribute","operator":"In","stringValues":["prod"]}]`; omit for no tag filter
 
 #### `signoz_get_alert_history`
 

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -637,6 +637,23 @@ func (s *SigNoz) GetServiceTopOperations(ctx context.Context, start, end, servic
 	return s.doReplaySafePost(ctx, reqURL, bodyBytes, DefaultQueryTimeout)
 }
 
+// GetServiceMap fetches the service dependency graph (the call graph behind
+// SigNoz's Service Map) for a time window. start and end are nanosecond epoch
+// strings; the endpoint is a POST only because it carries a request body, so it
+// is read-only and replay-safe.
+func (s *SigNoz) GetServiceMap(ctx context.Context, start, end string, tags json.RawMessage) (json.RawMessage, error) {
+	reqURL := fmt.Sprintf("%s/api/v1/dependency_graph", s.baseURL)
+	if len(tags) == 0 {
+		tags = json.RawMessage("[]")
+	}
+	payload := map[string]any{"start": start, "end": end, "tags": tags}
+	bodyBytes, _ := json.Marshal(payload)
+
+	s.logger.DebugContext(s.ensureTenantContext(ctx), "Fetching service dependency graph",
+		slog.String("start", start), slog.String("end", end))
+	return s.doReplaySafePost(ctx, reqURL, bodyBytes, DefaultQueryTimeout)
+}
+
 func (s *SigNoz) QueryBuilderV5(ctx context.Context, body []byte) (json.RawMessage, error) {
 	ctx = s.ensureTenantContext(ctx)
 	reqURL := fmt.Sprintf("%s/api/v5/query_range", s.baseURL)

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -1979,3 +1979,100 @@ func TestDoRequest_AllowsLargeUnderCapResponse(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, len(body), len(got))
 }
+
+func TestGetServiceMap(t *testing.T) {
+	const start = "1640995200000000000"
+	const end = "1641081600000000000"
+
+	tests := []struct {
+		name          string
+		tags          json.RawMessage
+		expectedTags  []interface{}
+		resp          interface{}
+		statusCode    int
+		expectedError bool
+		expectedEdges int
+	}{
+		{
+			name:         "successful dependency graph retrieval",
+			tags:         json.RawMessage(`[{"key":"deployment.environment","tagType":"ResourceAttribute","operator":"In","stringValues":["prod"]}]`),
+			expectedTags: []interface{}{map[string]interface{}{"key": "deployment.environment", "tagType": "ResourceAttribute", "operator": "In", "stringValues": []interface{}{"prod"}}},
+			resp: []map[string]interface{}{
+				{"parent": "frontend", "child": "checkout", "callCount": 120.0, "callRate": 3.3, "errorRate": 1.2, "p99": 420.5},
+				{"parent": "checkout", "child": "payments", "callCount": 80.0, "callRate": 2.2, "errorRate": 9.7, "p99": 900.1},
+			},
+			statusCode:    http.StatusOK,
+			expectedEdges: 2,
+		},
+		{
+			// An omitted tag filter must still send a valid empty array; the
+			// backend rejects a null tags field.
+			name:          "nil tags defaults to empty array",
+			tags:          nil,
+			expectedTags:  []interface{}{},
+			resp:          []map[string]interface{}{},
+			statusCode:    http.StatusOK,
+			expectedEdges: 0,
+		},
+		{
+			name:          "server error",
+			tags:          nil,
+			expectedTags:  []interface{}{},
+			resp:          map[string]interface{}{"status": "error", "message": "Internal server error"},
+			statusCode:    http.StatusInternalServerError,
+			expectedError: true,
+		},
+		{
+			name:          "unauthorized",
+			tags:          nil,
+			expectedTags:  []interface{}{},
+			resp:          map[string]interface{}{"status": "error", "message": "Unauthorized"},
+			statusCode:    http.StatusUnauthorized,
+			expectedError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				assert.Equal(t, http.MethodPost, r.Method)
+				assert.Equal(t, "/api/v1/dependency_graph", r.URL.Path)
+				assert.Equal(t, "application/json", r.Header.Get("Content-Type"))
+				assert.Equal(t, "test-api-key", r.Header.Get("SIGNOZ-API-KEY"))
+
+				var requestBody map[string]interface{}
+				err := json.NewDecoder(r.Body).Decode(&requestBody)
+				require.NoError(t, err)
+				// start/end must be nanosecond epoch strings; the endpoint
+				// parses them with strconv.ParseInt then time.Unix(0, v).
+				assert.Equal(t, start, requestBody["start"])
+				assert.Equal(t, end, requestBody["end"])
+				assert.Equal(t, tt.expectedTags, requestBody["tags"])
+
+				w.WriteHeader(tt.statusCode)
+				responseBody, _ := json.Marshal(tt.resp)
+				_, _ = w.Write(responseBody)
+			}))
+			defer server.Close()
+
+			client := NewClient(logpkg.New("debug"), server.URL, "test-api-key", "SIGNOZ-API-KEY", nil)
+
+			result, err := client.GetServiceMap(context.Background(), start, end, tt.tags)
+
+			if tt.expectedError {
+				assert.Error(t, err)
+				assert.Nil(t, result)
+				return
+			}
+
+			require.NoError(t, err)
+			var edges []map[string]interface{}
+			require.NoError(t, json.Unmarshal(result, &edges))
+			assert.Len(t, edges, tt.expectedEdges)
+			if tt.expectedEdges > 0 {
+				assert.Equal(t, "frontend", edges[0]["parent"])
+				assert.Equal(t, "checkout", edges[0]["child"])
+			}
+		})
+	}
+}

--- a/internal/client/interface.go
+++ b/internal/client/interface.go
@@ -25,6 +25,7 @@ type Client interface {
 	DeleteDashboard(ctx context.Context, id string) error
 	ListServices(ctx context.Context, start, end string) (json.RawMessage, error)
 	GetServiceTopOperations(ctx context.Context, start, end, service string, tags json.RawMessage) (json.RawMessage, error)
+	GetServiceMap(ctx context.Context, start, end string, tags json.RawMessage) (json.RawMessage, error)
 	QueryBuilderV5(ctx context.Context, body []byte) (json.RawMessage, error)
 	ListViews(ctx context.Context, sourcePage, name, category string) (json.RawMessage, error)
 	GetView(ctx context.Context, viewID string) (json.RawMessage, error)

--- a/internal/client/mock.go
+++ b/internal/client/mock.go
@@ -26,6 +26,7 @@ type MockClient struct {
 	DeleteDashboardFn           func(ctx context.Context, id string) error
 	ListServicesFn              func(ctx context.Context, start, end string) (json.RawMessage, error)
 	GetServiceTopOperationsFn   func(ctx context.Context, start, end, service string, tags json.RawMessage) (json.RawMessage, error)
+	GetServiceMapFn             func(ctx context.Context, start, end string, tags json.RawMessage) (json.RawMessage, error)
 	QueryBuilderV5Fn            func(ctx context.Context, body []byte) (json.RawMessage, error)
 	ListViewsFn                 func(ctx context.Context, sourcePage, name, category string) (json.RawMessage, error)
 	GetViewFn                   func(ctx context.Context, viewID string) (json.RawMessage, error)
@@ -154,6 +155,13 @@ func (m *MockClient) GetServiceTopOperations(ctx context.Context, start, end, se
 		return m.GetServiceTopOperationsFn(ctx, start, end, service, tags)
 	}
 	return json.RawMessage(`{}`), nil
+}
+
+func (m *MockClient) GetServiceMap(ctx context.Context, start, end string, tags json.RawMessage) (json.RawMessage, error) {
+	if m.GetServiceMapFn != nil {
+		return m.GetServiceMapFn(ctx, start, end, tags)
+	}
+	return json.RawMessage(`[]`), nil
 }
 
 func (m *MockClient) QueryBuilderV5(ctx context.Context, body []byte) (json.RawMessage, error) {

--- a/internal/handler/tools/annotations_inventory_test.go
+++ b/internal/handler/tools/annotations_inventory_test.go
@@ -39,6 +39,7 @@ var expectedToolAnnotations = map[string]annotationTriple{
 	"signoz_get_field_keys":              readTriple,
 	"signoz_get_field_values":            readTriple,
 	"signoz_get_notification_channel":    readTriple,
+	"signoz_get_service_map":             readTriple,
 	"signoz_get_service_top_operations":  readTriple,
 	"signoz_get_top_metrics":             readTriple,
 	"signoz_get_trace_details":           readTriple,

--- a/internal/handler/tools/services.go
+++ b/internal/handler/tools/services.go
@@ -42,6 +42,153 @@ func (h *Handler) RegisterServiceHandlers(s *server.MCPServer) {
 	)
 
 	h.addTool(s, getOpsTool, h.handleGetServiceTopOperations)
+
+	serviceMapTool := mcp.NewTool("signoz_get_service_map",
+		withReadOnlyToolAnnotations(),
+		mcp.WithString("searchContext", mcp.Description("Copy the user's entire original request verbatim, including any preflight or confirmation context; do not summarize, shorten, or omit clauses.")),
+		mcp.WithDescription("Use this when the user wants the service dependency graph — which services call which — behind SigNoz's Service Map. It returns one record per caller/callee edge with call count, call rate, error rate, and latency quantiles, so you can trace a failure to a downstream service. Filter to one service with \"service\" plus \"direction\" to get just its callers or callees. Use signoz_list_services for the flat service list and signoz_get_service_top_operations for one service's operations. Edges come from a per-minute rollup table, so very narrow windows can legitimately return nothing; widen timeRange before concluding a dependency does not exist."),
+		mcp.WithString("timeRange", mcp.DefaultString("6h"), mcp.Description(timeRangeDesc("Defaults to last 6 hours if not provided."))),
+		mcp.WithString("start", intOrStringType(), mcp.Description("Start time in unix milliseconds (optional, defaults to 6 hours ago).")),
+		mcp.WithString("end", intOrStringType(), mcp.Description("End time in unix milliseconds (optional, defaults to now).")),
+		mcp.WithString("service", mcp.Description("Optional exact service name to filter edges to, typically from signoz_list_services. Omit for the full graph.")),
+		mcp.WithString("direction", mcp.DefaultString("both"), mcp.Description("Which edges to keep relative to \"service\": \"downstream\" (services it calls), \"upstream\" (services that call it), or \"both\" (default). Requires \"service\"; ignored otherwise.")),
+		mcp.WithString("limit", mcp.DefaultString("50"), intOrStringType(), mcp.Description("Maximum edges per page. Default: 50; max: 1000 (higher values are clamped).")),
+		mcp.WithString("offset", mcp.DefaultString("0"), intOrStringType(), mcp.Description("Number of edges to skip. Default: 0; use pagination.nextOffset for the next page.")),
+		mcp.WithString("tags", mcp.Description("JSON-encoded TagQueryParam array applied server-side before the graph is built; omit for no tag filter. Example: [{\"key\":\"deployment.environment\",\"tagType\":\"ResourceAttribute\",\"operator\":\"In\",\"stringValues\":[\"prod\"]}]. Pass the array as a string, not as a JSON array value.")),
+	)
+
+	h.addTool(s, serviceMapTool, h.handleGetServiceMap)
+}
+
+// serviceMapDirections enumerates the accepted "direction" values so an invalid
+// one fails validation instead of silently degrading to an unfiltered graph.
+var serviceMapDirections = map[string]bool{"both": true, "upstream": true, "downstream": true}
+
+func (h *Handler) handleGetServiceMap(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	args := req.GetArguments()
+
+	// Reject a present-but-malformed start/end loudly; otherwise
+	// GetTimestampsWithDefaults silently falls back to the default window.
+	if err := timeutil.ValidateExplicitTimestamps(args); err != nil {
+		h.logger.WarnContext(ctx, "Invalid explicit timestamp", logpkg.ErrAttr(err))
+		return errorWithCode(CodeValidationFailed, "Parameter validation failed: "+err.Error()), nil
+	}
+
+	service, _ := args["service"].(string)
+
+	direction := "both"
+	if d, ok := args["direction"].(string); ok && d != "" {
+		direction = d
+	}
+	if !serviceMapDirections[direction] {
+		return validationError("direction", "must be one of \"both\", \"upstream\", or \"downstream\""), nil
+	}
+	// direction only means something relative to a named service. Silently
+	// ignoring it would let an agent believe it received a filtered graph.
+	if direction != "both" && service == "" {
+		return validationError("direction", "requires \"service\" to be set; direction is relative to one service"), nil
+	}
+
+	start, end := timeutil.GetTimestampsWithDefaults(args, timeutil.UnitNanos)
+	limit, offset, limitClamped := paginate.ParseParamsClamped(req.Params.Arguments)
+
+	// tags is passed through to the SigNoz API verbatim, matching
+	// signoz_get_service_top_operations: the backend expects a structured
+	// []TagQueryParam array, so the caller supplies that raw JSON.
+	var tags json.RawMessage
+	if t, ok := args["tags"].(string); ok && t != "" {
+		tags = json.RawMessage(t)
+	} else {
+		tags = json.RawMessage("[]")
+	}
+
+	h.logger.DebugContext(ctx, "Tool called: signoz_get_service_map",
+		slog.String("start", start),
+		slog.String("end", end),
+		slog.String("service", service),
+		slog.String("direction", direction))
+
+	client, err := h.GetClient(ctx)
+	if err != nil {
+		return clientError(err), nil
+	}
+	result, err := client.GetServiceMap(ctx, start, end, tags)
+	if err != nil {
+		h.logUpstreamFailure(ctx, "Failed to get service map", err, slog.String("start", start), slog.String("end", end))
+		return upstreamError(err), nil
+	}
+
+	edges, errResult := h.parseServiceMapEdges(ctx, result)
+	if errResult != nil {
+		return errResult, nil
+	}
+
+	if service != "" {
+		edges = filterServiceMapEdges(edges, service, direction)
+	}
+
+	total := len(edges)
+	resultJSON, err := paginate.Wrap(paginate.Array(edges, offset, limit), total, offset, limit)
+	if err != nil {
+		h.logger.ErrorContext(ctx, "Failed to wrap service map with pagination", logpkg.ErrAttr(err))
+		return InternalErrorResult("failed to marshal response: " + err.Error()), nil
+	}
+
+	return listResult(resultJSON, limitClamped), nil
+}
+
+// parseServiceMapEdges decodes /api/v1/dependency_graph, which is an
+// undocumented internal endpoint. It currently answers with a bare JSON array
+// (the legacy WriteJSON path), but the newer render.Success helper used
+// elsewhere in SigNoz wraps payloads as {"status":..,"data":..}. Accept both and
+// WARN on the wrapped form so upstream drift produces a signal rather than an
+// empty result the caller would read as "no dependencies".
+func (h *Handler) parseServiceMapEdges(ctx context.Context, raw json.RawMessage) ([]any, *mcp.CallToolResult) {
+	var edges []any
+	if err := json.Unmarshal(raw, &edges); err == nil {
+		return edges, nil
+	}
+
+	var wrapped struct {
+		Data []any `json:"data"`
+	}
+	if err := json.Unmarshal(raw, &wrapped); err != nil {
+		h.logger.ErrorContext(ctx, "Failed to parse service map response", logpkg.ErrAttr(err))
+		return nil, upstreamResponseError("failed to parse response: " + err.Error())
+	}
+
+	h.logger.WarnContext(ctx, "Service map response was wrapped in a status/data envelope; /api/v1/dependency_graph previously returned a bare array. Upstream response shape may have changed.",
+		slog.Int("edges", len(wrapped.Data)))
+	return wrapped.Data, nil
+}
+
+// filterServiceMapEdges keeps only edges touching service, in the requested
+// direction. Edges whose parent/child are not strings are dropped rather than
+// guessed at.
+func filterServiceMapEdges(edges []any, service, direction string) []any {
+	filtered := make([]any, 0, len(edges))
+	for _, edge := range edges {
+		m, ok := edge.(map[string]any)
+		if !ok {
+			continue
+		}
+		parent, _ := m["parent"].(string)
+		child, _ := m["child"].(string)
+
+		var keep bool
+		switch direction {
+		case "downstream":
+			keep = parent == service
+		case "upstream":
+			keep = child == service
+		default:
+			keep = parent == service || child == service
+		}
+		if keep {
+			filtered = append(filtered, edge)
+		}
+	}
+	return filtered
 }
 
 func (h *Handler) handleListServices(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {

--- a/internal/handler/tools/services_test.go
+++ b/internal/handler/tools/services_test.go
@@ -129,3 +129,163 @@ func TestHandleGetServiceTopOperations_NanosecondBackwardCompat(t *testing.T) {
 		t.Fatalf("ns values must round-trip to the top-operations client unchanged: start=%s end=%s", capturedStart, capturedEnd)
 	}
 }
+
+const serviceMapFixture = `[
+	{"parent":"frontend","child":"checkout","callCount":120,"callRate":3.3,"errorRate":1.2,"p99":420.5,"p50":120.4},
+	{"parent":"checkout","child":"payments","callCount":80,"callRate":2.2,"errorRate":9.7,"p99":900.1,"p50":300.0},
+	{"parent":"cron","child":"reporting","callCount":5,"callRate":0.1,"errorRate":0,"p99":50,"p50":20}
+]`
+
+func serviceMapHandler(t *testing.T, payload string) *Handler {
+	t.Helper()
+	return newTestHandler(&client.MockClient{
+		GetServiceMapFn: func(ctx context.Context, start, end string, tags json.RawMessage) (json.RawMessage, error) {
+			return json.RawMessage(payload), nil
+		},
+	})
+}
+
+func TestHandleGetServiceMap_ReturnsAllEdgesUnfiltered(t *testing.T) {
+	h := serviceMapHandler(t, serviceMapFixture)
+	req := makeToolRequest("signoz_get_service_map", map[string]any{"timeRange": "1h"})
+
+	result, err := h.handleGetServiceMap(testCtx(), req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("handler returned error result: %s", textContent(t, result))
+	}
+	body := textContent(t, result)
+	if !strings.Contains(body, `"total":3`) {
+		t.Fatalf("expected all 3 edges, got: %s", body)
+	}
+	if !strings.Contains(body, `"parent":"frontend"`) || !strings.Contains(body, `"p99":420.5`) {
+		t.Fatalf("expected upstream edge fields preserved verbatim, got: %s", body)
+	}
+}
+
+func TestHandleGetServiceMap_FiltersByServiceAndDirection(t *testing.T) {
+	tests := []struct {
+		name       string
+		direction  string
+		wantTotal  string
+		wantEdge   string
+		unwantEdge string
+	}{
+		{"downstream keeps callees", "downstream", `"total":1`, `"child":"payments"`, `"parent":"frontend"`},
+		{"upstream keeps callers", "upstream", `"total":1`, `"parent":"frontend"`, `"child":"payments"`},
+		{"both keeps either side", "both", `"total":2`, `"child":"payments"`, `"parent":"cron"`},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			h := serviceMapHandler(t, serviceMapFixture)
+			req := makeToolRequest("signoz_get_service_map", map[string]any{
+				"service":   "checkout",
+				"direction": tc.direction,
+			})
+
+			result, err := h.handleGetServiceMap(testCtx(), req)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if result.IsError {
+				t.Fatalf("handler returned error result: %s", textContent(t, result))
+			}
+			body := textContent(t, result)
+			if !strings.Contains(body, tc.wantTotal) {
+				t.Fatalf("expected %s, got: %s", tc.wantTotal, body)
+			}
+			if !strings.Contains(body, tc.wantEdge) {
+				t.Fatalf("expected edge %s, got: %s", tc.wantEdge, body)
+			}
+			if strings.Contains(body, tc.unwantEdge) {
+				t.Fatalf("expected %s to be filtered out, got: %s", tc.unwantEdge, body)
+			}
+		})
+	}
+}
+
+// direction is meaningless without a service; silently ignoring it would let an
+// agent believe it received a filtered graph.
+func TestHandleGetServiceMap_RejectsDirectionWithoutService(t *testing.T) {
+	h := serviceMapHandler(t, serviceMapFixture)
+	req := makeToolRequest("signoz_get_service_map", map[string]any{"direction": "upstream"})
+
+	result, err := h.handleGetServiceMap(testCtx(), req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !result.IsError {
+		t.Fatalf("expected validation error, got success: %s", textContent(t, result))
+	}
+	if !strings.Contains(textContent(t, result), "direction") {
+		t.Fatalf("expected error to name the direction field, got: %s", textContent(t, result))
+	}
+}
+
+func TestHandleGetServiceMap_RejectsUnknownDirection(t *testing.T) {
+	h := serviceMapHandler(t, serviceMapFixture)
+	req := makeToolRequest("signoz_get_service_map", map[string]any{
+		"service":   "checkout",
+		"direction": "sideways",
+	})
+
+	result, err := h.handleGetServiceMap(testCtx(), req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !result.IsError {
+		t.Fatalf("expected validation error for unknown direction, got: %s", textContent(t, result))
+	}
+}
+
+// /api/v1/dependency_graph is undocumented and answers with a bare array today.
+// If it ever starts using SigNoz's render.Success envelope we must still return
+// edges rather than a silent empty graph.
+func TestHandleGetServiceMap_AcceptsWrappedEnvelope(t *testing.T) {
+	h := serviceMapHandler(t, `{"status":"success","data":[{"parent":"frontend","child":"checkout","callCount":9}]}`)
+	req := makeToolRequest("signoz_get_service_map", map[string]any{})
+
+	result, err := h.handleGetServiceMap(testCtx(), req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("handler returned error result: %s", textContent(t, result))
+	}
+	body := textContent(t, result)
+	if !strings.Contains(body, `"total":1`) || !strings.Contains(body, `"child":"checkout"`) {
+		t.Fatalf("expected wrapped envelope to be unwrapped into edges, got: %s", body)
+	}
+}
+
+func TestHandleGetServiceMap_ReportsUnparseableResponse(t *testing.T) {
+	h := serviceMapHandler(t, `not json at all`)
+	req := makeToolRequest("signoz_get_service_map", map[string]any{})
+
+	result, err := h.handleGetServiceMap(testCtx(), req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !result.IsError {
+		t.Fatalf("expected an error result for an unparseable response, got: %s", textContent(t, result))
+	}
+}
+
+func TestHandleGetServiceMap_RejectsMalformedExplicitTimestamps(t *testing.T) {
+	h := serviceMapHandler(t, serviceMapFixture)
+	req := makeToolRequest("signoz_get_service_map", map[string]any{
+		"start": "not-a-timestamp",
+		"end":   "1641081600000",
+	})
+
+	result, err := h.handleGetServiceMap(testCtx(), req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !result.IsError {
+		t.Fatalf("expected validation error for malformed start, got: %s", textContent(t, result))
+	}
+}

--- a/manifest.json
+++ b/manifest.json
@@ -122,6 +122,10 @@
       "description": "Return one traced service's built-in operation table, ranked by p99 with p50/p95/p99, calls, and errors; use signoz_aggregate_traces for custom aggregation"
     },
     {
+      "name": "signoz_get_service_map",
+      "description": "Return the service dependency graph as caller/callee edges with call count, call rate, error rate, and latency quantiles; filter to one service's callers or callees with service plus direction"
+    },
+    {
       "name": "signoz_list_views",
       "description": "List paginated saved Explorer views for traces, logs, metrics, or Cost Meter, with optional name/category filters"
     },

--- a/plans/service-map.context.md
+++ b/plans/service-map.context.md
@@ -1,0 +1,75 @@
+# Feature: Service Dependency Map Tool — Context & Discussion
+
+## Original Prompt
+
+> SigNoz's own UI has a Service Map feature — the call graph between services, including
+> per-edge error rate and latency. The MCP server currently exposes `signoz_list_services`
+> and `signoz_get_service_top_operations`, but nothing surfaces the actual dependency edges
+> between services. This is a real gap for diagnostic workflows: answering "is the checkout
+> failure caused by something downstream" requires knowing what checkout actually calls,
+> which today requires leaving the chat to check the SigNoz UI directly.
+
+Filed as SigNoz/signoz-mcp-server#269.
+
+## Reference Links
+
+- Issue: https://github.com/SigNoz/signoz-mcp-server/issues/269
+- Route registration: `SigNoz/signoz` `pkg/query-service/app/http_handler.go:527`
+- Request parsing: `pkg/query-service/app/parser.go:216` (`parseGetServicesRequest`), `:366` (`parseTimeStr`)
+- Response item: `pkg/query-service/model/response.go:328` (`ServiceMapDependencyResponseItem`)
+- ClickHouse query: `pkg/query-service/app/clickhouseReader/reader.go:861` (`BuildServiceMapQuery`)
+
+## Key Decisions & Discussion Log
+
+### 2026-08-03 — endpoint research
+
+- The endpoint is `POST /api/v1/dependency_graph`, **not** `serviceMapDependencies` as
+  guessed while writing the issue. Confirmed at `http_handler.go:527`.
+- It is still the current path — the Service Map has no query-builder replacement in
+  `main`, so this is not a v5-QB migration candidate.
+- `start`/`end` are **strings containing nanosecond epoch**: `parseTimeStr` does
+  `strconv.ParseInt` then `time.Unix(0, v)`. Both are required; missing values 400.
+  This matches what `timeutil.GetTimestampsWithDefaults(args, timeutil.UnitNanos)` already
+  produces for `signoz_list_services`, so no new time handling was needed.
+- `end` is passed through `parseTimeMinusBufferStr` server-side, which subtracts a small
+  recency buffer. Not compensated for client-side — the buffer is the backend's choice.
+- The response is a **bare JSON array** (legacy `WriteJSON` path), not the
+  `{"status":"success","data":...}` envelope that newer `render.Success` routes use.
+- `errorRate` is a **percentage** (`sum(error_count)/sum(total_count)*100`), and quantiles
+  are in **milliseconds**. Both documented in the tool description and README so an agent
+  does not report a ratio as a percentage or vice versa.
+- Source table is the `dependency_graph_minutes` family, so resolution is per-minute and
+  narrow windows can legitimately return zero edges. Called out in the tool description
+  because "no edges" reads as "no dependencies" to an agent otherwise.
+
+### 2026-08-03 — design decisions
+
+- **No output schema / typed edge struct.** Deliberate. `signoz_list_services` also passes
+  upstream records through as `[]any`. `/api/v1/dependency_graph` is an undocumented
+  internal endpoint, so mapping it into a fixed Go struct would silently drop any field
+  SigNoz adds later. Passthrough preserves forward compatibility; the tradeoff is no
+  `outputSchema` advertised to clients.
+- **`service` + `direction` filtering is client-side.** The endpoint has no service
+  parameter — it returns the whole graph. Filtering locally still helps: it keeps the
+  agent's context small when the question is about one service, which is the common case.
+- **`direction` without `service` is a validation error, not a silent no-op.** Ignoring it
+  would let an agent believe it received a filtered graph and reason from a wrong premise.
+  Same reasoning for rejecting an unknown `direction` value instead of defaulting.
+- **`tags` is raw-JSON passthrough**, matching the existing
+  `signoz_get_service_top_operations` convention rather than inventing a typed filter here.
+- **Defensive envelope parsing + WARN.** Per the external-contract rule in CLAUDE.md, the
+  parser accepts both the bare array and a `{"status","data"}` envelope, and logs a WARN
+  when it sees the wrapped form. A fixture test alone would not catch that drift, and the
+  failure mode without this is an empty graph an agent reads as "no dependencies" —
+  exactly the silent degradation the rule targets.
+
+## Open Questions
+
+- [ ] Should the tool also emit `webUrl` deep links per edge? Deferred — the SigNoz UI
+      route for a service-map edge (as opposed to a service) is not obvious, and guessing a
+      URL shape is worse than omitting the field.
+- [ ] Not verified against a live SigNoz instance: the bare-array envelope and the
+      nanosecond `start`/`end` units are both read from source, not from a real response.
+      Flagged in the PR body so a maintainer with an instance can confirm.
+- [x] Full graph vs. one named service's dependencies (asked in the issue)? — Resolved:
+      support both, via an optional `service` parameter, defaulting to the full graph.

--- a/plans/service-map.plan.md
+++ b/plans/service-map.plan.md
@@ -1,0 +1,68 @@
+# Plan: Service Dependency Map Tool
+
+## Status
+
+Done
+
+## Context
+
+`signoz_list_services` and `signoz_get_service_top_operations` cover services individually,
+but nothing exposes the edges between them. An agent asked "is the checkout failure caused
+by something downstream" cannot answer without knowing what checkout calls, forcing the
+user out of the conversation into the SigNoz UI's Service Map. Closes #269.
+
+## Approach
+
+Add one read-only tool, `signoz_get_service_map`, over
+`POST /api/v1/dependency_graph`.
+
+- **Client** (`internal/client/client.go`): `GetServiceMap(ctx, start, end string, tags
+  json.RawMessage)`. POST carries only a body, so it is read-only and goes through
+  `doReplaySafePost` — this makes it retryable, unlike a mutating POST. `start`/`end` are
+  nanosecond epoch strings. A nil `tags` is normalized to `[]` because the backend rejects
+  a null tag filter.
+- **Handler** (`internal/handler/tools/services.go`, the service tool family): validate
+  explicit timestamps, validate `direction`, resolve the window with
+  `timeutil.UnitNanos`, call the client, parse defensively, optionally filter by
+  `service`/`direction`, then paginate with `paginate.Array`/`paginate.Wrap` and return
+  `listResult`.
+- **Edges pass through as `[]any`**, not a typed struct, so fields SigNoz adds later are
+  not silently dropped. Consequence: no `outputSchema`, matching `signoz_list_services`.
+- **`parseServiceMapEdges`** accepts both the bare array the endpoint returns today and a
+  `{"status","data"}` envelope, WARNing on the latter. The endpoint is undocumented, and
+  the silent-failure mode — an empty graph an agent reads as "no dependencies" — is what
+  CLAUDE.md's external-contract rule exists to prevent.
+- **`direction` is rejected without `service`**, and unknown values are rejected, rather
+  than degrading to an unfiltered graph an agent would misread as filtered.
+
+## Files to Modify
+
+- `internal/client/client.go` — add `GetServiceMap`
+- `internal/client/interface.go` — add `GetServiceMap` to `Client`
+- `internal/client/mock.go` — add `GetServiceMapFn` + method (defaults to `[]`)
+- `internal/handler/tools/services.go` — register `signoz_get_service_map`, add
+  `handleGetServiceMap`, `parseServiceMapEdges`, `filterServiceMapEdges`
+- `internal/handler/tools/annotations_inventory_test.go` — pin `readTriple`
+- `internal/handler/tools/services_test.go` — handler tests
+- `internal/client/client_test.go` — `TestGetServiceMap` pinning method, path, and the
+  nanosecond-string body contract
+- `manifest.json` — tool entry
+- `README.md` — summary-table row and per-tool detail section
+
+Not modified: `register.go` (the tool joins the existing `RegisterServiceHandlers` group),
+`schema_inventory_test.go` (no output schema), `nil_arguments_test.go` (every parameter is
+optional, so nil arguments are a valid full-graph call).
+
+## Verification
+
+- `go build ./...`
+- `go test ./...`
+- `go test -count=1 -run '^TestGuardrail_' ./...`
+- `make fmt goimports`
+- Handler tests cover: unfiltered graph, all three `direction` values, `direction` without
+  `service`, unknown `direction`, wrapped envelope, unparseable body, malformed timestamps.
+- Client test pins method `POST`, path `/api/v1/dependency_graph`, nanosecond-string
+  `start`/`end`, `tags` defaulting to `[]`, and 500/401 error propagation.
+- **Not verified live.** The bare-array envelope and nanosecond units are read from the
+  SigNoz source, not from a real instance response. Called out in the PR for maintainer
+  confirmation.


### PR DESCRIPTION
Closes #269.

## What

Adds one read-only tool, `signoz_get_service_map`, exposing the service-to-service call graph behind SigNoz's Service Map. `signoz_list_services` and `signoz_get_service_top_operations` cover services individually; nothing surfaced the edges between them, so an agent asked "is the checkout failure caused by something downstream" had to send the user to the SigNoz UI.

Returns one record per edge — `parent`, `child`, `callCount`, `callRate`, `errorRate`, and `p50`/`p75`/`p90`/`p95`/`p99` — paginated, with optional filtering to a single service.

## Endpoint

`POST /api/v1/dependency_graph` (`pkg/query-service/app/http_handler.go:527`). A POST only because it carries a body, so it is read-only and routed through `doReplaySafePost` rather than the single-attempt mutating-POST path.

`start`/`end` are nanosecond epoch strings (`parseTimeStr` → `strconv.ParseInt` → `time.Unix(0, v)`), which is what `timeutil.GetTimestampsWithDefaults(args, timeutil.UnitNanos)` already produces for `signoz_list_services` — no new time handling.

Two upstream details are documented in the tool description and README because getting them wrong changes an agent's conclusion: `errorRate` is a **percentage** (`sum(error_count)/sum(total_count)*100`) and quantiles are in **milliseconds**. A third is called out for the same reason — edges come from the per-minute `dependency_graph_minutes` rollup, so a very narrow window can legitimately return nothing, which an agent would otherwise report as "no dependencies".

## Design decisions worth reviewing

- **Edges pass through as `[]any`, no typed struct and no `outputSchema`.** Matches `signoz_list_services`. This endpoint is undocumented, so mapping it into a fixed struct would silently drop fields SigNoz adds later. Happy to add a typed output schema instead if you would rather advertise one — it is a real tradeoff, not an oversight.
- **`service`/`direction` filtering is client-side**, because the endpoint has no service parameter and returns the whole graph. It still earns its place by keeping the agent's context small for the common single-service question.
- **`direction` without `service` is a validation error**, as is an unknown `direction` value — rather than silently falling back to an unfiltered graph the agent would reason about as if it were filtered.
- **Defensive envelope parsing with a WARN.** The endpoint uses the legacy `WriteJSON` path and returns a bare array today, while newer SigNoz routes wrap payloads via `render.Success`. `parseServiceMapEdges` accepts both and WARNs on the wrapped form. Per the external-contract rule in `CLAUDE.md`: a fixture test cannot catch that drift, and the failure mode without the fallback is an empty graph a caller reads as "no dependencies" — silent degradation rather than a signal.

## Not verified against a live instance

The bare-array response shape and the nanosecond `start`/`end` units are read from the SigNoz source, not confirmed against a running instance — I do not have one to test against. Both are pinned by the client test, so if either is wrong the test documents the wrong assumption rather than hiding it. Would appreciate a sanity check from someone with an instance, and I am glad to adjust.

## Verification

- `go build ./...`, `go test ./...`, `go test -count=1 -run '^TestGuardrail_' ./...` — all pass
- `make fmt goimports` — clean
- Handler tests cover the unfiltered graph, all three `direction` values, `direction` without `service`, an unknown `direction`, the wrapped envelope, an unparseable body, and malformed explicit timestamps
- `TestGetServiceMap` in the client pins method, path, the nanosecond-string body, `tags` defaulting to `[]`, and 500/401 propagation

## Docs & metadata sync

- `README.md` — summary-table row plus a per-tool detail section
- `manifest.json` — tool entry
- `plans/service-map.{context,plan}.md` — added per the planning convention, including the endpoint research and the reasoning behind the passthrough and validation choices
- Annotation inventory pinned as `readTriple`
- Not touched, deliberately: `register.go` (joins the existing `RegisterServiceHandlers` group), `schema_inventory_test.go` (no output schema), `nil_arguments_test.go` (all parameters optional, so nil arguments are a valid full-graph call)

**agent-skills (CMP-3):** no companion change needed. This is purely additive — no existing tool, parameter, payload shape, or documented behavior changes, so nothing SigNoz/agent-skills currently teaches is affected.