### PR TITLE
feat(observability): capture failed MCP requests

### DIFF
--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -236,12 +236,14 @@ func (s *SigNoz) GetAnalyticsIdentity(ctx context.Context) (*AnalyticsIdentity, 
 	if s.cachedIdentity != nil && time.Since(s.identityCachedAt) < analyticsIdentityCacheTTL {
 		if s.meters != nil {
 			attrs := otelpkg.AppendTenantURL(ctx, nil)
+			attrs = otelpkg.AppendClientSource(ctx, attrs)
 			s.meters.IdentityCacheHits.Add(ctx, 1, metric.WithAttributes(attrs...))
 		}
 		return s.cachedIdentity, nil
 	}
 	if s.meters != nil {
 		attrs := otelpkg.AppendTenantURL(ctx, nil)
+		attrs = otelpkg.AppendClientSource(ctx, attrs)
 		s.meters.IdentityCacheMisses.Add(ctx, 1, metric.WithAttributes(attrs...))
 	}
 

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -17,9 +17,14 @@ import (
 	"testing"
 	"time"
 
+	"github.com/SigNoz/signoz-mcp-server/internal/testutil/oteltest"
 	logpkg "github.com/SigNoz/signoz-mcp-server/pkg/log"
+	otelpkg "github.com/SigNoz/signoz-mcp-server/pkg/otel"
+	"github.com/SigNoz/signoz-mcp-server/pkg/util"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 
 	"github.com/SigNoz/signoz-mcp-server/pkg/types"
 	"github.com/SigNoz/signoz-mcp-server/pkg/version"
@@ -455,14 +460,32 @@ func TestGetAnalyticsIdentity_CachesResult(t *testing.T) {
 
 	logger := logpkg.New("debug")
 	client := NewClient(logger, server.URL, "Bearer jwt", "Authorization", nil)
+	reader := sdkmetric.NewManualReader()
+	meterProvider := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+	t.Cleanup(func() { _ = meterProvider.Shutdown(context.Background()) })
+	meters, err := otelpkg.NewMeters(meterProvider)
+	require.NoError(t, err)
+	client.SetMeters(meters)
+	ctx := util.SetClientSource(context.Background(), "ai-assistant")
 
 	for i := 0; i < 5; i++ {
-		identity, err := client.GetAnalyticsIdentity(context.Background())
+		identity, err := client.GetAnalyticsIdentity(ctx)
 		require.NoError(t, err)
 		assert.Equal(t, "user-1", identity.UserID)
 	}
 
 	assert.Equal(t, 1, requests, "expected identity cache to serve repeated lookups")
+
+	var collected metricdata.ResourceMetrics
+	require.NoError(t, reader.Collect(context.Background(), &collected))
+	for _, metricName := range []string{"mcp.identity_cache.hit", "mcp.identity_cache.miss"} {
+		sum, found := oteltest.FindInt64SumMetric(collected, metricName)
+		require.True(t, found, "%s metric not found", metricName)
+		require.Len(t, sum.DataPoints, 1, "%s datapoints", metricName)
+		attr, present := sum.DataPoints[0].Attributes.Value(otelpkg.MCPClientSourceKey)
+		require.True(t, present, "%s missing mcp.client_source", metricName)
+		assert.Equal(t, "ai-assistant", attr.AsString(), "%s mcp.client_source", metricName)
+	}
 }
 
 func TestGetAnalyticsIdentity_ConcurrentCallsDedupe(t *testing.T) {

--- a/internal/handler/tools/docs.go
+++ b/internal/handler/tools/docs.go
@@ -8,6 +8,7 @@ import (
 	"log/slog"
 	"time"
 
+	otelpkg "github.com/SigNoz/signoz-mcp-server/pkg/otel"
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
 	"go.opentelemetry.io/otel/attribute"
@@ -91,8 +92,11 @@ func (h *Handler) handleSearchDocs(ctx context.Context, req mcp.CallToolRequest)
 		case len(result.Results) >= 1:
 			bucket = "1-4"
 		}
-		h.meters.DocsSearches.Add(ctx, 1, metric.WithAttributes(attribute.String("result_count_bucket", bucket)))
-		h.meters.DocsSearchDuration.Record(ctx, time.Since(start).Seconds())
+		attrs := []attribute.KeyValue{attribute.String("result_count_bucket", bucket)}
+		attrs = otelpkg.AppendClientSource(ctx, attrs)
+		h.meters.DocsSearches.Add(ctx, 1, metric.WithAttributes(attrs...))
+		durationAttrs := otelpkg.AppendClientSource(ctx, nil)
+		h.meters.DocsSearchDuration.Record(ctx, time.Since(start).Seconds(), metric.WithAttributes(durationAttrs...))
 	}
 	if err != nil {
 		if err.Error() == docsindex.CodeIndexNotReady {
@@ -126,7 +130,9 @@ func (h *Handler) handleFetchDoc(ctx context.Context, req mcp.CallToolRequest) (
 
 	result, code, err := h.docsIndex.FetchDoc(ctx, rawURL, heading)
 	if h.meters != nil && err == nil && code == "" {
-		h.meters.DocsFetches.Add(ctx, 1, metric.WithAttributes(attribute.Bool("cached", true)))
+		attrs := []attribute.KeyValue{attribute.Bool("cached", true)}
+		attrs = otelpkg.AppendClientSource(ctx, attrs)
+		h.meters.DocsFetches.Add(ctx, 1, metric.WithAttributes(attrs...))
 	}
 	if err != nil {
 		return errorWithCause(err, CodeInternalError, err.Error()), nil

--- a/internal/handler/tools/docs_test.go
+++ b/internal/handler/tools/docs_test.go
@@ -9,13 +9,18 @@ import (
 
 	signozclient "github.com/SigNoz/signoz-mcp-server/internal/client"
 	docsindex "github.com/SigNoz/signoz-mcp-server/internal/docs"
+	"github.com/SigNoz/signoz-mcp-server/internal/testutil/oteltest"
+	otelpkg "github.com/SigNoz/signoz-mcp-server/pkg/otel"
+	"github.com/SigNoz/signoz-mcp-server/pkg/util"
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
 	"github.com/stretchr/testify/require"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 )
 
 func TestDocsHandlers(t *testing.T) {
-	ctx := context.Background()
+	ctx := util.SetClientSource(context.Background(), "ai-assistant")
 
 	t.Run("index not ready", func(t *testing.T) {
 		h := newTestHandler(nil)
@@ -27,6 +32,12 @@ func TestDocsHandlers(t *testing.T) {
 
 	h, cleanup := newDocsTestHandler(t)
 	defer cleanup()
+	reader := sdkmetric.NewManualReader()
+	meterProvider := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+	t.Cleanup(func() { _ = meterProvider.Shutdown(context.Background()) })
+	meters, err := otelpkg.NewMeters(meterProvider)
+	require.NoError(t, err)
+	h.SetMeters(meters)
 
 	t.Run("search section filter and snippet", func(t *testing.T) {
 		result, err := h.handleSearchDocs(ctx, makeToolRequest("signoz_search_docs", map[string]any{
@@ -98,7 +109,7 @@ func TestDocsHandlers(t *testing.T) {
 	})
 
 	t.Run("search cancellation preserves cause", func(t *testing.T) {
-		canceledCtx, cancel := context.WithCancel(context.Background())
+		canceledCtx, cancel := context.WithCancel(ctx)
 		cancel()
 		result, err := h.handleSearchDocs(canceledCtx, makeToolRequest("signoz_search_docs", map[string]any{
 			"searchText": "docker",
@@ -108,7 +119,7 @@ func TestDocsHandlers(t *testing.T) {
 	})
 
 	t.Run("fetch deadline preserves cause", func(t *testing.T) {
-		expiredCtx, cancel := context.WithDeadline(context.Background(), time.Now().Add(-time.Second))
+		expiredCtx, cancel := context.WithDeadline(ctx, time.Now().Add(-time.Second))
 		defer cancel()
 		result, err := h.handleFetchDoc(expiredCtx, makeToolRequest("signoz_fetch_doc", map[string]any{
 			"url": "/docs/install/docker/",
@@ -156,6 +167,25 @@ func TestDocsHandlers(t *testing.T) {
 		require.Equal(t, docsindex.DocsSitemapURI, text.URI)
 		require.Contains(t, text.Text, "Send logs to SigNoz")
 	})
+
+	var collected metricdata.ResourceMetrics
+	require.NoError(t, reader.Collect(context.Background(), &collected))
+	for _, metricName := range []string{"signoz_docs_searches_total", "signoz_docs_fetches_total"} {
+		sum, found := oteltest.FindInt64SumMetric(collected, metricName)
+		require.True(t, found, "%s metric not found", metricName)
+		for _, point := range sum.DataPoints {
+			attr, present := point.Attributes.Value(otelpkg.MCPClientSourceKey)
+			require.True(t, present, "%s missing mcp.client_source", metricName)
+			require.Equal(t, "ai-assistant", attr.AsString(), "%s mcp.client_source", metricName)
+		}
+	}
+	duration, found := oteltest.FindFloat64HistogramMetric(collected, "signoz_docs_search_duration_seconds")
+	require.True(t, found, "signoz_docs_search_duration_seconds metric not found")
+	for _, point := range duration.DataPoints {
+		attr, present := point.Attributes.Value(otelpkg.MCPClientSourceKey)
+		require.True(t, present, "signoz_docs_search_duration_seconds missing mcp.client_source")
+		require.Equal(t, "ai-assistant", attr.AsString(), "signoz_docs_search_duration_seconds mcp.client_source")
+	}
 }
 
 // TestSearchDocs_SearchTextNotSchemaRequired pins the schema-aware-client

--- a/internal/handler/tools/handler.go
+++ b/internal/handler/tools/handler.go
@@ -23,9 +23,9 @@ type Handler struct {
 	customHeaders map[string]string
 	meters        *otelpkg.Meters
 	docsIndex     *docsindex.IndexRegistry
-	// validationWarned deduplicates validation WARN logs per bounded
-	// (tool, direction, path, constraint) key; see warnValidationOnce.
-	validationWarned sync.Map
+	// validationLogs rate-limits representative validation request WARNs per
+	// bounded tool/direction/path/constraint tuple; counters remain exact.
+	validationLogs sync.Map
 
 	// registrations tracks the names advertised through each composed SDK
 	// server. mcp-go stores registrations in maps and silently overwrites a

--- a/internal/handler/tools/output_schema_test.go
+++ b/internal/handler/tools/output_schema_test.go
@@ -13,6 +13,7 @@ import (
 	logpkg "github.com/SigNoz/signoz-mcp-server/pkg/log"
 	otelpkg "github.com/SigNoz/signoz-mcp-server/pkg/otel"
 	"github.com/SigNoz/signoz-mcp-server/pkg/types"
+	"github.com/SigNoz/signoz-mcp-server/pkg/util"
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
 	"go.opentelemetry.io/otel/attribute"
@@ -118,7 +119,7 @@ func TestAllowlistedOutputToolsReturnStructuredContentOnSuccess(t *testing.T) {
 	}
 }
 
-func TestInputMismatchServedBestEffortAndNeverLogsArgumentValues(t *testing.T) {
+func TestInputMismatchServedBestEffortLogsRedactedRequestAndAttributedMetric(t *testing.T) {
 	var logs bytes.Buffer
 	logger := slog.New(logpkg.NewContextHandler(slog.NewJSONHandler(&logs, &slog.HandlerOptions{Level: slog.LevelDebug})))
 	reader := sdkmetric.NewManualReader()
@@ -137,10 +138,12 @@ func TestInputMismatchServedBestEffortAndNeverLogsArgumentValues(t *testing.T) {
 		return mcp.NewToolResultText("ok"), nil
 	})
 
-	response := s.HandleMessage(context.Background(), json.RawMessage(`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"shadow_probe","arguments":{"webhook_password":"super-secret-value"}}}`))
+	ctx := util.SetClientSource(context.Background(), "ai-assistant")
+	response := s.HandleMessage(ctx, json.RawMessage(`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"shadow_probe","arguments":{"searchContext":"create a webhook","webhook_password":"super-secret-value"}}}`))
 	if !called {
 		t.Fatal("input mismatch must not block the handler call")
 	}
+	s.HandleMessage(ctx, json.RawMessage(`{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"shadow_probe","arguments":{"searchContext":"second attempt","webhook_password":"another-secret-value"}}}`))
 	encoded, err := json.Marshal(response)
 	if err != nil {
 		t.Fatal(err)
@@ -157,16 +160,37 @@ func TestInputMismatchServedBestEffortAndNeverLogsArgumentValues(t *testing.T) {
 	if !strings.Contains(logs.String(), "tool schema validation mismatch") || !strings.Contains(logs.String(), `"validation.direction":"input"`) {
 		t.Fatalf("missing shadow mismatch warning: %s", logs.String())
 	}
-	if strings.Contains(logs.String(), "super-secret-value") {
+	if count := strings.Count(logs.String(), "tool schema validation mismatch"); count != 1 {
+		t.Fatalf("mismatch warning count = %d, want one representative request per rate-limit window; logs=%s", count, logs.String())
+	}
+	if strings.Contains(logs.String(), "super-secret-value") || strings.Contains(logs.String(), "another-secret-value") {
 		t.Fatalf("validation telemetry leaked raw argument values: %s", logs.String())
+	}
+	if !strings.Contains(logs.String(), `"mcp.request":`) || !strings.Contains(logs.String(), `create a webhook`) || !strings.Contains(logs.String(), `[REDACTED]`) {
+		t.Fatalf("validation telemetry missing reproducible redacted requests: %s", logs.String())
+	}
+	if strings.Contains(logs.String(), `second attempt`) {
+		t.Fatalf("identical mismatch inside rate-limit window should be suppressed: %s", logs.String())
 	}
 	var collected metricdata.ResourceMetrics
 	if err := reader.Collect(context.Background(), &collected); err != nil {
 		t.Fatal(err)
 	}
 	sum, ok := oteltest.FindInt64SumMetric(collected, "mcp.tool.validation.mismatches")
-	if !ok || len(sum.DataPoints) != 1 || sum.DataPoints[0].Value != 1 {
+	if !ok || len(sum.DataPoints) != 1 || sum.DataPoints[0].Value != 2 {
 		t.Fatalf("shadow mismatch counter = %#v, found=%t", sum, ok)
+	}
+	for key, want := range map[attribute.Key]string{
+		attribute.Key("gen_ai.tool.name"):      "shadow_probe",
+		attribute.Key("validation.direction"):  "input",
+		attribute.Key("validation.path"):       "/webhook_password",
+		attribute.Key("validation.constraint"): "type",
+		otelpkg.MCPClientSourceKey:             "ai-assistant",
+	} {
+		got, present := sum.DataPoints[0].Attributes.Value(key)
+		if !present || got.AsString() != want {
+			t.Fatalf("mismatch metric %s = %v, present=%t; want %q", key, got, present, want)
+		}
 	}
 }
 

--- a/internal/handler/tools/schema_compat.go
+++ b/internal/handler/tools/schema_compat.go
@@ -9,7 +9,11 @@ import (
 	"log/slog"
 	"strconv"
 	"strings"
+	"sync/atomic"
+	"time"
 
+	logpkg "github.com/SigNoz/signoz-mcp-server/pkg/log"
+	otelpkg "github.com/SigNoz/signoz-mcp-server/pkg/otel"
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
 	"github.com/santhosh-tekuri/jsonschema/v6"
@@ -22,7 +26,12 @@ const (
 	// successful result whose arguments mismatched the advertised schema.
 	inputValidationNoticePrefix = "Input validation notice:"
 	maxValidationMetadataLength = 96
+	validationLogInterval       = time.Minute
 )
+
+type validationLogState struct {
+	nextAllowedUnixNano atomic.Int64
+}
 
 type compiledToolSchema struct {
 	validator          *jsonschema.Schema
@@ -177,7 +186,7 @@ func (h *Handler) validationDecorator(toolName string, input, output *compiledTo
 		if input != nil {
 			if err := validateArguments(input.validator, req); err != nil {
 				path, constraint := validationMetadata(err, input.topLevelProperties)
-				h.recordValidationMismatch(ctx, toolName, "input", path, constraint)
+				h.recordValidationMismatch(ctx, req, toolName, "input", path, constraint)
 				notice = inputValidationNotice(err)
 			}
 		}
@@ -193,12 +202,12 @@ func (h *Handler) validationDecorator(toolName string, input, output *compiledTo
 			return result, nil
 		}
 		if result.StructuredContent == nil {
-			h.recordMissingStructuredContent(ctx, toolName)
+			h.recordMissingStructuredContent(ctx, req, toolName)
 			return result, nil
 		}
 		if err := validateSchemaValue(output.validator, result.StructuredContent, false); err != nil {
 			path, constraint := validationMetadata(err, output.topLevelProperties)
-			h.recordValidationMismatch(ctx, toolName, "output", path, constraint)
+			h.recordValidationMismatch(ctx, req, toolName, "output", path, constraint)
 		}
 		return result, nil
 	}
@@ -316,20 +325,26 @@ func boundedMetadata(value string) string {
 	return value
 }
 
-func (h *Handler) recordValidationMismatch(ctx context.Context, toolName, direction, path, constraint string) {
-	if h.warnValidationOnce(toolName, direction, path, constraint) {
-		h.logger.WarnContext(ctx, "tool schema validation mismatch (further identical mismatches suppressed; see mcp.tool.validation.mismatches)",
-			slog.String("gen_ai.tool.name", toolName),
-			slog.String("validation.direction", direction),
-			slog.String("validation.path", path),
-			slog.String("validation.constraint", constraint))
+func (h *Handler) recordValidationMismatch(ctx context.Context, req mcp.CallToolRequest, toolName, direction, path, constraint string) {
+	if h.logger.Enabled(ctx, slog.LevelWarn) {
+		if h.shouldLogValidationRequest(toolName, direction, path, constraint) {
+			h.logger.WarnContext(ctx, "tool schema validation mismatch (repeats rate-limited; see mcp.tool.validation.mismatches)",
+				slog.String("gen_ai.tool.name", toolName),
+				slog.String("validation.direction", direction),
+				slog.String("validation.path", path),
+				slog.String("validation.constraint", constraint),
+				slog.String("mcp.request", logpkg.RedactedTruncAny(req)))
+		}
 	}
 	if h.meters != nil {
-		h.meters.ToolValidationMismatches.Add(ctx, 1, metric.WithAttributes(
+		attrs := []attribute.KeyValue{
 			attribute.String("gen_ai.tool.name", toolName),
 			attribute.String("validation.direction", direction),
 			attribute.String("validation.path", path),
-			attribute.String("validation.constraint", constraint)))
+			attribute.String("validation.constraint", constraint),
+		}
+		attrs = otelpkg.AppendClientSource(ctx, attrs)
+		h.meters.ToolValidationMismatches.Add(ctx, 1, metric.WithAttributes(attrs...))
 	}
 }
 
@@ -345,14 +360,35 @@ func (h *Handler) recordSchemaCompileFailure(ctx context.Context, toolName, dire
 	}
 }
 
-func (h *Handler) recordMissingStructuredContent(ctx context.Context, toolName string) {
-	if h.warnValidationOnce(toolName, "output", "<root>", "missing_structured_content") {
-		h.logger.WarnContext(ctx, "successful schema-declaring tool returned no structured content (further occurrences suppressed; see mcp.tool.output.missing_structured_content)",
-			slog.String("gen_ai.tool.name", toolName))
+func (h *Handler) recordMissingStructuredContent(ctx context.Context, req mcp.CallToolRequest, toolName string) {
+	if h.logger.Enabled(ctx, slog.LevelWarn) {
+		if h.shouldLogValidationRequest(toolName, "output", "<root>", "missing_structured_content") {
+			h.logger.WarnContext(ctx, "successful schema-declaring tool returned no structured content (repeats rate-limited; see mcp.tool.output.missing_structured_content)",
+				slog.String("gen_ai.tool.name", toolName),
+				slog.String("mcp.request", logpkg.RedactedTruncAny(req)))
+		}
 	}
 	if h.meters != nil {
-		h.meters.ToolOutputMissingStructuredContent.Add(ctx, 1, metric.WithAttributes(
-			attribute.String("gen_ai.tool.name", toolName)))
+		attrs := []attribute.KeyValue{attribute.String("gen_ai.tool.name", toolName)}
+		attrs = otelpkg.AppendClientSource(ctx, attrs)
+		h.meters.ToolOutputMissingStructuredContent.Add(ctx, 1, metric.WithAttributes(attrs...))
+	}
+}
+
+func (h *Handler) shouldLogValidationRequest(toolName, direction, path, constraint string) bool {
+	key := toolName + "|" + direction + "|" + path + "|" + constraint
+	value, _ := h.validationLogs.LoadOrStore(key, &validationLogState{})
+	state := value.(*validationLogState)
+
+	now := time.Now().UnixNano()
+	for {
+		next := state.nextAllowedUnixNano.Load()
+		if now < next {
+			return false
+		}
+		if state.nextAllowedUnixNano.CompareAndSwap(next, now+validationLogInterval.Nanoseconds()) {
+			return true
+		}
 	}
 }
 
@@ -427,15 +463,6 @@ func openInputObjects(schema any) any {
 		}
 	}
 	return schema
-}
-
-// warnValidationOnce reports whether this (tool, direction, path, constraint)
-// key has not been logged yet this process. Metrics stay exact per event; only
-// the WARN log is deduplicated so a looping client cannot flood logs.
-func (h *Handler) warnValidationOnce(toolName, direction, path, constraint string) bool {
-	key := toolName + "|" + direction + "|" + path + "|" + constraint
-	_, seen := h.validationWarned.LoadOrStore(key, struct{}{})
-	return !seen
 }
 
 func normalizeToolOutputSchema(schema *mcp.ToolOutputSchema) {

--- a/internal/mcp-server/server.go
+++ b/internal/mcp-server/server.go
@@ -656,7 +656,9 @@ func (m *MCPServer) buildHooks() *server.Hooks {
 		m.finishMethodObservation(ctx, id, method, message, nil)
 	})
 	hooks.AddOnError(func(ctx context.Context, id any, method mcp.MCPMethod, message any, err error) {
+		toolHandlerObserved := false
 		if method == mcp.MethodToolsCall {
+			_, toolHandlerObserved, _ = otelpkg.MCPToolRequestObservation(ctx)
 			m.completeUnobservedToolCall(ctx, nil, err)
 		} else if shouldObserveMethod(method) {
 			// finish returns true iff a matching observation existed (even if
@@ -676,9 +678,18 @@ func (m *MCPServer) buildHooks() *server.Hooks {
 			span.RecordError(err)
 			span.SetStatus(codes.Error, err.Error())
 		}
-		m.logger.Log(ctx, methodErrorLogLevel(err), "mcp error",
+		level := methodErrorLogLevel(err)
+		logAttrs := []any{
 			slog.String("mcp.method.name", otelpkg.NormalizeMCPMethod(string(method))),
-			logpkg.ErrAttr(err))
+			logpkg.BoundedErrAttr(err),
+		}
+		if method == mcp.MethodToolsCall && !toolHandlerObserved && m.logger.Enabled(ctx, level) {
+			switch request := message.(type) {
+			case *mcp.CallToolRequest:
+				logAttrs = append(logAttrs, slog.String("mcp.request", logpkg.RedactedTruncAny(*request)))
+			}
+		}
+		m.logger.Log(ctx, level, "mcp error", logAttrs...)
 	})
 	hooks.AddAfterInitialize(func(ctx context.Context, id any, message *mcp.InitializeRequest, result *mcp.InitializeResult) {
 		signozURL, ok := util.GetSigNozURL(ctx)
@@ -811,17 +822,28 @@ func (m *MCPServer) loggingMiddleware() server.ToolHandlerMiddleware {
 			case err != nil:
 				// Client-driven cancellations (context.Canceled) log at DEBUG;
 				// deadline-exceeded and real failures stay ERROR.
-				m.logger.Log(ctx, logpkg.LevelForError(err), "tool call failed",
+				level := logpkg.LevelForError(err)
+				attrs := []any{
 					slog.Duration("duration", duration),
 					slog.Bool("mcp.tool.is_error", isErr),
 					sizeAttr,
-					logpkg.ErrAttr(err))
+					logpkg.BoundedErrAttr(err),
+				}
+				if m.logger.Enabled(ctx, level) {
+					attrs = append(attrs, slog.String("mcp.request", logpkg.RedactedTruncAny(req)))
+				}
+				m.logger.Log(ctx, level, "tool call failed", attrs...)
 			case result != nil && result.IsError:
-				m.logger.WarnContext(ctx, "tool call returned error result",
+				attrs := []any{
 					slog.Duration("duration", duration),
 					slog.Bool("mcp.tool.is_error", isErr),
 					sizeAttr,
-					slog.String("error_message", extractToolErrorMessage(result)))
+					slog.String("error_message", logpkg.TruncBody([]byte(extractToolErrorMessage(result)))),
+				}
+				if m.logger.Enabled(ctx, slog.LevelWarn) {
+					attrs = append(attrs, slog.String("mcp.request", logpkg.RedactedTruncAny(req)))
+				}
+				m.logger.WarnContext(ctx, "tool call returned error result", attrs...)
 			default:
 				m.logger.DebugContext(ctx, "tool call finished",
 					slog.Duration("duration", duration),
@@ -863,6 +885,8 @@ func (m *MCPServer) completeUnobservedToolCall(ctx context.Context, rawResult an
 		otelpkg.MCPToolIsErrorKey.Bool(isErr),
 		otelpkg.MCPToolResultBytesKey.Int64(resultBytes),
 	}
+	spanAttrs = otelpkg.AppendTenantURL(ctx, spanAttrs)
+	spanAttrs = otelpkg.AppendCallerCorrelation(ctx, spanAttrs)
 	if errorType != "" {
 		spanAttrs = append(spanAttrs, attribute.String("error.type", errorType))
 	}
@@ -1100,6 +1124,7 @@ func (m *MCPServer) logAuthFailure(ctx context.Context, r *http.Request, status 
 			attribute.String("mcp.auth.mode", authMode),
 		}
 		metricAttrs = otelpkg.AppendTenantURL(ctx, metricAttrs)
+		metricAttrs = otelpkg.AppendClientSource(ctx, metricAttrs)
 		m.meters.AuthFailures.Add(ctx, 1, metric.WithAttributes(metricAttrs...))
 	}
 
@@ -1131,10 +1156,7 @@ func (m *MCPServer) authMiddleware(next http.Handler) http.Handler {
 		// 401/early-reject paths) propagates them. Values are advisory and
 		// flow into every log/span/event, so they are normalized
 		// (trim + length-cap) before being stashed.
-		clientSource := util.NormalizeCallerCorrelationValue(r.Header.Get("X-SigNoz-Client-Source"))
-		if clientSource == "" {
-			clientSource = util.ClientSourceUserClient
-		}
+		clientSource := util.NormalizeClientSource(r.Header.Get("X-SigNoz-Client-Source"))
 		ctx = util.SetClientSource(ctx, clientSource)
 		if threadID := util.NormalizeCallerCorrelationValue(r.Header.Get("X-SigNoz-Assistant-Thread-Id")); threadID != "" {
 			ctx = util.SetAssistantThreadID(ctx, threadID)

--- a/internal/mcp-server/server_test.go
+++ b/internal/mcp-server/server_test.go
@@ -2918,7 +2918,7 @@ func TestUnknownToolCallRecordsBoundedFallbackTelemetry(t *testing.T) {
 	}
 }
 
-func TestUnknownToolFailureLogBoundsRequestAndError(t *testing.T) {
+func TestUnknownToolFailureLogUsesSeparateRequestAndErrorBounds(t *testing.T) {
 	var logs bytes.Buffer
 	logger := newBufferedLogger(&logs, slog.LevelDebug)
 	cfg := &config.Config{ClientCacheSize: 1, ClientCacheTTL: time.Minute}
@@ -2928,11 +2928,13 @@ func TestUnknownToolFailureLogBoundsRequestAndError(t *testing.T) {
 
 	sdkServer.HandleMessage(context.Background(), json.RawMessage(`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"`+requestedName+`","arguments":{}}}`))
 	record, _ := logRecordByMessage(t, &logs, "mcp error")
-	for _, key := range []string{"error", "mcp.request"} {
-		value, ok := record[key].(string)
-		if !ok || len(value) > 4*1024 || !strings.HasSuffix(value, "...(truncated)") {
-			t.Fatalf("%s = %T len=%d, want bounded truncated string", key, record[key], len(value))
-		}
+	errorValue, ok := record["error"].(string)
+	if !ok || len(errorValue) > 4*1024 || !strings.HasSuffix(errorValue, "...(truncated)") {
+		t.Fatalf("error = %T len=%d, want 4 KiB-bounded string", record["error"], len(errorValue))
+	}
+	requestValue, ok := record["mcp.request"].(string)
+	if !ok || len(requestValue) <= 4*1024 || len(requestValue) > 1024*1024 || strings.HasSuffix(requestValue, "...(truncated)") || !json.Valid([]byte(requestValue)) {
+		t.Fatalf("mcp.request = %T len=%d, want complete JSON under 1 MiB", record["mcp.request"], len(requestValue))
 	}
 }
 

--- a/internal/mcp-server/server_test.go
+++ b/internal/mcp-server/server_test.go
@@ -998,6 +998,9 @@ func TestAuthMiddlewareExpiredOAuthLogsDebugAndRecordsAuthFailureMetric(t *testi
 	if attr, ok := dp.Attributes.Value(otelpkg.MCPTenantURLKey); !ok || attr.AsString() != "https://oauth.example.com" {
 		t.Fatalf("metric mcp.tenant_url = %v, want OAuth token tenant", attr)
 	}
+	if attr, ok := dp.Attributes.Value(otelpkg.MCPClientSourceKey); !ok || attr.AsString() != util.ClientSourceUserClient {
+		t.Fatalf("metric mcp.client_source = %v, want %s", attr, util.ClientSourceUserClient)
+	}
 }
 
 func TestAuthMiddlewareMissingCredentialsLogsDebugAndRecordsAuthFailureMetric(t *testing.T) {
@@ -1021,6 +1024,7 @@ func TestAuthMiddlewareMissingCredentialsLogsDebugAndRecordsAuthFailureMetric(t 
 	server := &MCPServer{logger: newBufferedLogger(&buf, slog.LevelDebug), config: cfg, analytics: noopanalytics.New(), meters: meters}
 
 	req := httptest.NewRequest(http.MethodPost, "https://mcp.example.com/mcp", nil)
+	req.Header.Set("X-SigNoz-Client-Source", "attacker-controlled-source")
 	rr := httptest.NewRecorder()
 
 	server.authMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -1062,6 +1066,9 @@ func TestAuthMiddlewareMissingCredentialsLogsDebugAndRecordsAuthFailureMetric(t 
 	}
 	if attr, ok := dp.Attributes.Value(attribute.Key("mcp.auth.mode")); !ok || attr.AsString() != authModeNone {
 		t.Fatalf("metric mcp.auth.mode = %v, want %s", attr, authModeNone)
+	}
+	if attr, ok := dp.Attributes.Value(otelpkg.MCPClientSourceKey); !ok || attr.AsString() != util.ClientSourceOther {
+		t.Fatalf("metric mcp.client_source = %v, want %s", attr, util.ClientSourceOther)
 	}
 }
 
@@ -2104,11 +2111,13 @@ func TestLoggingMiddlewareAddsToolNameToLifecycleAndDownstreamLogs(t *testing.T)
 			_, err := middleware(func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 				logger.DebugContext(ctx, "downstream tool log")
 				return tt.result, tt.err
-			})(context.Background(), mcp.CallToolRequest{
+			})(util.SetClientSource(context.Background(), "ai-assistant"), mcp.CallToolRequest{
 				Params: mcp.CallToolParams{
 					Name: "signoz_query",
 					Arguments: map[string]any{
-						"searchContext": "find slow services",
+						"searchContext":    "find slow services",
+						"filter":           "service.name = 'api'",
+						"webhook_password": "secret-canary",
 					},
 				},
 			})
@@ -2127,6 +2136,9 @@ func TestLoggingMiddlewareAddsToolNameToLifecycleAndDownstreamLogs(t *testing.T)
 				if rec["mcp.search_context"] != "find slow services" {
 					t.Fatalf("%s mcp.search_context = %v, want search text", msg, rec["mcp.search_context"])
 				}
+				if rec["mcp.client_source"] != "ai-assistant" {
+					t.Fatalf("%s mcp.client_source = %v, want ai-assistant", msg, rec["mcp.client_source"])
+				}
 				if strings.HasPrefix(msg, "tool call ") {
 					count := strings.Count(line, `"gen_ai.tool.name":`)
 					if count != 1 {
@@ -2138,6 +2150,17 @@ func TestLoggingMiddlewareAddsToolNameToLifecycleAndDownstreamLogs(t *testing.T)
 			terminal, _ := logRecordByMessage(t, &buf, tt.terminalMsg)
 			if terminal["level"] != tt.terminalLevel {
 				t.Fatalf("%s level = %v, want %s", tt.terminalMsg, terminal["level"], tt.terminalLevel)
+			}
+			request, hasRequest := terminal["mcp.request"].(string)
+			if tt.err != nil || (tt.result != nil && tt.result.IsError) {
+				if !hasRequest || !strings.Contains(request, `service.name = 'api'`) || !strings.Contains(request, `[REDACTED]`) {
+					t.Fatalf("%s mcp.request = %v, want reproducible redacted request", tt.terminalMsg, terminal["mcp.request"])
+				}
+				if strings.Contains(request, "secret-canary") {
+					t.Fatalf("%s mcp.request leaked credential: %s", tt.terminalMsg, request)
+				}
+			} else if hasRequest {
+				t.Fatalf("successful terminal log should not carry mcp.request: %s", request)
 			}
 		})
 	}
@@ -2152,7 +2175,7 @@ func TestLoggingMiddleware_ErrorResultLogsWarn(t *testing.T) {
 	_, err := middleware(func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 		return &mcp.CallToolResult{
 			IsError: true,
-			Content: []mcp.Content{mcp.TextContent{Text: "tool exploded"}},
+			Content: []mcp.Content{mcp.TextContent{Text: strings.Repeat("tool exploded", 1024)}},
 		}, nil
 	})(context.Background(), mcp.CallToolRequest{
 		Params: mcp.CallToolParams{Name: "signoz_query"},
@@ -2167,10 +2190,40 @@ func TestLoggingMiddleware_ErrorResultLogsWarn(t *testing.T) {
 			if rec["level"] != "WARN" {
 				t.Fatalf("level = %v, want WARN", rec["level"])
 			}
+			errorMessage, ok := rec["error_message"].(string)
+			if !ok || len(errorMessage) > 4*1024 || !strings.HasSuffix(errorMessage, "...(truncated)") {
+				t.Fatalf("error_message = %T len=%d, want bounded string", rec["error_message"], len(errorMessage))
+			}
 			return
 		}
 	}
 	t.Fatalf("tool error-result log not found in %v", records)
+}
+
+func TestRegisteredToolGoErrorLogsRequestOnce(t *testing.T) {
+	var logs bytes.Buffer
+	logger := newBufferedLogger(&logs, slog.LevelDebug)
+	cfg := &config.Config{ClientCacheSize: 1, ClientCacheTTL: time.Minute}
+	handler := tools.NewHandler(logger, cfg)
+	mcpServer := NewMCPServer(logger, handler, cfg, noopanalytics.New(), nil)
+	sdkServer := mcpServer.newSDKServer()
+	handler.AddTool(sdkServer, mcp.NewTool("go_error_probe"), func(context.Context, mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		return nil, errors.New("handler failed")
+	})
+
+	ctx := util.SetClientSource(context.Background(), "ai-assistant")
+	sdkServer.HandleMessage(ctx, json.RawMessage(`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"go_error_probe","arguments":{"filter":"service.name = 'api'"}}}`))
+	if count := strings.Count(logs.String(), `"mcp.request":`); count != 1 {
+		t.Fatalf("mcp.request log count = %d, want exactly one; logs=%s", count, logs.String())
+	}
+	terminal, _ := logRecordByMessage(t, &logs, "tool call failed")
+	if request, ok := terminal["mcp.request"].(string); !ok || !strings.Contains(request, "go_error_probe") {
+		t.Fatalf("tool failure mcp.request = %v", terminal["mcp.request"])
+	}
+	hookLog, _ := logRecordByMessage(t, &logs, "mcp error")
+	if _, duplicated := hookLog["mcp.request"]; duplicated {
+		t.Fatalf("mcp error hook duplicated registered-tool request: %v", hookLog["mcp.request"])
+	}
 }
 
 func TestLoggingMiddleware_GoErrorLogsError(t *testing.T) {
@@ -2802,11 +2855,14 @@ func TestUnknownToolCallRecordsBoundedFallbackTelemetry(t *testing.T) {
 		t.Fatalf("new meters: %v", err)
 	}
 
+	var logs bytes.Buffer
+	logger := newBufferedLogger(&logs, slog.LevelDebug)
 	cfg := &config.Config{ClientCacheSize: 1, ClientCacheTTL: time.Minute}
-	mcpServer := NewMCPServer(logpkg.New("error"), tools.NewHandler(logpkg.New("error"), cfg), cfg, noopanalytics.New(), meters)
+	mcpServer := NewMCPServer(logger, tools.NewHandler(logger, cfg), cfg, noopanalytics.New(), meters)
 	sdkServer := mcpServer.newSDKServer()
 	const requestedName = "attacker-generated-tool-name"
-	response := sdkServer.HandleMessage(context.Background(), json.RawMessage(`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"`+requestedName+`","arguments":{}}}`))
+	ctx := util.SetClientSource(context.Background(), "ai-assistant")
+	response := sdkServer.HandleMessage(ctx, json.RawMessage(`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"`+requestedName+`","arguments":{"filter":"service.name = 'api'"}}}`))
 	encoded, err := json.Marshal(response)
 	if err != nil {
 		t.Fatalf("marshal response: %v", err)
@@ -2826,6 +2882,7 @@ func TestUnknownToolCallRecordsBoundedFallbackTelemetry(t *testing.T) {
 	for key, want := range map[attribute.Key]string{
 		otelpkg.GenAIToolNameKey:    unknownToolName,
 		attribute.Key("error.type"): "not_found",
+		otelpkg.MCPClientSourceKey:  "ai-assistant",
 	} {
 		got, ok := toolCalls.DataPoints[0].Attributes.Value(key)
 		if !ok || got.AsString() != want {
@@ -2853,6 +2910,29 @@ func TestUnknownToolCallRecordsBoundedFallbackTelemetry(t *testing.T) {
 	}
 	if strings.Contains(spans[0].Name, requestedName) {
 		t.Fatalf("span name contains unvalidated tool name: %q", spans[0].Name)
+	}
+	errorLog, _ := logRecordByMessage(t, &logs, "mcp error")
+	request, ok := errorLog["mcp.request"].(string)
+	if !ok || !strings.Contains(request, requestedName) || !strings.Contains(request, `service.name = 'api'`) {
+		t.Fatalf("unknown-tool mcp.request = %v, want handler-visible request", errorLog["mcp.request"])
+	}
+}
+
+func TestUnknownToolFailureLogBoundsRequestAndError(t *testing.T) {
+	var logs bytes.Buffer
+	logger := newBufferedLogger(&logs, slog.LevelDebug)
+	cfg := &config.Config{ClientCacheSize: 1, ClientCacheTTL: time.Minute}
+	mcpServer := NewMCPServer(logger, tools.NewHandler(logger, cfg), cfg, noopanalytics.New(), nil)
+	sdkServer := mcpServer.newSDKServer()
+	requestedName := "unknown-" + strings.Repeat("x", 8*1024)
+
+	sdkServer.HandleMessage(context.Background(), json.RawMessage(`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"`+requestedName+`","arguments":{}}}`))
+	record, _ := logRecordByMessage(t, &logs, "mcp error")
+	for _, key := range []string{"error", "mcp.request"} {
+		value, ok := record[key].(string)
+		if !ok || len(value) > 4*1024 || !strings.HasSuffix(value, "...(truncated)") {
+			t.Fatalf("%s = %T len=%d, want bounded truncated string", key, record[key], len(value))
+		}
 	}
 }
 

--- a/pkg/log/handler_test.go
+++ b/pkg/log/handler_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"log/slog"
 	"strings"
 	"testing"
@@ -248,9 +249,55 @@ func TestRedactedTruncAny(t *testing.T) {
 		}
 	}
 
-	big := RedactedTruncAny(map[string]any{"query": strings.Repeat("x", truncBodyLimit*2)})
-	if len(big) > truncBodyLimit || !strings.HasSuffix(big, truncBodySuffix) {
+	big := RedactedTruncAny(map[string]any{"query": strings.Repeat("x", requestCaptureLimit*2)})
+	if len(big) > requestCaptureLimit || !strings.HasSuffix(big, truncBodySuffix) {
 		t.Fatalf("RedactedTruncAny oversized payload len/suffix = %d/%q", len(big), big[len(big)-len(truncBodySuffix):])
+	}
+}
+
+func TestRedactedTruncAnyPreservesLargeDashboardUnderOneMiB(t *testing.T) {
+	const panelCount = 300
+	panels := make(map[string]any, panelCount)
+	for i := 0; i < panelCount; i++ {
+		id := fmt.Sprintf("panel-%03d", i)
+		panels[id] = map[string]any{
+			"kind": "Panel",
+			"spec": map[string]any{
+				"display": map[string]any{
+					"name":        fmt.Sprintf("Latency Panel %03d", i),
+					"description": strings.Repeat("service latency dashboard detail ", 48),
+				},
+			},
+		}
+	}
+	payload := map[string]any{
+		"method": "tools/call",
+		"params": map[string]any{
+			"name": "signoz_create_dashboard",
+			"arguments": map[string]any{
+				"schemaVersion": "v6",
+				"tags":          []any{},
+				"spec": map[string]any{
+					"display": map[string]any{"name": "Large Service Latency Dashboard"},
+					"panels":  panels,
+				},
+			},
+		},
+	}
+	raw, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(raw) <= truncBodyLimit || len(raw) >= requestCaptureLimit {
+		t.Fatalf("dashboard request size = %d, want between %d and %d", len(raw), truncBodyLimit, requestCaptureLimit)
+	}
+
+	got := RedactedTruncAny(payload)
+	if !json.Valid([]byte(got)) || strings.HasSuffix(got, truncBodySuffix) {
+		t.Fatalf("large dashboard capture should remain complete JSON: len=%d suffix=%t", len(got), strings.HasSuffix(got, truncBodySuffix))
+	}
+	if !strings.Contains(got, `"panel-299"`) {
+		t.Fatal("large dashboard capture omitted the final panel")
 	}
 }
 

--- a/pkg/log/handler_test.go
+++ b/pkg/log/handler_test.go
@@ -205,3 +205,75 @@ func TestTruncBody(t *testing.T) {
 		t.Fatalf("TruncBody(big) len = %d, want <= 4096", len(got))
 	}
 }
+
+func TestRedactedTruncAny(t *testing.T) {
+	slackURL := "https://hooks.slack.com/services/T1/B2/secret-slack"
+	webhookURL := "https://alerts.example.com/hook/secret-webhook"
+	teamsURL := "https://teams.example.com/webhook/secret-teams"
+	routingKey := "pagerduty-routing-secret"
+	payload := map[string]any{
+		"name": "signoz_create_notification_channel",
+		"arguments": map[string]any{
+			"webhook_password":      "secret-canary",
+			"slack_api_url":         slackURL,
+			"webhook_url":           webhookURL,
+			"msteams_webhook_url":   teamsURL,
+			"pagerduty_routing_key": routingKey,
+			"searchContext":         "configure notification channels",
+			"nested": []any{
+				map[string]any{"clientSecret": "nested-canary", "filter": "service.name = 'api'"},
+			},
+		},
+	}
+
+	got := RedactedTruncAny(payload)
+	for _, secret := range []string{"secret-canary", "nested-canary", slackURL, webhookURL, teamsURL, routingKey} {
+		if strings.Contains(got, secret) {
+			t.Fatalf("RedactedTruncAny leaked credential %q: %s", secret, got)
+		}
+	}
+	for _, want := range []string{
+		`"name":"signoz_create_notification_channel"`,
+		`"webhook_password":"[REDACTED]"`,
+		`"slack_api_url":"[REDACTED]"`,
+		`"webhook_url":"[REDACTED]"`,
+		`"msteams_webhook_url":"[REDACTED]"`,
+		`"pagerduty_routing_key":"[REDACTED]"`,
+		`"searchContext":"configure notification channels"`,
+		`"clientSecret":"[REDACTED]"`,
+		`"filter":"service.name = 'api'"`,
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("RedactedTruncAny = %s, want %s", got, want)
+		}
+	}
+
+	big := RedactedTruncAny(map[string]any{"query": strings.Repeat("x", truncBodyLimit*2)})
+	if len(big) > truncBodyLimit || !strings.HasSuffix(big, truncBodySuffix) {
+		t.Fatalf("RedactedTruncAny oversized payload len/suffix = %d/%q", len(big), big[len(big)-len(truncBodySuffix):])
+	}
+}
+
+func TestBoundedErrAttr(t *testing.T) {
+	var buf bytes.Buffer
+	logger := newTestLogger(&buf)
+	exporter := tracetest.NewInMemoryExporter()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSyncer(exporter))
+	t.Cleanup(func() { _ = tp.Shutdown(context.Background()) })
+	ctx, span := tp.Tracer("t").Start(context.Background(), "op")
+	logger.ErrorContext(ctx, "failed", BoundedErrAttr(errors.New(strings.Repeat("x", truncBodyLimit*2))))
+	span.End()
+
+	var record map[string]any
+	if err := json.Unmarshal(buf.Bytes(), &record); err != nil {
+		t.Fatal(err)
+	}
+	got, ok := record["error"].(string)
+	if !ok || len(got) > truncBodyLimit || !strings.HasSuffix(got, truncBodySuffix) {
+		t.Fatalf("bounded error = %T len=%d suffix=%t", record["error"], len(got), strings.HasSuffix(got, truncBodySuffix))
+	}
+	spans := exporter.GetSpans()
+	if len(spans) != 1 || spans[0].Status.Code != codes.Error || spans[0].Status.Description != got {
+		t.Fatalf("bounded error span status = %#v, want Error with bounded description", spans)
+	}
+}

--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -13,9 +13,10 @@ import (
 )
 
 const (
-	truncBodyLimit  = 4 * 1024
-	truncBodySuffix = "...(truncated)"
-	redactedValue   = "[REDACTED]"
+	truncBodyLimit      = 4 * 1024
+	requestCaptureLimit = 1024 * 1024
+	truncBodySuffix     = "...(truncated)"
+	redactedValue       = "[REDACTED]"
 )
 
 var (
@@ -101,11 +102,15 @@ func LevelForError(err error) slog.Level {
 }
 
 func TruncBody(b []byte) string {
-	if len(b) <= truncBodyLimit {
+	return truncBodyAt(b, truncBodyLimit)
+}
+
+func truncBodyAt(b []byte, limit int) string {
+	if len(b) <= limit {
 		return string(b)
 	}
 
-	cutoff := truncBodyLimit - len(truncBodySuffix)
+	cutoff := limit - len(truncBodySuffix)
 	if cutoff < 0 {
 		cutoff = 0
 	}
@@ -117,18 +122,23 @@ func TruncBody(b []byte) string {
 // (e.g. response bodies of unknown size) can be logged without leaking
 // unbounded payloads into stdout or the collector pipeline.
 func TruncAny(v any) string {
+	return truncAnyAt(v, truncBodyLimit)
+}
+
+func truncAnyAt(v any, limit int) string {
 	b, err := json.Marshal(v)
 	if err != nil {
 		return "<unmarshalable>"
 	}
-	return TruncBody(b)
+	return truncBodyAt(b, limit)
 }
 
 // RedactedTruncAny serializes a structured log payload while replacing values
 // under credential-shaped keys at any depth. It is intended for diagnostic
 // request capture: callers retain the payload's reproducible shape and
-// non-secret values without copying credentials into logs. The existing body
-// cap still applies so a single failed request cannot flood the log pipeline.
+// non-secret values without copying credentials into logs. Request captures
+// use a dedicated 1 MiB cap; ordinary body and error logs remain capped at
+// 4 KiB.
 func RedactedTruncAny(v any) string {
 	b, err := json.Marshal(v)
 	if err != nil {
@@ -142,7 +152,7 @@ func RedactedTruncAny(v any) string {
 		return "<unmarshalable>"
 	}
 	decoded = redactSensitiveValues(decoded)
-	return TruncAny(decoded)
+	return truncAnyAt(decoded, requestCaptureLimit)
 }
 
 func redactSensitiveValues(value any) any {

--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -1,6 +1,7 @@
 package log
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -14,6 +15,24 @@ import (
 const (
 	truncBodyLimit  = 4 * 1024
 	truncBodySuffix = "...(truncated)"
+	redactedValue   = "[REDACTED]"
+)
+
+var (
+	sensitiveKeyNormalizer = strings.NewReplacer("_", "", "-", "", ".", "", " ", "")
+	sensitiveKeySuffixes   = [...]string{
+		"apikey",
+		"credential",
+		"credentials",
+		"password",
+		"passwd",
+		"passphrase",
+		"privatekey",
+		"routingkey",
+		"secret",
+		"token",
+		"webhookurl",
+	}
 )
 
 // New creates a JSON slog logger that matches the Zeus field naming convention.
@@ -54,6 +73,19 @@ func ErrAttr(err error) slog.Attr {
 	return slog.Any("error", err)
 }
 
+type boundedLogError string
+
+func (e boundedLogError) Error() string { return string(e) }
+
+// BoundedErrAttr preserves error semantics for ContextHandler while capping
+// client- or upstream-controlled text before it reaches the log pipeline.
+func BoundedErrAttr(err error) slog.Attr {
+	if err == nil {
+		return slog.Any("error", nil)
+	}
+	return slog.Any("error", boundedLogError(TruncBody([]byte(err.Error()))))
+}
+
 // LevelForError maps an error to the severity it should be logged at.
 // context.Canceled means the caller (typically an MCP client) disconnected or
 // aborted the request mid-flight — expected behavior logged at DEBUG so it
@@ -90,4 +122,60 @@ func TruncAny(v any) string {
 		return "<unmarshalable>"
 	}
 	return TruncBody(b)
+}
+
+// RedactedTruncAny serializes a structured log payload while replacing values
+// under credential-shaped keys at any depth. It is intended for diagnostic
+// request capture: callers retain the payload's reproducible shape and
+// non-secret values without copying credentials into logs. The existing body
+// cap still applies so a single failed request cannot flood the log pipeline.
+func RedactedTruncAny(v any) string {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return "<unmarshalable>"
+	}
+
+	decoder := json.NewDecoder(bytes.NewReader(b))
+	decoder.UseNumber()
+	var decoded any
+	if err := decoder.Decode(&decoded); err != nil {
+		return "<unmarshalable>"
+	}
+	decoded = redactSensitiveValues(decoded)
+	return TruncAny(decoded)
+}
+
+func redactSensitiveValues(value any) any {
+	switch typed := value.(type) {
+	case map[string]any:
+		for key, child := range typed {
+			normalizedKey := normalizeLogKey(key)
+			if isSensitiveNormalizedKey(normalizedKey) {
+				typed[key] = redactedValue
+				continue
+			}
+			typed[key] = redactSensitiveValues(child)
+		}
+	case []any:
+		for i, child := range typed {
+			typed[i] = redactSensitiveValues(child)
+		}
+	}
+	return value
+}
+
+func normalizeLogKey(key string) string {
+	return sensitiveKeyNormalizer.Replace(strings.ToLower(strings.TrimSpace(key)))
+}
+
+func isSensitiveNormalizedKey(normalized string) bool {
+	if normalized == "authorization" || normalized == "slackapiurl" {
+		return true
+	}
+	for _, suffix := range sensitiveKeySuffixes {
+		if strings.HasSuffix(normalized, suffix) {
+			return true
+		}
+	}
+	return false
 }

--- a/pkg/otel/attr.go
+++ b/pkg/otel/attr.go
@@ -37,9 +37,9 @@ const (
 	// Non-standard (the registry has no equivalent today); scoped under the
 	// mcp.tool.* namespace used by this server's other tool-call attrs.
 	MCPToolResultBytesKey = attribute.Key("mcp.tool.result.size_bytes")
-	// ClientSource is low-cardinality (categorical) and safe on metrics; the
-	// two assistant IDs are per-execution UUIDs and MUST NOT be applied as
-	// metric attributes.
+	// ClientSource is normalized at ingress to a bounded categorical value and
+	// is safe on metrics. The two assistant IDs are per-execution UUIDs and MUST
+	// NOT be applied as metric attributes.
 	MCPClientSourceKey         = attribute.Key("mcp.client_source")
 	MCPAssistantThreadIDKey    = attribute.Key("mcp.assistant.thread_id")
 	MCPAssistantExecutionIDKey = attribute.Key("mcp.assistant.execution_id")
@@ -75,8 +75,7 @@ func ClientSourceAttr(ctx context.Context) (attribute.KeyValue, bool) {
 	return MCPClientSourceKey.String(source), true
 }
 
-// AppendClientSource appends mcp.client_source. Safe on both span and metric
-// attribute lists — client_source is bounded categorical.
+// AppendClientSource appends the ingress-normalized mcp.client_source.
 func AppendClientSource(ctx context.Context, attrs []attribute.KeyValue) []attribute.KeyValue {
 	if attr, ok := ClientSourceAttr(ctx); ok {
 		return append(attrs, attr)

--- a/pkg/util/context.go
+++ b/pkg/util/context.go
@@ -20,10 +20,12 @@ const (
 	assistantExecutionIDContextKey contextKey = "assistant_execution_id"
 )
 
-// ClientSourceUserClient is the default for client_source when the header
-// is absent or blank — emitting a concrete value keeps downstream group-bys
-// free of null-handling.
-const ClientSourceUserClient = "user-client"
+// Client source values used by the bounded request telemetry taxonomy.
+const (
+	ClientSourceUserClient  = "user-client"
+	ClientSourceAIAssistant = "ai-assistant"
+	ClientSourceOther       = "other"
+)
 
 // CallerCorrelationHeaderMaxLen bounds advisory caller-correlation header
 // values. They flow into every log record, span attribute, and Segment
@@ -45,6 +47,20 @@ func NormalizeCallerCorrelationValue(s string) string {
 		return s
 	}
 	return string(runes[:CallerCorrelationHeaderMaxLen])
+}
+
+// NormalizeClientSource collapses the advisory ingress header to a bounded
+// metric-safe taxonomy used consistently across logs, spans, metrics, and
+// analytics.
+func NormalizeClientSource(s string) string {
+	switch normalized := NormalizeCallerCorrelationValue(s); normalized {
+	case ClientSourceAIAssistant:
+		return normalized
+	case "", ClientSourceUserClient:
+		return ClientSourceUserClient
+	default:
+		return ClientSourceOther
+	}
 }
 
 // SetAPIKey stores the API key in the context

--- a/pkg/util/context_test.go
+++ b/pkg/util/context_test.go
@@ -1,0 +1,21 @@
+package util
+
+import "testing"
+
+func TestNormalizeClientSource(t *testing.T) {
+	for _, tt := range []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{name: "default", input: "", want: ClientSourceUserClient},
+		{name: "assistant", input: " ai-assistant ", want: ClientSourceAIAssistant},
+		{name: "unknown", input: "attacker-controlled-source", want: ClientSourceOther},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := NormalizeClientSource(tt.input); got != tt.want {
+				t.Fatalf("NormalizeClientSource(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}

--- a/plans/assistant-correlation-headers.context.md
+++ b/plans/assistant-correlation-headers.context.md
@@ -60,4 +60,4 @@
 - [x] Suppress analytics events when `client_source = ai-assistant`? Answer: no — emit with tag, filter downstream.
 - [x] Add `thread_id` / `execution_id` to metrics? Answer: no, cardinality risk; logs + spans + analytics only.
 - [x] Keep `searchContext` on analytics events? Answer: no — drop from analytics, retain on logs and spans.
-- [ ] Future: when `X-SigNoz-Client-Source` taxonomy expands beyond `ai-assistant`, do we want a server-side allowlist or stay permissive? Out of scope for this change.
+- [x] Future: when `X-SigNoz-Client-Source` taxonomy expands beyond `ai-assistant`, do we want a server-side allowlist or stay permissive? Answered 2026-08-05: use a server-side bounded taxonomy in `pkg/util/context.go`; retain `user-client`/`ai-assistant` and collapse unknown values to `other` at ingress.

--- a/plans/failure-request-observability.context.md
+++ b/plans/failure-request-observability.context.md
@@ -57,6 +57,12 @@
 - An unknown tool with an 8 KiB name bounded both `error` and `mcp.request` at 4,096 characters and normalized an unsupported client source to `other`.
 - The server was stopped, port 18091 was confirmed closed, the temporary directory was removed, and the credential was unset. Live metric export was deliberately disabled; metric dimensions remain covered by deterministic manual-reader tests.
 
+### 2026-08-05 — Raise failure-request capture to 1 MiB
+- A local real-middleware probe used a 637,041-byte `signoz_create_dashboard` request with 300 panels. The handler received all 637,041 bytes, but the original 4 KiB `mcp.request` log was invalid truncated JSON containing none of the panel objects, so it could not satisfy the replay goal for large dashboards.
+- The owner chose the simple bounded compromise: raise only redacted `mcp.request` captures to 1 MiB. Ordinary body/error logs and client-visible bounded error details stay at 4 KiB; changing their shared limit would be an unrelated MCP behavior change.
+- Requests at or below 1 MiB remain complete valid JSON after redaction. Larger requests retain the explicit `...(truncated)` marker; the existing 4 MiB inbound HTTP request limit is unchanged.
+- After implementation, the real logging-middleware probe passed with a 503,652-byte, 300-panel dashboard: handler and logged request sizes matched, the logged value was valid JSON, no truncation marker was present, and the final panel remained available for replay.
+
 ## Open Questions
 - [x] Should raw auth headers be logged? — No. `mcp.CallToolRequest.Header` is excluded from JSON serialization by `mcp-go`, and the failure payload helper accepts only the handler-visible request.
 - [x] Should repeated schema mismatches remain deduplicated? — Rate-limit WARN request capture per bounded mismatch tuple. The first representative request is enough to reproduce the contract mismatch; counters remain exact and the WARN points operators to the counter for total volume.

--- a/plans/failure-request-observability.context.md
+++ b/plans/failure-request-observability.context.md
@@ -1,0 +1,63 @@
+# Feature: Failure Request Observability — Context & Discussion
+
+## Original Prompt
+> We want to log full request in case of validation or any tool failures so that we can replicate and imporve MCP server
+> Let's support for it
+>
+> Also we want to ensure mcp.client_source is added everywhere
+> *> Data note: advisory schema-validation mismatch events were 73 vs 50 (+46.0%) and are not failed calls. The metric lacks mcp.client\_source and populated bounded tool/path/constraint labels, so cohort and tool attribution is unavailable.*
+
+## Reference Links
+- [`docs/mcp-best-practices.md`](../docs/mcp-best-practices.md)
+- [`plans/observability-refactor.plan.md`](observability-refactor.plan.md)
+- [`plans/mcp-go-v0.56-upgrade.plan.md`](mcp-go-v0.56-upgrade.plan.md)
+
+## Key Decisions & Discussion Log
+
+### 2026-08-05 — Central failure capture and request-scoped attribution
+- Capture the complete handler-visible `mcp.CallToolRequest` on every schema mismatch, missing structured output, returned tool error, and Go tool error. HTTP headers remain excluded by `mcp-go`'s request JSON contract, so ingress credentials are never copied into the payload field.
+- Preserve the existing observability safety boundary: recursively redact credential-shaped argument keys and cap the serialized request at 4 KiB. The remaining tool name, argument structure, non-secret values, MCP metadata, and task parameters are sufficient for a local replay in ordinary requests; truncation is explicit in the field value.
+- Stop deduplicating schema-mismatch WARN records. Two requests can hit the same bounded `(tool, direction, path, constraint)` tuple with different payloads, so suppressing later records defeats reproduction. Metrics remain exact as before.
+- Treat `mcp.client_source` as a required dimension on request-scoped telemetry. Add it to validation/missing-output, auth-failure, docs-tool, and identity-cache metrics that currently omit it. Registration-time schema compilation and background docs/OAuth metrics remain excluded because they do not represent an MCP client request.
+- Keep validation metric dimensions bounded: registered tool name, normalized direction, normalized schema path, and normalized constraint. Add regressions that assert these labels are populated together with `mcp.client_source`.
+- This is internal observability only: no MCP tool/resource/prompt/configuration contract changes, so README/manifest and the companion `SigNoz/agent-skills` repo do not require updates.
+
+### 2026-08-05 — Implementation and verification
+- Added redacted, 4 KiB-bounded `mcp.request` capture to every schema mismatch, missing structured output, returned tool error, Go tool error, and pre-handler/unknown-tool error log path.
+- Added `mcp.client_source` to validation, missing-output, auth-failure, docs-tool, and analytics-identity-cache metrics, with regressions covering each family and the bounded validation dimensions.
+- Focused tests, `go test ./...`, `go vet ./...`, `go build ./cmd/server`, formatting/imports, and `git diff --check` pass.
+- Agent CI could not start because `/var/run/docker.sock` is unavailable on this machine; repository-native checks were run as the fallback. No live tenant verification was needed because the change is local logging/OTel instrumentation with manual-reader tests.
+
+### 2026-08-05 — Multi-agent review and hardening
+- Three independent reviews covered reuse, code quality/security, and efficiency/overengineering. Confirmed findings: request redaction was eagerly evaluated on successful calls; registered Go errors could serialize the request twice; notification-channel webhook URLs/routing keys escaped generic redaction; repeated advisory mismatches could amplify WARN logs; and raw error strings were not bounded with the request payload.
+- Fixed the confirmed findings: failure payloads are now built only when the relevant log level is enabled, hook capture is skipped after registered middleware observes the request, known notification credentials are redacted everywhere they recur (including `searchContext`), error text is 4 KiB-bounded, and validation WARNs are rate-limited per bounded tool/direction/path/constraint tuple while metrics remain exact.
+- Reused `TruncAny` after redaction and hoisted key-normalization tables per the reuse/efficiency reviews.
+- Declined a streaming one-pass redactor: after lazy evaluation it runs only on emitted failure/WARN paths, inbound requests are already capped at 4 MiB, `mcp-go`'s custom `CallToolParams.MarshalJSON` preserves `RawArguments`, and a multi-pass representation is needed to discover credential values before removing them from repeated free text.
+- Retained caller-attribute stamping in `completeUnobservedToolCall`: `BeforeAny` covers unknown/filtered tools, but malformed `tools/call` requests can invoke `OnError` without `BeforeAny`, so the fallback remains necessary for that path.
+
+### 2026-08-05 — Claude Opus 5 high-effort overengineering review
+- Ran an uncapped, read-only `claude-opus-5` review in high-effort mode after two capped attempts were stopped before verdict. The completed run explicitly reviewed correctness, security, performance, and removable complexity.
+- Confirmed and fixed two P1s: cross-field substring replacement could become quadratic on a 4 MiB failure request, and the context logger could emit raw `mcp.search_context` beside a redacted `mcp.request` on the same record.
+- Simplified redaction to deterministic key-based replacement. Advisory free-text `searchContext` is always redacted from captured failure requests; `ContextHandler` omits the duplicate raw context whenever a captured request is present. Replay-critical tool arguments remain available except credential-shaped fields.
+- Collapsed validation rate limiting from per-tuple mutex/counter state to one atomic deadline, removed unreachable value/nil request-hook branches, restored metric discovery hints in rate-limited WARN messages, and preserved the bounded error type with a span-status regression.
+- Bounded the newly added pre-auth auth-failure metric dimension: known `user-client`/`ai-assistant` values remain, while arbitrary unauthenticated header values collapse to `other`. Authenticated tool/method telemetry retains normalized custom source taxonomy.
+- Opus's one-pass/request-precision concern was not applicable after source verification: `mcp-go` v0.56 `CallToolParams.MarshalJSON` explicitly re-emits `RawArguments`, and the helper now runs only on enabled failure/WARN logs. Docs-duration attribution was retained because adding `mcp.client_source` to request-scoped metrics is the requested contract.
+
+### 2026-08-05 — Final Opus 5 approval and superseding decisions
+- Final uncapped `claude-opus-5` high-effort verification approved the production code with no P0/P1/P2 findings and no overengineering after the following two simplifications.
+- `searchContext` remains verbatim on both existing observability surfaces (`mcp.search_context` and the captured `mcp.request`). It is established observability content rather than a credential field; credential-shaped tool arguments and ingress headers remain redacted/excluded. This supersedes the earlier intermediate decision to redact it only from failure records.
+- `util.NormalizeClientSource` is now the single ingress policy for HTTP requests: `user-client` and `ai-assistant` are retained, every other value collapses to `other`, and that same bounded value flows to logs, spans, metrics, and analytics. Stdio seeds `user-client`. This supersedes the intermediate pre-auth-only clamp and permissive authenticated taxonomy.
+- Opus's remaining findings were planning-record consistency only; the plan file and the earlier assistant-correlation open question were updated accordingly.
+
+### 2026-08-05 — Live staging MCP E2E
+- Delegated a credential-hygienic live run of the modified HTTP server against `https://app.us.staging.signoz.cloud`. The supplied bearer token stayed process-ephemeral and was not printed, persisted, or committed.
+- Initialization negotiated protocol `2025-11-25`; `tools/list` returned 43 tools; the read-only `signoz_list_alerts` call returned structured `data` and `pagination`. No tenant resource was created or modified.
+- An intentionally wrong-type `limit` on `signoz_search_docs` remained advisory (`isError=false`) and appended the input-validation notice. Its WARN carried `direction=input`, `path=/limit`, `constraint=type`, and `mcp.client_source=ai-assistant`; the captured request redacted a nested dummy `apiToken` and truncated at 4,096 characters.
+- A bad alert UUID returned coded `VALIDATION_FAILED` and logged the handler-visible method, tool name, `searchContext`, ID, and a redacted dummy `privateKey`. A successful tool call emitted no `mcp.request`, confirming failure-only serialization.
+- An unknown tool with an 8 KiB name bounded both `error` and `mcp.request` at 4,096 characters and normalized an unsupported client source to `other`.
+- The server was stopped, port 18091 was confirmed closed, the temporary directory was removed, and the credential was unset. Live metric export was deliberately disabled; metric dimensions remain covered by deterministic manual-reader tests.
+
+## Open Questions
+- [x] Should raw auth headers be logged? — No. `mcp.CallToolRequest.Header` is excluded from JSON serialization by `mcp-go`, and the failure payload helper accepts only the handler-visible request.
+- [x] Should repeated schema mismatches remain deduplicated? — Rate-limit WARN request capture per bounded mismatch tuple. The first representative request is enough to reproduce the contract mismatch; counters remain exact and the WARN points operators to the counter for total volume.
+- [x] Does `mcp.client_source` apply to background or browser-only telemetry? — No. It is required on request-scoped MCP telemetry only; background schema/docs work and OAuth browser flows have no MCP client source.

--- a/plans/failure-request-observability.plan.md
+++ b/plans/failure-request-observability.plan.md
@@ -7,11 +7,11 @@ In Progress
 Schema-mismatch telemetry counts advisory contract drift, but operators cannot currently split it by `mcp.client_source` or recover the request that triggered it. Tool failure logs similarly carry the error and tool context but omit the request arguments needed for a local replay. Several secondary request-scoped metrics also omit caller attribution even though the request context already contains the bounded source value.
 
 ## Approach
-1. Add a shared JSON-log helper that serializes the handler-visible request, recursively redacts credential-shaped fields, and applies the established 4 KiB payload cap.
+1. Add a shared JSON-log helper that serializes the handler-visible request, recursively redacts credential-shaped fields, and applies a dedicated 1 MiB request-capture cap. Keep ordinary body and error log values at the established 4 KiB cap.
 2. Attach the resulting `mcp.request` field to schema mismatches, missing-structured-output warnings, returned tool errors, and Go tool failures. Rate-limit repeated advisory validation WARNs per bounded mismatch tuple while keeping exact counters; registered handler errors emit the request once, and pre-handler failures retain hook-level capture.
 3. Normalize `mcp.client_source` once at ingress to the bounded taxonomy `user-client`, `ai-assistant`, or `other`, then append it to all request-scoped metric paths that currently omit it: validation mismatches, missing structured content, auth failures, docs searches/fetches, and analytics identity cache hit/miss.
 4. Preserve and explicitly test populated bounded validation dimensions (`gen_ai.tool.name`, `validation.direction`, `validation.path`, `validation.constraint`).
-5. Add focused regressions for request capture, notification-credential and repeated-value redaction, size bounds, repeated mismatch suppression, registered/pre-handler tool failures, and metric attribution.
+5. Add focused regressions for request capture, notification-credential and repeated-value redaction, a complete large-dashboard capture below 1 MiB, explicit truncation above 1 MiB, repeated mismatch suppression, registered/pre-handler tool failures, and metric attribution.
 
 ## Files to Modify
 - `pkg/log/log.go` — safe structured-payload serialization/redaction helper.

--- a/plans/failure-request-observability.plan.md
+++ b/plans/failure-request-observability.plan.md
@@ -1,0 +1,34 @@
+# Plan: Failure Request Observability
+
+## Status
+In Progress
+
+## Context
+Schema-mismatch telemetry counts advisory contract drift, but operators cannot currently split it by `mcp.client_source` or recover the request that triggered it. Tool failure logs similarly carry the error and tool context but omit the request arguments needed for a local replay. Several secondary request-scoped metrics also omit caller attribution even though the request context already contains the bounded source value.
+
+## Approach
+1. Add a shared JSON-log helper that serializes the handler-visible request, recursively redacts credential-shaped fields, and applies the established 4 KiB payload cap.
+2. Attach the resulting `mcp.request` field to schema mismatches, missing-structured-output warnings, returned tool errors, and Go tool failures. Rate-limit repeated advisory validation WARNs per bounded mismatch tuple while keeping exact counters; registered handler errors emit the request once, and pre-handler failures retain hook-level capture.
+3. Normalize `mcp.client_source` once at ingress to the bounded taxonomy `user-client`, `ai-assistant`, or `other`, then append it to all request-scoped metric paths that currently omit it: validation mismatches, missing structured content, auth failures, docs searches/fetches, and analytics identity cache hit/miss.
+4. Preserve and explicitly test populated bounded validation dimensions (`gen_ai.tool.name`, `validation.direction`, `validation.path`, `validation.constraint`).
+5. Add focused regressions for request capture, notification-credential and repeated-value redaction, size bounds, repeated mismatch suppression, registered/pre-handler tool failures, and metric attribution.
+
+## Files to Modify
+- `pkg/log/log.go` — safe structured-payload serialization/redaction helper.
+- `pkg/log/handler_test.go` — redaction and truncation regressions.
+- `pkg/util/context.go` — central bounded client-source normalization.
+- `pkg/util/context_test.go` — client-source taxonomy regressions.
+- `internal/handler/tools/handler.go` — hold the bounded-tuple validation WARN rate-limit state.
+- `internal/handler/tools/schema_compat.go` — pass requests into validation telemetry, log each occurrence, and append caller attribution to request-scoped metrics.
+- `internal/handler/tools/output_schema_test.go` — schema mismatch request/label/source regressions.
+- `internal/handler/tools/docs.go` — append caller attribution to docs-tool metrics.
+- `internal/client/client.go` — append caller attribution to identity-cache metrics.
+- `internal/mcp-server/server.go` — attach failure requests to tool logs and append caller attribution to auth-failure metrics.
+- `internal/mcp-server/server_test.go` — tool failure request and metric-attribution regressions.
+
+## Verification
+- `make fmt goimports`
+- Focused: `go test ./pkg/log ./internal/handler/tools ./internal/mcp-server ./internal/client`
+- Full: `go test ./...`
+- Build: `go build ./cmd/server`
+- MCP checklist: no client-visible contract changed; README, `manifest.json`, docs surfaces, and companion agent skills remain unchanged.


### PR DESCRIPTION
## Summary

- capture the complete handler-visible MCP request on validation mismatches and tool failures
- recursively redact credential-shaped argument fields
- retain redacted failure requests up to 1 MiB; larger requests truncate explicitly
- keep ordinary body and error log values at the existing 4 KiB cap
- rate-limit representative validation WARNs while keeping mismatch counters exact
- normalize `mcp.client_source` at ingress to `user-client`, `ai-assistant`, or `other`
- add client-source attribution to validation, missing-output, auth-failure, docs, and analytics identity-cache metrics

## Why

Advisory schema-validation mismatches were measurable but could not be attributed by client cohort, tool, schema path, or constraint. Failure logs also lacked the request arguments needed to reproduce a failing MCP call.

This keeps advisory mismatches fail-open while making them reproducible and attributable, and gives tool failures bounded diagnostic request context large enough for real dashboard payloads.

## Safety and compatibility

- request serialization runs only on emitted failure or validation-warning paths
- credential-shaped keys are redacted recursively before logging
- redacted request captures are bounded to 1 MiB; requests above that retain the `...(truncated)` marker
- ordinary client-controlled error and response log values remain bounded to 4 KiB
- registered handler failures emit one request dump; pre-handler failures retain hook-level capture
- repeated validation warnings are limited per bounded tool/direction/path/constraint tuple; metrics remain exact
- no client-visible MCP tool, resource, prompt, schema, or configuration contract changed
- README, `manifest.json`, user-facing docs, and the companion `SigNoz/agent-skills` repository do not require changes

## Validation

- `make fmt goimports`
- `go test ./...`
- `go vet ./...`
- `go build ./cmd/server`
- `go test -race ./pkg/log ./internal/mcp-server`
- `git diff --check`
- three independent reviews covering reuse, quality/security, and efficiency/overengineering
- uncapped Claude Opus 5 high-effort review; final result had no P0/P1/P2 findings and no overengineering concerns

## Large-dashboard request proof

A real logging-middleware probe used a 300-panel `signoz_create_dashboard` failure request:

- before the limit change, a 637,041-byte request produced a 4,096-byte invalid JSON fragment containing none of the panels
- after the change, a 503,652-byte request reached the handler unchanged and the logged `mcp.request` retained all 503,652 bytes
- the resulting log value was valid JSON, had no truncation marker, and retained the final panel
- a permanent regression covers complete dashboard capture below 1 MiB and explicit truncation above 1 MiB

## Live staging E2E

Ran the modified Streamable HTTP server against the staging SigNoz API using a process-ephemeral credential:

- initialize passed with protocol `2025-11-25`
- `tools/list` returned 43 tools
- read-only `signoz_list_alerts` returned structured data and pagination
- an intentional input mismatch remained `isError=false`, added the validation notice, and logged bounded path/constraint/client-source/request evidence
- a coded `VALIDATION_FAILED` tool result logged the redacted handler-visible request
- unsupported client source normalized to `other`
- no tenant resources were created or modified; the local server and temporary artifacts were removed

Agent CI could not start locally because the Docker socket was unavailable; the equivalent repository-native checks above passed.