### PR TITLE
chore(build): upgrade to go 1.26

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,7 +17,7 @@ jobs:
     secrets: inherit
     with:
       PRIMUS_REF: main
-      GO_VERSION: 1.25
+      GO_VERSION: 1.26
   lint:
     if: |
       (github.event_name == 'pull_request' && ! github.event.pull_request.head.repo.fork && github.event.pull_request.user.login != 'dependabot[bot]' && ! contains(github.event.pull_request.labels.*.name, 'safe-to-test')) ||
@@ -26,7 +26,7 @@ jobs:
     secrets: inherit
     with:
       PRIMUS_REF: main
-      GO_VERSION: 1.25
+      GO_VERSION: 1.26
   test:
     if: |
       (github.event_name == 'pull_request' && ! github.event.pull_request.head.repo.fork && github.event.pull_request.user.login != 'dependabot[bot]' && ! contains(github.event.pull_request.labels.*.name, 'safe-to-test')) ||
@@ -36,7 +36,7 @@ jobs:
     with:
       PRIMUS_REF: main
       GO_TEST_CONTEXT: ./...
-      GO_VERSION: 1.25
+      GO_VERSION: 1.26
   deps:
     if: |
       (github.event_name == 'pull_request' && ! github.event.pull_request.head.repo.fork && github.event.pull_request.user.login != 'dependabot[bot]' && ! contains(github.event.pull_request.labels.*.name, 'safe-to-test')) ||
@@ -45,7 +45,7 @@ jobs:
     secrets: inherit
     with:
       PRIMUS_REF: main
-      GO_VERSION: 1.25
+      GO_VERSION: 1.26
   build:
     if: |
       (github.event_name == 'pull_request' && ! github.event.pull_request.head.repo.fork && github.event.pull_request.user.login != 'dependabot[bot]' && ! contains(github.event.pull_request.labels.*.name, 'safe-to-test')) ||
@@ -55,7 +55,7 @@ jobs:
     with:
       PRIMUS_REF: main
       GO_BUILD_CONTEXT: ./cmd/server
-      GO_VERSION: 1.25
+      GO_VERSION: 1.26
       GO_BUILD_FLAGS: ""
       DOCKER_BASE_IMAGES: '{"distroless":"gcr.io/distroless/base:latest"}'
       DOCKER_DOCKERFILE_PATH: Dockerfile.multi-arch

--- a/.github/workflows/dockerbuildci.yaml
+++ b/.github/workflows/dockerbuildci.yaml
@@ -17,7 +17,7 @@ jobs:
     with:
       PRIMUS_REF: main
       GO_BUILD_CONTEXT: ./cmd/server
-      GO_VERSION: 1.25
+      GO_VERSION: 1.26
       GO_BUILD_FLAGS: "-ldflags=-X=github.com/SigNoz/signoz-mcp-server/pkg/version.Version=$($MAKE info-version)"
       DOCKER_BASE_IMAGES: '{"distroless":"gcr.io/distroless/base:latest"}'
       DOCKER_DOCKERFILE_PATH: Dockerfile.multi-arch

--- a/.github/workflows/docs-index-refresh.yml
+++ b/.github/workflows/docs-index-refresh.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.25"
+          go-version: "1.26"
           cache: true
 
       - name: Rebuild docs corpus blob

--- a/.github/workflows/guardrails.yaml
+++ b/.github/workflows/guardrails.yaml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.25"
+          go-version: "1.26"
           cache: true
 
       - name: Verify guardrail test inventory

--- a/.github/workflows/mcp-protocol.yaml
+++ b/.github/workflows/mcp-protocol.yaml
@@ -21,7 +21,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.25"
+          go-version: "1.26"
           cache: true
 
       - name: Set up Node.js
@@ -52,7 +52,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.25"
+          go-version: "1.26"
           cache: true
 
       - name: Set up Node.js

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage
-FROM golang:1.25-alpine AS builder
+FROM golang:1.26-alpine AS builder
 
 ARG VERSION=dev
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # SigNoz MCP Server
 
-[![Go Version](https://img.shields.io/badge/Go-1.25+-blue.svg)](https://golang.org)
+[![Go Version](https://img.shields.io/badge/Go-1.26+-blue.svg)](https://golang.org)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)
 [![MCP Protocol](https://img.shields.io/badge/MCP-2025--11--25_%7C_2026--07--28-orange.svg)](https://modelcontextprotocol.io)
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/SigNoz/signoz-mcp-server
 
-go 1.25.5
+go 1.26.0
 
 require (
 	github.com/SigNoz/signoz-otel-collector v0.129.12

--- a/plans/go-1.26-upgrade.context.md
+++ b/plans/go-1.26-upgrade.context.md
@@ -1,0 +1,39 @@
+# Feature: Go 1.26 Toolchain Upgrade — Context & Discussion
+
+## Original Prompt
+> Now let's upgrade go version
+
+## Reference Links
+- [Go release policy](https://go.dev/doc/devel/release)
+- [Go 1.26 release notes](https://go.dev/doc/go1.26)
+- [Go toolchain configuration](https://go.dev/doc/toolchain)
+
+## Key Decisions & Discussion Log
+
+### 2026-08-14 — Target and scope
+- Upgrade this repository from Go 1.25 to the supported Go 1.26 release line.
+- Set the module minimum to `go 1.26.0`. The `go` directive is a minimum
+  requirement, so do not add a `toolchain` directive that would force one patch
+  release on contributors.
+- Update every active build surface together: `go.mod`, the builder Dockerfile,
+  reusable CI inputs, secret-free protocol/guardrail checks, the manual docs
+  refresh workflow, and the README badge. Do not rewrite historical planning
+  baselines that mention Go 1.25.
+- Current direct and transitive dependencies declare at most Go 1.25, so this
+  is a compiler/toolchain upgrade only; do not bundle dependency upgrades.
+- Go 1.26 maintains the Go 1 compatibility promise. The relevant release-note
+  changes do not affect this server's source or build targets; verification will
+  compile, test, race-test the affected transport-heavy packages, and build the
+  container.
+
+## Open Questions
+- [x] Which target line? Go 1.26, the currently supported major line available
+  in the local toolchain and official release documentation.
+- [x] Pin a patch release with `toolchain`? No; require Go 1.26.0 or later and
+  let CI/Docker resolve the current 1.26 patch.
+- [x] Upgrade dependencies at the same time? No; all known minimums are at or
+  below Go 1.25 and unrelated dependency movement would obscure this migration.
+
+### 2026-08-15 — Completion
+- The Go 1.26 upgrade and its planned verification are complete. Mark the plan
+  `Done` so the planning record reflects the shipped implementation.

--- a/plans/go-1.26-upgrade.plan.md
+++ b/plans/go-1.26-upgrade.plan.md
@@ -1,0 +1,43 @@
+# Plan: Go 1.26 Toolchain Upgrade
+
+## Status
+Done
+
+## Context
+
+The repository declares Go 1.25.5 while the active local toolchain is Go
+1.26. The builder image and all active CI lanes must agree with `go.mod`; a
+partial update could test one language version and release another.
+
+## Approach
+
+1. Set the module minimum to `go 1.26.0` without adding a `toolchain`
+   directive or changing dependencies.
+2. Update the Docker builder and every active workflow Go selector from `1.25`
+   to `1.26`, including reusable Primus workflow inputs and secret-free
+   guardrail/protocol/manual-refresh jobs.
+3. Update the README badge. Preserve historical references in completed or
+   baseline planning documents.
+4. Verify module tidiness without dependency upgrades, then run formatting,
+   full tests, focused race coverage, vet, server build, Docker build, and the
+   repository's local workflow runner where its credentials permit.
+
+## Files to Modify
+
+- `go.mod` — declare Go 1.26.0 as the minimum supported toolchain.
+- `Dockerfile` — build with `golang:1.26-alpine`.
+- `.github/workflows/ci.yaml` — use Go 1.26 in all reusable Go jobs.
+- `.github/workflows/dockerbuildci.yaml` — use Go 1.26 for release image builds.
+- `.github/workflows/guardrails.yaml` — use Go 1.26 in the contract lane.
+- `.github/workflows/mcp-protocol.yaml` — use Go 1.26 in Inspector and conformance lanes.
+- `.github/workflows/docs-index-refresh.yml` — use Go 1.26 in the manual corpus refresh.
+- `README.md` — advertise the Go 1.26 minimum.
+
+## Verification
+
+- `go mod tidy -go=1.26.0 -diff` reports no unplanned dependency changes.
+- `make fmt goimports`, `go test ./...`, focused `-race`, `go vet ./...`, and
+  `go build ./cmd/server` pass under Go 1.26.
+- Build the production Dockerfile with the new builder image.
+- Run the local workflow runner; distinguish unavailable repository secrets
+  from source failures. Confirm remote CI after push.


### PR DESCRIPTION
## Summary

- Upgrade the repository toolchain baseline from Go 1.25 to Go 1.26.
- Align `go.mod`, Docker, reusable CI inputs, protocol/guardrail workflows, manual docs refresh, and the README badge.
- Keep this a toolchain-only change: no dependency or MCP client-contract changes.

## Why

Go 1.26 is the current supported release line. Keeping all build surfaces aligned prevents CI, Docker, and contributor builds from using different compiler versions.

## Validation

- `go mod tidy -go=1.26.0 -diff`
- `make fmt goimports`
- `go test -count=1 ./...`
- `go test -race -count=1 ./internal/client ./internal/mcp-server`
- `go vet ./...`
- `go build ./cmd/server`
- Docker production build with `golang:1.26-alpine`
- `actionlint` for changed workflows
- Local protocol and guardrail CI lanes

The local reusable CI jobs needing Primus, DockerHub, or release credentials could not start locally; GitHub Actions will validate them.

## Contract / documentation

No MCP client-visible tool, resource, prompt, or configuration contract changes. CMP-3: no companion `agent-skills` change is required.
