### PR TITLE
docs: add Grok Build MCP configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,17 @@ url = "https://mcp.<region>.signoz.cloud/mcp"
 enabled = true
 ```
 
-Grok Build starts the OAuth flow the first time it connects, so no API key is stored in the config file.
+Adding the server does not authenticate it. Start Grok Build, run `/mcps`, select the `signoz` server, and complete the OAuth flow in your browser:
+
+```bash
+grok
+```
+
+```
+/mcps
+```
+
+No API key is stored in the config file; credentials are saved separately once the OAuth flow completes.
 
 Use `-s project` on the `add` command to write to `./.grok/config.toml` instead, so the server is shared with everyone working in that directory.
 

--- a/README.md
+++ b/README.md
@@ -131,6 +131,33 @@ codex mcp login signoz
 
 Then run `/mcp` inside Codex to verify the connection.
 
+### Grok Build
+
+Run this command to add the hosted SigNoz MCP server:
+
+```bash
+grok mcp add -t http signoz https://mcp.<region>.signoz.cloud/mcp
+```
+
+Or add this configuration to `~/.grok/config.toml`:
+
+```toml
+[mcp_servers.signoz]
+url = "https://mcp.<region>.signoz.cloud/mcp"
+enabled = true
+```
+
+Grok Build starts the OAuth flow the first time it connects, so no API key is stored in the config file.
+
+Use `-s project` on the `add` command to write to `./.grok/config.toml` instead, so the server is shared with everyone working in that directory.
+
+Verify the connection with:
+
+```bash
+grok mcp list
+grok mcp doctor
+```
+
 ### SigNoz Cloud Authentication
 
 When you add the hosted MCP URL to your client, the client initiates an authentication flow. You will be prompted to enter:


### PR DESCRIPTION
Supersedes #291 by recreating the same README-only change on a first-party branch so the repository's normal CI can run. The original contributor remains the author of both commits.

Adds a **Grok Build** section to the SigNoz Cloud client list in the README, alongside Cursor, VS Code / GitHub Copilot, Claude Desktop, Claude Code and OpenAI Codex.

Grok Build (xAI) ships an MCP client but was not documented here, so users had to work the config out from `grok mcp add --help`.

## What is added

- The `grok mcp add -t http signoz https://mcp.<region>.signoz.cloud/mcp` command
- The equivalent `~/.grok/config.toml` block
- The `-s project` scope flag for sharing the server via `./.grok/config.toml`
- `grok mcp list` / `grok mcp doctor` for verification
- A note that Grok Build runs OAuth on first connect, so no API key is stored in the config

README only. No code, tools or `manifest.json` changes.

## Validation

Verified against a real Grok Build install rather than written from docs:

- `grok --version` → `grok 1.0.4 (d846eb93d94d) [stable]`
- `grok mcp add --help` confirms `-t/--transport {stdio,http,sse}`, `-s/--scope {user,project}`, and that `user` writes `~/.grok/config.toml`
- A live `~/.grok/config.toml` produced by the CLI contains exactly the documented block:

  ```toml
  [mcp_servers.signoz]
  url = "https://mcp.us.signoz.cloud/mcp"
  enabled = true
  ```

- `grok mcp list` → `signoz: https://mcp.us.signoz.cloud/mcp`
- The hosted OAuth flow was exercised end to end against SigNoz Cloud US and works; credentials land in `~/.grok/mcp_credentials.json`, not in `config.toml`

The non-OAuth / self-hosted path is not covered in this section, matching how the existing Cloud client sections are scoped.

## PR checklist

- [x] Code/tests updated as needed (n/a, docs only)
- [x] README/docs updated for user-facing changes
- [x] `manifest.json` updated for MCP tool metadata changes (n/a, no tool changes)
- [x] Validation commands and results included in PR description