### PR TITLE
test(mcp): add selected official conformance

### DIFF
--- a/.github/workflows/mcp-protocol.yaml
+++ b/.github/workflows/mcp-protocol.yaml
@@ -40,3 +40,34 @@ jobs:
 
       - name: Run MCP protocol checks
         run: scripts/test-mcp-protocol.sh
+
+  conformance:
+    name: conformance
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout pull request
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.25"
+          cache: true
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+          cache: npm
+          cache-dependency-path: tools/mcp-ci/package-lock.json
+
+      - name: Install MCP conformance runner
+        working-directory: tools/mcp-ci
+        run: npm ci --ignore-scripts
+
+      - name: Parse conformance harness
+        run: bash -n scripts/test-mcp-conformance.sh
+
+      - name: Run MCP conformance checks
+        run: scripts/test-mcp-conformance.sh

--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ go.work.sum
 
 # Local scripts (root-only; explicitly reviewed CI helpers are tracked)
 /scripts/*
+!/scripts/test-mcp-conformance.sh
 !/scripts/test-mcp-protocol.sh
 
 # env file

--- a/guardrails/README.md
+++ b/guardrails/README.md
@@ -10,7 +10,8 @@ access to unexported retry, registration, middleware, and server-composition hel
 - `tests.txt` is the exact inventory executed by the `guardrails / contract` GitHub check.
 - `internal/mcp-server/testdata/wire-catalog/` holds the immutable pre-migration JSON-RPC oracle.
 - `.github/workflows/guardrails.yaml` verifies the inventory and runs the guarded tests.
-- `.github/workflows/mcp-protocol.yaml` runs the real-server Inspector compatibility check.
+- `.github/workflows/mcp-protocol.yaml` runs the real-server Inspector and
+  selected official conformance checks.
 - Package-local functions named `TestGuardrail_*` contain the enforcement logic.
 
 ## Invariants covered
@@ -52,16 +53,50 @@ an independent initialized-client check for tools, resources, resource
 templates, and prompts. It runs on every pull request to `main` without
 credentials or a live SigNoz backend.
 
+The separate `protocol / conformance` check pins
+`@modelcontextprotocol/conformance@0.2.0-alpha.11` and runs selected official
+scenarios against the same real `cmd/server` HTTP binary. It supplies a fake
+API key and `https://example.invalid`; the selected catalog operations do not
+contact a live SigNoz backend. Each scenario runs independently through the
+official CLI:
+
+```text
+node tools/mcp-ci/node_modules/@modelcontextprotocol/conformance/dist/index.js \
+  server --url http://127.0.0.1:<port>/mcp \
+  --scenario <name> --spec-version <version> --output-dir <temp>
+```
+
+The exact selected scenarios are:
+
+- legacy `2025-11-25`: `server-initialize`, `ping`, `tools-list`,
+  `resources-list`, `prompts-list`, `dns-rebinding-protection`;
+- modern `2026-07-28`: `tools-list`, `resources-list`,
+  `sep-2164-resource-not-found`, `prompts-list`,
+  `dns-rebinding-protection`, `caching`.
+
+This is selected official conformance, not a claim that the full frozen
+requirements pass. The unselected requirements depend on diagnostic fixture
+tools and product features that SigNoz intentionally does not expose. Do not
+add an everything-server copy, separate fixture binary, expected-failures
+baseline, or `--requirements` claim to make those scenarios appear applicable.
+The SDK-free wire oracle, focused Go matrices, and Inspector continue to own
+complete SigNoz catalog and transport compatibility.
+
 Focused Go matrices own exact HTTP and stdio wire behavior: both protocol eras,
 standardized modern headers, JSON Content-Type/Accept handling, stateless
 GET/DELETE 405 responses, absent `Mcp-Session-Id`, cancellation, and accepted
 official-SDK differences. Do not duplicate those matrices in the shell script.
 
-Protocol policy is split across three review-sensitive files:
+Protocol policy is split across these review-sensitive files:
 
-- `tools/mcp-ci/package.json` and its lockfile pin the Inspector CLI.
-- `scripts/test-mcp-protocol.sh` owns the server lifecycle and selective response assertions.
-- `.github/workflows/mcp-protocol.yaml` owns the Node/Go toolchain and required check name.
+- `tools/mcp-ci/package.json` and its lockfile pin the Inspector and official
+  conformance CLIs exactly.
+- `scripts/test-mcp-protocol.sh` owns the Inspector server lifecycle and
+  selective response assertions.
+- `scripts/test-mcp-conformance.sh` owns the selected official scenario list,
+  production server lifecycle, and temporary report cleanup.
+- `.github/workflows/mcp-protocol.yaml` owns the Node/Go toolchain and the
+  separate `protocol / inspector` and `protocol / conformance` check names.
 
 Keep assertions focused on usable protocol surfaces, stable identity, and
 non-empty result envelopes. Do not assert deprecated logging behavior or turn
@@ -69,17 +104,23 @@ this check into a full catalog snapshot by pinning counts, ordering,
 descriptions, schemas, or ranked documentation content. `tests.txt` remains the
 inventory for Go `TestGuardrail_*` tests only.
 
-After the workflow succeeds once on the default branch, configure `protocol / inspector` as a required `main` branch check. Upgrade Inspector only in a reviewed dependency change that reruns the same assertions.
-
 Run the protocol lane on Ubuntu with:
 
 ```bash
 npm ci --ignore-scripts --prefix tools/mcp-ci
 bash -n scripts/test-mcp-protocol.sh
 shellcheck scripts/test-mcp-protocol.sh
+bash -n scripts/test-mcp-conformance.sh
+shellcheck scripts/test-mcp-conformance.sh
 actionlint .github/workflows/mcp-protocol.yaml
 scripts/test-mcp-protocol.sh
+scripts/test-mcp-conformance.sh
 ```
+
+After each check succeeds once on the default branch, configure both
+`protocol / inspector` and `protocol / conformance` as required `main` branch
+checks. Upgrade either CLI only in a reviewed dependency change that reruns its
+documented assertions; do not float a dist-tag or version range.
 
 ## Changing a guardrail
 

--- a/plans/official-go-sdk-migration.context.md
+++ b/plans/official-go-sdk-migration.context.md
@@ -498,7 +498,45 @@
   annotations, resources, templates, prompts, and structured results remain
   unchanged.
 
+### 2026-08-14 — Stacked conformance audit and STOP condition
+- After PR #286 returned to ready with seven green checks, created
+  `codex/official-go-sdk-conformance` at exact parent `0e33180` as requested.
+  No conformance PR has been opened yet; its eventual base will be the runtime
+  branch while stacked, then `main` after #286 merges.
+- Verified current official sources and npm metadata. Stable/latest remains
+  `0.1.16`; exact prerelease `0.2.0-alpha.11` is the only current package with
+  frozen `--requirements 2025-11-25` and `--requirements 2026-07-28`, and one
+  alpha.11 pin can run both eras. The package was published from git commit
+  `c321dd32035556e6769d3724a8ee97d87c3faaac`.
+- Added that exact package to `tools/mcp-ci`. Its initial compatible dependency
+  resolution contained four dev-only advisories; kept alpha.11 fixed and moved
+  only transitive packages within their declared ranges. A clean `npm ci`,
+  both requirement-list commands, and `npm audit` now pass with zero findings.
+- Enumerated the requirement sets: the server leg scores 30 legacy scenarios
+  and 37 modern scenarios. Full coverage requires nearly all behavior in the
+  official Go SDK's 1,316-line everything server, including media/mixed
+  content, completion, logging/progress, sampling/elicitation, subscriptions,
+  four fixture prompts, and fourteen MRTR scenarios. A supposedly minimal
+  local fixture would therefore be a large upstream copy and mostly retest SDK
+  code; the plan's explicit STOP condition is satisfied.
+- Ran a no-write production-binary spike with fake tenant credentials. Six
+  catalog-independent legacy scenarios and six modern scenarios passed with
+  wire-schema checks. Modern `server-stateless` passed 24 of 28 scored checks;
+  the four remaining checks were untestable solely because production omits
+  three named diagnostic `test_*` tools, as intended by issue #194's out-of-
+  scope product-feature rule.
+- The next implementation decision materially changes the claim: either add a
+  lean selected-scenario production lane and revise #194's full-suite
+  acceptance wording, or accept a large nonshipping fixture to satisfy all
+  frozen requirements. Do not silently pick one or disguise missing fixture
+  behavior with a broad baseline.
+
 ## Open Questions
+- [ ] Which honest conformance claim should the stacked PR ship? Recommended:
+  selected catalog-independent official scenarios against the actual
+  production binary, with #194's full-suite acceptance wording revised. The
+  alternative is a large nonshipping fixture recreating nearly all of the
+  official 1,316-line everything server to pass all 30/37 scored scenarios.
 - [ ] Is an exactly pinned prerelease `@modelcontextprotocol/conformance` dependency acceptable as a release-blocking referee until its `0.2.x` line becomes stable? Recommended: yes; use its frozen `--requirements` sets, document the exception, and upgrade deliberately when stable.
 - [ ] Should protected SigNoz AI Assistant/Claude Code/Codex/Cursor smokes block merge or block only release promotion? Recommended: keep deterministic raw/Inspector/conformance checks merge-blocking and make credentialed native-client checks protected pre-release gates with an explicit owner.
 - [x] Can legacy HTTP disconnect cancellation be preserved through an official supported hook? Resolved: not in v1.7.0 stateless HTTP. Accept the bounded capacity-impact limitation, retain protocol cancellation notifications, and avoid a custom transport.
@@ -514,4 +552,8 @@
 - [x] Replace the custom OAuth flow with SDK helpers? Resolved: no; explicitly out of scope.
 - [x] Does `SigNoz/agent-skills` require a planned companion change? Resolved for the intended design: no, subject to a repeat audit of the implementation diff.
 - [x] Include nerve-pod#191/#164 in the SDK migration PR? Resolved: no. Merge the #194 runtime migration PR first, then implement #191 as the complete successor scope for #164 in one independent official-SDK follow-up.
-- [x] Use stacked PRs for the SDK migration? Resolved: no. Use one atomic runtime PR from `main`, with the pre-swap oracle as its first green commit, then a sequential post-merge conformance PR; keep ERR-6 as an independent post-runtime branch from `main`. Closed, unmerged #283 is reference material only.
+- [x] Use stacked PRs for the SDK migration? Resolved by latest maintainer
+  direction: keep runtime PR #286 atomic against `main`, then temporarily stack
+  the conformance successor on its ready branch and rebase/retarget after #286
+  merges. Keep ERR-6 independent from `main`. Closed, unmerged #283 is
+  reference material only.

--- a/plans/official-go-sdk-migration.context.md
+++ b/plans/official-go-sdk-migration.context.md
@@ -602,6 +602,32 @@
   GoReleaser credentials; those are unrelated protected-environment blockers,
   not conformance or code failures. Its temporary runners were removed.
 
+### 2026-08-14 — Opus/Grok pre-ready review of stacked conformance
+- Exact `claude-opus-5-thinking-xhigh` and `cursor-grok-4.6-xhigh` reviewed
+  only `0e33180..61271ec` plus the resulting harness fixes in read-only mode.
+  No third review model ran.
+- Opus found one P1 false-green: alpha.11 prints `SKIPPED:` and exits zero when
+  a scenario is incompatible with the requested version. The harness now
+  rejects every skipped selected scenario. It also enables best-effort
+  diagnostics inside the EXIT trap before cleanup, reduces each scenario
+  timeout to 30 seconds so the twelve-scenario worst case fits the ten-minute
+  job, and removes a redundant path-sensitive package-version probe.
+- Opus's stacked-PR trigger finding is handled operationally: the permanent
+  pull-request filter remains scoped to `main`; dispatch the same workflow on
+  the stacked branch and link its run, then let it rerun automatically after
+  #287 is retargeted to `main`. The compatible transitive lock refresh is
+  intentional and documented because the initial clean install contained four
+  dev-only advisories; the final lock audits at zero.
+- Grok's first invocation returned no result and was discarded. A single
+  bounded retry inspected the fixed tree, verified the four harness fixes
+  against local alpha.11, and its resumed final verdict reported no remaining
+  actionable findings. This was completion of the same requested review, not a
+  third model or duplicate review pass.
+- Re-ran Bash parsing, ShellCheck, actionlint, all twelve selected scenarios,
+  and cleanup/port checks after the fixes; all passed. Opus's sandboxed review
+  processes had already stopped, and its exact `/tmp/conf-review` artifacts
+  were removed.
+
 ## Open Questions
 - [x] Which honest conformance claim should the stacked PR ship? Resolved:
   selected catalog-independent official scenarios against the actual

--- a/plans/official-go-sdk-migration.context.md
+++ b/plans/official-go-sdk-migration.context.md
@@ -531,18 +531,96 @@
   frozen requirements. Do not silently pick one or disguise missing fixture
   behavior with a broad baseline.
 
+### 2026-08-14 — Maintainer-approved selected production conformance
+- The maintainer approved the lean claim. Pin exact prerelease
+  `@modelcontextprotocol/conformance@0.2.0-alpha.11` and run six
+  catalog-independent official scenarios per protocol era against the real
+  production `cmd/server` binary. This is **selected official conformance**;
+  neither the plan, CI check, nor PR may claim that the full frozen
+  `--requirements` sets pass.
+- The selected legacy `2025-11-25` scenarios are `server-initialize`, `ping`,
+  `tools-list`, `resources-list`, `prompts-list`, and
+  `dns-rebinding-protection`. The selected modern `2026-07-28` scenarios are
+  `tools-list`, `resources-list`, `sep-2164-resource-not-found`,
+  `prompts-list`, `dns-rebinding-protection`, and `caching`.
+- Do not add `internal/mcpconformance`, `cmd/conformance-server`, an
+  everything-server copy, fixture-only product surfaces, an expected-failures
+  baseline, or the partial `server-stateless` result. Those alternatives add
+  substantial code while primarily retesting official SDK behavior. Existing
+  SDK-free wire goldens, focused Go protocol matrices, guardrails, and the
+  Inspector lane continue to own complete SigNoz catalog and transport
+  behavior; the selected official runner is an independent referee for the
+  production composition it can exercise honestly.
+- The stacked conformance PR is CI-only: dependency/lockfile, bounded harness,
+  workflow, and documentation changes. It must not change production runtime
+  code or any client-visible tool schema, description, resource content,
+  prompt, or result contract.
+- Credentialed Assistant and native-client E2E remains a protected
+  release-promotion gate, not a pull-request check. It passed on exact runtime
+  commit `0e33180`: 39/39 top-level live tests plus 29/29 subtests; 43/43 real
+  `tools/call` invocations; 22/22 static resources, 2/2 resource templates,
+  and 4/4 prompts; and create/update/read-back/delete/verify-gone lifecycles
+  for notification channels, views, dashboards (including JSON Patch and
+  import), and disabled alerts. OAuth DCR, browser consent, state/CSRF, PKCE,
+  token exchange/refresh/revocation, the real Assistant consumer, and Codex,
+  Claude Code, and Cursor calls also passed, with all temporary resources and
+  credentials deleted and verified gone.
+- Notification-channel read-back did not return the webhook URL in a
+  byte-comparable form, which is an acceptable server-side secret-redaction
+  boundary; its update, delete, and verify-gone checks passed.
+- Raw MCP wire retained the coded validation result. Claude preserved
+  `isError` but hid the structured error code, while Cursor rewrote
+  `isError:true` to false and removed `structuredContent`; those are recorded
+  client presentation limitations, not server contract changes.
+
+### 2026-08-14 — Selected production conformance implemented
+- Added one bounded `scripts/test-mcp-conformance.sh` harness and a separate
+  `protocol / conformance` job. The existing Inspector job and production Go
+  runtime are unchanged; no fixture package, test-only binary, diagnostic
+  catalog, or expected-failures baseline was added.
+- All twelve approved scenarios passed locally against the real production
+  HTTP binary with fake `example.invalid` credentials. The harness verifies
+  the exact alpha.11 package and CLI versions, bounds readiness and each
+  scenario, preserves per-scenario diagnostics on failure, and removes the
+  server process and temporary reports on every exit path.
+- Updated nerve-pod #194 so its scope and acceptance criteria explicitly name
+  selected catalog-independent production conformance rather than full frozen
+  suites. Updated runtime PR #286 with the final exhaustive E2E evidence and
+  the stacked conformance follow-up wording.
+- Local gates passed: clean `npm ci` with zero advisories, Bash parsing,
+  ShellCheck, actionlint, both protocol scripts, `go test -count=1 ./...`,
+  `go vet ./...`, `go build ./cmd/server`, and `git diff --check`.
+
+### 2026-08-14 — Local workflow validation of selected conformance
+- Agent CI completed the three jobs that can start without repository secrets:
+  `guardrails / contract`, `protocol / inspector`, and the new
+  `protocol / conformance` all passed. The five `ci.yaml` jobs were blocked at
+  startup by unavailable Primus and Docker Hub credentials; no code step in
+  those jobs ran or failed. Their equivalent direct formatting, lint, test,
+  dependency, and build commands are covered by the local gates above.
+- Agent CI also listed release/docs/version workflows that require GitHub or
+  GoReleaser credentials; those are unrelated protected-environment blockers,
+  not conformance or code failures. Its temporary runners were removed.
+
 ## Open Questions
-- [ ] Which honest conformance claim should the stacked PR ship? Recommended:
+- [x] Which honest conformance claim should the stacked PR ship? Resolved:
   selected catalog-independent official scenarios against the actual
-  production binary, with #194's full-suite acceptance wording revised. The
-  alternative is a large nonshipping fixture recreating nearly all of the
-  official 1,316-line everything server to pass all 30/37 scored scenarios.
-- [ ] Is an exactly pinned prerelease `@modelcontextprotocol/conformance` dependency acceptable as a release-blocking referee until its `0.2.x` line becomes stable? Recommended: yes; use its frozen `--requirements` sets, document the exception, and upgrade deliberately when stable.
-- [ ] Should protected SigNoz AI Assistant/Claude Code/Codex/Cursor smokes block merge or block only release promotion? Recommended: keep deterministic raw/Inspector/conformance checks merge-blocking and make credentialed native-client checks protected pre-release gates with an explicit owner.
+  production binary. Do not recreate the everything-server fixture or claim
+  the full 30/37 frozen requirement sets.
+- [x] Is exact prerelease `@modelcontextprotocol/conformance@0.2.0-alpha.11`
+  acceptable as a release-blocking referee? Resolved: yes. Keep the exact pin
+  and lockfile, document that it is prerelease, and upgrade deliberately after
+  a reviewed stable release provides the needed scenario interface.
+- [x] Should protected SigNoz AI Assistant/Claude Code/Codex/Cursor smokes
+  block merge or only release promotion? Resolved: release promotion. The
+  protected gate passed on `0e33180`; deterministic raw, Inspector, selected
+  conformance, and repository checks remain merge-blocking.
 - [x] Can legacy HTTP disconnect cancellation be preserved through an official supported hook? Resolved: not in v1.7.0 stateless HTTP. Accept the bounded capacity-impact limitation, retain protocol cancellation notifications, and avoid a custom transport.
 - [x] Use low-level or typed official tool registration? Resolved: low-level only for the migration.
 - [x] Preserve or retire the stateless GET heartbeat listener? Resolved: retire it; official stateless GET/DELETE return 405 and the product has no server-message use case.
-- [x] Run the full official requirements against the production catalog? Resolved: no; use a test-only fixture server plus a separate real-production compatibility matrix.
+- [x] Run the full official requirements against the production catalog?
+  Resolved: no. Run only the named catalog-independent scenarios against the
+  real production binary, with no test-only fixture server or broad baseline.
 - [x] Preserve legacy logging? Resolved: no; omit `capabilities.logging`, add no shim or parity assertion for legacy `logging/setLevel`, and let the official SDK reject it for modern requests.
 - [x] Preserve catalog order? Resolved: no; compare top-level discovery collections order-insensitively while retaining all fields and nested order.
 - [x] Preserve mark3's unknown-resource `-32002`? Resolved: no; accept official `-32602 Invalid Params` and document it.

--- a/plans/official-go-sdk-migration.plan.md
+++ b/plans/official-go-sdk-migration.plan.md
@@ -439,9 +439,13 @@ legacy/modern stdio smokes pass, the Go raw production matrix independently
 proves both eras, modern calls never initialize, legacy calls still do, and
 mismatch probes reject before handler execution.
 
-### Phase 4 — Add honest official conformance coverage as a bounded post-merge follow-up
+### Phase 4 — Add honest official conformance coverage in the stacked follow-up
 
-Deliver this phase as one explicitly linked, sequential follow-up PR branched from `main` only after the production runtime PR has merged and the raw dual-era matrix is green. Do not open it as a child PR based on the unmerged runtime branch: the repository's CI, guardrail, and protocol workflows trigger only for pull requests targeting `main`, and the repository squash-merges and deletes merged branches. The runtime PR may merge without conformance, but this plan remains `In Progress` and issue #194 does not close until the conformance PR lands. Do not split any other phase into another tracker merely to reduce the diff.
+The maintainer requested that this phase begin from the ready runtime branch as
+a stacked PR. Target `codex/official-go-sdk-migration` while #286 is open, then
+rebase/retarget to `main` after #286 merges. The raw dual-era matrix is already
+green. This plan remains `In Progress` and issue #194 stays open until the
+conformance claim below is resolved and delivered.
 
 #### 4.1 Pin the official referee
 - Add an exact `@modelcontextprotocol/conformance` version to `tools/mcp-ci/package.json` and lockfile. At planning time the applicable package is prerelease `0.2.0-alpha.11`; confirm the exact current release before implementation and use a stable `0.2.x` instead if one now provides both frozen requirements sets.
@@ -465,6 +469,39 @@ Factor production server construction just enough that both binaries exercise th
 - request-size/logging transport plumbing where relevant.
 
 The fixture binary may expose the official `test_*`, `test://`, and test prompt surfaces required by the frozen requirements. It may implement callback/subscription/MRTR fixtures only in this profile. It must not import SigNoz credentials or call a live backend. If passing the frozen set requires duplicating most of upstream's everything server and therefore mostly retests unmodified SDK behavior, stop: record upstream pinned SDK evidence and ask maintainers whether issue #194 should accept explicit selected scenarios instead. Do not silently change the claim or add a broad expected-failures baseline.
+
+Implementation audit on 2026-08-14 triggered that STOP condition. Exact
+`0.2.0-alpha.11` requires 30 scored legacy server scenarios and 37 scored
+modern server scenarios, plus report-only cases. The fixed fixture contract
+requires image/audio/mixed content, logging/progress, completion,
+sampling/elicitation, resource subscriptions, four prompts, and fourteen MRTR
+scenarios backed by diagnostic `test_*` tools. The official Go SDK fixture is
+1,316 lines. Recreating it locally would copy most of the upstream fixture and
+would primarily retest official SDK internals rather than SigNoz composition.
+
+The actual production binary passed every catalog-independent scenario probed:
+
+- legacy: `server-initialize`, `ping`, `tools-list`, `resources-list`,
+  `prompts-list`, and `dns-rebinding-protection`;
+- modern: `tools-list`, `resources-list`, `sep-2164-resource-not-found`,
+  `prompts-list`, `dns-rebinding-protection`, and `caching`;
+- modern `server-stateless` passed 24/28 scored checks. Its four failures were
+  explicitly untestable because production correctly omits the suite's
+  `test_missing_capability`, `test_streaming_elicitation`, and
+  `test_logging_tool` diagnostic fixtures.
+
+Do not proceed past the exact dependency pin until the maintainer chooses one
+of these honest claims:
+
+1. **Recommended lean claim:** run the catalog-independent scenarios against
+   the actual production binary for both eras, optionally retain the 24/28
+   `server-stateless` result with four check-level expected failures, and state
+   clearly that this is selected official conformance—not the frozen full
+   requirement sets. Update issue #194's acceptance wording before closing it.
+2. **Full frozen claim:** implement the large nonshipping fixture needed for
+   all 30/37 scored server scenarios through shared composition. Accept that
+   most fixture behavior duplicates the upstream everything server; keep
+   exhaustive leakage guards and do not add it to production catalogs.
 
 Run separate profiles/processes as the frozen requirement sets require:
 

--- a/plans/official-go-sdk-migration.plan.md
+++ b/plans/official-go-sdk-migration.plan.md
@@ -43,7 +43,9 @@ Official v1.7.0 differs at each of those seams. This plan freezes the old wire c
 - Freeze this surface with compact, reviewable fixtures: complete catalog JSON for descriptors/schemas, per-entry content digests and metadata for all deterministic resource/prompt payloads, and literal fixtures for small or shape-sensitive results.
 - Support legacy `2025-11-25` initialize/list/call/read/get and modern `2026-07-28` discover/direct-call flows over HTTP and stdio.
 - Preserve direct API-key and OAuth auth branches, middleware order, request limits, readiness, cancellation, shutdown, tenant/correlation attribution, and exactly-once observability.
-- Add deterministic production compatibility and official conformance gates without exposing conformance-only product behavior.
+- Add deterministic production compatibility and selected official conformance
+  gates against the real binary without exposing conformance-only product
+  behavior or claiming the full fixture requirements.
 - Keep README, architecture, manifest metadata, guardrails, and CMP-3 documentation truthful.
 
 ## Non-goals
@@ -54,7 +56,8 @@ Official v1.7.0 differs at each of those seams. This plan freezes the old wire c
 - MRTR confirmations, input-required product flows, Tasks, MCP Apps, sampling, elicitation, resource subscriptions, or new server-to-client traffic in production.
 - Replacing the custom OAuth product flow with official SDK OAuth helpers.
 - Refactoring unrelated handler/business logic or changing upstream SigNoz API behavior.
-- Treating fixture-only conformance features as part of the production contract.
+- Recreating fixture-only conformance features or claiming them as part of the
+  production contract.
 
 ## Invariants
 1. `Handler.addTool` remains the only production tool registration and policy path.
@@ -66,7 +69,9 @@ Official v1.7.0 differs at each of those seams. This plan freezes the old wire c
 7. Production HTTP is stateless, emits no `Mcp-Session-Id`, requires no sticky routing, and preserves current JSON POST framing with `JSONResponse: true`.
 8. The migration intentionally omits `capabilities.logging`, does not guarantee or actively suppress legacy `logging/setLevel`, accepts official discovery ordering, and uses official `-32602` resource-not-found semantics. These decisions are documented rather than hidden behind compatibility shims.
 9. Every request that reaches official SDK dispatch produces one terminal method observation and, for `tools/call`, one terminal tool observation across success/error/cancellation/panic paths. Pre-dispatch transport/lifecycle rejections retain the outer HTTP span/status and bounded SDK diagnostics without fabricated MCP metrics; stdio parity is measured before adding fallback machinery.
-10. Conformance fixtures never enter the production dependency graph, discovery results, README, manifest, or guardrail inventory.
+10. Conformance runs only the approved catalog-independent scenarios against
+    `cmd/server`; no conformance fixture package, binary, surface, or broad
+    baseline is added.
 
 ## Delivery Plan
 
@@ -164,7 +169,13 @@ Add a small internal tool-contract layer with only the pieces used by this repos
 - one adapter from official `*mcp.CallToolRequest` to the local request. Protocol/client/capability metadata stays on the official request and is consumed by receiving middleware instead of being cloned into an unused second request model;
 - one request-scoped argument decode shared by search-context extraction, the adapter, repository validation, and business handlers. Retain the exact raw bytes for compatibility characterization without reparsing them in validation.
 
-All registration-time descriptor/schema transforms must be copy-on-write. Definitions may be reused by production, tests, and the conformance profile, so normalization or annotation conversion must not mutate the original `mcp.Tool`, `*jsonschema.Schema`, `Properties`, property schemas, `Extra` maps, `Required` slices, or raw-schema bytes. Add original-unchanged, repeat-registration, and concurrent-registration race tests. Clone only the branches actually modified; do not add a general deep-copy framework.
+All registration-time descriptor/schema transforms must be copy-on-write.
+Definitions may be reused by production and tests, so normalization or
+annotation conversion must not mutate the original `mcp.Tool`,
+`*jsonschema.Schema`, `Properties`, property schemas, `Extra` maps, `Required`
+slices, or raw-schema bytes. Add original-unchanged, repeat-registration, and
+concurrent-registration race tests. Clone only the branches actually modified;
+do not add a general deep-copy framework.
 
 The adapter's JSON contract is frozen by table tests:
 
@@ -239,7 +250,11 @@ Expected result: `rg` prints no production mark3 import or santhosh validator de
 ### Phase 2 — Swap server composition, transport, and observability
 
 #### 2.1 Construct the official server explicitly
-Replace `newSDKServer` with one fully configured-and-registered official server factory used by HTTP, stdio, in-process tests, and, later, the test-only conformance binary. Callers supply only the bounded profile differences; they must not reassemble capabilities, middleware order, recovery, or registration independently. The production profile sets:
+Replace `newSDKServer` with one fully configured-and-registered official server
+factory used by HTTP, stdio, and in-process tests. Callers supply only the
+bounded transport differences; they must not reassemble capabilities,
+middleware order, recovery, or registration independently. The production
+profile sets:
 
 - implementation name/version and existing instructions;
 - explicit non-logging capabilities matching the intended migrated surface, with non-nil empty tools/prompts/resources capability structs so `listChanged` remains absent/false rather than inferred true;
@@ -439,110 +454,89 @@ legacy/modern stdio smokes pass, the Go raw production matrix independently
 proves both eras, modern calls never initialize, legacy calls still do, and
 mismatch probes reject before handler execution.
 
-### Phase 4 — Add honest official conformance coverage in the stacked follow-up
+### Phase 4 — Add selected official conformance in the stacked follow-up
 
-The maintainer requested that this phase begin from the ready runtime branch as
-a stacked PR. Target `codex/official-go-sdk-migration` while #286 is open, then
-rebase/retarget to `main` after #286 merges. The raw dual-era matrix is already
-green. This plan remains `In Progress` and issue #194 stays open until the
-conformance claim below is resolved and delivered.
+The maintainer approved a lean selected-scenario claim on 2026-08-14. Begin
+this phase from the ready runtime branch as a stacked PR targeting
+`codex/official-go-sdk-migration`; rebase/retarget to `main` after #286 merges.
+This plan remains `In Progress` and issue #194 stays open until this phase
+lands.
 
 #### 4.1 Pin the official referee
-- Add an exact `@modelcontextprotocol/conformance` version to `tools/mcp-ci/package.json` and lockfile. At planning time the applicable package is prerelease `0.2.0-alpha.11`; confirm the exact current release before implementation and use a stable `0.2.x` instead if one now provides both frozen requirements sets.
-- Record why a prerelease is blocking if still necessary. Never use `latest`, `next`, or an unbounded range.
-- Use the runner's frozen `--requirements 2025-11-25` and `--requirements 2026-07-28` sets; `--requirements` replaces `--suite` and `--spec-version`. Start with no expected-failures file. Any proposed entry requires a per-check root-cause review; never baseline a whole scenario or inherit the upstream SDK baseline as this repository's result.
+- Pin exact prerelease
+  `@modelcontextprotocol/conformance@0.2.0-alpha.11` in
+  `tools/mcp-ci/package.json` and its lockfile. The maintainer approved the
+  prerelease because it is the first published runner that supports both target
+  protocol eras through the required scenario interface.
+- Never use `latest`, `next`, a version range, or an inherited upstream
+  baseline. Upgrade to a stable release only in a separately reviewed
+  dependency change that reruns the same selected scenarios.
+- Call the runner through the locally installed package. The CI and PR must say
+  **selected official conformance**, not full conformance or passing frozen
+  `--requirements` sets.
 
-#### 4.2 Reuse the smallest non-shipping official fixture profile
-The official frozen requirements call fixed fixture names and cannot run truthfully against the SigNoz catalog. Use go-sdk v1.7.0's own `conformance/everything-server` as the upstream behavior reference. Do not copy that large server into this repository or claim that rerunning it alone proves SigNoz composition. First enumerate the exact frozen requirements with `list --requirements <revision>`, then implement the smallest local fixture profile capable of passing them through this repository's option builder, low-level registration adapter, panic/lifecycle middleware, and HTTP wrapper composition. If that necessarily duplicates most of the upstream everything server, stop and resolve the scope/acceptance claim with maintainers rather than adding baselines.
+#### 4.2 Run only catalog-independent scenarios against production
 
-```text
-internal/mcpconformance/       # fixture registrations/behavior only
-cmd/conformance-server/       # CI-only entry point
-```
+Build and start the real `cmd/server` HTTP binary on loopback with a fake API
+key and `https://example.invalid`, so no credential or live SigNoz backend is
+required. Invoke each named official scenario independently with the matching
+protocol version:
 
-Factor production server construction just enough that both binaries exercise the same:
+- legacy `2025-11-25`: `server-initialize`, `ping`, `tools-list`,
+  `resources-list`, `prompts-list`, `dns-rebinding-protection`;
+- modern `2026-07-28`: `tools-list`, `resources-list`,
+  `sep-2164-resource-not-found`, `prompts-list`,
+  `dns-rebinding-protection`, `caching`.
 
-- official SDK version and server option builder;
-- descriptor/registration adapters;
-- receiving/panic/observability middleware;
-- Streamable HTTP option assembly and header validation;
-- request-size/logging transport plumbing where relevant.
+Each invocation must succeed, including its official wire-schema checks. Keep
+bounded per-scenario reports in a temporary directory for failure diagnostics,
+then clean up the server process and temporary files on both success and
+failure.
 
-The fixture binary may expose the official `test_*`, `test://`, and test prompt surfaces required by the frozen requirements. It may implement callback/subscription/MRTR fixtures only in this profile. It must not import SigNoz credentials or call a live backend. If passing the frozen set requires duplicating most of upstream's everything server and therefore mostly retests unmodified SDK behavior, stop: record upstream pinned SDK evidence and ask maintainers whether issue #194 should accept explicit selected scenarios instead. Do not silently change the claim or add a broad expected-failures baseline.
+Do not add `internal/mcpconformance`, `cmd/conformance-server`, an official
+everything-server copy, diagnostic `test_*` tools/resources/prompts, a broad
+expected-failures file, or a partial `server-stateless` baseline. Full frozen
+requirements cover fixture-only sampling, elicitation, subscriptions,
+completion, progress/logging, media, and MRTR behavior absent from the SigNoz
+product; recreating those fixtures would overengineer this production-runtime
+migration and mostly retest the SDK.
 
-Implementation audit on 2026-08-14 triggered that STOP condition. Exact
-`0.2.0-alpha.11` requires 30 scored legacy server scenarios and 37 scored
-modern server scenarios, plus report-only cases. The fixed fixture contract
-requires image/audio/mixed content, logging/progress, completion,
-sampling/elicitation, resource subscriptions, four prompts, and fourteen MRTR
-scenarios backed by diagnostic `test_*` tools. The official Go SDK fixture is
-1,316 lines. Recreating it locally would copy most of the upstream fixture and
-would primarily retest official SDK internals rather than SigNoz composition.
+The selected runner does not own complete product compatibility. Existing
+SDK-free wire goldens, guardrails, focused Go HTTP/stdio matrices, and the
+Inspector lane remain authoritative for the complete SigNoz catalog, both
+transports, standardized headers, coded results, and all intentional migration
+differences.
 
-The actual production binary passed every catalog-independent scenario probed:
+This follow-up changes only CI dependencies, its bounded harness/workflow, and
+documentation. It must not change production Go code or any client-visible
+tool schema, description, resource content, prompt, or result contract.
 
-- legacy: `server-initialize`, `ping`, `tools-list`, `resources-list`,
-  `prompts-list`, and `dns-rebinding-protection`;
-- modern: `tools-list`, `resources-list`, `sep-2164-resource-not-found`,
-  `prompts-list`, `dns-rebinding-protection`, and `caching`;
-- modern `server-stateless` passed 24/28 scored checks. Its four failures were
-  explicitly untestable because production correctly omits the suite's
-  `test_missing_capability`, `test_streaming_elicitation`, and
-  `test_logging_tool` diagnostic fixtures.
+#### 4.3 Add a separate CI job
 
-Do not proceed past the exact dependency pin until the maintainer chooses one
-of these honest claims:
+Keep `protocol / inspector` unchanged and add `protocol / conformance`. The
+new job installs the exact lockfile, runs the bounded production-binary script,
+and fails if any of the twelve named scenario invocations fails. It needs no
+repository/client assessment, GitHub token, SigNoz credential, fixture server,
+or expected-failures file.
 
-1. **Recommended lean claim:** run the catalog-independent scenarios against
-   the actual production binary for both eras, optionally retain the 24/28
-   `server-stateless` result with four check-level expected failures, and state
-   clearly that this is selected official conformance—not the frozen full
-   requirement sets. Update issue #194's acceptance wording before closing it.
-2. **Full frozen claim:** implement the large nonshipping fixture needed for
-   all 30/37 scored server scenarios through shared composition. Accept that
-   most fixture behavior duplicates the upstream everything server; keep
-   exhaustive leakage guards and do not add it to production catalogs.
+The official runner covers HTTP only. Focused Go tests and the existing
+real-binary protocol script continue to own stdio and the complete 2×2
+HTTP/stdio × legacy/modern matrix.
 
-Run separate profiles/processes as the frozen requirement sets require:
-
-- legacy `2025-11-25`: stateful when required by the frozen sampling/elicitation/subscription scenarios;
-- modern `2026-07-28`: stateless and sessionless.
-
-This profile difference is confined to the conformance binary. The production endpoint remains stateless for both eras and is covered by Phase 3.
-
-#### 4.3 Add leakage guards
-- `cmd/server` dependency closure must not include `internal/mcpconformance`.
-- Production `tools/list`, resources, templates, and prompts must not contain `test_*`, `test://`, or conformance prompt names.
-- Fixture surfaces must not appear in `manifest.json`, README tables, initialized-wire budgets, or production catalog counts.
-- MRTR, Tasks, and Apps must remain absent from production discovery.
-
-#### 4.4 Add a separate CI job
-Keep the existing stable `protocol / inspector` check and add `protocol / conformance`. The conformance job:
-
-- builds the test-only fixture binary;
-- starts bounded legacy and modern processes on different loopback ports;
-- runs `server --requirements 2025-11-25` and `server --requirements 2026-07-28` separately;
-- retains each report for failure diagnostics without uploading secrets;
-- fails on every required scored scenario and its synthetic wire-schema failure;
-- reports non-required extension/pending outcomes separately without enabling those features in production.
-
-If the team wants wire-schema failures from non-scored scenarios to block too, add explicit report post-processing and document that policy; the conformance CLI exit code does not promote them by itself.
-
-Do not use `tier-check`; repository/client assessment and GitHub tokens are
-outside this server gate. The official runner covers HTTP only, so the raw Go
-matrix and bounded real-binary smoke remain responsible for stdio.
-
-Verification for Phase 4:
+Local verification for Phase 4:
 
 ```bash
-node tools/mcp-ci/node_modules/@modelcontextprotocol/conformance/dist/index.js \
-  list --server --requirements 2025-11-25
-node tools/mcp-ci/node_modules/@modelcontextprotocol/conformance/dist/index.js \
-  list --server --requirements 2026-07-28
+npm ci --ignore-scripts --prefix tools/mcp-ci
+bash -n scripts/test-mcp-conformance.sh
+shellcheck scripts/test-mcp-conformance.sh
 actionlint .github/workflows/mcp-protocol.yaml
+scripts/test-mcp-conformance.sh
 ```
 
-Expected result: both frozen requirement sets pass against the isolated shared-stack fixture with no broad baseline, and the production 2×2 raw matrix independently proves the SigNoz endpoint/catalog. If maintainers explicitly approve selected-scenario scope instead, rewrite this phase and the acceptance claim before implementation.
+Expected result: all six selected scenarios for each era pass against the real
+production binary, no live backend is contacted, and the script leaves no
+server process or temporary artifacts. This result does not imply that all
+30/37 frozen server scenarios pass.
 
 ### Phase 5 — Documentation, companion audit, and representative clients
 
@@ -550,7 +544,9 @@ Expected result: both frozen requirement sets pass against the isolated shared-s
 - `README.md`: supported protocol-era/transport table, `server/discover` and legacy initialize behavior, stateless POST-only endpoint, no session ID, and unchanged client configuration.
 - `docs/architecture.md`: official SDK ownership, per-request modern identity/capabilities, receiving middleware, HTTP wrapper order, `JSONResponse: true`, explicit GET/DELETE 405, removal of heartbeat, malformed-stdio behavior, cancellation limitations, and shutdown behavior.
 - `docs/mcp-best-practices.md`: record the dual-era review expectations and exact compatibility/conformance ownership if section 11 needs it.
-- `guardrails/README.md`: runtime/tool pins, raw/Inspector/conformance layers, required check names, update procedure, no-baseline/leakage policy, and local commands.
+- `guardrails/README.md`: runtime/tool pins, raw/Inspector/selected-conformance
+  ownership, required check names, update procedure, no-full-suite-claim
+  policy, and local commands.
 - `manifest.json`: expect no semantic tool/resource change; compare rather than churn. Update only SDK/protocol metadata fields that genuinely describe the new endpoint.
 - `server.json`: audit after refreshing main; it is already at v0.12.0 on `30acf69`, so change only metadata that is genuinely made stale by the SDK migration.
 - Remove stale mark3 references from comments and documentation.
@@ -569,43 +565,51 @@ Use a delegated, credential-safe protected/manual run for live clients:
 - Cursor;
 - at least one local stdio client configuration.
 
-For each, record exact client version, transport, negotiated protocol era, discover/initialize outcome, catalog success, a read-only `signoz_search_docs` call, one coded validation/error result, auth mode, session-header absence for HTTP, and Assistant correlation behavior. Do not create or mutate tenant resources. Never print or persist credentials.
+For each, record exact client version, transport, negotiated protocol era,
+discover/initialize outcome, catalog success, a real tool call, one coded
+validation/error result, auth mode, session-header absence for HTTP, and
+Assistant correlation behavior. Temporary staging mutations are allowed only
+for a named lifecycle check; delete every created object and credential and
+verify it is gone. Never print or persist credentials.
 
-Deterministic wire goldens, raw dual-era tests, and Inspector block the runtime migration merge. The separate conformance follow-up must land before issue #194 closes or release promotion. Unless the open question is resolved differently, credentialed native-client smokes also block release promotion rather than untrusted pull requests.
+Deterministic wire goldens, raw dual-era tests, Inspector, and selected official
+conformance block their respective PRs. Credentialed Assistant and native-
+client smokes are a protected release-promotion gate rather than an untrusted
+pull-request check.
 
-Completed runtime-PR staging evidence on 2026-08-13:
+Completed protected E2E evidence on exact runtime commit `0e33180`:
 
-- 35/35 selected read-only build-tagged live tests passed; all channel/view and
-  other mutation tests were excluded.
-- The built production binary passed HTTP and stdio under both `2025-11-25`
-  and `2026-07-28`, including all four catalog counts, representative local
-  resource/prompt reads, coded validation, one live read-only backend tool,
-  stateless HTTP method/session behavior, and clean shutdown.
-- The read-only matrix created no staging resource. The later OAuth run used one
-  temporary viewer service account and expiring key; the key was revoked and
-  verified unauthorized, and the account was deleted (retained only as the
-  backend's soft-deleted audit row).
+- 39/39 top-level staging tests and 29/29 subtests passed with zero failures or
+  skips. The actual production binary passed HTTP and stdio under legacy
+  `2025-11-25` and modern `2026-07-28`, including stateless/session behavior,
+  coded validation, live backend calls, and clean shutdown.
+- Every client-visible surface was exercised: 43/43 tools were invoked through
+  real MCP `tools/call`; 22/22 static resources and 2/2 live resource templates
+  were read; and 4/4 prompts were generated.
+- Notification channels, cloned views, cloned dashboards, dashboard JSON
+  Patch, dashboard import, and cloned disabled alerts each completed the
+  applicable create/read/update/read-back/delete/verify-gone lifecycle. All
+  temporary staging resources were independently scanned and confirmed absent.
+  Notification-channel GET did not expose its webhook URL in a byte-comparable
+  form; treat that as acceptable secret redaction because update, deletion,
+  and verify-gone still passed.
+- Browser OAuth passed metadata, DCR, consent, state/CSRF, PKCE rejection and
+  success, code exchange, refresh, bearer challenges, revocation, and token
+  invalidation. Temporary viewer credentials were revoked and verified 401;
+  service accounts were deleted and confirmed inactive. Credential canaries
+  were absent from bounded logs.
+- The real SigNoz Assistant `McpToolClient`, Codex, Claude Code, and Cursor all
+  completed real MCP calls against the built binary. Assistant success,
+  validation, OAuth tenant precedence, and terminal correlation passed.
+- Raw MCP wire preserved `isError:true` and the structured validation code.
+  Claude retained `isError` but hid the structured code; Cursor rewrote
+  `isError:true` to false and removed `structuredContent`. These are documented
+  client presentation limitations, not server output regressions.
 
-Browser OAuth and the actual Assistant consumer subsequently passed on the
-built server, including DCR, PKCE, consent, code/token/refresh, bearer
-challenges, live read-only calls, coded validation, correlation, and log-secret
-scans. That run found and fixed one auth-precedence defect: server-issued OAuth
-tokens are now decrypted before considering `X-SigNoz-URL`, so their encrypted
-tenant is authoritative and cannot be downgraded into a direct bearer.
-
-Representative native clients were also exercised against the built binary.
-Codex completed catalog, local docs, and coded-error calls; Claude connected and
-read the catalogs but its provider account limit blocked invocation before MCP;
-Cursor initialized and listed all tools, while its noninteractive invocation
-was rejected client-side before `tools/call`. The actual SigNoz Assistant
-consumer path completed live success and coded-error calls through OAuth with
-exact correlation, which is the production consumer boundary for this server.
-
-The final Opus review additionally required real-transport proof for two
-observability contracts. Production HTTP initialize now proves the legacy
-client analytics event through the SDK-created server request, and HTTP
-tool-failure tests prove request capture projects only marshalable MCP params,
-redacts credential-shaped arguments, and cannot copy headers or token state.
+Real-transport tests also prove legacy initialize analytics and tool-failure
+request projection through the SDK-created server request. Captured request
+data remains marshalable, redacts credential-shaped arguments, and cannot copy
+headers or token state.
 
 ### Phase 6 — Final verification and delivery
 
@@ -634,9 +638,15 @@ git diff --check
 
 Both formatting commands must print nothing. Run the configured GitHub `lint`, `fmt`, `test`, `deps`, `build`, guardrail, and Inspector jobs.
 
-When Phase 4 is present in its linked follow-up, run the exact pinned
-conformance-runner command introduced by that PR; do not overload the production
-Inspector script with an unused suite variable.
+When Phase 4 is present in its linked follow-up, also run:
+
+```bash
+bash -n scripts/test-mcp-conformance.sh
+shellcheck scripts/test-mcp-conformance.sh
+scripts/test-mcp-conformance.sh
+```
+
+Keep this selected official lane separate from the production Inspector script.
 
 Require the conformance job before completing this plan and closing issue #194. Promote `protocol / conformance` to a required check only after its first clean default-branch bootstrap.
 
@@ -649,7 +659,11 @@ branched from PR #286 after it becomes ready. Rebase the conformance PR onto
 2. Its first green commit is `test(mcp): freeze pre-migration wire contracts`. Create the complete Phase 0 SDK-free oracle and capture all fixtures while the branch still uses mark3; run the Phase 0 gates and review the fixture diff before changing `go.mod` in any later commit.
 3. Later commits in the same PR implement Phases 1–3 and 5: the complete dependency/type/registration/runtime/transport/observability cutover, ported existing tests, raw dual-era tests, Inspector updates, documentation, metadata, and CMP-3 result. Never regenerate the pre-swap fixtures after the first dependency-changing commit. Use logical commits for review, but do not create adapter-only, tool-family, transport-only, or observability-only PRs: no intermediate boundary is both production-functional and free of temporary dual-SDK shims.
 4. Merge the runtime PR only when its complete parity and production gates pass. The clean operational/revert boundary is mark3 runtime versus official runtime.
-5. Branch the Phase 4 conformance PR from the ready runtime branch as a stacked PR targeting that branch. It contains only the pinned referee, non-shipping fixture, leakage guards, CI job, and conformance-specific documentation. After #286 merges, rebase/retarget it to `main`. Keep #194 open until it lands.
+5. Branch the Phase 4 conformance PR from the ready runtime branch as a stacked
+   PR targeting that branch. It contains only the pinned referee, bounded
+   selected-scenario production script, separate CI job, and conformance-
+   specific documentation. After #286 merges, rebase/retarget it to `main`.
+   Keep #194 open until it lands.
 6. After the runtime PR merges, the conformance PR and the independent #191/#164 ERR-6 follow-up may proceed in parallel from `main`; neither depends on the other.
 
 ### Post-merge follow-up — ERR-6 guidance fidelity (#191 and #164)
@@ -699,12 +713,16 @@ The eventual PR title should follow repository convention, for example `feat(mcp
 - `internal/handler/tools/*_test.go`, especially registration/schema/normalization/output/structured/error inventories — port types while retaining behavior.
 - `pkg/otel/mcp_test.go`, `pkg/toolerrors/errors_test.go`, `pkg/prompts/*_test.go` — official types and lifecycle parity.
 
-### Protocol CI and fixture conformance
+### Protocol CI and selected official conformance
 - `tools/mcp-ci/package.json`, `package-lock.json` — exact Inspector and conformance pins.
-- `scripts/test-mcp-protocol.sh` — 2×2 production matrix and conformance suite modes.
+- `scripts/test-mcp-protocol.sh` — existing Inspector and bounded real-binary
+  production checks; do not add conformance modes to it.
+- `scripts/test-mcp-conformance.sh` — twelve named official scenarios against
+  the real production HTTP binary, with bounded process/artifact cleanup.
 - `.github/workflows/mcp-protocol.yaml` — retain Inspector check, add conformance check.
-- Minimal `internal/mcpconformance/` and `cmd/conformance-server/` only if needed to wrap/reuse the pinned official fixture catalog and shared server/transport composition.
-- `guardrails/policy.go`, `guardrails/tests.txt` only if new package-sensitive leakage tests meet guardrail ownership rules; otherwise keep tests beside packages.
+- Do not add `internal/mcpconformance`, `cmd/conformance-server`, fixture
+  catalogs, or package-sensitive leakage guardrails; the approved design has no
+  fixture code to leak.
 
 ### Docs and metadata
 - `README.md`, `docs/architecture.md`, `docs/mcp-best-practices.md`, `guardrails/README.md` — protocol/runtime/CI behavior.
@@ -723,8 +741,7 @@ The eventual PR title should follow repository convention, for example `feat(mcp
 | Auth/request limit/wrapper order | focused handler tests | real-binary protocol harness |
 | Cancellation/shutdown/readiness | race-focused Go tests | real process cleanup in scripts |
 | Exactly-once telemetry | in-memory/fake meter/span/log/analytics tests | staging Assistant correlation smoke |
-| Official conformance | frozen `--requirements` sets against isolated shared-stack fixture | production 2×2 raw matrix (different claim) |
-| Fixture non-leakage | dependency/catalog tests | manifest/README audit |
+| Selected official conformance | six named scenarios per era against real `cmd/server` HTTP | production 2×2 raw matrix (broader SigNoz claim) |
 
 ## Risks
 - **HIGH — Catalog drift:** different schema/annotation structs and SDK serialization can change valid but client-sensitive JSON.
@@ -732,11 +749,16 @@ The eventual PR title should follow repository convention, for example `feat(mcp
 - **HIGH — Handler decode drift:** raw arguments, nil semantics, float precision, defaults, aliases, or unknown fields can change behavior across all 43 tools.
 - **HIGH — Error-channel drift:** generic SDK helpers can turn coded tool failures into JSON-RPC errors or replace structured recovery content.
 - **HIGH — Observability lifecycle:** replacing hooks/tracer/middleware can duplicate or lose terminal metrics, spans, logs, analytics, tenant, or Assistant correlation.
-- **HIGH — False conformance claim:** full official scenarios require fixture names/features absent from the production catalog; direct production runs or broad baselines would be misleading.
+- **HIGH — False conformance claim:** selected production scenarios must not be
+  described as the full 30/37 frozen requirement sets; full requirements need
+  fixture names and product features intentionally absent from SigNoz.
 - **MEDIUM — Capability/pagination drift:** official inference defaults (`listChanged`, page size) can alter initialize/discover/list responses beyond the accepted logging removal.
 - **MEDIUM — Transport drift:** official JSON/SSE default, stateless GET/DELETE 405, request-cap defaults, legacy disconnect cancellation, malformed stdio, DNS-rebinding protection, and `Server.Run` cancellation/logging differ from mark3.
-- **MEDIUM — Prerelease CI referee:** the applicable conformance package may still be prerelease and needs an exact, reviewed pin.
-- **MEDIUM — Shared-SDK blind spot:** server and some tests use the same SDK; raw wire, Inspector, canonical fixtures, and the external conformance runner remain necessary.
+- **MEDIUM — Prerelease CI referee:** the approved referee is prerelease and
+  therefore requires the exact reviewed pin plus deliberate upgrades.
+- **MEDIUM — Shared-SDK blind spot:** server and some tests use the same SDK;
+  raw wire, Inspector, immutable catalog fixtures, and the selected external
+  conformance runner remain necessary independent layers.
 - **LOW — Documentation/version drift:** `server.json` is current at v0.12.0 on the planning baseline, but SDK/protocol documentation and metadata can still become stale during the migration.
 
 ## STOP Conditions
@@ -757,9 +779,14 @@ The eventual PR title should follow repository convention, for example `feat(mcp
 - STOP if a standardized header mismatch reaches the handler, returns a code other than `-32020`, or lacks the request ID.
 - STOP if auth/request-limit/readiness/DNS-rebinding/shutdown order changes, graceful stdio cancellation exits non-zero or logs as an operational error, or legacy disconnect cancellation changes without an explicitly approved limitation and capacity-impact note.
 - STOP if any SDK-dispatched path loses or duplicates terminal method/tool telemetry, leaves spans open, leaks client metadata between modern requests, or loses tenant/correlation attribution. Pre-dispatch HTTP paths must remain on HTTP telemetry only and emit zero MCP method/tool metrics. For stdio, stop on loss of existing dispatched-request telemetry or unbounded/raw transport logs; add fallback machinery only in response to a named failing parity test. Do not label wholly unparseable frames with an invented method.
-- STOP if the full official requirements are pointed directly at the production SigNoz catalog or missing fixtures are hidden with broad baselines.
-- STOP if fixture code/surfaces/MRTR/Tasks/Apps enter `cmd/server`, production discovery, README, manifest, or guardrail inventories.
-- STOP if a blocking prerelease conformance dependency is not approved; rewrite the acceptance claim rather than silently substituting an older suite.
+- STOP if CI or documentation claims full conformance or frozen
+  `--requirements` coverage from the selected scenario set, or if missing
+  fixtures are hidden with any baseline.
+- STOP if fixture code/surfaces/MRTR/Tasks/Apps, an everything-server copy, or
+  a separate conformance binary is added; the approved lane must exercise the
+  existing production `cmd/server`.
+- STOP if the exact approved prerelease pin is floated or silently replaced;
+  any upgrade requires a reviewed dependency change and the same scenario gate.
 - STOP release if a representative client fails or a taught contract changes without a linked `SigNoz/agent-skills` companion PR.
 
 ## Done Criteria
@@ -776,7 +803,10 @@ targeted question later, but must not duplicate either review.
 - Mark3 imports and dependency are gone; official Go SDK v1.7.0 (or a separately reviewed newer stable target) owns HTTP and stdio.
 - The immutable SDK-free characterization covers every advertised tool schema/description/annotation and every resource/template/prompt descriptor; compact digests cover all deterministic resource/prompt payloads; literal fixtures cover shape-sensitive handlers/errors. Only the named accepted differences remain, and independent inventories, budgets, normalization, structured-result, and coded-error tests pass.
 - The production HTTP/stdio × legacy/modern matrix and exact standardized-header tests pass.
-- Official frozen `--requirements` sets for both eras pass against the minimal isolated shared-stack fixture in the bounded follow-up with no broad baseline; fixture leakage guards pass. If maintainers approve narrower selected-scenario scope instead, the plan/issue claim is updated before coding.
+- Exact `@modelcontextprotocol/conformance@0.2.0-alpha.11` passes the six named
+  legacy and six named modern scenarios against the real production binary,
+  with no fixture server, expected-failures baseline, live credential, or full
+  `--requirements` claim.
 - Auth/OAuth, request limits, readiness, JSON POST framing, DNS-rebinding protection, approved cancellation behavior, shutdown, panic recovery, and dispatched-request exactly-once observability retain parity; pre-dispatch HTTP failures remain transport-only, while stdio behavior is measured, bounded, and documents malformed-frame termination.
 - README, architecture, MCP best practices, guardrails, manifest/server metadata, and CMP-3 statement are synchronized.
 - Representative client results are recorded, all repository gates pass, and the plan status is updated to `Done` only after the feature ships.

--- a/scripts/test-mcp-conformance.sh
+++ b/scripts/test-mcp-conformance.sh
@@ -1,0 +1,228 @@
+#!/usr/bin/env bash
+
+set -Eeuo pipefail
+
+ROOT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+CONFORMANCE_VERSION=0.2.0-alpha.11
+CONFORMANCE_PACKAGE_DIR="$ROOT_DIR/tools/mcp-ci/node_modules/@modelcontextprotocol/conformance"
+CONFORMANCE_CLI="$CONFORMANCE_PACKAGE_DIR/dist/index.js"
+MCP_CONFORMANCE_HOST=127.0.0.1
+MCP_CONFORMANCE_PORT=${MCP_CONFORMANCE_PORT:-18081}
+MCP_URL="http://${MCP_CONFORMANCE_HOST}:${MCP_CONFORMANCE_PORT}/mcp"
+READY_URL="http://${MCP_CONFORMANCE_HOST}:${MCP_CONFORMANCE_PORT}/readyz"
+READINESS_TIMEOUT_SECONDS=30
+SCENARIO_TIMEOUT_SECONDS=60
+
+CONFORMANCE_TMP_DIR=""
+SERVER_PID=""
+SERVER_LOG=""
+CURRENT_PHASE="setup"
+CURRENT_STDOUT=""
+CURRENT_STDERR=""
+CURRENT_RESULTS_DIR=""
+
+print_bounded_file() {
+  local label=$1
+  local file=$2
+
+  if [[ -s "$file" ]]; then
+    printf '%s\n' "--- ${label} (first 200 lines) ---" >&2
+    sed -n '1,200p' "$file" >&2
+  fi
+}
+
+stop_server_for_cleanup() {
+  if [[ -z "$SERVER_PID" ]]; then
+    return
+  fi
+
+  if kill -0 "$SERVER_PID" 2>/dev/null; then
+    kill -TERM "$SERVER_PID" 2>/dev/null || true
+    for _ in {1..25}; do
+      if ! kill -0 "$SERVER_PID" 2>/dev/null; then
+        break
+      fi
+      sleep 0.2
+    done
+    if kill -0 "$SERVER_PID" 2>/dev/null; then
+      kill -KILL "$SERVER_PID" 2>/dev/null || true
+    fi
+  fi
+  wait "$SERVER_PID" 2>/dev/null || true
+  SERVER_PID=""
+}
+
+cleanup() {
+  local status=$?
+  local checks_file=""
+  trap - EXIT INT TERM
+
+  if [[ $status -ne 0 ]]; then
+    printf 'MCP conformance check failed during: %s\n' "$CURRENT_PHASE" >&2
+    if [[ -n "$CURRENT_STDOUT" ]]; then
+      print_bounded_file 'command stdout' "$CURRENT_STDOUT"
+    fi
+    if [[ -n "$CURRENT_STDERR" ]]; then
+      print_bounded_file 'command stderr' "$CURRENT_STDERR"
+    fi
+    if [[ -n "$CURRENT_RESULTS_DIR" && -d "$CURRENT_RESULTS_DIR" ]]; then
+      checks_file=$(find "$CURRENT_RESULTS_DIR" -name checks.json -type f -print -quit)
+      if [[ -n "$checks_file" ]]; then
+        print_bounded_file 'conformance checks' "$checks_file"
+      fi
+    fi
+    if [[ -n "$SERVER_LOG" && -s "$SERVER_LOG" ]]; then
+      printf '%s\n' '--- server log (last 120 lines) ---' >&2
+      tail -n 120 "$SERVER_LOG" >&2
+    fi
+  fi
+
+  stop_server_for_cleanup
+  if [[ -n "$CONFORMANCE_TMP_DIR" && -d "$CONFORMANCE_TMP_DIR" ]]; then
+    rm -r "$CONFORMANCE_TMP_DIR"
+  fi
+
+  exit "$status"
+}
+
+trap cleanup EXIT
+trap 'exit 130' INT TERM
+
+fail() {
+  printf '%s\n' "$1" >"$CURRENT_STDERR"
+  return 1
+}
+
+run_scenario() {
+  local spec_version=$1
+  local scenario=$2
+  local slug="${spec_version}-${scenario}"
+
+  CURRENT_PHASE="${spec_version} ${scenario}"
+  CURRENT_STDOUT="$CONFORMANCE_TMP_DIR/${slug}.stdout"
+  CURRENT_STDERR="$CONFORMANCE_TMP_DIR/${slug}.stderr"
+  CURRENT_RESULTS_DIR="$CONFORMANCE_TMP_DIR/${slug}-results"
+
+  timeout --signal=TERM --kill-after=5s "${SCENARIO_TIMEOUT_SECONDS}s" \
+    node "$CONFORMANCE_CLI" server \
+    --url "$MCP_URL" \
+    --scenario "$scenario" \
+    --spec-version "$spec_version" \
+    --output-dir "$CURRENT_RESULTS_DIR" \
+    >"$CURRENT_STDOUT" 2>"$CURRENT_STDERR"
+
+  printf 'passed: %s / %s\n' "$spec_version" "$scenario"
+}
+
+for dependency in curl go node timeout; do
+  if ! command -v "$dependency" >/dev/null 2>&1; then
+    printf 'Required command is unavailable: %s\n' "$dependency" >&2
+    exit 1
+  fi
+done
+
+if [[ ! "$MCP_CONFORMANCE_PORT" =~ ^[0-9]+$ ]] || ((MCP_CONFORMANCE_PORT < 1 || MCP_CONFORMANCE_PORT > 65535)); then
+  printf 'MCP_CONFORMANCE_PORT must be an integer between 1 and 65535\n' >&2
+  exit 1
+fi
+
+CONFORMANCE_TMP_DIR=$(mktemp -d)
+SERVER_LOG="$CONFORMANCE_TMP_DIR/server.log"
+CURRENT_STDOUT="$CONFORMANCE_TMP_DIR/setup.stdout"
+CURRENT_STDERR="$CONFORMANCE_TMP_DIR/setup.stderr"
+
+if [[ ! -f "$CONFORMANCE_PACKAGE_DIR/package.json" || ! -f "$CONFORMANCE_CLI" ]]; then
+  fail "MCP conformance runner is not installed; run npm ci in tools/mcp-ci"
+fi
+
+installed_package_version=$(node -p "require('$CONFORMANCE_PACKAGE_DIR/package.json').version")
+if [[ "$installed_package_version" != "$CONFORMANCE_VERSION" ]]; then
+  fail "MCP conformance package ${CONFORMANCE_VERSION} is required; found ${installed_package_version}"
+fi
+
+installed_runner_version=$(node "$CONFORMANCE_CLI" --version)
+if [[ "$installed_runner_version" != "$CONFORMANCE_VERSION" ]]; then
+  fail "MCP conformance runner ${CONFORMANCE_VERSION} is required; found ${installed_runner_version}"
+fi
+
+if ! node -e '
+  const net = require("node:net");
+  const server = net.createServer();
+  server.once("error", () => process.exit(1));
+  server.listen({ host: process.argv[1], port: Number(process.argv[2]) }, () => server.close());
+' "$MCP_CONFORMANCE_HOST" "$MCP_CONFORMANCE_PORT" >"$CURRENT_STDOUT" 2>"$CURRENT_STDERR"; then
+  fail "Port ${MCP_CONFORMANCE_PORT} is already occupied on ${MCP_CONFORMANCE_HOST}"
+fi
+
+CURRENT_PHASE="build production server"
+go build -o "$CONFORMANCE_TMP_DIR/signoz-mcp-server" ./cmd/server >"$CURRENT_STDOUT" 2>"$CURRENT_STDERR"
+
+env \
+  TRANSPORT_MODE=http \
+  MCP_SERVER_HOST="$MCP_CONFORMANCE_HOST" \
+  MCP_SERVER_PORT="$MCP_CONFORMANCE_PORT" \
+  SIGNOZ_URL=https://example.invalid \
+  SIGNOZ_API_KEY=conformance-test-key \
+  OAUTH_ENABLED=false \
+  ANALYTICS_ENABLED=false \
+  OTEL_TRACES_EXPORTER=none \
+  OTEL_METRICS_EXPORTER=none \
+  "$CONFORMANCE_TMP_DIR/signoz-mcp-server" >"$SERVER_LOG" 2>&1 &
+SERVER_PID=$!
+
+CURRENT_PHASE="server readiness"
+CURRENT_STDOUT="$CONFORMANCE_TMP_DIR/readiness.stdout"
+CURRENT_STDERR="$CONFORMANCE_TMP_DIR/readiness.stderr"
+readiness_deadline=$((SECONDS + READINESS_TIMEOUT_SECONDS))
+until curl --fail --silent --show-error --max-time 2 "$READY_URL" >"$CURRENT_STDOUT" 2>"$CURRENT_STDERR"; do
+  if ! kill -0 "$SERVER_PID" 2>/dev/null; then
+    fail "Server exited before becoming ready"
+  fi
+  if ((SECONDS >= readiness_deadline)); then
+    fail "Server did not become ready within ${READINESS_TIMEOUT_SECONDS} seconds"
+  fi
+  sleep 1
+done
+
+legacy_scenarios=(
+  server-initialize
+  ping
+  tools-list
+  resources-list
+  prompts-list
+  dns-rebinding-protection
+)
+modern_scenarios=(
+  tools-list
+  resources-list
+  sep-2164-resource-not-found
+  prompts-list
+  dns-rebinding-protection
+  caching
+)
+
+for scenario in "${legacy_scenarios[@]}"; do
+  run_scenario 2025-11-25 "$scenario"
+done
+for scenario in "${modern_scenarios[@]}"; do
+  run_scenario 2026-07-28 "$scenario"
+done
+
+CURRENT_PHASE="clean server shutdown"
+CURRENT_STDOUT="$CONFORMANCE_TMP_DIR/shutdown.stdout"
+CURRENT_STDERR="$CONFORMANCE_TMP_DIR/shutdown.stderr"
+kill -TERM "$SERVER_PID"
+shutdown_deadline=$((SECONDS + 5))
+while kill -0 "$SERVER_PID" 2>/dev/null && ((SECONDS < shutdown_deadline)); do
+  sleep 0.2
+done
+if kill -0 "$SERVER_PID" 2>/dev/null; then
+  fail "Server did not stop within 5 seconds of SIGTERM"
+fi
+if ! wait "$SERVER_PID"; then
+  SERVER_PID=""
+  fail "Server exited unsuccessfully after SIGTERM"
+fi
+SERVER_PID=""
+
+printf '%s\n' 'MCP conformance check passed: 6 legacy and 6 modern scenarios against the production server'

--- a/scripts/test-mcp-conformance.sh
+++ b/scripts/test-mcp-conformance.sh
@@ -11,7 +11,7 @@ MCP_CONFORMANCE_PORT=${MCP_CONFORMANCE_PORT:-18081}
 MCP_URL="http://${MCP_CONFORMANCE_HOST}:${MCP_CONFORMANCE_PORT}/mcp"
 READY_URL="http://${MCP_CONFORMANCE_HOST}:${MCP_CONFORMANCE_PORT}/readyz"
 READINESS_TIMEOUT_SECONDS=30
-SCENARIO_TIMEOUT_SECONDS=60
+SCENARIO_TIMEOUT_SECONDS=30
 
 CONFORMANCE_TMP_DIR=""
 SERVER_PID=""
@@ -55,6 +55,7 @@ stop_server_for_cleanup() {
 cleanup() {
   local status=$?
   local checks_file=""
+  set +e
   trap - EXIT INT TERM
 
   if [[ $status -ne 0 ]]; then
@@ -111,6 +112,10 @@ run_scenario() {
     --output-dir "$CURRENT_RESULTS_DIR" \
     >"$CURRENT_STDOUT" 2>"$CURRENT_STDERR"
 
+  if grep -q '^SKIPPED:' "$CURRENT_STDOUT"; then
+    fail "Scenario ${scenario} was skipped at ${spec_version}; every selected scenario must run"
+  fi
+
   printf 'passed: %s / %s\n' "$spec_version" "$scenario"
 }
 
@@ -133,11 +138,6 @@ CURRENT_STDERR="$CONFORMANCE_TMP_DIR/setup.stderr"
 
 if [[ ! -f "$CONFORMANCE_PACKAGE_DIR/package.json" || ! -f "$CONFORMANCE_CLI" ]]; then
   fail "MCP conformance runner is not installed; run npm ci in tools/mcp-ci"
-fi
-
-installed_package_version=$(node -p "require('$CONFORMANCE_PACKAGE_DIR/package.json').version")
-if [[ "$installed_package_version" != "$CONFORMANCE_VERSION" ]]; then
-  fail "MCP conformance package ${CONFORMANCE_VERSION} is required; found ${installed_package_version}"
 fi
 
 installed_runner_version=$(node "$CONFORMANCE_CLI" --version)

--- a/tools/mcp-ci/package-lock.json
+++ b/tools/mcp-ci/package-lock.json
@@ -8,6 +8,7 @@
       "name": "signoz-mcp-protocol-ci",
       "version": "1.0.0",
       "devDependencies": {
+        "@modelcontextprotocol/conformance": "0.2.0-alpha.11",
         "@modelcontextprotocol/inspector-cli": "1.0.0"
       },
       "engines": {
@@ -15,9 +16,9 @@
       }
     },
     "node_modules/@hono/node-server": {
-      "version": "1.19.14",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
-      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "version": "1.19.17",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.17.tgz",
+      "integrity": "sha512-dSneS5qhiauZWGDCeK4o695Xd9nUNjviSZCMQrj10eetr8Uln1ucn6bbphOM6UynAMMtNIzZNSpL9vnASJwrPQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -25,6 +26,39 @@
       },
       "peerDependencies": {
         "hono": "^4"
+      }
+    },
+    "node_modules/@modelcontextprotocol/conformance": {
+      "version": "0.2.0-alpha.11",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/conformance/-/conformance-0.2.0-alpha.11.tgz",
+      "integrity": "sha512-imPK9tx5gQsL6ZKQq4MrsyDYfSaIwpRmX6+ogjbeAXs9LGvxkBxWcY7KcS7TvwaBk/ZiVWl6b/naF4q83UwDRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@modelcontextprotocol/sdk": "^1.29.0",
+        "@octokit/rest": "^22.0.0",
+        "ajv": "^8.20.0",
+        "ajv-formats": "^3.0.1",
+        "commander": "^14.0.2",
+        "eventsource-parser": "^3.0.8",
+        "express": "^5.1.0",
+        "jose": "^6.1.2",
+        "undici": "^7.25.0",
+        "yaml": "^2.8.2",
+        "zod": "^4.3.6"
+      },
+      "bin": {
+        "conformance": "dist/index.js"
+      }
+    },
+    "node_modules/@modelcontextprotocol/conformance/node_modules/commander": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
+      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@modelcontextprotocol/inspector-cli": {
@@ -84,6 +118,221 @@
         }
       }
     },
+    "node_modules/@octokit/auth-token": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-6.0.0.tgz",
+      "integrity": "sha512-P4YJBPdPSpWTQ1NU4XYdvHvXJJDxM6YwpS0FZHRgP7YFkdVxsWcpWGy/NVqlAA7PcPCnMacXlRm1y2PFZRWL/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/core": {
+      "version": "7.0.7",
+      "resolved": "https://registry.npmjs.org/@octokit/core/-/core-7.0.7.tgz",
+      "integrity": "sha512-DcB0M3KFgr9ECI328lhBMVsyFT2DnmNucSBTqEN3exyNKUzkkpUSCHmTRcunF41Eou2TIQKW4seewri8ON9bSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/auth-token": "^6.0.0",
+        "@octokit/graphql": "^9.0.4",
+        "@octokit/request": "^10.0.13",
+        "@octokit/request-error": "^7.1.1",
+        "@octokit/types": "^17.0.0",
+        "before-after-hook": "^4.0.0",
+        "universal-user-agent": "^7.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/endpoint": {
+      "version": "11.0.4",
+      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-11.0.4.tgz",
+      "integrity": "sha512-f1cOWoHPmxryJFknxbtDdjODWfV8A9tc8Aae6ermXPNgHFZ/x91AtHIz4gicEjL8hkJiip+u21QHJORfBv/qiA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^17.0.0",
+        "universal-user-agent": "^7.0.2"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/graphql": {
+      "version": "9.0.4",
+      "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-9.0.4.tgz",
+      "integrity": "sha512-5s15CCiY8XXQ+FG+b1YQcl6Z2FA++nwAz/tg2VUrTmnMncP+2nnGUEYANImdnxsA2Fnq+Mbl7hDjUTw7cFAwcg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/request": "^10.0.13",
+        "@octokit/types": "^17.0.0",
+        "universal-user-agent": "^7.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/openapi-types": {
+      "version": "28.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-28.0.0.tgz",
+      "integrity": "sha512-0rFyLuyHvIj6uuZWuDslxkowFYdPXoNIkeAv4b27dzm2Tf4vGWXnPsMcxs7d65kLdMERgP3wc1AEPlqMz8e1cQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@octokit/plugin-paginate-rest": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-14.0.0.tgz",
+      "integrity": "sha512-fNVRE7ufJiAA3XUrha2omTA39M6IXIc6GIZLvlbsm8QOQCYvpq/LkMNGyFlB1d8hTDzsAXa3OKtybdMAYsV/fw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^16.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      },
+      "peerDependencies": {
+        "@octokit/core": ">=6"
+      }
+    },
+    "node_modules/@octokit/plugin-paginate-rest/node_modules/@octokit/openapi-types": {
+      "version": "27.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-27.0.0.tgz",
+      "integrity": "sha512-whrdktVs1h6gtR+09+QsNk2+FO+49j6ga1c55YZudfEG+oKJVvJLQi3zkOm5JjiUXAagWK2tI2kTGKJ2Ys7MGA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@octokit/plugin-paginate-rest/node_modules/@octokit/types": {
+      "version": "16.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-16.0.0.tgz",
+      "integrity": "sha512-sKq+9r1Mm4efXW1FCk7hFSeJo4QKreL/tTbR0rz/qx/r1Oa2VV83LTA/H/MuCOX7uCIJmQVRKBcbmWoySjAnSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/openapi-types": "^27.0.0"
+      }
+    },
+    "node_modules/@octokit/plugin-request-log": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-6.0.0.tgz",
+      "integrity": "sha512-UkOzeEN3W91/eBq9sPZNQ7sUBvYCqYbrrD8gTbBuGtHEuycE4/awMXcYvx6sVYo7LypPhmQwwpUe4Yyu4QZN5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20"
+      },
+      "peerDependencies": {
+        "@octokit/core": ">=6"
+      }
+    },
+    "node_modules/@octokit/plugin-rest-endpoint-methods": {
+      "version": "17.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-17.0.0.tgz",
+      "integrity": "sha512-B5yCyIlOJFPqUUeiD0cnBJwWJO8lkJs5d8+ze9QDP6SvfiXSz1BF+91+0MeI1d2yxgOhU/O+CvtiZ9jSkHhFAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^16.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      },
+      "peerDependencies": {
+        "@octokit/core": ">=6"
+      }
+    },
+    "node_modules/@octokit/plugin-rest-endpoint-methods/node_modules/@octokit/openapi-types": {
+      "version": "27.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-27.0.0.tgz",
+      "integrity": "sha512-whrdktVs1h6gtR+09+QsNk2+FO+49j6ga1c55YZudfEG+oKJVvJLQi3zkOm5JjiUXAagWK2tI2kTGKJ2Ys7MGA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@octokit/plugin-rest-endpoint-methods/node_modules/@octokit/types": {
+      "version": "16.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-16.0.0.tgz",
+      "integrity": "sha512-sKq+9r1Mm4efXW1FCk7hFSeJo4QKreL/tTbR0rz/qx/r1Oa2VV83LTA/H/MuCOX7uCIJmQVRKBcbmWoySjAnSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/openapi-types": "^27.0.0"
+      }
+    },
+    "node_modules/@octokit/request": {
+      "version": "10.0.13",
+      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-10.0.13.tgz",
+      "integrity": "sha512-v2269YxL9Yf+x3d+gRI63FP0vFQEiWgLyBzxe/Y+0yFDg2B/Tzf5dhh9VNfccVAQnfcfwQWyk/y6Bn7rUXXs7A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/endpoint": "^11.0.3",
+        "@octokit/request-error": "^7.1.1",
+        "@octokit/types": "^17.0.0",
+        "content-type": "^2.0.0",
+        "json-with-bigint": "^3.5.3",
+        "universal-user-agent": "^7.0.2"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/request-error": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-7.1.1.tgz",
+      "integrity": "sha512-+eaY7G2VVpSf2pc5Gn1+mph837V/d/TYTJAgWL9Tb0ogGYcpN3IlAVFgjL+Vv93F/sevrxkvsYCedtpLdcFLzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^17.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/request/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@octokit/rest": {
+      "version": "22.0.1",
+      "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-22.0.1.tgz",
+      "integrity": "sha512-Jzbhzl3CEexhnivb1iQ0KJ7s5vvjMWcmRtq5aUsKmKDrRW6z3r84ngmiFKFvpZjpiU/9/S6ITPFRpn5s/3uQJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/core": "^7.0.6",
+        "@octokit/plugin-paginate-rest": "^14.0.0",
+        "@octokit/plugin-request-log": "^6.0.0",
+        "@octokit/plugin-rest-endpoint-methods": "^17.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/types": {
+      "version": "17.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-17.0.0.tgz",
+      "integrity": "sha512-ByP1v7YL5SMveFPP7+sj0/ZuWCOOg/Chs4NafOMpq6WNIM/hdGY0S7C0TCGDBWu1aGmOxmUIhMx3cO+IdwYZ1Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/openapi-types": "^28.0.0"
+      }
+    },
     "node_modules/accepts": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
@@ -132,6 +381,13 @@
           "optional": true
         }
       }
+    },
+    "node_modules/before-after-hook": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-4.0.0.tgz",
+      "integrity": "sha512-q6tR3RPqIB1pMiTRMFcZwuG5T8vwp+vUvEG0vuI6B+Rikh5BfPp2fQ82c925FOs+b0lcFQ8CFrL+KbilfZFhOQ==",
+      "dev": true,
+      "license": "Apache-2.0"
     },
     "node_modules/body-parser": {
       "version": "2.3.0",
@@ -505,9 +761,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
-      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "dev": true,
       "funding": [
         {
@@ -652,9 +908,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.31",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.31.tgz",
-      "integrity": "sha512-zJIHFrl6bq3RDd2YusFNCDlM8qUprxKswyi/OPzPyzKDdyBXDqWx8bZlZ7R+saTdSTatUmb3O7K4SspGPaEOQg==",
+      "version": "4.13.2",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.13.2.tgz",
+      "integrity": "sha512-JydRilDRkYBQMt9qR9U92mXxmbGqsqSn/IKOrh4e7/gEbn+0zSr8igTu0obwJoNGN4sez28DIql7FBHWydoJpA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -707,9 +963,9 @@
       "license": "ISC"
     },
     "node_modules/ip-address": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
-      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.5.0.tgz",
+      "integrity": "sha512-R5SnVLJmgYYvf2F2ZgwSBnelz5G4q5AxIC277GDfUaNbrZKNANcBC7RHqYYePlszf4kBolVkJauG0ZjHHFh55g==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -763,6 +1019,13 @@
       "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
       "dev": true,
       "license": "BSD-2-Clause"
+    },
+    "node_modules/json-with-bigint": {
+      "version": "3.5.10",
+      "resolved": "https://registry.npmjs.org/json-with-bigint/-/json-with-bigint-3.5.10.tgz",
+      "integrity": "sha512-Vcx+JVNEBts/xfcoCS69sKrOhOk/3TVlvlT+XzUOefVKnnrbYSCKpDCm10pohsJFtsJVYnwa/cXRZ4eElzaM6w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
@@ -1257,6 +1520,23 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/undici": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
+    "node_modules/universal-user-agent": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-7.0.3.tgz",
+      "integrity": "sha512-TmnEAEAsBJVZM/AADELsK76llnwcf9vMKuPz8JflO1frO8Lchitr0fNaN9d+Ap0BjKtqWqd/J17qeDnXh8CL2A==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/unpipe": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
@@ -1299,6 +1579,22 @@
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
     },
     "node_modules/zod": {
       "version": "4.4.3",

--- a/tools/mcp-ci/package.json
+++ b/tools/mcp-ci/package.json
@@ -6,6 +6,7 @@
     "node": ">=22.7.5"
   },
   "devDependencies": {
+    "@modelcontextprotocol/conformance": "0.2.0-alpha.11",
     "@modelcontextprotocol/inspector-cli": "1.0.0"
   }
 }


### PR DESCRIPTION
Part of SigNoz/nerve-pod#194. This PR is stacked on #286 at runtime commit `47e12f5` and will be rebased/retargeted to `main` after #286 merges.

## What changed

- Pinned `@modelcontextprotocol/conformance@0.2.0-alpha.11` exactly. A clean compatible lock resolution also refreshes existing transitive Inspector dependencies; the initial combined lock had four dev-only advisories and the committed lock audits at zero.
- Added a bounded real-production-server harness that runs six catalog-independent official scenarios for legacy `2025-11-25` and six for modern `2026-07-28`.
- Added a separate `protocol / conformance` job while leaving `protocol / inspector` unchanged.
- Documented the exact scenario ownership, cleanup, upgrade policy, and protected E2E evidence.

## Honest scope

This is **selected official conformance**, not a full frozen `--requirements` claim. The full 30 legacy / 37 modern server requirement sets depend on diagnostic `test_*` fixtures, media/callback behavior, subscriptions, and MRTR/product capabilities that SigNoz intentionally does not expose. Recreating the official everything server here would mostly retest SDK internals.

The selected scenarios run against the actual `cmd/server` HTTP binary:

- Legacy: `server-initialize`, `ping`, `tools-list`, `resources-list`, `prompts-list`, `dns-rebinding-protection`.
- Modern: `tools-list`, `resources-list`, `sep-2164-resource-not-found`, `prompts-list`, `dns-rebinding-protection`, `caching`.

There is no fixture server, expected-failures baseline, live credential, production Go change, or client-visible tool/resource/prompt/result change. CMP-3: no `SigNoz/agent-skills` companion change is needed.

## Independent review

- Exact `claude-opus-5-thinking-xhigh` found a skipped-scenario false-green, failure-cleanup ordering, worst-case timeout, and redundant path-sensitive version check. All are fixed in `34dc5c3`.
- Exact `cursor-grok-4.6-xhigh` verified the fixed harness against local alpha.11 and reported no remaining actionable findings.
- No third review model ran.

## Verification

- Clean `npm ci --ignore-scripts --prefix tools/mcp-ci`; `npm audit` reports zero vulnerabilities.
- All 12 selected official scenarios pass against the real production binary.
- Existing `scripts/test-mcp-protocol.sh` passes unchanged.
- Bash parsing, ShellCheck, and actionlint pass.
- `go test -count=1 ./...`, `go vet ./...`, and `go build ./cmd/server` pass.
- Agent CI: `guardrails / contract`, `protocol / inspector`, and `protocol / conformance` pass. Five unrelated jobs are startup-blocked locally by unavailable protected Primus/Docker Hub credentials; their equivalent direct commands pass.
- GitHub-hosted workflow dispatch [31766469629](https://github.com/SigNoz/signoz-mcp-server/actions/runs/31766469629) passed both `protocol / inspector` and `protocol / conformance` on equivalent pre-restack content commit `34dc5c3`; the pull-request workflow reruns after the restack at `fdff969` and will run again after retargeting to `main`.

The exhaustive staging/OAuth/Assistant/native-client evidence remains recorded on parent PR #286. No additional client contract changed in this CI-only follow-up.


