### PR TITLE
feat(saved-views): migrate saved view tools to v2 saved_views API (nerve-pod#100)

### DIFF
--- a/README.md
+++ b/README.md
@@ -703,7 +703,7 @@ The response is `{ "status": "success", "data": { "items": [...], "total": <n>, 
 List saved Explorer views or discover a view UUID for one Logs, Traces, Metrics, Cost Meter, or AI Observability page. A view stores one reusable Explorer query spec; it is not a multi-panel dashboard. Apply name filters before pagination and follow `pagination.nextOffset` while `pagination.hasMore` is true.
 
 - **Parameters**:
-  - `source` (required) - One of: `traces`, `logs`, `metrics`, `meter`, `ai_observability`. Cost Meter views are filed under `meter` (a distinct Explorer page), not `metrics`
+  - `source` (required) - One of: `traces`, `logs`, `metrics`, `meter`. Cost Meter views are filed under `meter` (a distinct Explorer page), not `metrics`
   - `name` (optional) - Partial-match filter on view name (server-side)
   - `limit` (optional) - Page size (default: 50, max: 1000; higher values are clamped)
   - `offset` (optional) - Number of results to skip (default: 0)

--- a/README.md
+++ b/README.md
@@ -429,11 +429,11 @@ HTTP mode exposes unauthenticated probe endpoints. New Kubernetes deployments sh
 | `signoz_list_dashboard_templates` | List curated templates and discover an import path |
 | `signoz_list_services` | List APM services with trace activity in a time range |
 | `signoz_get_service_top_operations` | Get ranked operations for one traced service |
-| `signoz_list_views` | List saved Explorer views for traces/logs/metrics/Cost Meter and discover UUIDs |
+| `signoz_list_views` | List saved Explorer views for traces/logs/metrics/Cost Meter/AI Observability and discover UUIDs |
 | `signoz_get_view` | Get one saved Explorer view's complete definition by `id` |
 | `signoz_search_docs` | Find ranked official-doc matches when no exact page is selected |
 | `signoz_fetch_doc` | Fetch one known official-doc page or heading as Markdown |
-| `signoz_create_view` | Save one reusable Explorer query |
+| `signoz_create_view` | Save one reusable Explorer query spec |
 | `signoz_update_view` | Fully replace a fetched saved view while preserving unrequested fields |
 | `signoz_delete_view` | Permanently delete a confirmed saved view by `id` |
 | `signoz_aggregate_logs` | Aggregate log statistics and grouped or top-N breakdowns |
@@ -481,8 +481,8 @@ Docs tools use the same authentication path as other MCP tools.
 | `signoz://logs/query-builder-guide` | Logs Query Builder v5 JSON or unfamiliar log fields |
 | `signoz://traces/query-builder-guide` | Traces Query Builder v5 JSON or unfamiliar trace fields |
 | `signoz://metrics-aggregation-guide` | Metric aggregations, formulas, grouping, limits, and Cost Meter queries |
-| `signoz://view/instructions` | Saved Explorer view fields and read-before-replace workflow |
-| `signoz://view/examples` | Saved-view payloads for traces, logs, metrics, and Cost Meter |
+| `signoz://view/instructions` | Saved view fields, the v2 typed spec, and read-before-replace workflow |
+| `signoz://view/examples` | Saved-view typed-spec payloads for traces, logs, metrics, and Cost Meter |
 | `signoz://docs/sitemap` | Indexed official-doc catalog and page URLs |
 
 ### Resource Template Migration
@@ -700,14 +700,15 @@ The response is `{ "status": "success", "data": { "items": [...], "total": <n>, 
 
 #### `signoz_list_views`
 
-List saved Explorer views or discover a view UUID for one Logs, Traces, Metrics, or Cost Meter page. A view stores one reusable Explorer query; it is not a multi-panel dashboard. Apply name/category filters before pagination and follow `pagination.nextOffset` while `pagination.hasMore` is true.
+List saved Explorer views or discover a view UUID for one Logs, Traces, Metrics, Cost Meter, or AI Observability page. A view stores one reusable Explorer query spec; it is not a multi-panel dashboard. Apply name filters before pagination and follow `pagination.nextOffset` while `pagination.hasMore` is true.
 
 - **Parameters**:
-  - `sourcePage` (required) - One of: `traces`, `logs`, `metrics`, `meter`. Cost Meter views are filed under `meter` (a distinct Explorer page), not `metrics`
+  - `source` (required) - One of: `traces`, `logs`, `metrics`, `meter`, `ai_observability`. Cost Meter views are filed under `meter` (a distinct Explorer page), not `metrics`
   - `name` (optional) - Partial-match filter on view name (server-side)
-  - `category` (optional) - Partial-match filter on view category (server-side)
   - `limit` (optional) - Page size (default: 50, max: 1000; higher values are clamped)
   - `offset` (optional) - Number of results to skip (default: 0)
+
+> **Requires SigNoz ≥ v0.137.0**, the first release to serve the v2 saved-view routes (`/api/v2/saved_views/*`; [SigNoz #12342](https://github.com/SigNoz/signoz/pull/12342)). Earlier deployments only expose the legacy `GET /api/v1/explorer/views`.
 
 #### `signoz_get_view`
 
@@ -736,19 +737,24 @@ Fetch one known official SigNoz docs page's full Markdown or a requested heading
 
 #### `signoz_create_view`
 
-Save one reusable Explorer query. Use `signoz_create_dashboard` for a multi-panel dashboard. Cost Meter views use `sourcePage="meter"` with `signal="metrics"` and `source="meter"` in builder specs.
+Save one reusable Explorer query spec. Use `signoz_create_dashboard` for a multi-panel dashboard. Cost Meter views use `source="meter"` with `signal="metrics"` and builder-spec `source="meter"`.
 
-- **Parameters**: JSON payload matching the `SavedView` schema.
+- **Parameters** (v2 typed shape):
+  - `name` (optional) - View name (DNS-1123 label). Required unless `generateName` is true
+  - `generateName` (optional) - When true, the server generates `name` from `spec.displayName` and `name` must be empty
+  - `source` (required) - Which Explorer this view belongs to
+  - `spec` (required) - Typed view content: `displayName`, `panelType`, `requestType`, `queries`, `selectedFields`, `display`
+  - `schemaVersion` (optional) - Always `v2`; defaults when omitted
 - **Required**: Read both MCP resources `signoz://view/instructions` and `signoz://view/examples` before composing any payload.
 
 #### `signoz_update_view`
 
-Fully replace an existing saved Explorer view. Fetch it with `signoz_get_view`, modify its returned `data` object, preserve every unrequested field, and pass that full object as `view`.
+Fully replace an existing saved Explorer view. Fetch it with `signoz_get_view`, modify its returned `data` object, preserve every unrequested field, and pass that full object as `view`. Upstream keeps `name` immutable on update; the display label lives in `spec.displayName`.
 
 - **Parameters**:
   - `id` (required) - UUID of the view to replace
-  - `view` (required) - Full `SavedView` object (`name`, `sourcePage`, `compositeQuery`, plus any of `category`, `tags`, `extraData`)
-- **Resource rule**: Read `signoz://view/instructions` and `signoz://view/examples` when composing the body or changing `sourcePage`/`compositeQuery`. Skip them for name-, category-, or tags-only changes when a complete fetched body is already prepared. Call `signoz_get_view` first; partial bodies wipe unspecified fields.
+  - `view` (required) - Full `source`/`spec` pair (required); drop `name` and server-populated fields
+- **Resource rule**: Read `signoz://view/instructions` and `signoz://view/examples` when changing `source` or `spec`. Skip them for a pass-through of the fetched body. Call `signoz_get_view` first; partial bodies wipe unspecified fields.
 
 #### `signoz_delete_view`
 

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -688,40 +688,37 @@ func (s *SigNoz) DeleteAlertRule(ctx context.Context, ruleID string) error {
 	return err
 }
 
-func (s *SigNoz) ListViews(ctx context.Context, sourcePage, name, category string) (json.RawMessage, error) {
+func (s *SigNoz) ListViews(ctx context.Context, source, name string) (json.RawMessage, error) {
 	params := url.Values{}
-	params.Set("sourcePage", sourcePage)
+	params.Set("source", source)
 	if name != "" {
 		params.Set("name", name)
 	}
-	if category != "" {
-		params.Set("category", category)
-	}
-	reqURL := fmt.Sprintf("%s/api/v1/explorer/views?%s", s.baseURL, params.Encode())
-	s.logger.DebugContext(s.ensureTenantContext(ctx), "Listing saved views", slog.String("sourcePage", sourcePage))
+	reqURL := fmt.Sprintf("%s/api/v2/saved_views?%s", s.baseURL, params.Encode())
+	s.logger.DebugContext(s.ensureTenantContext(ctx), "Listing saved views", slog.String("source", source))
 	return s.doRequest(ctx, http.MethodGet, reqURL, nil, DefaultQueryTimeout)
 }
 
 func (s *SigNoz) GetView(ctx context.Context, viewID string) (json.RawMessage, error) {
-	reqURL := fmt.Sprintf("%s/api/v1/explorer/views/%s", s.baseURL, url.PathEscape(viewID))
+	reqURL := fmt.Sprintf("%s/api/v2/saved_views/%s", s.baseURL, url.PathEscape(viewID))
 	s.logger.DebugContext(s.ensureTenantContext(ctx), "Fetching saved view", slog.String("viewID", viewID))
 	return s.doRequest(ctx, http.MethodGet, reqURL, nil, DefaultQueryTimeout)
 }
 
 func (s *SigNoz) CreateView(ctx context.Context, body []byte) (json.RawMessage, error) {
-	reqURL := fmt.Sprintf("%s/api/v1/explorer/views", s.baseURL)
+	reqURL := fmt.Sprintf("%s/api/v2/saved_views", s.baseURL)
 	s.logger.DebugContext(s.ensureTenantContext(ctx), "Creating saved view")
 	return s.doRequest(ctx, http.MethodPost, reqURL, body, DashboardWriteTimeout)
 }
 
 func (s *SigNoz) UpdateView(ctx context.Context, viewID string, body []byte) (json.RawMessage, error) {
-	reqURL := fmt.Sprintf("%s/api/v1/explorer/views/%s", s.baseURL, url.PathEscape(viewID))
+	reqURL := fmt.Sprintf("%s/api/v2/saved_views/%s", s.baseURL, url.PathEscape(viewID))
 	s.logger.DebugContext(s.ensureTenantContext(ctx), "Updating saved view", slog.String("viewID", viewID))
 	return s.doRequest(ctx, http.MethodPut, reqURL, body, DashboardWriteTimeout)
 }
 
 func (s *SigNoz) DeleteView(ctx context.Context, viewID string) (json.RawMessage, error) {
-	reqURL := fmt.Sprintf("%s/api/v1/explorer/views/%s", s.baseURL, url.PathEscape(viewID))
+	reqURL := fmt.Sprintf("%s/api/v2/saved_views/%s", s.baseURL, url.PathEscape(viewID))
 	s.logger.DebugContext(s.ensureTenantContext(ctx), "Deleting saved view", slog.String("viewID", viewID))
 	return s.doRequest(ctx, http.MethodDelete, reqURL, nil, DashboardWriteTimeout)
 }

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -1918,13 +1918,13 @@ func TestListViews(t *testing.T) {
 	defer server.Close()
 
 	c := NewClient(logpkg.New("error"), server.URL, "k", "SIGNOZ-API-KEY", nil)
-	_, err := c.ListViews(context.Background(), "traces", "ak", "ops")
+	_, err := c.ListViews(context.Background(), "traces", "ak")
 	require.NoError(t, err)
 	assert.Equal(t, http.MethodGet, gotMethod)
-	assert.Equal(t, "/api/v1/explorer/views", gotPath)
-	assert.Contains(t, gotRawQuery, "sourcePage=traces")
+	assert.Equal(t, "/api/v2/saved_views", gotPath)
+	assert.Contains(t, gotRawQuery, "source=traces")
 	assert.Contains(t, gotRawQuery, "name=ak")
-	assert.Contains(t, gotRawQuery, "category=ops")
+	assert.NotContains(t, gotRawQuery, "category=")
 }
 
 func TestListDashboards_ForwardsFilterSortOrder(t *testing.T) {
@@ -1981,7 +1981,7 @@ func TestGetView(t *testing.T) {
 	_, err := c.GetView(context.Background(), "view-uuid-1")
 	require.NoError(t, err)
 	assert.Equal(t, http.MethodGet, gotMethod)
-	assert.Equal(t, "/api/v1/explorer/views/view-uuid-1", gotPath)
+	assert.Equal(t, "/api/v2/saved_views/view-uuid-1", gotPath)
 }
 
 func TestCreateView(t *testing.T) {
@@ -1995,11 +1995,11 @@ func TestCreateView(t *testing.T) {
 	}))
 	defer server.Close()
 	c := NewClient(logpkg.New("error"), server.URL, "k", "SIGNOZ-API-KEY", nil)
-	body := []byte(`{"name":"x","sourcePage":"traces","compositeQuery":{}}`)
+	body := []byte(`{"name":"x","source":"traces","spec":{}}`)
 	_, err := c.CreateView(context.Background(), body)
 	require.NoError(t, err)
 	assert.Equal(t, http.MethodPost, gotMethod)
-	assert.Equal(t, "/api/v1/explorer/views", gotPath)
+	assert.Equal(t, "/api/v2/saved_views", gotPath)
 	assert.JSONEq(t, string(body), string(gotBody))
 }
 
@@ -2015,7 +2015,7 @@ func TestUpdateView(t *testing.T) {
 	_, err := c.UpdateView(context.Background(), "view-1", []byte(`{}`))
 	require.NoError(t, err)
 	assert.Equal(t, http.MethodPut, gotMethod)
-	assert.Equal(t, "/api/v1/explorer/views/view-1", gotPath)
+	assert.Equal(t, "/api/v2/saved_views/view-1", gotPath)
 }
 
 func TestDeleteView(t *testing.T) {
@@ -2030,7 +2030,7 @@ func TestDeleteView(t *testing.T) {
 	_, err := c.DeleteView(context.Background(), "view-1")
 	require.NoError(t, err)
 	assert.Equal(t, http.MethodDelete, gotMethod)
-	assert.Equal(t, "/api/v1/explorer/views/view-1", gotPath)
+	assert.Equal(t, "/api/v2/saved_views/view-1", gotPath)
 }
 
 func TestSharedTransportPoolTuning(t *testing.T) {

--- a/internal/client/interface.go
+++ b/internal/client/interface.go
@@ -27,7 +27,7 @@ type Client interface {
 	ListServices(ctx context.Context, start, end string) (json.RawMessage, error)
 	GetServiceTopOperations(ctx context.Context, start, end, service string, tags json.RawMessage) (json.RawMessage, error)
 	QueryBuilderV5(ctx context.Context, body []byte) (json.RawMessage, error)
-	ListViews(ctx context.Context, sourcePage, name, category string) (json.RawMessage, error)
+	ListViews(ctx context.Context, source, name string) (json.RawMessage, error)
 	GetView(ctx context.Context, viewID string) (json.RawMessage, error)
 	CreateView(ctx context.Context, body []byte) (json.RawMessage, error)
 	UpdateView(ctx context.Context, viewID string, body []byte) (json.RawMessage, error)

--- a/internal/client/mock.go
+++ b/internal/client/mock.go
@@ -28,7 +28,7 @@ type MockClient struct {
 	ListServicesFn              func(ctx context.Context, start, end string) (json.RawMessage, error)
 	GetServiceTopOperationsFn   func(ctx context.Context, start, end, service string, tags json.RawMessage) (json.RawMessage, error)
 	QueryBuilderV5Fn            func(ctx context.Context, body []byte) (json.RawMessage, error)
-	ListViewsFn                 func(ctx context.Context, sourcePage, name, category string) (json.RawMessage, error)
+	ListViewsFn                 func(ctx context.Context, source, name string) (json.RawMessage, error)
 	GetViewFn                   func(ctx context.Context, viewID string) (json.RawMessage, error)
 	CreateViewFn                func(ctx context.Context, body []byte) (json.RawMessage, error)
 	UpdateViewFn                func(ctx context.Context, viewID string, body []byte) (json.RawMessage, error)
@@ -171,9 +171,9 @@ func (m *MockClient) QueryBuilderV5(ctx context.Context, body []byte) (json.RawM
 	return json.RawMessage(`{}`), nil
 }
 
-func (m *MockClient) ListViews(ctx context.Context, sourcePage, name, category string) (json.RawMessage, error) {
+func (m *MockClient) ListViews(ctx context.Context, source, name string) (json.RawMessage, error) {
 	if m.ListViewsFn != nil {
-		return m.ListViewsFn(ctx, sourcePage, name, category)
+		return m.ListViewsFn(ctx, source, name)
 	}
 	return json.RawMessage(`{}`), nil
 }

--- a/internal/handler/tools/e2e_familyb_test.go
+++ b/internal/handler/tools/e2e_familyb_test.go
@@ -239,7 +239,7 @@ func TestE2EFamilyB_HappyPathStillSucceeds(t *testing.T) {
 		},
 		{
 			name: "list_views_traces",
-			args: map[string]any{"sourcePage": "traces"},
+			args: map[string]any{"source": "traces"},
 			run: func(a map[string]any) (bool, string) {
 				r, err := h.handleListViews(ctx, makeToolRequest("signoz_list_views", a))
 				if err != nil {

--- a/internal/handler/tools/e2e_familyc_test.go
+++ b/internal/handler/tools/e2e_familyc_test.go
@@ -131,7 +131,7 @@ func TestE2EFamilyC_StructuredContentOnListTools(t *testing.T) {
 	assertStructuredMatchesText(t, "list_alerts", callOK(t, h.handleListAlerts, ctx, "signoz_list_alerts", map[string]any{}))
 	assertStructuredMatchesText(t, "list_alert_rules", callOK(t, h.handleListAlertRules, ctx, "signoz_list_alert_rules", map[string]any{}))
 	assertStructuredMatchesText(t, "list_dashboards", callOK(t, h.handleListDashboards, ctx, "signoz_list_dashboards", map[string]any{}))
-	assertStructuredMatchesText(t, "list_views", callOK(t, h.handleListViews, ctx, "signoz_list_views", map[string]any{"sourcePage": "traces"}))
+	assertStructuredMatchesText(t, "list_views", callOK(t, h.handleListViews, ctx, "signoz_list_views", map[string]any{"source": "traces"}))
 	assertStructuredMatchesText(t, "list_notification_channels", callOK(t, h.handleListNotificationChannels, ctx, "signoz_list_notification_channels", map[string]any{}))
 }
 
@@ -154,10 +154,10 @@ func TestE2EFamilyC_StructuredContentOnGetTools(t *testing.T) {
 		t.Log("SKIP get_alert: no alert rules on instance")
 	}
 
-	// get_view — viewId from list_views (try each sourcePage).
+	// get_view — viewId from list_views (try each source).
 	var viewID string
 	for _, sp := range []string{"traces", "logs", "metrics"} {
-		vl := callOK(t, h.handleListViews, ctx, "signoz_list_views", map[string]any{"sourcePage": sp})
+		vl := callOK(t, h.handleListViews, ctx, "signoz_list_views", map[string]any{"source": sp})
 		if viewID = firstDataID(firstText(vl), "id", "uuid"); viewID != "" {
 			break
 		}

--- a/internal/handler/tools/e2e_familye_test.go
+++ b/internal/handler/tools/e2e_familye_test.go
@@ -406,14 +406,14 @@ func firstField(body, fieldName string) string {
 // unique mcp-e2e-e-<rand> name, reads it back via BOTH the canonical "id" and
 // legacy "viewId" params, then deletes it via the legacy key and confirms it is
 // gone. A t.Cleanup guarantees deletion even on failure. If no existing view is
-// found on any sourcePage, the CRUD subtest is skipped (never hand-crafted).
+// found on any source, the CRUD subtest is skipped (never hand-crafted).
 func TestE2EFamilyE_K5_ViewCRUDRoundTrip(t *testing.T) {
 	h, ctx := e2eHandlerE(t)
 
-	// 1. Find a real existing view to clone its shape from. Try each sourcePage.
-	srcViewID, srcSourcePage := findExistingView(t, h, ctx)
+	// 1. Find a real existing view to clone its shape from. Try each source.
+	srcViewID, srcSource := findExistingView(t, h, ctx)
 	if srcViewID == "" {
-		t.Skip("no existing saved view found on any sourcePage to clone; skipping view CRUD round-trip (refusing to hand-craft a payload)")
+		t.Skip("no existing saved view found on any source to clone; skipping view CRUD round-trip (refusing to hand-craft a payload)")
 	}
 
 	// 2. Read the source view's full config.
@@ -438,8 +438,7 @@ func TestE2EFamilyE_K5_ViewCRUDRoundTrip(t *testing.T) {
 		createArgs[k] = v
 	}
 	createArgs["name"] = name
-	delete(createArgs, "category") // keep the clone minimal/unambiguous
-	t.Logf("cloning existing %q view (sourcePage=%s) into %q", srcViewID, srcSourcePage, name)
+	t.Logf("cloning existing %q view (source=%s) into %q", srcViewID, srcSource, name)
 
 	createRes, err := h.handleCreateView(ctx, makeToolRequest("signoz_create_view", createArgs))
 	if err != nil {
@@ -448,9 +447,9 @@ func TestE2EFamilyE_K5_ViewCRUDRoundTrip(t *testing.T) {
 	if createRes.IsError {
 		t.Fatalf("create_view (cloned shape) error: %s", e2eText(t, createRes))
 	}
-	// create_view returns {"status":"success","data":"<id>"} — data is the new
-	// view id as a STRING (not an object like get_view). Use the create-specific
-	// extractor so the id is recovered and the cleanup below can fire.
+	// v2 create_view returns {"status":"success","data":{"id":"..."}}: data is
+	// an object carrying the new view id. Use the create-specific extractor so
+	// the id is recovered and the cleanup below can fire.
 	viewID := extractCreatedViewID(e2eText(t, createRes))
 
 	// Register the cleanup backstop IMMEDIATELY after a successful create, before
@@ -506,11 +505,15 @@ func TestE2EFamilyE_K5_ViewCRUDRoundTrip(t *testing.T) {
 	}
 }
 
-// extractCreatedViewID parses the create_view success response, where the new
-// view id is returned as a STRING under "data": {"status":"success","data":"<id>"}.
-// It falls back to the object/top-level shapes for robustness against drift.
+// extractCreatedViewID parses the create_view success response. In v2 the new
+// view id is returned as an OBJECT under "data": {"id":"..."}. It falls back to
+// the string/top-level shapes for robustness against drift.
 func extractCreatedViewID(body string) string {
-	// Primary shape: data is a string id.
+	// Primary shape: data is an object carrying an id.
+	if id := extractViewID(body); id != "" {
+		return id
+	}
+	// Fallback: data is a bare string id (pre-v2 shape).
 	var asString struct {
 		Data string `json:"data"`
 		ID   string `json:"id"`
@@ -523,8 +526,7 @@ func extractCreatedViewID(body string) string {
 			return asString.ID
 		}
 	}
-	// Fallback: data is an object carrying an id (get_view-style envelope).
-	return extractViewID(body)
+	return ""
 }
 
 func extractViewID(body string) string {
@@ -559,15 +561,15 @@ func extractViewName(body string) string {
 	return env.Name
 }
 
-// findExistingView returns the id and sourcePage of the first existing saved
-// view found across the standard sourcePages, or ("", "") if none exist. Used
+// findExistingView returns the id and source of the first existing saved
+// view found across the standard sources, or ("", "") if none exist. Used
 // to clone a real view's shape rather than hand-craft a create payload.
-func findExistingView(t *testing.T, h *Handler, ctx context.Context) (id, sourcePage string) {
+func findExistingView(t *testing.T, h *Handler, ctx context.Context) (id, source string) {
 	t.Helper()
 	for _, sp := range []string{"traces", "logs", "metrics", "meter"} {
 		res, err := h.handleListViews(ctx, makeToolRequest("signoz_list_views", map[string]any{
-			"sourcePage": sp,
-			"limit":      "1",
+			"source": sp,
+			"limit":  "1",
 		}))
 		if err != nil || res.IsError {
 			continue

--- a/internal/handler/tools/filter_param_consistency_test.go
+++ b/internal/handler/tools/filter_param_consistency_test.go
@@ -392,7 +392,7 @@ func TestFilterAlias_FalseFriendHandlersUnaffected(t *testing.T) {
 		}
 	})
 
-	t.Run("create_view_filter_args_do_not_mutate_nested_composite_query", func(t *testing.T) {
+	t.Run("create_view_filter_args_do_not_mutate_nested_spec_query", func(t *testing.T) {
 		var gotBody []byte
 		mock := &client.MockClient{
 			CreateViewFn: func(ctx context.Context, body []byte) (json.RawMessage, error) {
@@ -403,13 +403,13 @@ func TestFilterAlias_FalseFriendHandlersUnaffected(t *testing.T) {
 		h := newTestHandler(mock)
 		nestedFilter := "severity_text = 'ERROR'"
 		result, err := h.handleCreateView(testCtx(), makeToolRequest("signoz_create_view", map[string]any{
-			"name":       "logs errors",
-			"sourcePage": "logs",
-			"filter":     "service.name = 'frontend'",
-			"query":      "service.name = 'legacy'",
-			"compositeQuery": map[string]any{
-				"queryType": "builder",
-				"panelType": "list",
+			"name":   "logs errors",
+			"source": "logs",
+			"filter": "service.name = 'frontend'",
+			"query":  "service.name = 'legacy'",
+			"spec": map[string]any{
+				"panelType":   "list",
+				"requestType": "raw",
 				"queries": []any{map[string]any{
 					"type": "builder_query",
 					"spec": map[string]any{
@@ -427,7 +427,7 @@ func TestFilterAlias_FalseFriendHandlersUnaffected(t *testing.T) {
 			t.Fatalf("handler returned error result: %v", result.Content)
 		}
 		if got := savedViewNestedFilterExpression(t, gotBody); got != nestedFilter {
-			t.Fatalf("nested compositeQuery filter = %q, want %q", got, nestedFilter)
+			t.Fatalf("nested spec.query filter = %q, want %q", got, nestedFilter)
 		}
 	})
 }
@@ -568,7 +568,7 @@ func savedViewNestedFilterExpression(t *testing.T, body []byte) string {
 		t.Fatal("view body was not captured")
 	}
 	var decoded struct {
-		CompositeQuery struct {
+		Spec struct {
 			Queries []struct {
 				Spec struct {
 					Filter struct {
@@ -576,15 +576,15 @@ func savedViewNestedFilterExpression(t *testing.T, body []byte) string {
 					} `json:"filter"`
 				} `json:"spec"`
 			} `json:"queries"`
-		} `json:"compositeQuery"`
+		} `json:"spec"`
 	}
 	if err := json.Unmarshal(body, &decoded); err != nil {
 		t.Fatalf("unmarshal view body: %v", err)
 	}
-	if len(decoded.CompositeQuery.Queries) != 1 {
-		t.Fatalf("view query count = %d, want 1", len(decoded.CompositeQuery.Queries))
+	if len(decoded.Spec.Queries) != 1 {
+		t.Fatalf("view query count = %d, want 1", len(decoded.Spec.Queries))
 	}
-	return decoded.CompositeQuery.Queries[0].Spec.Filter.Expression
+	return decoded.Spec.Queries[0].Spec.Filter.Expression
 }
 
 func noteText(t *testing.T, result *mcp.CallToolResult, index int) string {

--- a/internal/handler/tools/id_alias_test.go
+++ b/internal/handler/tools/id_alias_test.go
@@ -369,7 +369,7 @@ func TestUpdateView_IDAndLegacyAlias(t *testing.T) {
 			var capturedBody []byte
 			mock := &client.MockClient{
 				GetViewFn: func(ctx context.Context, viewID string) (json.RawMessage, error) {
-					return json.RawMessage(`{"data":{"sourcePage":"logs"}}`), nil
+					return json.RawMessage(`{"data":{"source":"logs"}}`), nil
 				},
 				UpdateViewFn: func(ctx context.Context, viewID string, body []byte) (json.RawMessage, error) {
 					capturedID = viewID
@@ -384,11 +384,10 @@ func TestUpdateView_IDAndLegacyAlias(t *testing.T) {
 					// Server-populated "id" is included to prove it gets stripped
 					// from the outgoing body (matches the signoz_get_view shape a
 					// caller is told to paste back under "view").
-					"id":         "v1",
-					"name":       "My View",
-					"sourcePage": "logs",
-					"compositeQuery": map[string]any{
-						"queryType": "builder",
+					"id":     "v1",
+					"name":   "My View",
+					"source": "logs",
+					"spec": map[string]any{
 						"queries": []any{
 							map[string]any{
 								"type": "builder_query",
@@ -469,7 +468,7 @@ func TestResourceID_MissingBothKeys_Errors(t *testing.T) {
 		}},
 		{"update_view", func() (*mcp.CallToolResult, error) {
 			return h.handleUpdateView(testCtx(), makeToolRequest("signoz_update_view", map[string]any{
-				"view": map[string]any{"name": "n", "sourcePage": "logs", "compositeQuery": map[string]any{}},
+				"view": map[string]any{"name": "n", "source": "logs", "spec": map[string]any{}},
 			}))
 		}},
 	}

--- a/internal/handler/tools/param_schema_test.go
+++ b/internal/handler/tools/param_schema_test.go
@@ -163,7 +163,7 @@ func TestStableSetEnumsArePresent(t *testing.T) {
 		{"signoz_get_field_values", "signal", []string{"logs", "metrics", "traces"}},
 		// "source" carries the v2 saved-views source enum; pin it so a
 		// regression that drops it fails here too.
-		{"signoz_create_view", "source", []string{"ai_observability", "logs", "meter", "metrics", "traces"}},
+		{"signoz_create_view", "source", []string{"logs", "meter", "metrics", "traces"}},
 	}
 
 	for _, tc := range cases {

--- a/internal/handler/tools/param_schema_test.go
+++ b/internal/handler/tools/param_schema_test.go
@@ -161,9 +161,9 @@ func TestStableSetEnumsArePresent(t *testing.T) {
 		{"signoz_get_alert_history", "state", []string{"disabled", "firing", "inactive", "nodata", "pending", "recovering"}},
 		{"signoz_get_field_keys", "signal", []string{"logs", "metrics", "traces"}},
 		{"signoz_get_field_values", "signal", []string{"logs", "metrics", "traces"}},
-		// sourcePage already carried an enum before this change; pin it so a
+		// "source" carries the v2 saved-views source enum; pin it so a
 		// regression that drops it fails here too.
-		{"signoz_create_view", "sourcePage", []string{"logs", "meter", "metrics", "traces"}},
+		{"signoz_create_view", "source", []string{"ai_observability", "logs", "meter", "metrics", "traces"}},
 	}
 
 	for _, tc := range cases {

--- a/internal/handler/tools/read_write_back_contract_test.go
+++ b/internal/handler/tools/read_write_back_contract_test.go
@@ -70,12 +70,12 @@ func TestAlertReadWriteBackContractAcrossServerVersions(t *testing.T) {
 func TestViewReadWriteBackPreservesQueryBounds(t *testing.T) {
 	const viewID = "view-1"
 	view := map[string]any{
-		"id":         viewID,
-		"name":       "Error Logs",
-		"sourcePage": "logs",
-		"compositeQuery": map[string]any{
-			"queryType": "builder",
-			"panelType": "list",
+		"id":     viewID,
+		"name":   "Error Logs",
+		"source": "logs",
+		"spec": map[string]any{
+			"panelType":   "list",
+			"requestType": "raw",
 			"queries": []any{map[string]any{
 				"type": "builder_query",
 				"spec": map[string]any{
@@ -117,7 +117,7 @@ func TestViewReadWriteBackPreservesQueryBounds(t *testing.T) {
 	if _, present := body["id"]; present {
 		t.Fatalf("server-populated id leaked into view update body: %s", gotBody)
 	}
-	spec := body["compositeQuery"].(map[string]any)["queries"].([]any)[0].(map[string]any)["spec"].(map[string]any)
+	spec := body["spec"].(map[string]any)["queries"].([]any)[0].(map[string]any)["spec"].(map[string]any)
 	if spec["limit"] != float64(100) {
 		t.Fatalf("view builder limit did not survive read-write-back: %s", gotBody)
 	}

--- a/internal/handler/tools/structured_content_test.go
+++ b/internal/handler/tools/structured_content_test.go
@@ -226,7 +226,7 @@ func TestStructuredContent_PresentOnCodeControlledTools(t *testing.T) {
 		CreateDashboardRawFn: func(ctx context.Context, dashboardJSON []byte) (json.RawMessage, error) {
 			return json.RawMessage(`{"id":"d-new","name":"x-abc123","spec":{"display":{"name":"X"}}}`), nil
 		},
-		ListViewsFn: func(ctx context.Context, sourcePage, name, category string) (json.RawMessage, error) {
+		ListViewsFn: func(ctx context.Context, source, name string) (json.RawMessage, error) {
 			return json.RawMessage(`{"status":"success","data":[{"id":"v1","name":"V"}]}`), nil
 		},
 		GetViewFn: func(ctx context.Context, viewID string) (json.RawMessage, error) {
@@ -258,7 +258,7 @@ func TestStructuredContent_PresentOnCodeControlledTools(t *testing.T) {
 		{"get_dashboard", h.handleGetDashboard, makeToolRequest("signoz_get_dashboard", map[string]any{"uuid": "d1"})},
 		{"create_dashboard", h.handleCreateDashboard, makeToolRequest("signoz_create_dashboard", map[string]any{"spec": map[string]any{"display": map[string]any{"name": "X"}}})},
 		{"list_dashboard_templates", h.handleListDashboardTemplates, makeToolRequest("signoz_list_dashboard_templates", map[string]any{})},
-		{"list_views", h.handleListViews, makeToolRequest("signoz_list_views", map[string]any{"sourcePage": "logs"})},
+		{"list_views", h.handleListViews, makeToolRequest("signoz_list_views", map[string]any{"source": "logs"})},
 		{"get_view", h.handleGetView, makeToolRequest("signoz_get_view", map[string]any{"viewId": "v1"})},
 		{"list_notification_channels", h.handleListNotificationChannels, makeToolRequest("signoz_list_notification_channels", map[string]any{})},
 		{"get_notification_channel", h.handleGetNotificationChannel, makeToolRequest("signoz_get_notification_channel", map[string]any{"id": "c1"})},

--- a/internal/handler/tools/views.go
+++ b/internal/handler/tools/views.go
@@ -18,19 +18,18 @@ import (
 // product (its own Meter Explorer route), even though its queries run
 // against the metrics signal with spec.source="meter".
 var validSources = map[string]struct{}{
-	"traces":           {},
-	"logs":             {},
-	"metrics":          {},
-	"meter":            {},
-	"ai_observability": {},
+	"traces":  {},
+	"logs":    {},
+	"metrics": {},
+	"meter":   {},
 }
 
 func validateSource(s string) error {
 	if s == "" {
-		return fmt.Errorf(`%s "source" is required. Must be one of: "traces", "logs", "metrics", "meter", "ai_observability"`, validationErrorPrefix)
+		return fmt.Errorf(`%s "source" is required. Must be one of: "traces", "logs", "metrics", "meter"`, validationErrorPrefix)
 	}
 	if _, ok := validSources[s]; !ok {
-		return fmt.Errorf(`%s "source" must be one of: "traces", "logs", "metrics", "meter", "ai_observability" (got %q)`, validationErrorPrefix, s)
+		return fmt.Errorf(`%s "source" must be one of: "traces", "logs", "metrics", "meter" (got %q)`, validationErrorPrefix, s)
 	}
 	return nil
 }
@@ -43,8 +42,8 @@ func (h *Handler) RegisterViewHandlers(s *mcp.Server) {
 	listTool := mcp.NewTool("signoz_list_views",
 		withReadOnlyToolAnnotations(),
 		mcp.WithString("searchContext", mcp.Description("Copy the user's entire original request verbatim, including any preflight or confirmation context; do not summarize, shorten, or omit clauses.")),
-		mcp.WithDescription("Use this when the user wants to discover saved views or find a view UUID for the Logs, Traces, Metrics, Cost Meter, or AI Observability explorer pages. A view stores one query spec; it is not a multi-widget dashboard. Apply name filters before pagination, and follow pagination.nextOffset while pagination.hasMore is true before concluding a view is absent. Use signoz_get_view for one full definition."),
-		mcp.WithString("source", mcp.Required(), mcp.Enum("traces", "logs", "metrics", "meter", "ai_observability"), mcp.Description(`Explorer whose views to list: "traces", "logs", "metrics", "meter", or "ai_observability". Use "meter" for Cost Meter, not "metrics".`)),
+		mcp.WithDescription("Use this when the user wants to discover saved views or find a view UUID for the Logs, Traces, Metrics, or Cost Meter explorer pages. A view stores one query spec; it is not a multi-widget dashboard. Apply name filters before pagination, and follow pagination.nextOffset while pagination.hasMore is true before concluding a view is absent. Use signoz_get_view for one full definition."),
+		mcp.WithString("source", mcp.Required(), mcp.Enum("traces", "logs", "metrics", "meter"), mcp.Description(`Explorer whose views to list: "traces", "logs", "metrics", or "meter". Use "meter" for Cost Meter, not "metrics".`)),
 		mcp.WithString("name", mcp.Description("Partial, server-side match on the saved-view name. Omit to include every name.")),
 		mcp.WithString("limit", mcp.DefaultString("50"), intOrStringType(), mcp.Description("Maximum number of views to return per page. Default: 50, max: 1000 (higher values are clamped).")),
 		mcp.WithString("offset", mcp.DefaultString("0"), intOrStringType(), mcp.Description("Number of results to skip before returning results. Use 'pagination.nextOffset' from the previous page. Default: 0.")),
@@ -65,12 +64,11 @@ func (h *Handler) RegisterViewHandlers(s *mcp.Server) {
 		withCreateToolAnnotations(),
 		mcp.WithString("searchContext", mcp.Description("Copy the user's entire original request verbatim, including any preflight or confirmation context; do not summarize, shorten, or omit clauses.")),
 		mcp.WithDescription(
-			"Use this when the user wants to save one reusable query spec for Logs, Traces, Metrics, Cost Meter, or AI Observability; use signoz_create_dashboard for a multi-widget dashboard. Before composing any payload, you must read both signoz://view/instructions and signoz://view/examples. Cost Meter views use source=\"meter\" while each builder spec uses signal=\"metrics\" and source=\"meter\". Do not send server-populated IDs or timestamps.",
+			"Use this when the user wants to save one reusable query spec for Logs, Traces, Metrics, or Cost Meter; use signoz_create_dashboard for a multi-widget dashboard. Before composing any payload, you must read both signoz://view/instructions and signoz://view/examples. Cost Meter views use source=\"meter\" while each builder spec uses signal=\"metrics\" and source=\"meter\". Do not send server-populated IDs or timestamps.",
 		),
-		mcp.WithString("name", mcp.Description("Display name of the view. Required unless generateName is true.")),
+		mcp.WithString("name", mcp.Description("The view's machine name, a DNS-1123 label (lowercase letters, digits, hyphens). The human-facing display name lives in spec.displayName. Required unless generateName is true.")),
 		mcp.WithBoolean("generateName", mcp.Description("When true, the server generates the view name from spec.displayName; name must be empty. Default: false.")),
-		mcp.WithString("source", mcp.Required(), mcp.Enum("traces", "logs", "metrics", "meter", "ai_observability"), mcp.Description(`Which Explorer this view belongs to. One of: "traces", "logs", "metrics", "meter", "ai_observability". Use "meter" for Cost Meter views (queried as metrics with source "meter").`)),
-		mcp.WithString("schemaVersion", mcp.Description(`Schema version of the view spec. Default: "v2".`)),
+		mcp.WithString("source", mcp.Required(), mcp.Enum("traces", "logs", "metrics", "meter"), mcp.Description(`Which Explorer this view belongs to. One of: "traces", "logs", "metrics", "meter". Use "meter" for Cost Meter views (queried as metrics with source "meter").`)),
 		mcp.WithObject("spec", mcp.Required(), mcp.AdditionalProperties(true), mcp.Description("The saved-view spec object: displayName, panelType, requestType, queries, selectedFields, and display. See signoz://view/instructions and signoz://view/examples.")),
 	)
 	h.addTool(s, createTool, h.handleCreateView)
@@ -142,12 +140,8 @@ func savedViewSchemaProperties() map[string]any {
 	return map[string]any{
 		"source": map[string]any{
 			"type":        "string",
-			"enum":        []string{"traces", "logs", "metrics", "meter", "ai_observability"},
-			"description": `Which Explorer this view belongs to. One of: "traces", "logs", "metrics", "meter", "ai_observability". Use "meter" for Cost Meter views (queried as metrics with source "meter").`,
-		},
-		"schemaVersion": map[string]any{
-			"type":        "string",
-			"description": `Schema version of the view spec. Default: "v2".`,
+			"enum":        []string{"traces", "logs", "metrics", "meter"},
+			"description": `Which Explorer this view belongs to. One of: "traces", "logs", "metrics", "meter". Use "meter" for Cost Meter views (queried as metrics with source "meter").`,
 		},
 		"spec": map[string]any{
 			"type":                 "object",
@@ -181,7 +175,7 @@ var serverPopulatedViewFields = []string{
 //     spec.source="meter". So a "meter" view must use signal "metrics" AND
 //     source "meter" — omitting source="meter" would silently query the
 //     default metrics store instead of the meter store.
-//   - For the ordinary pages (traces/logs/metrics/ai_observability),
+//   - For the ordinary pages (traces/logs/metrics),
 //     `signal` must equal source, and source must not be "meter" — a Cost
 //     Meter query belongs on the dedicated "meter" page, not mis-filed
 //     under "metrics".
@@ -418,9 +412,9 @@ func (h *Handler) handleCreateView(ctx context.Context, req mcp.CallToolRequest)
 	if err := validateBuilderSignal(spec, source); err != nil {
 		return errorWithCode(CodeValidationFailed, err.Error()), nil
 	}
-	if _, present := args["schemaVersion"]; !present {
-		args["schemaVersion"] = "v2"
-	}
+	// schemaVersion is not a supported input; force "v2" so a caller-supplied
+	// value can never reach upstream.
+	args["schemaVersion"] = "v2"
 	body, err := marshalViewBody(args)
 	if err != nil {
 		h.logger.ErrorContext(ctx, "Failed to marshal view body", logpkg.ErrAttr(err))
@@ -486,9 +480,9 @@ func (h *Handler) handleUpdateView(ctx context.Context, req mcp.CallToolRequest)
 	if err := validateBuilderSignal(spec, source); err != nil {
 		return errorWithCode(CodeValidationFailed, err.Error()), nil
 	}
-	if _, present := view["schemaVersion"]; !present {
-		view["schemaVersion"] = "v2"
-	}
+	// schemaVersion is not a supported input; force "v2" so a caller-supplied
+	// value can never reach upstream.
+	view["schemaVersion"] = "v2"
 
 	// Upstream v2 update (UpdatableSavedView) has no "name": name is
 	// immutable and the decoder rejects unknown fields, so echoing back a

--- a/internal/handler/tools/views.go
+++ b/internal/handler/tools/views.go
@@ -13,39 +13,39 @@ import (
 	"github.com/SigNoz/signoz-mcp-server/pkg/views"
 )
 
-// validSourcePages is the allow-list for the explorer-views sourcePage param.
-// "meter" is the Cost Meter Explorer — a distinct page in the SigNoz product
-// (its own Meter Explorer route), even though its queries run against the
-// metrics signal with spec.source="meter".
-var validSourcePages = map[string]struct{}{
-	"traces":  {},
-	"logs":    {},
-	"metrics": {},
-	"meter":   {},
+// validSources is the allow-list for the v2 saved-views source param.
+// "meter" is the Cost Meter Explorer — a distinct page in the SigNoz
+// product (its own Meter Explorer route), even though its queries run
+// against the metrics signal with spec.source="meter".
+var validSources = map[string]struct{}{
+	"traces":           {},
+	"logs":             {},
+	"metrics":          {},
+	"meter":            {},
+	"ai_observability": {},
 }
 
-func validateSourcePage(sp string) error {
-	if sp == "" {
-		return fmt.Errorf(`%s "sourcePage" is required. Must be one of: "traces", "logs", "metrics", "meter"`, validationErrorPrefix)
+func validateSource(s string) error {
+	if s == "" {
+		return fmt.Errorf(`%s "source" is required. Must be one of: "traces", "logs", "metrics", "meter", "ai_observability"`, validationErrorPrefix)
 	}
-	if _, ok := validSourcePages[sp]; !ok {
-		return fmt.Errorf(`%s "sourcePage" must be one of: "traces", "logs", "metrics", "meter" (got %q)`, validationErrorPrefix, sp)
+	if _, ok := validSources[s]; !ok {
+		return fmt.Errorf(`%s "source" must be one of: "traces", "logs", "metrics", "meter", "ai_observability" (got %q)`, validationErrorPrefix, s)
 	}
 	return nil
 }
 
-// RegisterViewHandlers registers the unified saved-views CRUD tools plus
-// the signoz://view/instructions and signoz://view/examples resources.
+// RegisterViewHandlers registers the saved-views CRUD tools plus the
+// signoz://view/instructions and signoz://view/examples resources.
 func (h *Handler) RegisterViewHandlers(s *mcp.Server) {
 	h.logger.Debug("Registering view handlers")
 
 	listTool := mcp.NewTool("signoz_list_views",
 		withReadOnlyToolAnnotations(),
 		mcp.WithString("searchContext", mcp.Description("Copy the user's entire original request verbatim, including any preflight or confirmation context; do not summarize, shorten, or omit clauses.")),
-		mcp.WithDescription("Use this when the user wants to discover saved Explorer views or find a view UUID for one Logs, Traces, Metrics, or Cost Meter page. A view stores an Explorer query; it is not a multi-widget dashboard. Apply name/category filters before pagination, and follow pagination.nextOffset while pagination.hasMore is true before concluding a view is absent. Use signoz_get_view for one full definition."),
-		mcp.WithString("sourcePage", mcp.Required(), mcp.Enum("traces", "logs", "metrics", "meter"), mcp.Description(`Explorer whose views to list: "traces", "logs", "metrics", or "meter". Use "meter" for Cost Meter, not "metrics".`)),
+		mcp.WithDescription("Use this when the user wants to discover saved views or find a view UUID for the Logs, Traces, Metrics, Cost Meter, or AI Observability explorer pages. A view stores one query spec; it is not a multi-widget dashboard. Apply name filters before pagination, and follow pagination.nextOffset while pagination.hasMore is true before concluding a view is absent. Use signoz_get_view for one full definition."),
+		mcp.WithString("source", mcp.Required(), mcp.Enum("traces", "logs", "metrics", "meter", "ai_observability"), mcp.Description(`Explorer whose views to list: "traces", "logs", "metrics", "meter", or "ai_observability". Use "meter" for Cost Meter, not "metrics".`)),
 		mcp.WithString("name", mcp.Description("Partial, server-side match on the saved-view name. Omit to include every name.")),
-		mcp.WithString("category", mcp.Description("Partial, server-side match on the saved-view category. Omit to include every category.")),
 		mcp.WithString("limit", mcp.DefaultString("50"), intOrStringType(), mcp.Description("Maximum number of views to return per page. Default: 50, max: 1000 (higher values are clamped).")),
 		mcp.WithString("offset", mcp.DefaultString("0"), intOrStringType(), mcp.Description("Number of results to skip before returning results. Use 'pagination.nextOffset' from the previous page. Default: 0.")),
 	)
@@ -54,7 +54,7 @@ func (h *Handler) RegisterViewHandlers(s *mcp.Server) {
 	getTool := mcp.NewTool("signoz_get_view",
 		withReadOnlyToolAnnotations(),
 		mcp.WithString("searchContext", mcp.Description("Copy the user's entire original request verbatim, including any preflight or confirmation context; do not summarize, shorten, or omit clauses.")),
-		mcp.WithDescription("Use this when the user wants the complete definition of one known saved Explorer view. Use signoz_list_views first when its UUID is unknown. The returned data object is the required base for signoz_update_view because updates fully replace a view. Do not use this for multi-widget dashboards; use signoz_get_dashboard."),
+		mcp.WithDescription("Use this when the user wants the complete definition of one known saved view. Use signoz_list_views first when its UUID is unknown. The returned data object is the required base for signoz_update_view because updates fully replace a view. Do not use this for multi-widget dashboards; use signoz_get_dashboard."),
 		// Not mcp.Required(): the legacy alias "viewId" must remain a valid call
 		// for schema-aware clients. The handler validates id/viewId presence.
 		mcp.WithString("id", mcp.Description("Saved view UUID. Use signoz_list_views to discover IDs. Required.")),
@@ -65,14 +65,13 @@ func (h *Handler) RegisterViewHandlers(s *mcp.Server) {
 		withCreateToolAnnotations(),
 		mcp.WithString("searchContext", mcp.Description("Copy the user's entire original request verbatim, including any preflight or confirmation context; do not summarize, shorten, or omit clauses.")),
 		mcp.WithDescription(
-			"Use this when the user wants to save one reusable Explorer query for Logs, Traces, Metrics, or Cost Meter; use signoz_create_dashboard for a multi-widget dashboard. Before composing any payload, you must read both signoz://view/instructions and signoz://view/examples. Cost Meter views use sourcePage=\"meter\" while each builder spec uses signal=\"metrics\" and source=\"meter\". Do not send server-populated IDs or timestamps.",
+			"Use this when the user wants to save one reusable query spec for Logs, Traces, Metrics, Cost Meter, or AI Observability; use signoz_create_dashboard for a multi-widget dashboard. Before composing any payload, you must read both signoz://view/instructions and signoz://view/examples. Cost Meter views use source=\"meter\" while each builder spec uses signal=\"metrics\" and source=\"meter\". Do not send server-populated IDs or timestamps.",
 		),
-		mcp.WithString("name", mcp.Required(), mcp.Description("Display name of the view.")),
-		mcp.WithString("sourcePage", mcp.Required(), mcp.Enum("traces", "logs", "metrics", "meter"), mcp.Description(`Which Explorer this view belongs to. One of: "traces", "logs", "metrics", "meter". Use "meter" for Cost Meter views (queried as metrics with source "meter").`)),
-		mcp.WithObject("compositeQuery", mcp.Required(), mcp.AdditionalProperties(true), mcp.Description("The Query Builder payload as an object (not a string). Must contain queryType plus matching sub-query. See signoz://view/instructions and signoz://view/examples.")),
-		mcp.WithString("category", mcp.Description("Optional free-form grouping label.")),
-		mcp.WithArray("tags", mcp.WithStringItems(), mcp.Description("Optional free-form tags.")),
-		mcp.WithString("extraData", mcp.Description("Optional UI-controlled options as a JSON-encoded string (safe to leave empty).")),
+		mcp.WithString("name", mcp.Description("Display name of the view. Required unless generateName is true.")),
+		mcp.WithBoolean("generateName", mcp.Description("When true, the server generates the view name from spec.displayName; name must be empty. Default: false.")),
+		mcp.WithString("source", mcp.Required(), mcp.Enum("traces", "logs", "metrics", "meter", "ai_observability"), mcp.Description(`Which Explorer this view belongs to. One of: "traces", "logs", "metrics", "meter", "ai_observability". Use "meter" for Cost Meter views (queried as metrics with source "meter").`)),
+		mcp.WithString("schemaVersion", mcp.Description(`Schema version of the view spec. Default: "v2".`)),
+		mcp.WithObject("spec", mcp.Required(), mcp.AdditionalProperties(true), mcp.Description("The saved-view spec object: displayName, panelType, requestType, queries, selectedFields, and display. See signoz://view/instructions and signoz://view/examples.")),
 	)
 	h.addTool(s, createTool, h.handleCreateView)
 
@@ -80,14 +79,14 @@ func (h *Handler) RegisterViewHandlers(s *mcp.Server) {
 		withUpdateToolAnnotations(),
 		mcp.WithString("searchContext", mcp.Description("Copy the user's entire original request verbatim, including any preflight or confirmation context; do not summarize, shorten, or omit clauses.")),
 		mcp.WithDescription(
-			"Use this when the user wants to change an existing saved Explorer view. This is a full replacement: call signoz_get_view first, modify its data object, preserve every unrequested field, and pass that full object as view. Read signoz://view/instructions and signoz://view/examples when changing sourcePage or compositeQuery; skip them for name-, category-, or tags-only changes when you already have the complete fetched view. Keep the UUID only in id; omit server-populated IDs and timestamps from view.",
+			"Use this when the user wants to change an existing saved view. This is a full replacement: call signoz_get_view first, modify its data object, preserve every unrequested field, and pass that full object as view. Upstream keeps name immutable on update; the display name lives in spec.displayName. Read signoz://view/instructions and signoz://view/examples when changing source or spec. Keep the UUID only in id; omit server-populated IDs and timestamps from view.",
 		),
 		mcp.WithString("id", mcp.Description("UUID of the view to replace. Required.")),
 		mcp.WithObject("view",
 			mcp.Required(),
 			mcp.Properties(savedViewSchemaProperties()),
 			mcp.AdditionalProperties(true),
-			withRequiredFields("name", "sourcePage", "compositeQuery"),
+			withRequiredFields("source", "spec"),
 			mcp.Description("Complete saved view after the requested changes. Start with the data returned by signoz_get_view and pass the full object here."),
 		),
 	)
@@ -96,7 +95,7 @@ func (h *Handler) RegisterViewHandlers(s *mcp.Server) {
 	deleteTool := mcp.NewTool("signoz_delete_view",
 		withDeleteToolAnnotations(),
 		mcp.WithString("searchContext", mcp.Description("Copy the user's entire original request verbatim, including any preflight or confirmation context; do not summarize, shorten, or omit clauses.")),
-		mcp.WithDescription("Use this when the user has confirmed they want to permanently delete one saved Explorer view. The deletion is irreversible. Use signoz_list_views to discover the UUID when needed; do not use this for dashboards; delete those with signoz_delete_dashboard."),
+		mcp.WithDescription("Use this when the user has confirmed they want to permanently delete one saved view. The deletion is irreversible. Use signoz_list_views to discover the UUID when needed; do not use this for dashboards; delete those with signoz_delete_dashboard."),
 		mcp.WithString("id", mcp.Description("UUID of the saved view to delete. Required; use signoz_list_views to discover it.")),
 	)
 	h.addTool(s, deleteTool, h.handleDeleteView)
@@ -104,7 +103,7 @@ func (h *Handler) RegisterViewHandlers(s *mcp.Server) {
 	viewInstructions := mcp.NewResource(
 		"signoz://view/instructions",
 		"Saved View Instructions",
-		mcp.WithResourceDescription("Read this before creating or updating a saved Explorer view. It explains view fields, sourcePage, Query Builder v5, Cost Meter views, and how to read a view before replacing it. It does not describe dashboards."),
+		mcp.WithResourceDescription("Read this before creating or updating a saved view. It explains view fields, source, the typed spec (schemaVersion v2), Cost Meter views, and how to read a view before replacing it. It does not describe dashboards."),
 		mcp.WithMIMEType("text/markdown"),
 		mcp.WithResourceSize(int64(len(views.Instructions))),
 	)
@@ -121,7 +120,7 @@ func (h *Handler) RegisterViewHandlers(s *mcp.Server) {
 	viewExamples := mcp.NewResource(
 		"signoz://view/examples",
 		"Saved View Examples",
-		mcp.WithResourceDescription("Read this after signoz://view/instructions when composing a saved Explorer view. It provides complete Query Builder v5 payloads for traces, logs, metrics, and Cost Meter source pages."),
+		mcp.WithResourceDescription("Read this after signoz://view/instructions when composing a saved view. It provides complete typed spec payloads for traces, logs, metrics, and Cost Meter sources."),
 		mcp.WithMIMEType("text/markdown"),
 		mcp.WithResourceSize(int64(len(views.Examples))),
 	)
@@ -141,32 +140,19 @@ func (h *Handler) RegisterViewHandlers(s *mcp.Server) {
 // empty effective schema for tools/list clients.
 func savedViewSchemaProperties() map[string]any {
 	return map[string]any{
-		"name": map[string]any{
+		"source": map[string]any{
 			"type":        "string",
-			"description": "Display name of the view.",
+			"enum":        []string{"traces", "logs", "metrics", "meter", "ai_observability"},
+			"description": `Which Explorer this view belongs to. One of: "traces", "logs", "metrics", "meter", "ai_observability". Use "meter" for Cost Meter views (queried as metrics with source "meter").`,
 		},
-		"sourcePage": map[string]any{
+		"schemaVersion": map[string]any{
 			"type":        "string",
-			"enum":        []string{"traces", "logs", "metrics", "meter"},
-			"description": `Which Explorer this view belongs to. One of: "traces", "logs", "metrics", "meter". Use "meter" for Cost Meter views (queried as metrics with source "meter").`,
+			"description": `Schema version of the view spec. Default: "v2".`,
 		},
-		"compositeQuery": map[string]any{
+		"spec": map[string]any{
 			"type":                 "object",
 			"additionalProperties": true,
-			"description":          "The Query Builder payload as an object (not a string). Must contain queryType plus matching sub-query. See signoz://view/instructions and signoz://view/examples.",
-		},
-		"category": map[string]any{
-			"type":        "string",
-			"description": "Optional free-form grouping label.",
-		},
-		"tags": map[string]any{
-			"type":        "array",
-			"items":       map[string]any{"type": "string"},
-			"description": "Optional free-form tags.",
-		},
-		"extraData": map[string]any{
-			"type":        "string",
-			"description": "Optional UI-controlled options as a JSON-encoded string (safe to leave empty).",
+			"description":          "The saved-view spec object: displayName, panelType, requestType, queries, selectedFields, and display. See signoz://view/instructions and signoz://view/examples.",
 		},
 	}
 }
@@ -185,27 +171,29 @@ var serverPopulatedViewFields = []string{
 }
 
 // validateBuilderSignal enforces the documented signal/source rules for a
-// view's builder_query specs. Upstream enforces none of this, so missing,
-// mismatched, or mis-filed values silently save unusable views.
+// view's builder_query specs inside spec.queries. Upstream enforces none of
+// this, so missing, mismatched, or mis-filed values silently save unusable
+// views.
 //
 //   - Every builder_query spec must set `signal`.
-//   - Cost Meter views (sourcePage "meter") are a distinct Explorer page in
-//     the SigNoz product but are queried against the metrics signal with
+//   - Cost Meter views (source "meter") are a distinct Explorer page in the
+//     SigNoz product but are queried against the metrics signal with
 //     spec.source="meter". So a "meter" view must use signal "metrics" AND
 //     source "meter" — omitting source="meter" would silently query the
 //     default metrics store instead of the meter store.
-//   - For the ordinary pages (traces/logs/metrics), `signal` must equal
-//     sourcePage, and source must not be "meter" — a Cost Meter query belongs
-//     on the dedicated "meter" page, not mis-filed under "metrics".
+//   - For the ordinary pages (traces/logs/metrics/ai_observability),
+//     `signal` must equal source, and source must not be "meter" — a Cost
+//     Meter query belongs on the dedicated "meter" page, not mis-filed
+//     under "metrics".
 //
 // Non-builder queries (promql, clickhouse_sql) don't carry these fields and
 // are skipped.
-func validateBuilderSignal(compositeQuery any, sourcePage string) error {
-	cq, ok := compositeQuery.(map[string]any)
+func validateBuilderSignal(spec any, source string) error {
+	s, ok := spec.(map[string]any)
 	if !ok {
 		return nil
 	}
-	queries, ok := cq["queries"].([]any)
+	queries, ok := s["queries"].([]any)
 	if !ok {
 		return nil
 	}
@@ -217,31 +205,31 @@ func validateBuilderSignal(compositeQuery any, sourcePage string) error {
 		if qt, _ := entry["type"].(string); qt != "builder_query" {
 			continue
 		}
-		spec, ok := entry["spec"].(map[string]any)
+		qspec, ok := entry["spec"].(map[string]any)
 		if !ok {
 			continue
 		}
-		signal, _ := spec["signal"].(string)
-		source, _ := spec["source"].(string)
+		signal, _ := qspec["signal"].(string)
+		qsource, _ := qspec["source"].(string)
 
-		if sourcePage == "meter" {
+		if source == "meter" {
 			// Cost Meter views are queried as metrics against the meter store.
 			if signal == "" {
 				return fmt.Errorf(
-					`%s compositeQuery.queries[%d].spec.signal is required for a "meter" view and must be "metrics"`,
+					`%s spec.queries[%d].spec.signal is required for a "meter" view and must be "metrics"`,
 					validationErrorPrefix, i,
 				)
 			}
 			if signal != "metrics" {
 				return fmt.Errorf(
-					`%s compositeQuery.queries[%d].spec.signal = %q but a "meter" (Cost Meter) view must use signal "metrics"`,
+					`%s spec.queries[%d].spec.signal = %q but a "meter" (Cost Meter) view must use signal "metrics"`,
 					validationErrorPrefix, i, signal,
 				)
 			}
-			if source != "meter" {
+			if qsource != "meter" {
 				return fmt.Errorf(
-					`%s compositeQuery.queries[%d].spec.source = %q but a "meter" (Cost Meter) view must set source "meter"`,
-					validationErrorPrefix, i, source,
+					`%s spec.queries[%d].spec.source = %q but a "meter" (Cost Meter) view must set source "meter"`,
+					validationErrorPrefix, i, qsource,
 				)
 			}
 			continue
@@ -249,21 +237,21 @@ func validateBuilderSignal(compositeQuery any, sourcePage string) error {
 
 		if signal == "" {
 			return fmt.Errorf(
-				`%s compositeQuery.queries[%d].spec.signal is required and must equal sourcePage (%q)`,
-				validationErrorPrefix, i, sourcePage,
+				`%s spec.queries[%d].spec.signal is required and must equal source (%q)`,
+				validationErrorPrefix, i, source,
 			)
 		}
-		if signal != sourcePage {
+		if signal != source {
 			return fmt.Errorf(
-				`%s compositeQuery.queries[%d].spec.signal = %q but sourcePage = %q, they must match`,
-				validationErrorPrefix, i, signal, sourcePage,
+				`%s spec.queries[%d].spec.signal = %q but source = %q, they must match`,
+				validationErrorPrefix, i, signal, source,
 			)
 		}
 		// A Cost Meter query (source="meter") must live on the "meter" page.
-		if source == "meter" {
+		if qsource == "meter" {
 			return fmt.Errorf(
-				`%s compositeQuery.queries[%d].spec.source = "meter" requires sourcePage "meter" (a Cost Meter view), but sourcePage = %q`,
-				validationErrorPrefix, i, sourcePage,
+				`%s spec.queries[%d].spec.source = "meter" requires source "meter" (a Cost Meter view), but source = %q`,
+				validationErrorPrefix, i, source,
 			)
 		}
 	}
@@ -292,7 +280,7 @@ func marshalViewBody(args map[string]any) ([]byte, error) {
 // signoz_get_view (shape: {"status":"success","data":{...}}) straight
 // into signoz_create_view / signoz_update_view. If the args look like
 // that envelope — a `data` field holding an object, and no top-level
-// `sourcePage` / `name` — replace args' contents with data's. The
+// `source` / `name` — replace args' contents with data's. The
 // tool descriptions explicitly instruct this flow, so supporting it
 // avoids a misleading "name is required" validation error.
 func unwrapViewEnvelope(args map[string]any) {
@@ -302,11 +290,11 @@ func unwrapViewEnvelope(args map[string]any) {
 	}
 	// Only unwrap when the outer object lacks the SavedView identity
 	// fields; otherwise the caller is legitimately sending a view that
-	// happens to have a `data` subfield (e.g. extraData).
+	// happens to have a `data` subfield.
 	if _, hasName := args["name"]; hasName {
 		return
 	}
-	if _, hasSourcePage := args["sourcePage"]; hasSourcePage {
+	if _, hasSource := args["source"]; hasSource {
 		return
 	}
 	// Preserve searchContext and viewId (MCP-level fields) across the swap.
@@ -333,26 +321,24 @@ func (h *Handler) handleListViews(ctx context.Context, req mcp.CallToolRequest) 
 	if !ok {
 		return notAJSONObjectError(), nil
 	}
-	sourcePage, _ := args["sourcePage"].(string)
-	if err := validateSourcePage(sourcePage); err != nil {
-		h.logger.WarnContext(ctx, "list_views validation failed", slog.String("sourcePage", sourcePage))
+	source, _ := args["source"].(string)
+	if err := validateSource(source); err != nil {
+		h.logger.WarnContext(ctx, "list_views validation failed", slog.String("source", source))
 		return errorWithCode(CodeValidationFailed, err.Error()), nil
 	}
 	name, _ := args["name"].(string)
-	category, _ := args["category"].(string)
 	limit, offset, limitClamped := paginate.ParseParamsClamped(req.Params.Arguments)
 
 	h.logger.DebugContext(ctx, "Tool called: signoz_list_views",
-		slog.String("sourcePage", sourcePage),
+		slog.String("source", source),
 		slog.String("name", name),
-		slog.String("category", category),
 	)
 
 	client, err := h.GetClient(ctx)
 	if err != nil {
 		return clientError(err), nil
 	}
-	result, err := client.ListViews(ctx, sourcePage, name, category)
+	result, err := client.ListViews(ctx, source, name)
 	if err != nil {
 		h.logUpstreamFailure(ctx, "Failed to list views", err)
 		return upstreamError(err), nil
@@ -416,28 +402,31 @@ func (h *Handler) handleCreateView(ctx context.Context, req mcp.CallToolRequest)
 	}
 	unwrapViewEnvelope(args)
 
-	name, errResult := requireStringArg(args, "name")
-	if errResult != nil {
-		return errResult, nil
+	generateName, _ := args["generateName"].(bool)
+	name, _ := args["name"].(string)
+	if !generateName && name == "" {
+		return errorWithCode(CodeValidationFailed, `Parameter validation failed: "name" is required unless "generateName" is true. Read signoz://view/instructions and signoz://view/examples for the schema.`), nil
 	}
-	sourcePage, _ := args["sourcePage"].(string)
-	if err := validateSourcePage(sourcePage); err != nil {
+	source, _ := args["source"].(string)
+	if err := validateSource(source); err != nil {
 		return errorWithCode(CodeValidationFailed, err.Error()), nil
 	}
-	cq, present := args["compositeQuery"]
+	spec, present := args["spec"]
 	if !present {
-		return errorWithCode(CodeValidationFailed, `Parameter validation failed: "compositeQuery" is required. Read signoz://view/instructions and signoz://view/examples for the schema.`), nil
+		return errorWithCode(CodeValidationFailed, `Parameter validation failed: "spec" is required. Read signoz://view/instructions and signoz://view/examples for the schema.`), nil
 	}
-	if err := validateBuilderSignal(cq, sourcePage); err != nil {
+	if err := validateBuilderSignal(spec, source); err != nil {
 		return errorWithCode(CodeValidationFailed, err.Error()), nil
 	}
-
+	if _, present := args["schemaVersion"]; !present {
+		args["schemaVersion"] = "v2"
+	}
 	body, err := marshalViewBody(args)
 	if err != nil {
 		h.logger.ErrorContext(ctx, "Failed to marshal view body", logpkg.ErrAttr(err))
 		return InternalErrorResult("failed to build request body: " + err.Error()), nil
 	}
-	h.logger.DebugContext(ctx, "Tool called: signoz_create_view", slog.String("name", name), slog.String("sourcePage", sourcePage))
+	h.logger.DebugContext(ctx, "Tool called: signoz_create_view", slog.String("name", name), slog.String("source", source))
 
 	client, err := h.GetClient(ctx)
 	if err != nil {
@@ -486,47 +475,51 @@ func (h *Handler) handleUpdateView(ctx context.Context, req mcp.CallToolRequest)
 		return errorWithCode(CodeValidationFailed, `Parameter validation failed: "view" is required. Pass the SavedView body under "view". Call signoz_get_view first and use the "data" field it returns.`), nil
 	}
 
-	name, _ := view["name"].(string)
-	if name == "" {
-		return errorWithCode(CodeValidationFailed, `Parameter validation failed: "view.name" is required. Call signoz_get_view first and pass its data field back as "view".`), nil
-	}
-	sourcePage, _ := view["sourcePage"].(string)
-	if err := validateSourcePage(sourcePage); err != nil {
+	source, _ := view["source"].(string)
+	if err := validateSource(source); err != nil {
 		return errorWithCode(CodeValidationFailed, err.Error()), nil
 	}
-	cq, present := view["compositeQuery"]
+	spec, present := view["spec"]
 	if !present {
-		return errorWithCode(CodeValidationFailed, `Parameter validation failed: "view.compositeQuery" is required. Call signoz_get_view first and pass its data field back as "view".`), nil
+		return errorWithCode(CodeValidationFailed, `Parameter validation failed: "view.spec" is required. Call signoz_get_view first and pass its data field back as "view".`), nil
 	}
-	if err := validateBuilderSignal(cq, sourcePage); err != nil {
+	if err := validateBuilderSignal(spec, source); err != nil {
 		return errorWithCode(CodeValidationFailed, err.Error()), nil
 	}
+	if _, present := view["schemaVersion"]; !present {
+		view["schemaVersion"] = "v2"
+	}
+
+	// Upstream v2 update (UpdatableSavedView) has no "name": name is
+	// immutable and the decoder rejects unknown fields, so echoing back a
+	// fetched view's name would 400. spec.displayName carries the label.
+	delete(view, "name")
 
 	stripNonBodyFields(view)
 	body, err := json.Marshal(view)
 	if err != nil {
 		return InternalErrorResult("failed to build request body: " + err.Error()), nil
 	}
-	h.logger.DebugContext(ctx, "Tool called: signoz_update_view", slog.String("viewId", viewID), slog.String("sourcePage", sourcePage))
+	h.logger.DebugContext(ctx, "Tool called: signoz_update_view", slog.String("viewId", viewID), slog.String("source", source))
 
 	client, err := h.GetClient(ctx)
 	if err != nil {
 		return clientError(err), nil
 	}
-	// Saved views are keyed to an Explorer; upstream PUT silently allows the
-	// sourcePage to be switched, which effectively moves the view to a
-	// different Explorer. Pre-fetch and reject the change — callers who truly
-	// want a cross-Explorer view should delete and re-create.
+	// Saved views are keyed to an Explorer; upstream PUT treats a source
+	// switch as moving the view to a different Explorer. Pre-fetch and
+	// reject the change — callers who truly want a cross-Explorer view
+	// should delete and re-create.
 	if existing, ferr := client.GetView(ctx, viewID); ferr == nil {
 		var probe struct {
 			Data struct {
-				SourcePage string `json:"sourcePage"`
+				Source string `json:"source"`
 			} `json:"data"`
 		}
-		if jerr := json.Unmarshal(existing, &probe); jerr == nil && probe.Data.SourcePage != "" && probe.Data.SourcePage != sourcePage {
+		if jerr := json.Unmarshal(existing, &probe); jerr == nil && probe.Data.Source != "" && probe.Data.Source != source {
 			return errorWithCode(CodeValidationFailed, fmt.Sprintf(
-				`Parameter validation failed: cannot change sourcePage on update (existing=%q, new=%q). Saved views are scoped to an Explorer; delete and re-create to move across Explorers.`,
-				probe.Data.SourcePage, sourcePage,
+				`Parameter validation failed: cannot change source on update (existing=%q, new=%q). Saved views are scoped to an Explorer; delete and re-create to move across Explorers.`,
+				probe.Data.Source, source,
 			)), nil
 		}
 	}
@@ -534,6 +527,11 @@ func (h *Handler) handleUpdateView(ctx context.Context, req mcp.CallToolRequest)
 	if err != nil {
 		h.logUpstreamFailure(ctx, "Failed to update view", err, slog.String("viewId", viewID))
 		return upstreamError(err), nil
+	}
+	// v2 returns 204 with an empty body; report success rather than an empty
+	// text block.
+	if len(data) == 0 {
+		data = json.RawMessage(`{"status":"success","data":null}`)
 	}
 	return mcp.NewToolResultText(string(data)), nil
 }
@@ -557,6 +555,11 @@ func (h *Handler) handleDeleteView(ctx context.Context, req mcp.CallToolRequest)
 	if err != nil {
 		h.logUpstreamFailure(ctx, "Failed to delete view", err, slog.String("viewId", viewID))
 		return upstreamError(err), nil
+	}
+	// v2 returns 204 with an empty body; report success rather than an empty
+	// text block.
+	if len(data) == 0 {
+		data = json.RawMessage(`{"status":"success"}`)
 	}
 	return mcp.NewToolResultText(string(data)), nil
 }

--- a/internal/handler/tools/views_codes_test.go
+++ b/internal/handler/tools/views_codes_test.go
@@ -20,29 +20,29 @@ func TestViewValidationErrorsCarryCode(t *testing.T) {
 		name string
 		call func() (*mcp.CallToolResult, error)
 	}{
-		{"list_views invalid sourcePage", func() (*mcp.CallToolResult, error) {
+		{"list_views invalid source", func() (*mcp.CallToolResult, error) {
 			return h.handleListViews(testCtx(), makeToolRequest("signoz_list_views", map[string]any{
-				"sourcePage": "bogus",
+				"source": "bogus",
 			}))
 		}},
-		{"create_view invalid sourcePage", func() (*mcp.CallToolResult, error) {
+		{"create_view invalid source", func() (*mcp.CallToolResult, error) {
 			return h.handleCreateView(testCtx(), makeToolRequest("signoz_create_view", map[string]any{
-				"name":           "v",
-				"sourcePage":     "bogus",
-				"compositeQuery": map[string]any{},
+				"name":   "v",
+				"source": "bogus",
+				"spec":   map[string]any{},
 			}))
 		}},
-		{"create_view missing compositeQuery", func() (*mcp.CallToolResult, error) {
+		{"create_view missing spec", func() (*mcp.CallToolResult, error) {
 			return h.handleCreateView(testCtx(), makeToolRequest("signoz_create_view", map[string]any{
-				"name":       "v",
-				"sourcePage": "traces",
+				"name":   "v",
+				"source": "traces",
 			}))
 		}},
-		{"create_view signal/sourcePage mismatch", func() (*mcp.CallToolResult, error) {
+		{"create_view signal/source mismatch", func() (*mcp.CallToolResult, error) {
 			return h.handleCreateView(testCtx(), makeToolRequest("signoz_create_view", map[string]any{
-				"name":       "v",
-				"sourcePage": "traces",
-				"compositeQuery": map[string]any{
+				"name":   "v",
+				"source": "traces",
+				"spec": map[string]any{
 					"queries": []any{
 						map[string]any{
 							"type": "builder_query",

--- a/internal/handler/tools/views_test.go
+++ b/internal/handler/tools/views_test.go
@@ -13,19 +13,18 @@ import (
 )
 
 func TestHandleListViews_Traces(t *testing.T) {
-	var gotSourcePage, gotName, gotCategory string
+	var gotSource, gotName string
 	mock := &client.MockClient{
-		ListViewsFn: func(ctx context.Context, sourcePage, name, category string) (json.RawMessage, error) {
-			gotSourcePage = sourcePage
+		ListViewsFn: func(ctx context.Context, source, name string) (json.RawMessage, error) {
+			gotSource = source
 			gotName = name
-			gotCategory = category
 			return json.RawMessage(`{"status":"success","data":[{"id":"v1","name":"akshay"}]}`), nil
 		},
 	}
 	h := newTestHandler(mock)
 	req := makeToolRequest("signoz_list_views", map[string]any{
-		"sourcePage": "traces",
-		"name":       "ak",
+		"source": "traces",
+		"name":   "ak",
 	})
 
 	result, err := h.handleListViews(testCtx(), req)
@@ -35,12 +34,12 @@ func TestHandleListViews_Traces(t *testing.T) {
 	if result.IsError {
 		t.Fatalf("handler returned error: %v", result.Content)
 	}
-	if gotSourcePage != "traces" || gotName != "ak" || gotCategory != "" {
-		t.Errorf("client called with unexpected args: sp=%q name=%q cat=%q", gotSourcePage, gotName, gotCategory)
+	if gotSource != "traces" || gotName != "ak" {
+		t.Errorf("client called with unexpected args: source=%q name=%q", gotSource, gotName)
 	}
 }
 
-func TestHandleListViews_MissingSourcePage(t *testing.T) {
+func TestHandleListViews_MissingSource(t *testing.T) {
 	h := newTestHandler(&client.MockClient{})
 	req := makeToolRequest("signoz_list_views", map[string]any{})
 	result, _ := h.handleListViews(testCtx(), req)
@@ -49,10 +48,10 @@ func TestHandleListViews_MissingSourcePage(t *testing.T) {
 	}
 }
 
-func TestHandleListViews_InvalidSourcePage(t *testing.T) {
+func TestHandleListViews_InvalidSource(t *testing.T) {
 	h := newTestHandler(&client.MockClient{})
 	req := makeToolRequest("signoz_list_views", map[string]any{
-		"sourcePage": "exceptions",
+		"source": "exceptions",
 	})
 	result, _ := h.handleListViews(testCtx(), req)
 	if !result.IsError {
@@ -60,7 +59,7 @@ func TestHandleListViews_InvalidSourcePage(t *testing.T) {
 	}
 	body := renderContent(result.Content)
 	if !strings.Contains(body, "traces") || !strings.Contains(body, "logs") || !strings.Contains(body, "metrics") {
-		t.Errorf("error should list valid sourcePage values; got: %s", body)
+		t.Errorf("error should list valid source values; got: %s", body)
 	}
 }
 
@@ -109,14 +108,19 @@ func TestHandleCreateView_Success(t *testing.T) {
 	mock := &client.MockClient{
 		CreateViewFn: func(ctx context.Context, body []byte) (json.RawMessage, error) {
 			gotBody = body
-			return json.RawMessage(`{"status":"success","data":{"id":"new-id","name":"x"}}`), nil
+			return json.RawMessage(`{"status":"success","data":{"id":"new-id"}}`), nil
 		},
 	}
 	h := newTestHandler(mock)
 	req := makeToolRequest("signoz_create_view", map[string]any{
-		"name":           "my view",
-		"sourcePage":     "traces",
-		"compositeQuery": map[string]any{"queryType": "builder"},
+		"name":   "my view",
+		"source": "traces",
+		"spec": map[string]any{
+			"queries": []any{map[string]any{
+				"type": "builder_query",
+				"spec": map[string]any{"name": "A", "signal": "traces"},
+			}},
+		},
 	})
 	result, err := h.handleCreateView(testCtx(), req)
 	if err != nil {
@@ -126,8 +130,8 @@ func TestHandleCreateView_Success(t *testing.T) {
 		t.Fatalf("handler error: %v", result.Content)
 	}
 	if !strings.Contains(string(gotBody), `"name":"my view"`) ||
-		!strings.Contains(string(gotBody), `"sourcePage":"traces"`) ||
-		!strings.Contains(string(gotBody), `"compositeQuery"`) {
+		!strings.Contains(string(gotBody), `"source":"traces"`) ||
+		!strings.Contains(string(gotBody), `"spec"`) {
 		t.Errorf("body missing required fields: %s", gotBody)
 	}
 	if strings.Contains(string(gotBody), `"searchContext"`) {
@@ -138,8 +142,8 @@ func TestHandleCreateView_Success(t *testing.T) {
 func TestHandleCreateView_MissingName(t *testing.T) {
 	h := newTestHandler(&client.MockClient{})
 	req := makeToolRequest("signoz_create_view", map[string]any{
-		"sourcePage":     "traces",
-		"compositeQuery": map[string]any{},
+		"source": "traces",
+		"spec":   map[string]any{},
 	})
 	result, _ := h.handleCreateView(testCtx(), req)
 	if !result.IsError {
@@ -147,12 +151,12 @@ func TestHandleCreateView_MissingName(t *testing.T) {
 	}
 }
 
-func TestHandleCreateView_InvalidSourcePage(t *testing.T) {
+func TestHandleCreateView_InvalidSource(t *testing.T) {
 	h := newTestHandler(&client.MockClient{})
 	req := makeToolRequest("signoz_create_view", map[string]any{
-		"name":           "x",
-		"sourcePage":     "bogus",
-		"compositeQuery": map[string]any{},
+		"name":   "x",
+		"source": "bogus",
+		"spec":   map[string]any{},
 	})
 	result, _ := h.handleCreateView(testCtx(), req)
 	if !result.IsError {
@@ -160,11 +164,11 @@ func TestHandleCreateView_InvalidSourcePage(t *testing.T) {
 	}
 }
 
-func TestHandleCreateView_MissingCompositeQuery(t *testing.T) {
+func TestHandleCreateView_MissingSpec(t *testing.T) {
 	h := newTestHandler(&client.MockClient{})
 	req := makeToolRequest("signoz_create_view", map[string]any{
-		"name":       "x",
-		"sourcePage": "traces",
+		"name":   "x",
+		"source": "traces",
 	})
 	result, _ := h.handleCreateView(testCtx(), req)
 	if !result.IsError {
@@ -186,9 +190,13 @@ func TestHandleUpdateView_Success(t *testing.T) {
 	req := makeToolRequest("signoz_update_view", map[string]any{
 		"viewId": "v1",
 		"view": map[string]any{
-			"name":           "renamed",
-			"sourcePage":     "logs",
-			"compositeQuery": map[string]any{"queryType": "builder"},
+			"source": "logs",
+			"spec": map[string]any{
+				"queries": []any{map[string]any{
+					"type": "builder_query",
+					"spec": map[string]any{"name": "A", "signal": "logs"},
+				}},
+			},
 		},
 	})
 	result, err := h.handleUpdateView(testCtx(), req)
@@ -204,7 +212,7 @@ func TestHandleUpdateView_Success(t *testing.T) {
 	if strings.Contains(string(gotBody), `"viewId"`) {
 		t.Errorf("viewId should not leak into body: %s", gotBody)
 	}
-	if !strings.Contains(string(gotBody), `"name":"renamed"`) {
+	if !strings.Contains(string(gotBody), `"source":"logs"`) {
 		t.Errorf("body missing view fields: %s", gotBody)
 	}
 }
@@ -213,9 +221,8 @@ func TestHandleUpdateView_MissingID(t *testing.T) {
 	h := newTestHandler(&client.MockClient{})
 	req := makeToolRequest("signoz_update_view", map[string]any{
 		"view": map[string]any{
-			"name":           "x",
-			"sourcePage":     "logs",
-			"compositeQuery": map[string]any{},
+			"source": "logs",
+			"spec":   map[string]any{},
 		},
 	})
 	result, _ := h.handleUpdateView(testCtx(), req)
@@ -236,10 +243,15 @@ func TestHandleUpdateView_FlatFieldsBackCompat(t *testing.T) {
 	}
 	h := newTestHandler(mock)
 	req := makeToolRequest("signoz_update_view", map[string]any{
-		"viewId":         "v1",
-		"name":           "flat",
-		"sourcePage":     "traces",
-		"compositeQuery": map[string]any{"queryType": "builder"},
+		"viewId": "v1",
+		"name":   "flat",
+		"source": "traces",
+		"spec": map[string]any{
+			"queries": []any{map[string]any{
+				"type": "builder_query",
+				"spec": map[string]any{"name": "A", "signal": "traces"},
+			}},
+		},
 	})
 	result, err := h.handleUpdateView(testCtx(), req)
 	if err != nil {
@@ -248,7 +260,7 @@ func TestHandleUpdateView_FlatFieldsBackCompat(t *testing.T) {
 	if result.IsError {
 		t.Fatalf("handler error: %v", result.Content)
 	}
-	if !strings.Contains(string(gotBody), `"name":"flat"`) {
+	if !strings.Contains(string(gotBody), `"source":"traces"`) {
 		t.Errorf("flat body not accepted: %s", gotBody)
 	}
 }
@@ -300,10 +312,15 @@ func TestHandleUpdateView_UnwrapsGetViewEnvelope(t *testing.T) {
 		"view": map[string]any{
 			"status": "success",
 			"data": map[string]any{
-				"id":             "v1",
-				"name":           "renamed",
-				"sourcePage":     "traces",
-				"compositeQuery": map[string]any{"queryType": "builder"},
+				"id":     "v1",
+				"name":   "renamed",
+				"source": "traces",
+				"spec": map[string]any{
+					"queries": []any{map[string]any{
+						"type": "builder_query",
+						"spec": map[string]any{"name": "A", "signal": "traces"},
+					}},
+				},
 			},
 		},
 	})
@@ -314,7 +331,7 @@ func TestHandleUpdateView_UnwrapsGetViewEnvelope(t *testing.T) {
 	if result.IsError {
 		t.Fatalf("handler error: %v", result.Content)
 	}
-	if !strings.Contains(string(gotBody), `"name":"renamed"`) {
+	if !strings.Contains(string(gotBody), `"source":"traces"`) {
 		t.Errorf("body missing unwrapped fields: %s", gotBody)
 	}
 	if strings.Contains(string(gotBody), `"status":"success"`) {
@@ -337,9 +354,14 @@ func TestHandleCreateView_UnwrapsEnvelope(t *testing.T) {
 	req := makeToolRequest("signoz_create_view", map[string]any{
 		"status": "success",
 		"data": map[string]any{
-			"name":           "my view",
-			"sourcePage":     "logs",
-			"compositeQuery": map[string]any{"queryType": "builder"},
+			"name":   "my view",
+			"source": "logs",
+			"spec": map[string]any{
+				"queries": []any{map[string]any{
+					"type": "builder_query",
+					"spec": map[string]any{"name": "A", "signal": "logs"},
+				}},
+			},
 		},
 	})
 	result, err := h.handleCreateView(testCtx(), req)
@@ -355,9 +377,9 @@ func TestHandleCreateView_UnwrapsEnvelope(t *testing.T) {
 }
 
 func TestHandleUpdateView_NoUnwrapWhenViewIsValid(t *testing.T) {
-	// When the "view" object has valid top-level name/sourcePage, the
-	// envelope unwrap must leave any `data` subfield alone — it might be
-	// legitimate SavedView payload content the caller wanted to preserve.
+	// When the "view" object has valid top-level name/source, the envelope
+	// unwrap must leave any `data` subfield alone — it might be legitimate
+	// SavedView payload content the caller wanted to preserve.
 	var gotBody []byte
 	mock := &client.MockClient{
 		UpdateViewFn: func(ctx context.Context, id string, body []byte) (json.RawMessage, error) {
@@ -369,10 +391,15 @@ func TestHandleUpdateView_NoUnwrapWhenViewIsValid(t *testing.T) {
 	req := makeToolRequest("signoz_update_view", map[string]any{
 		"viewId": "v1",
 		"view": map[string]any{
-			"name":           "direct",
-			"sourcePage":     "metrics",
-			"compositeQuery": map[string]any{"queryType": "builder"},
-			"data":           map[string]any{"unrelated": "stuff"},
+			"name":   "direct",
+			"source": "metrics",
+			"spec": map[string]any{
+				"queries": []any{map[string]any{
+					"type": "builder_query",
+					"spec": map[string]any{"name": "A", "signal": "metrics"},
+				}},
+			},
+			"data": map[string]any{"unrelated": "stuff"},
 		},
 	})
 	result, err := h.handleUpdateView(testCtx(), req)
@@ -382,7 +409,7 @@ func TestHandleUpdateView_NoUnwrapWhenViewIsValid(t *testing.T) {
 	if result.IsError {
 		t.Fatalf("handler error: %v", result.Content)
 	}
-	if !strings.Contains(string(gotBody), `"name":"direct"`) {
+	if !strings.Contains(string(gotBody), `"source":"metrics"`) {
 		t.Errorf("view body got clobbered: %s", gotBody)
 	}
 	if !strings.Contains(string(gotBody), `"unrelated"`) {
@@ -394,7 +421,7 @@ func TestHandleListViews_Pagination(t *testing.T) {
 	// Upstream returns 5 views; request page size 2, offset 2 → expect items
 	// [2, 3] and pagination metadata with total=5, hasMore=true, nextOffset=4.
 	mock := &client.MockClient{
-		ListViewsFn: func(ctx context.Context, sourcePage, name, category string) (json.RawMessage, error) {
+		ListViewsFn: func(ctx context.Context, source, name string) (json.RawMessage, error) {
 			return json.RawMessage(`{"status":"success","data":[` +
 				`{"id":"v0","name":"a"},` +
 				`{"id":"v1","name":"b"},` +
@@ -406,9 +433,9 @@ func TestHandleListViews_Pagination(t *testing.T) {
 	}
 	h := newTestHandler(mock)
 	req := makeToolRequest("signoz_list_views", map[string]any{
-		"sourcePage": "traces",
-		"limit":      "2",
-		"offset":     "2",
+		"source": "traces",
+		"limit":  "2",
+		"offset": "2",
 	})
 	result, err := h.handleListViews(testCtx(), req)
 	if err != nil {
@@ -443,14 +470,19 @@ func TestHandleCreateView_StripsServerPopulatedFields(t *testing.T) {
 	}
 	h := newTestHandler(mock)
 	req := makeToolRequest("signoz_create_view", map[string]any{
-		"id":             "019dade7-3edc-79f4-b885-f6fad49722f2",
-		"name":           "x",
-		"sourcePage":     "traces",
-		"compositeQuery": map[string]any{"queryType": "builder"},
-		"createdAt":      "2026-04-21T10:00:00Z",
-		"createdBy":      "user@example.com",
-		"updatedAt":      "2026-04-21T10:00:00Z",
-		"updatedBy":      "user@example.com",
+		"id":     "019dade7-3edc-79f4-b885-f6fad49722f2",
+		"name":   "x",
+		"source": "traces",
+		"spec": map[string]any{
+			"queries": []any{map[string]any{
+				"type": "builder_query",
+				"spec": map[string]any{"name": "A", "signal": "traces"},
+			}},
+		},
+		"createdAt": "2026-04-21T10:00:00Z",
+		"createdBy": "user@example.com",
+		"updatedAt": "2026-04-21T10:00:00Z",
+		"updatedBy": "user@example.com",
 	})
 	result, err := h.handleCreateView(testCtx(), req)
 	if err != nil {
@@ -481,14 +513,19 @@ func TestHandleUpdateView_StripsServerPopulatedFields(t *testing.T) {
 	req := makeToolRequest("signoz_update_view", map[string]any{
 		"viewId": "v1",
 		"view": map[string]any{
-			"id":             "v1",
-			"name":           "renamed",
-			"sourcePage":     "traces",
-			"compositeQuery": map[string]any{"queryType": "builder"},
-			"createdAt":      "2026-04-21T10:00:00Z",
-			"createdBy":      "user@example.com",
-			"updatedAt":      "2026-04-21T10:00:00Z",
-			"updatedBy":      "user@example.com",
+			"id":     "v1",
+			"name":   "renamed",
+			"source": "traces",
+			"spec": map[string]any{
+				"queries": []any{map[string]any{
+					"type": "builder_query",
+					"spec": map[string]any{"name": "A", "signal": "traces"},
+				}},
+			},
+			"createdAt": "2026-04-21T10:00:00Z",
+			"createdBy": "user@example.com",
+			"updatedAt": "2026-04-21T10:00:00Z",
+			"updatedBy": "user@example.com",
 		},
 	})
 	result, err := h.handleUpdateView(testCtx(), req)
@@ -507,15 +544,15 @@ func TestHandleUpdateView_StripsServerPopulatedFields(t *testing.T) {
 
 func TestHandleListViews_EmptyResult(t *testing.T) {
 	// Upstream returns `data: null` when there are zero views for a
-	// sourcePage. The handler must treat that as an empty list, not an
+	// source. The handler must treat that as an empty list, not an
 	// "invalid response format" error.
 	mock := &client.MockClient{
-		ListViewsFn: func(ctx context.Context, sourcePage, name, category string) (json.RawMessage, error) {
+		ListViewsFn: func(ctx context.Context, source, name string) (json.RawMessage, error) {
 			return json.RawMessage(`{"status":"success","data":null}`), nil
 		},
 	}
 	h := newTestHandler(mock)
-	req := makeToolRequest("signoz_list_views", map[string]any{"sourcePage": "metrics"})
+	req := makeToolRequest("signoz_list_views", map[string]any{"source": "metrics"})
 	result, err := h.handleListViews(testCtx(), req)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -534,12 +571,12 @@ func TestHandleListViews_EmptyResult(t *testing.T) {
 func TestHandleListViews_MissingDataField(t *testing.T) {
 	// Same fallback when upstream omits `data` entirely.
 	mock := &client.MockClient{
-		ListViewsFn: func(ctx context.Context, sourcePage, name, category string) (json.RawMessage, error) {
+		ListViewsFn: func(ctx context.Context, source, name string) (json.RawMessage, error) {
 			return json.RawMessage(`{"status":"success"}`), nil
 		},
 	}
 	h := newTestHandler(mock)
-	req := makeToolRequest("signoz_list_views", map[string]any{"sourcePage": "traces"})
+	req := makeToolRequest("signoz_list_views", map[string]any{"source": "traces"})
 	result, err := h.handleListViews(testCtx(), req)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -561,12 +598,12 @@ func TestHandleListViews_NonArrayDataIsEmpty(t *testing.T) {
 	for name, raw := range cases {
 		t.Run(name, func(t *testing.T) {
 			mock := &client.MockClient{
-				ListViewsFn: func(ctx context.Context, sourcePage, n, category string) (json.RawMessage, error) {
+				ListViewsFn: func(ctx context.Context, source, n string) (json.RawMessage, error) {
 					return json.RawMessage(raw), nil
 				},
 			}
 			h := newTestHandler(mock)
-			req := makeToolRequest("signoz_list_views", map[string]any{"sourcePage": "metrics"})
+			req := makeToolRequest("signoz_list_views", map[string]any{"source": "metrics"})
 			result, err := h.handleListViews(testCtx(), req)
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
@@ -582,16 +619,16 @@ func TestHandleListViews_NonArrayDataIsEmpty(t *testing.T) {
 	}
 }
 
-func TestHandleCreateView_RejectsSignalSourcePageMismatch(t *testing.T) {
-	// Documented rule: builder_query.spec.signal must equal sourcePage.
+func TestHandleCreateView_RejectsSignalSourceMismatch(t *testing.T) {
+	// Documented rule: builder_query.spec.signal must equal source.
 	// Upstream doesn't enforce this; a mismatch silently saves a broken view.
 	h := newTestHandler(&client.MockClient{})
 	req := makeToolRequest("signoz_create_view", map[string]any{
-		"name":       "bad",
-		"sourcePage": "logs",
-		"compositeQuery": map[string]any{
-			"queryType": "builder",
-			"panelType": "list",
+		"name":   "bad",
+		"source": "logs",
+		"spec": map[string]any{
+			"panelType":   "list",
+			"requestType": "raw",
 			"queries": []any{map[string]any{
 				"type": "builder_query",
 				"spec": map[string]any{"name": "A", "signal": "traces"},
@@ -600,11 +637,11 @@ func TestHandleCreateView_RejectsSignalSourcePageMismatch(t *testing.T) {
 	})
 	result, _ := h.handleCreateView(testCtx(), req)
 	if !result.IsError {
-		t.Fatalf("expected validation error for signal/sourcePage mismatch")
+		t.Fatalf("expected validation error for signal/source mismatch")
 	}
 	body := renderContent(result.Content)
-	if !strings.Contains(body, "signal") || !strings.Contains(body, "sourcePage") {
-		t.Errorf("error should mention signal and sourcePage; got: %s", body)
+	if !strings.Contains(body, "signal") || !strings.Contains(body, "source") {
+		t.Errorf("error should mention signal and source; got: %s", body)
 	}
 }
 
@@ -613,11 +650,11 @@ func TestHandleCreateView_RejectsEmptyBuilderSignal(t *testing.T) {
 	// signal silently saves an unusable view. Reject at the MCP boundary.
 	h := newTestHandler(&client.MockClient{})
 	req := makeToolRequest("signoz_create_view", map[string]any{
-		"name":       "missing-signal",
-		"sourcePage": "logs",
-		"compositeQuery": map[string]any{
-			"queryType": "builder",
-			"panelType": "list",
+		"name":   "missing-signal",
+		"source": "logs",
+		"spec": map[string]any{
+			"panelType":   "list",
+			"requestType": "raw",
 			"queries": []any{map[string]any{
 				"type": "builder_query",
 				"spec": map[string]any{"name": "A"},
@@ -639,16 +676,16 @@ func TestHandleCreateView_AllowsMatchingSignal(t *testing.T) {
 	mock := &client.MockClient{
 		CreateViewFn: func(ctx context.Context, body []byte) (json.RawMessage, error) {
 			called = true
-			return json.RawMessage(`{"status":"success","data":"ok"}`), nil
+			return json.RawMessage(`{"status":"success","data":{"id":"ok"}}`), nil
 		},
 	}
 	h := newTestHandler(mock)
 	req := makeToolRequest("signoz_create_view", map[string]any{
-		"name":       "ok",
-		"sourcePage": "traces",
-		"compositeQuery": map[string]any{
-			"queryType": "builder",
-			"panelType": "list",
+		"name":   "ok",
+		"source": "traces",
+		"spec": map[string]any{
+			"panelType":   "list",
+			"requestType": "raw",
 			"queries": []any{map[string]any{
 				"type": "builder_query",
 				"spec": map[string]any{"name": "A", "signal": "traces"},
@@ -676,11 +713,11 @@ func TestHandleCreateView_IgnoresSignalOnNonBuilderQuery(t *testing.T) {
 	}
 	h := newTestHandler(mock)
 	req := makeToolRequest("signoz_create_view", map[string]any{
-		"name":       "p",
-		"sourcePage": "metrics",
-		"compositeQuery": map[string]any{
-			"queryType": "promql",
-			"panelType": "graph",
+		"name":   "p",
+		"source": "metrics",
+		"spec": map[string]any{
+			"panelType":   "graph",
+			"requestType": "time_series",
 			"queries": []any{map[string]any{
 				"type": "promql_query",
 				"spec": map[string]any{"name": "A", "query": "rate(x[5m])"},
@@ -697,31 +734,31 @@ func TestHandleCreateView_IgnoresSignalOnNonBuilderQuery(t *testing.T) {
 }
 
 func TestHandleListViews_Meter(t *testing.T) {
-	// "meter" (Cost Meter Explorer) is a valid sourcePage and must be passed
+	// "meter" (Cost Meter Explorer) is a valid source and must be passed
 	// through to the client verbatim, not rejected as invalid.
-	var gotSourcePage string
+	var gotSource string
 	mock := &client.MockClient{
-		ListViewsFn: func(ctx context.Context, sourcePage, name, category string) (json.RawMessage, error) {
-			gotSourcePage = sourcePage
+		ListViewsFn: func(ctx context.Context, source, name string) (json.RawMessage, error) {
+			gotSource = source
 			return json.RawMessage(`{"status":"success","data":[]}`), nil
 		},
 	}
 	h := newTestHandler(mock)
-	req := makeToolRequest("signoz_list_views", map[string]any{"sourcePage": "meter"})
+	req := makeToolRequest("signoz_list_views", map[string]any{"source": "meter"})
 	result, err := h.handleListViews(testCtx(), req)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if result.IsError {
-		t.Fatalf("handler returned error for meter sourcePage: %v", result.Content)
+		t.Fatalf("handler returned error for meter source: %v", result.Content)
 	}
-	if gotSourcePage != "meter" {
-		t.Errorf("client called with sourcePage=%q, want meter", gotSourcePage)
+	if gotSource != "meter" {
+		t.Errorf("client called with source=%q, want meter", gotSource)
 	}
 }
 
 func TestHandleCreateView_AllowsMeterView(t *testing.T) {
-	// A Cost Meter view: sourcePage "meter", signal "metrics", source "meter".
+	// A Cost Meter view: source "meter", signal "metrics", spec.source "meter".
 	var gotBody []byte
 	mock := &client.MockClient{
 		CreateViewFn: func(ctx context.Context, body []byte) (json.RawMessage, error) {
@@ -731,11 +768,11 @@ func TestHandleCreateView_AllowsMeterView(t *testing.T) {
 	}
 	h := newTestHandler(mock)
 	req := makeToolRequest("signoz_create_view", map[string]any{
-		"name":       "log-ingestion",
-		"sourcePage": "meter",
-		"compositeQuery": map[string]any{
-			"queryType": "builder",
-			"panelType": "graph",
+		"name":   "log-ingestion",
+		"source": "meter",
+		"spec": map[string]any{
+			"panelType":   "graph",
+			"requestType": "time_series",
 			"queries": []any{map[string]any{
 				"type": "builder_query",
 				"spec": map[string]any{"name": "A", "signal": "metrics", "source": "meter"},
@@ -746,9 +783,9 @@ func TestHandleCreateView_AllowsMeterView(t *testing.T) {
 	if result.IsError {
 		t.Fatalf("expected meter view to be accepted; got: %v", result.Content)
 	}
-	if !strings.Contains(string(gotBody), `"sourcePage":"meter"`) ||
-		!strings.Contains(string(gotBody), `"source":"meter"`) {
-		t.Errorf("meter view body missing sourcePage/source: %s", gotBody)
+	if !strings.Contains(string(gotBody), `"source":"meter"`) ||
+		!strings.Contains(string(gotBody), `"signal":"metrics"`) {
+		t.Errorf("meter view body missing source/signal: %s", gotBody)
 	}
 }
 
@@ -757,11 +794,11 @@ func TestHandleCreateView_RejectsMeterWithoutSource(t *testing.T) {
 	// default metrics store. Reject it at the MCP boundary.
 	h := newTestHandler(&client.MockClient{})
 	req := makeToolRequest("signoz_create_view", map[string]any{
-		"name":       "bad-meter",
-		"sourcePage": "meter",
-		"compositeQuery": map[string]any{
-			"queryType": "builder",
-			"panelType": "graph",
+		"name":   "bad-meter",
+		"source": "meter",
+		"spec": map[string]any{
+			"panelType":   "graph",
+			"requestType": "time_series",
 			"queries": []any{map[string]any{
 				"type": "builder_query",
 				"spec": map[string]any{"name": "A", "signal": "metrics"},
@@ -782,11 +819,11 @@ func TestHandleCreateView_RejectsMeterWrongSignal(t *testing.T) {
 	// A "meter" view is queried as metrics; any other signal is invalid.
 	h := newTestHandler(&client.MockClient{})
 	req := makeToolRequest("signoz_create_view", map[string]any{
-		"name":       "bad-meter-signal",
-		"sourcePage": "meter",
-		"compositeQuery": map[string]any{
-			"queryType": "builder",
-			"panelType": "graph",
+		"name":   "bad-meter-signal",
+		"source": "meter",
+		"spec": map[string]any{
+			"panelType":   "graph",
+			"requestType": "time_series",
 			"queries": []any{map[string]any{
 				"type": "builder_query",
 				"spec": map[string]any{"name": "A", "signal": "logs", "source": "meter"},
@@ -805,14 +842,14 @@ func TestHandleCreateView_RejectsMeterWrongSignal(t *testing.T) {
 
 func TestHandleCreateView_RejectsSourceMeterOnMetricsPage(t *testing.T) {
 	// source="meter" belongs on the "meter" page, not mis-filed under
-	// "metrics" (this is the exact mis-filing the meter sourcePage fixes).
+	// "metrics" (this is the exact mis-filing the meter source fixes).
 	h := newTestHandler(&client.MockClient{})
 	req := makeToolRequest("signoz_create_view", map[string]any{
-		"name":       "misfiled-meter",
-		"sourcePage": "metrics",
-		"compositeQuery": map[string]any{
-			"queryType": "builder",
-			"panelType": "graph",
+		"name":   "misfiled-meter",
+		"source": "metrics",
+		"spec": map[string]any{
+			"panelType":   "graph",
+			"requestType": "time_series",
 			"queries": []any{map[string]any{
 				"type": "builder_query",
 				"spec": map[string]any{"name": "A", "signal": "metrics", "source": "meter"},
@@ -824,8 +861,8 @@ func TestHandleCreateView_RejectsSourceMeterOnMetricsPage(t *testing.T) {
 		t.Fatalf("expected rejection for source=meter on metrics page")
 	}
 	body := renderContent(result.Content)
-	if !strings.Contains(body, "meter") || !strings.Contains(body, "sourcePage") {
-		t.Errorf("error should point to sourcePage meter; got: %s", body)
+	if !strings.Contains(body, "meter") || !strings.Contains(body, "source") {
+		t.Errorf("error should point to source \"meter\"; got: %s", body)
 	}
 }
 
@@ -834,11 +871,11 @@ func TestHandleCreateView_RejectsSourceMeterOnTracesPage(t *testing.T) {
 	// on any non-meter page, including traces.
 	h := newTestHandler(&client.MockClient{})
 	req := makeToolRequest("signoz_create_view", map[string]any{
-		"name":       "misfiled-meter-traces",
-		"sourcePage": "traces",
-		"compositeQuery": map[string]any{
-			"queryType": "builder",
-			"panelType": "list",
+		"name":   "misfiled-meter-traces",
+		"source": "traces",
+		"spec": map[string]any{
+			"panelType":   "list",
+			"requestType": "raw",
 			"queries": []any{map[string]any{
 				"type": "builder_query",
 				"spec": map[string]any{"name": "A", "signal": "traces", "source": "meter"},
@@ -852,12 +889,12 @@ func TestHandleCreateView_RejectsSourceMeterOnTracesPage(t *testing.T) {
 }
 
 func TestHandleUpdateView_AllowsMeterView(t *testing.T) {
-	// Updating an existing meter view (sourcePage unchanged) must pass the
+	// Updating an existing meter view (source unchanged) must pass the
 	// meter validation branch and reach the client.
 	updateCalled := false
 	mock := &client.MockClient{
 		GetViewFn: func(ctx context.Context, id string) (json.RawMessage, error) {
-			return json.RawMessage(`{"status":"success","data":{"id":"m1","sourcePage":"meter"}}`), nil
+			return json.RawMessage(`{"status":"success","data":{"id":"m1","source":"meter"}}`), nil
 		},
 		UpdateViewFn: func(ctx context.Context, id string, body []byte) (json.RawMessage, error) {
 			updateCalled = true
@@ -868,11 +905,11 @@ func TestHandleUpdateView_AllowsMeterView(t *testing.T) {
 	req := makeToolRequest("signoz_update_view", map[string]any{
 		"viewId": "m1",
 		"view": map[string]any{
-			"name":       "renamed-meter",
-			"sourcePage": "meter",
-			"compositeQuery": map[string]any{
-				"queryType": "builder",
-				"panelType": "graph",
+			"name":   "renamed-meter",
+			"source": "meter",
+			"spec": map[string]any{
+				"panelType":   "graph",
+				"requestType": "time_series",
 				"queries": []any{map[string]any{
 					"type": "builder_query",
 					"spec": map[string]any{"name": "A", "signal": "metrics", "source": "meter"},
@@ -894,11 +931,11 @@ func TestHandleUpdateView_RejectsSignalMismatch(t *testing.T) {
 	req := makeToolRequest("signoz_update_view", map[string]any{
 		"viewId": "v1",
 		"view": map[string]any{
-			"name":       "x",
-			"sourcePage": "logs",
-			"compositeQuery": map[string]any{
-				"queryType": "builder",
-				"panelType": "list",
+			"name":   "x",
+			"source": "logs",
+			"spec": map[string]any{
+				"panelType":   "list",
+				"requestType": "raw",
 				"queries": []any{map[string]any{
 					"type": "builder_query",
 					"spec": map[string]any{"name": "A", "signal": "metrics"},
@@ -912,13 +949,13 @@ func TestHandleUpdateView_RejectsSignalMismatch(t *testing.T) {
 	}
 }
 
-func TestHandleUpdateView_RejectsSourcePageChange(t *testing.T) {
+func TestHandleUpdateView_RejectsSourceChange(t *testing.T) {
 	// Saved views are scoped to an Explorer. The handler must GET the
-	// existing view and reject a sourcePage that differs.
+	// existing view and reject a source that differs.
 	updateCalled := false
 	mock := &client.MockClient{
 		GetViewFn: func(ctx context.Context, id string) (json.RawMessage, error) {
-			return json.RawMessage(`{"status":"success","data":{"id":"v1","name":"old","sourcePage":"traces","compositeQuery":{"queryType":"builder"}}}`), nil
+			return json.RawMessage(`{"status":"success","data":{"id":"v1","name":"old","source":"traces","spec":{"queries":[]}}}`), nil
 		},
 		UpdateViewFn: func(ctx context.Context, id string, body []byte) (json.RawMessage, error) {
 			updateCalled = true
@@ -929,29 +966,34 @@ func TestHandleUpdateView_RejectsSourcePageChange(t *testing.T) {
 	req := makeToolRequest("signoz_update_view", map[string]any{
 		"viewId": "v1",
 		"view": map[string]any{
-			"name":           "renamed",
-			"sourcePage":     "logs",
-			"compositeQuery": map[string]any{"queryType": "builder"},
+			"name":   "renamed",
+			"source": "logs",
+			"spec": map[string]any{
+				"queries": []any{map[string]any{
+					"type": "builder_query",
+					"spec": map[string]any{"name": "A", "signal": "logs"},
+				}},
+			},
 		},
 	})
 	result, _ := h.handleUpdateView(testCtx(), req)
 	if !result.IsError {
-		t.Fatalf("expected sourcePage-change to be rejected")
+		t.Fatalf("expected source-change to be rejected")
 	}
 	if updateCalled {
-		t.Errorf("UpdateView must not be called when sourcePage is changing")
+		t.Errorf("UpdateView must not be called when source is changing")
 	}
 	body := renderContent(result.Content)
-	if !strings.Contains(body, "sourcePage") || !strings.Contains(body, "traces") || !strings.Contains(body, "logs") {
-		t.Errorf("error should name existing and new sourcePage; got: %s", body)
+	if !strings.Contains(body, "source") || !strings.Contains(body, "traces") || !strings.Contains(body, "logs") {
+		t.Errorf("error should name existing and new source; got: %s", body)
 	}
 }
 
-func TestHandleUpdateView_AllowsSameSourcePage(t *testing.T) {
+func TestHandleUpdateView_AllowsSameSource(t *testing.T) {
 	updateCalled := false
 	mock := &client.MockClient{
 		GetViewFn: func(ctx context.Context, id string) (json.RawMessage, error) {
-			return json.RawMessage(`{"status":"success","data":{"id":"v1","sourcePage":"logs"}}`), nil
+			return json.RawMessage(`{"status":"success","data":{"id":"v1","source":"logs"}}`), nil
 		},
 		UpdateViewFn: func(ctx context.Context, id string, body []byte) (json.RawMessage, error) {
 			updateCalled = true
@@ -962,9 +1004,14 @@ func TestHandleUpdateView_AllowsSameSourcePage(t *testing.T) {
 	req := makeToolRequest("signoz_update_view", map[string]any{
 		"viewId": "v1",
 		"view": map[string]any{
-			"name":           "renamed",
-			"sourcePage":     "logs",
-			"compositeQuery": map[string]any{"queryType": "builder"},
+			"name":   "renamed",
+			"source": "logs",
+			"spec": map[string]any{
+				"queries": []any{map[string]any{
+					"type": "builder_query",
+					"spec": map[string]any{"name": "A", "signal": "logs"},
+				}},
+			},
 		},
 	})
 	result, _ := h.handleUpdateView(testCtx(), req)
@@ -972,12 +1019,12 @@ func TestHandleUpdateView_AllowsSameSourcePage(t *testing.T) {
 		t.Fatalf("expected success; got: %v", result.Content)
 	}
 	if !updateCalled {
-		t.Fatalf("UpdateView should have been called when sourcePage matches")
+		t.Fatalf("UpdateView should have been called when source matches")
 	}
 }
 
 func TestHandleUpdateView_ProceedsWhenGetViewFails(t *testing.T) {
-	// If the sourcePage-lock pre-fetch fails (network blip, 404 after a
+	// If the source-lock pre-fetch fails (network blip, 404 after a
 	// concurrent delete), prefer to let the PUT attempt proceed rather than
 	// block on a diagnostic GET. Upstream will return its own error.
 	updateCalled := false
@@ -994,9 +1041,14 @@ func TestHandleUpdateView_ProceedsWhenGetViewFails(t *testing.T) {
 	req := makeToolRequest("signoz_update_view", map[string]any{
 		"viewId": "v1",
 		"view": map[string]any{
-			"name":           "x",
-			"sourcePage":     "traces",
-			"compositeQuery": map[string]any{"queryType": "builder"},
+			"name":   "x",
+			"source": "traces",
+			"spec": map[string]any{
+				"queries": []any{map[string]any{
+					"type": "builder_query",
+					"spec": map[string]any{"name": "A", "signal": "traces"},
+				}},
+			},
 		},
 	})
 	result, _ := h.handleUpdateView(testCtx(), req)

--- a/internal/mcp-server/testdata/wire-catalog/resources-content-inventory.json
+++ b/internal/mcp-server/testdata/wire-catalog/resources-content-inventory.json
@@ -267,8 +267,8 @@
         "kind": "text",
         "uri": "signoz://view/examples",
         "mimeType": "text/markdown",
-        "serializedLength": 6235,
-        "sha256": "1d38c7954588ed5189e8409cff9ce9e1968331d0b91097255998605a02aa0e32"
+        "serializedLength": 6218,
+        "sha256": "ca3535c71129d038d91b30f7f92e69a6afb378f94adb2bc68ad1423260215978"
       }
     ]
   },
@@ -280,8 +280,8 @@
         "kind": "text",
         "uri": "signoz://view/instructions",
         "mimeType": "text/markdown",
-        "serializedLength": 7291,
-        "sha256": "8380eedf79a364d5cfc927e438c29e2b4a805bb1e9dc97923bf5a87cd727fb1d"
+        "serializedLength": 7227,
+        "sha256": "dd795f86f12cb0b5389db98017eaa50ede52893919760b3d6c5afffa5190a1a6"
       }
     ]
   }

--- a/internal/mcp-server/testdata/wire-catalog/resources-content-inventory.json
+++ b/internal/mcp-server/testdata/wire-catalog/resources-content-inventory.json
@@ -267,8 +267,8 @@
         "kind": "text",
         "uri": "signoz://view/examples",
         "mimeType": "text/markdown",
-        "serializedLength": 6529,
-        "sha256": "7940d2099bad1404244cf780861feb5af66dfb9b065ac564a4c490d8c47e55c1"
+        "serializedLength": 6235,
+        "sha256": "1d38c7954588ed5189e8409cff9ce9e1968331d0b91097255998605a02aa0e32"
       }
     ]
   },
@@ -280,8 +280,8 @@
         "kind": "text",
         "uri": "signoz://view/instructions",
         "mimeType": "text/markdown",
-        "serializedLength": 6201,
-        "sha256": "7d8eb2d2ef9515e09eb94bf08943271b66055e02be736c75c74501ec7d4af881"
+        "serializedLength": 7291,
+        "sha256": "8380eedf79a364d5cfc927e438c29e2b4a805bb1e9dc97923bf5a87cd727fb1d"
       }
     ]
   }

--- a/internal/mcp-server/testdata/wire-catalog/resources-list.json
+++ b/internal/mcp-server/testdata/wire-catalog/resources-list.json
@@ -145,14 +145,14 @@
           "description": "Read this after signoz://view/instructions when composing a saved view. It provides complete typed spec payloads for traces, logs, metrics, and Cost Meter sources.",
           "mimeType": "text/markdown",
           "name": "Saved View Examples",
-          "size": 5550,
+          "size": 5533,
           "uri": "signoz://view/examples"
         },
         {
           "description": "Read this before creating or updating a saved view. It explains view fields, source, the typed spec (schemaVersion v2), Cost Meter views, and how to read a view before replacing it. It does not describe dashboards.",
           "mimeType": "text/markdown",
           "name": "Saved View Instructions",
-          "size": 6817,
+          "size": 6759,
           "uri": "signoz://view/instructions"
         },
         {

--- a/internal/mcp-server/testdata/wire-catalog/resources-list.json
+++ b/internal/mcp-server/testdata/wire-catalog/resources-list.json
@@ -142,17 +142,17 @@
           "uri": "signoz://dashboard/query-builder-example"
         },
         {
-          "description": "Read this after signoz://view/instructions when composing a saved Explorer view. It provides complete Query Builder v5 payloads for traces, logs, metrics, and Cost Meter source pages.",
+          "description": "Read this after signoz://view/instructions when composing a saved view. It provides complete typed spec payloads for traces, logs, metrics, and Cost Meter sources.",
           "mimeType": "text/markdown",
           "name": "Saved View Examples",
-          "size": 5737,
+          "size": 5550,
           "uri": "signoz://view/examples"
         },
         {
-          "description": "Read this before creating or updating a saved Explorer view. It explains view fields, sourcePage, Query Builder v5, Cost Meter views, and how to read a view before replacing it. It does not describe dashboards.",
+          "description": "Read this before creating or updating a saved view. It explains view fields, source, the typed spec (schemaVersion v2), Cost Meter views, and how to read a view before replacing it. It does not describe dashboards.",
           "mimeType": "text/markdown",
           "name": "Saved View Instructions",
-          "size": 5794,
+          "size": 6817,
           "uri": "signoz://view/instructions"
         },
         {

--- a/internal/mcp-server/testdata/wire-catalog/tools-list.json
+++ b/internal/mcp-server/testdata/wire-catalog/tools-list.json
@@ -3368,53 +3368,46 @@
             "openWorldHint": true,
             "readOnlyHint": false
           },
-          "description": "Use this when the user wants to save one reusable Explorer query for Logs, Traces, Metrics, or Cost Meter; use signoz_create_dashboard for a multi-widget dashboard. Before composing any payload, you must read both signoz://view/instructions and signoz://view/examples. Cost Meter views use sourcePage=\"meter\" while each builder spec uses signal=\"metrics\" and source=\"meter\". Do not send server-populated IDs or timestamps.",
+          "description": "Use this when the user wants to save one reusable query spec for Logs, Traces, Metrics, Cost Meter, or AI Observability; use signoz_create_dashboard for a multi-widget dashboard. Before composing any payload, you must read both signoz://view/instructions and signoz://view/examples. Cost Meter views use source=\"meter\" while each builder spec uses signal=\"metrics\" and source=\"meter\". Do not send server-populated IDs or timestamps.",
           "inputSchema": {
             "properties": {
-              "category": {
-                "description": "Optional free-form grouping label.",
-                "type": "string"
-              },
-              "compositeQuery": {
-                "additionalProperties": {},
-                "description": "The Query Builder payload as an object (not a string). Must contain queryType plus matching sub-query. See signoz://view/instructions and signoz://view/examples.",
-                "properties": {},
-                "type": "object"
-              },
-              "extraData": {
-                "description": "Optional UI-controlled options as a JSON-encoded string (safe to leave empty).",
-                "type": "string"
+              "generateName": {
+                "description": "When true, the server generates the view name from spec.displayName; name must be empty. Default: false.",
+                "type": "boolean"
               },
               "name": {
-                "description": "Display name of the view.",
+                "description": "Display name of the view. Required unless generateName is true.",
+                "type": "string"
+              },
+              "schemaVersion": {
+                "description": "Schema version of the view spec. Default: \"v2\".",
                 "type": "string"
               },
               "searchContext": {
                 "description": "Copy the user's entire original request verbatim, including any preflight or confirmation context; do not summarize, shorten, or omit clauses.",
                 "type": "string"
               },
-              "sourcePage": {
-                "description": "Which Explorer this view belongs to. One of: \"traces\", \"logs\", \"metrics\", \"meter\". Use \"meter\" for Cost Meter views (queried as metrics with source \"meter\").",
+              "source": {
+                "description": "Which Explorer this view belongs to. One of: \"traces\", \"logs\", \"metrics\", \"meter\", \"ai_observability\". Use \"meter\" for Cost Meter views (queried as metrics with source \"meter\").",
                 "enum": [
                   "traces",
                   "logs",
                   "metrics",
-                  "meter"
+                  "meter",
+                  "ai_observability"
                 ],
                 "type": "string"
               },
-              "tags": {
-                "description": "Optional free-form tags.",
-                "items": {
-                  "type": "string"
-                },
-                "type": "array"
+              "spec": {
+                "additionalProperties": {},
+                "description": "The saved-view spec object: displayName, panelType, requestType, queries, selectedFields, and display. See signoz://view/instructions and signoz://view/examples.",
+                "properties": {},
+                "type": "object"
               }
             },
             "required": [
-              "name",
-              "sourcePage",
-              "compositeQuery"
+              "source",
+              "spec"
             ],
             "type": "object"
           },
@@ -3501,7 +3494,7 @@
             "openWorldHint": true,
             "readOnlyHint": false
           },
-          "description": "Use this when the user has confirmed they want to permanently delete one saved Explorer view. The deletion is irreversible. Use signoz_list_views to discover the UUID when needed; do not use this for dashboards; delete those with signoz_delete_dashboard.",
+          "description": "Use this when the user has confirmed they want to permanently delete one saved view. The deletion is irreversible. Use signoz_list_views to discover the UUID when needed; do not use this for dashboards; delete those with signoz_delete_dashboard.",
           "inputSchema": {
             "properties": {
               "id": {
@@ -4827,7 +4820,7 @@
             "openWorldHint": true,
             "readOnlyHint": true
           },
-          "description": "Use this when the user wants the complete definition of one known saved Explorer view. Use signoz_list_views first when its UUID is unknown. The returned data object is the required base for signoz_update_view because updates fully replace a view. Do not use this for multi-widget dashboards; use signoz_get_dashboard.",
+          "description": "Use this when the user wants the complete definition of one known saved view. Use signoz_list_views first when its UUID is unknown. The returned data object is the required base for signoz_update_view because updates fully replace a view. Do not use this for multi-widget dashboards; use signoz_get_dashboard.",
           "inputSchema": {
             "properties": {
               "id": {
@@ -5377,13 +5370,9 @@
             "openWorldHint": true,
             "readOnlyHint": true
           },
-          "description": "Use this when the user wants to discover saved Explorer views or find a view UUID for one Logs, Traces, Metrics, or Cost Meter page. A view stores an Explorer query; it is not a multi-widget dashboard. Apply name/category filters before pagination, and follow pagination.nextOffset while pagination.hasMore is true before concluding a view is absent. Use signoz_get_view for one full definition.",
+          "description": "Use this when the user wants to discover saved views or find a view UUID for the Logs, Traces, Metrics, Cost Meter, or AI Observability explorer pages. A view stores one query spec; it is not a multi-widget dashboard. Apply name filters before pagination, and follow pagination.nextOffset while pagination.hasMore is true before concluding a view is absent. Use signoz_get_view for one full definition.",
           "inputSchema": {
             "properties": {
-              "category": {
-                "description": "Partial, server-side match on the saved-view category. Omit to include every category.",
-                "type": "string"
-              },
               "limit": {
                 "default": "50",
                 "description": "Maximum number of views to return per page. Default: 50, max: 1000 (higher values are clamped).",
@@ -5408,19 +5397,20 @@
                 "description": "Copy the user's entire original request verbatim, including any preflight or confirmation context; do not summarize, shorten, or omit clauses.",
                 "type": "string"
               },
-              "sourcePage": {
-                "description": "Explorer whose views to list: \"traces\", \"logs\", \"metrics\", or \"meter\". Use \"meter\" for Cost Meter, not \"metrics\".",
+              "source": {
+                "description": "Explorer whose views to list: \"traces\", \"logs\", \"metrics\", \"meter\", or \"ai_observability\". Use \"meter\" for Cost Meter, not \"metrics\".",
                 "enum": [
                   "traces",
                   "logs",
                   "metrics",
-                  "meter"
+                  "meter",
+                  "ai_observability"
                 ],
                 "type": "string"
               }
             },
             "required": [
-              "sourcePage"
+              "source"
             ],
             "type": "object"
           },
@@ -8928,7 +8918,7 @@
             "openWorldHint": true,
             "readOnlyHint": false
           },
-          "description": "Use this when the user wants to change an existing saved Explorer view. This is a full replacement: call signoz_get_view first, modify its data object, preserve every unrequested field, and pass that full object as view. Read signoz://view/instructions and signoz://view/examples when changing sourcePage or compositeQuery; skip them for name-, category-, or tags-only changes when you already have the complete fetched view. Keep the UUID only in id; omit server-populated IDs and timestamps from view.",
+          "description": "Use this when the user wants to change an existing saved view. This is a full replacement: call signoz_get_view first, modify its data object, preserve every unrequested field, and pass that full object as view. Upstream keeps name immutable on update; the display name lives in spec.displayName. Read signoz://view/instructions and signoz://view/examples when changing source or spec. Keep the UUID only in id; omit server-populated IDs and timestamps from view.",
           "inputSchema": {
             "properties": {
               "id": {
@@ -8943,45 +8933,30 @@
                 "additionalProperties": {},
                 "description": "Complete saved view after the requested changes. Start with the data returned by signoz_get_view and pass the full object here.",
                 "properties": {
-                  "category": {
-                    "description": "Optional free-form grouping label.",
+                  "schemaVersion": {
+                    "description": "Schema version of the view spec. Default: \"v2\".",
                     "type": "string"
                   },
-                  "compositeQuery": {
-                    "additionalProperties": {},
-                    "description": "The Query Builder payload as an object (not a string). Must contain queryType plus matching sub-query. See signoz://view/instructions and signoz://view/examples.",
-                    "type": "object"
-                  },
-                  "extraData": {
-                    "description": "Optional UI-controlled options as a JSON-encoded string (safe to leave empty).",
-                    "type": "string"
-                  },
-                  "name": {
-                    "description": "Display name of the view.",
-                    "type": "string"
-                  },
-                  "sourcePage": {
-                    "description": "Which Explorer this view belongs to. One of: \"traces\", \"logs\", \"metrics\", \"meter\". Use \"meter\" for Cost Meter views (queried as metrics with source \"meter\").",
+                  "source": {
+                    "description": "Which Explorer this view belongs to. One of: \"traces\", \"logs\", \"metrics\", \"meter\", \"ai_observability\". Use \"meter\" for Cost Meter views (queried as metrics with source \"meter\").",
                     "enum": [
                       "traces",
                       "logs",
                       "metrics",
-                      "meter"
+                      "meter",
+                      "ai_observability"
                     ],
                     "type": "string"
                   },
-                  "tags": {
-                    "description": "Optional free-form tags.",
-                    "items": {
-                      "type": "string"
-                    },
-                    "type": "array"
+                  "spec": {
+                    "additionalProperties": {},
+                    "description": "The saved-view spec object: displayName, panelType, requestType, queries, selectedFields, and display. See signoz://view/instructions and signoz://view/examples.",
+                    "type": "object"
                   }
                 },
                 "required": [
-                  "name",
-                  "sourcePage",
-                  "compositeQuery"
+                  "source",
+                  "spec"
                 ],
                 "type": "object"
               }

--- a/internal/mcp-server/testdata/wire-catalog/tools-list.json
+++ b/internal/mcp-server/testdata/wire-catalog/tools-list.json
@@ -3368,7 +3368,7 @@
             "openWorldHint": true,
             "readOnlyHint": false
           },
-          "description": "Use this when the user wants to save one reusable query spec for Logs, Traces, Metrics, Cost Meter, or AI Observability; use signoz_create_dashboard for a multi-widget dashboard. Before composing any payload, you must read both signoz://view/instructions and signoz://view/examples. Cost Meter views use source=\"meter\" while each builder spec uses signal=\"metrics\" and source=\"meter\". Do not send server-populated IDs or timestamps.",
+          "description": "Use this when the user wants to save one reusable query spec for Logs, Traces, Metrics, or Cost Meter; use signoz_create_dashboard for a multi-widget dashboard. Before composing any payload, you must read both signoz://view/instructions and signoz://view/examples. Cost Meter views use source=\"meter\" while each builder spec uses signal=\"metrics\" and source=\"meter\". Do not send server-populated IDs or timestamps.",
           "inputSchema": {
             "properties": {
               "generateName": {
@@ -3376,11 +3376,7 @@
                 "type": "boolean"
               },
               "name": {
-                "description": "Display name of the view. Required unless generateName is true.",
-                "type": "string"
-              },
-              "schemaVersion": {
-                "description": "Schema version of the view spec. Default: \"v2\".",
+                "description": "The view's machine name, a DNS-1123 label (lowercase letters, digits, hyphens). The human-facing display name lives in spec.displayName. Required unless generateName is true.",
                 "type": "string"
               },
               "searchContext": {
@@ -3388,13 +3384,12 @@
                 "type": "string"
               },
               "source": {
-                "description": "Which Explorer this view belongs to. One of: \"traces\", \"logs\", \"metrics\", \"meter\", \"ai_observability\". Use \"meter\" for Cost Meter views (queried as metrics with source \"meter\").",
+                "description": "Which Explorer this view belongs to. One of: \"traces\", \"logs\", \"metrics\", \"meter\". Use \"meter\" for Cost Meter views (queried as metrics with source \"meter\").",
                 "enum": [
                   "traces",
                   "logs",
                   "metrics",
-                  "meter",
-                  "ai_observability"
+                  "meter"
                 ],
                 "type": "string"
               },
@@ -5370,7 +5365,7 @@
             "openWorldHint": true,
             "readOnlyHint": true
           },
-          "description": "Use this when the user wants to discover saved views or find a view UUID for the Logs, Traces, Metrics, Cost Meter, or AI Observability explorer pages. A view stores one query spec; it is not a multi-widget dashboard. Apply name filters before pagination, and follow pagination.nextOffset while pagination.hasMore is true before concluding a view is absent. Use signoz_get_view for one full definition.",
+          "description": "Use this when the user wants to discover saved views or find a view UUID for the Logs, Traces, Metrics, or Cost Meter explorer pages. A view stores one query spec; it is not a multi-widget dashboard. Apply name filters before pagination, and follow pagination.nextOffset while pagination.hasMore is true before concluding a view is absent. Use signoz_get_view for one full definition.",
           "inputSchema": {
             "properties": {
               "limit": {
@@ -5398,13 +5393,12 @@
                 "type": "string"
               },
               "source": {
-                "description": "Explorer whose views to list: \"traces\", \"logs\", \"metrics\", \"meter\", or \"ai_observability\". Use \"meter\" for Cost Meter, not \"metrics\".",
+                "description": "Explorer whose views to list: \"traces\", \"logs\", \"metrics\", or \"meter\". Use \"meter\" for Cost Meter, not \"metrics\".",
                 "enum": [
                   "traces",
                   "logs",
                   "metrics",
-                  "meter",
-                  "ai_observability"
+                  "meter"
                 ],
                 "type": "string"
               }
@@ -8933,18 +8927,13 @@
                 "additionalProperties": {},
                 "description": "Complete saved view after the requested changes. Start with the data returned by signoz_get_view and pass the full object here.",
                 "properties": {
-                  "schemaVersion": {
-                    "description": "Schema version of the view spec. Default: \"v2\".",
-                    "type": "string"
-                  },
                   "source": {
-                    "description": "Which Explorer this view belongs to. One of: \"traces\", \"logs\", \"metrics\", \"meter\", \"ai_observability\". Use \"meter\" for Cost Meter views (queried as metrics with source \"meter\").",
+                    "description": "Which Explorer this view belongs to. One of: \"traces\", \"logs\", \"metrics\", \"meter\". Use \"meter\" for Cost Meter views (queried as metrics with source \"meter\").",
                     "enum": [
                       "traces",
                       "logs",
                       "metrics",
-                      "meter",
-                      "ai_observability"
+                      "meter"
                     ],
                     "type": "string"
                   },

--- a/manifest.json
+++ b/manifest.json
@@ -127,7 +127,7 @@
     },
     {
       "name": "signoz_list_views",
-      "description": "List paginated saved Explorer views for traces, logs, metrics, or Cost Meter, with optional name/category filters"
+      "description": "List paginated saved Explorer views for traces, logs, metrics, Cost Meter, or AI Observability, with an optional name filter"
     },
     {
       "name": "signoz_get_view",
@@ -143,11 +143,11 @@
     },
     {
       "name": "signoz_create_view",
-      "description": "Save one reusable Explorer query after reading both view authoring resources; use signoz_create_dashboard for a multi-widget dashboard"
+      "description": "Save one reusable Explorer query spec after reading both view authoring resources; use signoz_create_dashboard for a multi-widget dashboard"
     },
     {
       "name": "signoz_update_view",
-      "description": "Fully replace a fetched saved view while preserving other fields; read its guides when changing sourcePage or compositeQuery, not for name/category/tags-only changes"
+      "description": "Fully replace a fetched saved view while preserving other fields; read its guides when changing source or the typed spec"
     },
     {
       "name": "signoz_delete_view",
@@ -322,13 +322,13 @@
     {
       "uri": "signoz://view/examples",
       "name": "Saved View Examples",
-      "description": "Read this after signoz://view/instructions when composing a saved Explorer view. It provides complete Query Builder v5 payloads for traces, logs, metrics, and Cost Meter source pages.",
+      "description": "Read this after signoz://view/instructions when composing a saved view. It provides complete typed spec payloads for traces, logs, metrics, and Cost Meter sources.",
       "mimeType": "text/markdown"
     },
     {
       "uri": "signoz://view/instructions",
       "name": "Saved View Instructions",
-      "description": "Read this before creating or updating a saved Explorer view. It explains view fields, sourcePage, Query Builder v5, Cost Meter views, and how to read a view before replacing it. It does not describe dashboards.",
+      "description": "Read this before creating or updating a saved view. It explains view fields, source, the typed spec (schemaVersion v2), Cost Meter views, and how to read a view before replacing it. It does not describe dashboards.",
       "mimeType": "text/markdown"
     }
   ],

--- a/manifest.json
+++ b/manifest.json
@@ -127,7 +127,7 @@
     },
     {
       "name": "signoz_list_views",
-      "description": "List paginated saved Explorer views for traces, logs, metrics, Cost Meter, or AI Observability, with an optional name filter"
+      "description": "List paginated saved Explorer views for traces, logs, metrics, or Cost Meter, with an optional name filter"
     },
     {
       "name": "signoz_get_view",

--- a/pkg/views/examples.go
+++ b/pkg/views/examples.go
@@ -151,7 +151,7 @@ is queried as metrics: every builder spec sets "signal":"metrics" AND
   let the server generate one from spec.displayName, send
   "generateName": true with an empty name.
 - The signal inside each builder_query spec MUST match the view's source for
-  traces/logs/metrics/ai_observability. A Cost Meter view is source "meter"
+  traces/logs/metrics. A Cost Meter view is source "meter"
   with signal "metrics" + builder spec source "meter" (see Example 4).
 - spec.displayName is the visible label; it can differ from name.
 - spec.selectedFields is the Explorer column choice. Use [] when the view

--- a/pkg/views/examples.go
+++ b/pkg/views/examples.go
@@ -1,26 +1,27 @@
 package views
 
 // Examples is the body of signoz://view/examples. Complete SavedView
-// payloads covering each sourcePage (traces, logs, metrics, meter) that can
-// be sent directly to signoz_create_view. All use Query Builder v5 shape
-// ({queryType, panelType, queries[{type, spec}]}).
-const Examples = `# Saved View Examples (Query Builder v5 shape)
+// payloads covering traces, logs, metrics, and Cost Meter sources that can
+// be sent directly to signoz_create_view. All use the v2 typed spec shape
+// ({name, source, schemaVersion, spec{...}}).
+const Examples = `# Saved View Examples (v2 typed spec)
 
-The traces, logs, and metrics payloads below were round-tripped against a live
-SigNoz instance and work verbatim with signoz_create_view. The Cost Meter
-(meter) payload follows the same encoding the SigNoz product persists for
-Meter Explorer views (sourcePage "meter" + signal "metrics" + source "meter").
+The traces, logs, and metrics payloads below match the v2 SavedView shape
+the SigNoz server persists and work verbatim with signoz_create_view. The
+Cost Meter payload follows the same encoding the SigNoz product persists
+for Meter Explorer views (source "meter" + signal "metrics" + builder
+spec source "meter").
 
-## Example 1 — Traces list view (panelType: list)
+## Example 1 — Traces list view
 
     {
       "name": "slow-checkout-traces",
-      "category": "latency",
-      "sourcePage": "traces",
-      "tags": ["team:checkout"],
-      "compositeQuery": {
-        "queryType": "builder",
+      "source": "traces",
+      "schemaVersion": "v2",
+      "spec": {
+        "displayName": "Slow checkout traces",
         "panelType": "list",
+        "requestType": "raw",
         "queries": [{
           "type": "builder_query",
           "spec": {
@@ -33,46 +34,25 @@ Meter Explorer views (sourcePage "meter" + signal "metrics" + source "meter").
             "filter": { "expression": "service.name = 'checkoutservice' AND duration_nano > 500000000" },
             "having": { "expression": "" }
           }
-        }]
-      },
-      "extraData": "{\"selectColumns\":[{\"name\":\"service.name\",\"signal\":\"traces\"},{\"name\":\"name\",\"signal\":\"traces\"},{\"name\":\"duration_nano\",\"signal\":\"traces\"}]}"
+        }],
+        "selectedFields": [
+          {"name": "service.name", "signal": "traces", "fieldContext": "resource", "fieldDataType": "string"},
+          {"name": "name", "signal": "traces", "fieldContext": "span", "fieldDataType": "string"},
+          {"name": "duration_nano", "signal": "traces", "fieldContext": "span", "fieldDataType": "float64"}
+        ]
+      }
     }
 
-## Example 1b — Error traces view (panelType: list)
-
-    {
-      "name": "Error Traces",
-      "category": "errors",
-      "sourcePage": "traces",
-      "tags": ["debugging", "errors"],
-      "compositeQuery": {
-        "queryType": "builder",
-        "panelType": "list",
-        "queries": [{
-          "type": "builder_query",
-          "spec": {
-            "name": "A",
-            "signal": "traces",
-            "source": "",
-            "stepInterval": 0,
-            "limit": 100,
-            "order": [{"key":{"name":"timestamp"},"direction":"desc"}],
-            "filter": { "expression": "has_error = true" },
-            "having": { "expression": "" }
-          }
-        }]
-      },
-      "extraData": "{\"selectColumns\":[{\"name\":\"service.name\",\"signal\":\"traces\"},{\"name\":\"name\",\"signal\":\"traces\"},{\"name\":\"duration_nano\",\"signal\":\"traces\"},{\"name\":\"status_code\",\"signal\":\"traces\"}]}"
-    }
-
-## Example 2 — Logs search view (panelType: list)
+## Example 2 — Logs search view
 
     {
       "name": "payment-errors",
-      "sourcePage": "logs",
-      "compositeQuery": {
-        "queryType": "builder",
+      "source": "logs",
+      "schemaVersion": "v2",
+      "spec": {
+        "displayName": "Payment errors",
         "panelType": "list",
+        "requestType": "raw",
         "queries": [{
           "type": "builder_query",
           "spec": {
@@ -88,18 +68,24 @@ Meter Explorer views (sourcePage "meter" + signal "metrics" + source "meter").
             "filter": { "expression": "service.name = 'paymentservice' AND severity_text = 'ERROR'" },
             "having": { "expression": "" }
           }
-        }]
+        }],
+        "selectedFields": [
+          {"name": "service.name", "signal": "logs", "fieldContext": "resource", "fieldDataType": "string"},
+          {"name": "severity_text", "signal": "logs", "fieldContext": "log", "fieldDataType": "string"}
+        ]
       }
     }
 
-## Example 3 — Metrics time-series view (panelType: graph)
+## Example 3 — Metrics time-series view
 
     {
       "name": "http-request-rate",
-      "sourcePage": "metrics",
-      "compositeQuery": {
-        "queryType": "builder",
+      "source": "metrics",
+      "schemaVersion": "v2",
+      "spec": {
+        "displayName": "HTTP request rate",
         "panelType": "graph",
+        "requestType": "time_series",
         "queries": [{
           "type": "builder_query",
           "spec": {
@@ -117,25 +103,26 @@ Meter Explorer views (sourcePage "meter" + signal "metrics" + source "meter").
               "spaceAggregation": "sum"
             }]
           }
-        }]
+        }],
+        "selectedFields": []
       }
     }
 
-## Example 4 — Cost Meter usage view (sourcePage: meter, panelType: graph)
+## Example 4 — Cost Meter usage view (source "meter")
 
-A Cost Meter view lives on its own Explorer page (` + "`sourcePage:\"meter\"`" + `) but
-is queried as metrics: every builder spec sets ` + "`signal:\"metrics\"`" + ` AND
-` + "`source:\"meter\"`" + `. The backend rolls Cost Meter data up hourly, so use
-` + "`stepInterval: 3600`" + `.
+A Cost Meter view lives on its own Explorer page ("source":"meter") but
+is queried as metrics: every builder spec sets "signal":"metrics" AND
+"source":"meter". The backend rolls Cost Meter data up hourly, so use
+"stepInterval": 3600.
 
     {
       "name": "log-ingestion-volume",
-      "category": "cost",
-      "sourcePage": "meter",
-      "tags": ["cost-meter", "billing"],
-      "compositeQuery": {
-        "queryType": "builder",
+      "source": "meter",
+      "schemaVersion": "v2",
+      "spec": {
+        "displayName": "Log ingestion volume",
         "panelType": "graph",
+        "requestType": "time_series",
         "queries": [{
           "type": "builder_query",
           "spec": {
@@ -153,21 +140,27 @@ is queried as metrics: every builder spec sets ` + "`signal:\"metrics\"`" + ` AN
               "spaceAggregation": "sum"
             }]
           }
-        }]
+        }],
+        "selectedFields": []
       }
     }
 
 ## Notes
 
-- Explorer saved views are **builder-query only**. Set "queryType" to "builder"
-  and use "builder_query" entries in "queries". PromQL / raw ClickHouse query
-  types are not supported for Explorer saved views.
-- "signal" inside each spec MUST match the view's sourcePage for
-  traces/logs/metrics. A **Cost Meter** view is sourcePage "meter" with
-  signal "metrics" + source "meter" (see Example 4).
-- stepInterval is 0 for list panels, typically 60 for minute-resolution graphs,
-  and 3600 for Cost Meter (meter) views, which the backend aggregates hourly.
-- Every builder query carries a limit and the v5 ` + "`order`" + ` field.
+- name must be a DNS-1123 label (lowercase letters, digits, hyphens). To
+  let the server generate one from spec.displayName, send
+  "generateName": true with an empty name.
+- The signal inside each builder_query spec MUST match the view's source for
+  traces/logs/metrics/ai_observability. A Cost Meter view is source "meter"
+  with signal "metrics" + builder spec source "meter" (see Example 4).
+- spec.displayName is the visible label; it can differ from name.
+- spec.selectedFields is the Explorer column choice. Use [] when the view
+  has no column preference (e.g. graphs); each entry needs name plus
+  signal/fieldContext/fieldDataType.
+- stepInterval is 0 for list panels, typically 60 for minute-resolution
+  graphs, and 3600 for Cost Meter views, which the backend aggregates
+  hourly.
+- Every builder query carries a limit and the v5 order field.
   The 100-group limit on a graph ranks groups over the whole selected window;
   a short-lived local spike may be outside the returned top N.
 `

--- a/pkg/views/instructions.go
+++ b/pkg/views/instructions.go
@@ -19,7 +19,7 @@ meter / Cost Meter, and AI Observability explorers). The tools call the
 | id              | string (UUID)     | No (server-assigned) | Path param on get/update/delete. Do not send on create/update |
 | name            | string            | Yes, unless generateName is true | DNS-1123 label (lowercase letters, digits, hyphens). Immutable after create; the display label lives in spec.displayName |
 | generateName    | bool              | No                  | When true, the server generates name from spec.displayName and name must be empty. Default: false |
-| source          | string            | Yes                 | One of: "traces", "logs", "metrics", "meter", "ai_observability". "meter" is the Cost Meter Explorer (a distinct page) |
+| source          | string            | Yes                 | One of: "traces", "logs", "metrics", "meter". "meter" is the Cost Meter Explorer (a distinct page) |
 | schemaVersion   | string            | No                  | Always "v2"; the MCP server fills it in when omitted |
 | spec            | object            | Yes                 | Typed view content (see below) |
 | createdAt / createdBy, updatedAt / updatedBy | — | Server-populated | Do not send |
@@ -51,7 +51,7 @@ allowed but skipped by the signal check.
 | Field        | Type     | Notes |
 |--------------|----------|-------|
 | name         | string   | Reference name, e.g. "A" |
-| signal       | string   | Required. MUST match source for "traces"/"logs"/"metrics"/"ai_observability". For a "meter" view, signal MUST be "metrics" |
+| signal       | string   | Required. MUST match source for "traces"/"logs"/"metrics". For a "meter" view, signal MUST be "metrics" |
 | source       | string   | Usually "". For a "meter" view it MUST be "meter". Do NOT set "meter" on a "metrics" (or other) source view; Cost Meter views belong on source "meter" |
 | stepInterval | integer  | Seconds per bucket. 0 for list panels, e.g. 60 for graphs |
 | filter       | object   | { "expression": "SigNoz filter expression" } |
@@ -62,7 +62,7 @@ allowed but skipped by the signal check.
 
 ## Rules
 
-- **signal must equal source** for "traces"/"logs"/"metrics"/"ai_observability".
+- **signal must equal source** for "traces"/"logs"/"metrics".
   A "source":"traces" view must use "signal":"traces" in every
   builder_query spec.
 - **Cost Meter views are special.** A Cost Meter view is "source":"meter"

--- a/pkg/views/instructions.go
+++ b/pkg/views/instructions.go
@@ -5,57 +5,54 @@
 package views
 
 // Instructions is the body of signoz://view/instructions.
-const Instructions = `# SigNoz Saved View Schema
+const Instructions = `# SigNoz Saved View Schema (v2 typed spec)
 
 A saved view is a reusable snapshot of an Explorer query. It maps 1:1
-to the "Saved Views" feature in the SigNoz UI (traces-explorer,
-logs-explorer, metrics-explorer, meter-explorer / Cost Meter).
+to the "Saved Views" feature in the SigNoz UI (traces, logs, metrics,
+meter / Cost Meter, and AI Observability explorers). The tools call the
+/api/v2/saved_views endpoints; schemaVersion is "v2".
 
 ## SavedView fields
 
 | Field           | Type              | Required on create? | Notes |
 |-----------------|-------------------|---------------------|-------|
-| id              | string (UUID)     | No (server-assigned) | Path param on get/update/delete. Do not send on create/update. |
-| name            | string            | Yes                 | Display name |
-| category        | string            | No                  | Free-form grouping label |
-| sourcePage      | string            | Yes                 | One of: "traces", "logs", "metrics", "meter". "meter" is the Cost Meter Explorer (a distinct page) |
-| tags            | string[]          | No                  | Free-form tags |
-| compositeQuery  | object            | Yes                 | Query Builder v5 (see below) |
-| extraData       | string            | No                  | UI-controlled options (JSON string). Safe to leave "" |
-| createdAt / by, updatedAt / by | — | Server-populated | Do not send |
+| id              | string (UUID)     | No (server-assigned) | Path param on get/update/delete. Do not send on create/update |
+| name            | string            | Yes, unless generateName is true | DNS-1123 label (lowercase letters, digits, hyphens). Immutable after create; the display label lives in spec.displayName |
+| generateName    | bool              | No                  | When true, the server generates name from spec.displayName and name must be empty. Default: false |
+| source          | string            | Yes                 | One of: "traces", "logs", "metrics", "meter", "ai_observability". "meter" is the Cost Meter Explorer (a distinct page) |
+| schemaVersion   | string            | No                  | Always "v2"; the MCP server fills it in when omitted |
+| spec            | object            | Yes                 | Typed view content (see below) |
+| createdAt / createdBy, updatedAt / updatedBy | — | Server-populated | Do not send |
 
-## compositeQuery (Query Builder v5 shape)
+## spec fields
 
-Explorer saved views are **builder-query only**. CompositeQuery at the top
-level has exactly three fields:
+| Field          | Type   | Required | Notes |
+|----------------|--------|----------|-------|
+| displayName    | string | Yes      | Human label shown in the Explorer view list |
+| panelType      | string | Yes      | One of: "value", "graph", "table", "list", "trace" |
+| requestType    | string | Yes      | One of: "raw", "trace", "time_series", "scalar" (Query Builder v5) |
+| queries        | array  | Yes      | At least one query envelope (see below) |
+| selectedFields | array  | No       | Explorer column selection; each entry needs a name, plus signal/fieldContext/fieldDataType |
+| display        | object | No       | Rendering preferences: { maxLines, fontSize, format, color } |
 
-    {
-      "queryType": "builder",
-      "panelType": "list" | "graph" | "table" | "value",
-      "queries":   [ { "type": "builder_query", "spec": { ... } }, ... ]
-    }
+## spec.queries[] entries
 
-PromQL and raw ClickHouse query types (queryType "promql" / "clickhouse_sql",
-entries with type "promql_query" / "clickhouse_query") are **not supported**
-for Explorer saved views; use them in dashboards instead.
-
-**Do not send** legacy v3/v4 fields like ` + "`builder`" + `,
-` + "`promql`" + `, ` + "`clickhouse_sql`" + ` (as sub-objects at the top level),
-` + "`unit`" + `, ` + "`id`" + `, ` + "`queryFormulas`" + `, or ` + "`queryTraceOperator`" + `.
-The server rejects them with HTTP 400 "failed to validate request body".
-
-### Each entry in queries[]
+Each entry is a Query Builder v5 envelope with type plus spec:
 
     { "type": "builder_query",
       "spec": { ...builder_query fields... } }
+
+Only builder_query envelopes carry signal/source, and only they fall
+under the rules below. promql_query and clickhouse_query envelopes are
+allowed but skipped by the signal check.
 
 ### builder_query spec fields
 
 | Field        | Type     | Notes |
 |--------------|----------|-------|
 | name         | string   | Reference name, e.g. "A" |
-| signal       | string   | Required. MUST match sourcePage for "traces"/"logs"/"metrics". For a "meter" view, signal MUST be "metrics" |
-| source       | string   | Usually "". For a "meter" view it MUST be "meter". Do NOT set "meter" on a "metrics" (or other) sourcePage; Cost Meter views belong on sourcePage "meter" |
+| signal       | string   | Required. MUST match source for "traces"/"logs"/"metrics"/"ai_observability". For a "meter" view, signal MUST be "metrics" |
+| source       | string   | Usually "". For a "meter" view it MUST be "meter". Do NOT set "meter" on a "metrics" (or other) source view; Cost Meter views belong on source "meter" |
 | stepInterval | integer  | Seconds per bucket. 0 for list panels, e.g. 60 for graphs |
 | filter       | object   | { "expression": "SigNoz filter expression" } |
 | having       | object   | { "expression": "" } unless aggregating |
@@ -65,22 +62,25 @@ The server rejects them with HTTP 400 "failed to validate request body".
 
 ## Rules
 
-- **signal must equal sourcePage** for "traces"/"logs"/"metrics". A
-  ` + "`sourcePage:\"traces\"`" + ` view must use ` + "`\"signal\":\"traces\"`" + ` in every
+- **signal must equal source** for "traces"/"logs"/"metrics"/"ai_observability".
+  A "source":"traces" view must use "signal":"traces" in every
   builder_query spec.
-- **Cost Meter views are special.** A Cost Meter view is
-  ` + "`sourcePage:\"meter\"`" + ` (its own Explorer page) but is queried as metrics:
-  every builder_query spec must set ` + "`\"signal\":\"metrics\"`" + ` AND
-  ` + "`\"source\":\"meter\"`" + `. Do not file a Cost Meter view under
-  ` + "`sourcePage:\"metrics\"`" + `; it will land in the wrong Explorer's list.
+- **Cost Meter views are special.** A Cost Meter view is "source":"meter"
+  (its own Explorer page) but is queried as metrics: every builder_query
+  spec sets "signal":"metrics" AND "source":"meter". Do not file a Cost
+  Meter view under "source":"metrics"; it will land in the wrong Explorer's
+  list.
+- **name is immutable.** Upstream rejects name on update; spec.displayName
+  carries the visible label.
 - **panelType by intent:** "list" for tabular spans/logs; "graph" for
-  time-series; "table" for grouped tables; "value" for a single number.
+  time-series; "table" for grouped tables; "value" for a single number;
+  "trace" for a trace waterfall.
 - **Discover unknown fields before writing filters.** Call
   signoz_get_field_keys with the view's signal and fieldContext; use
   signoz_get_field_values when observed values help verify a predicate. Do not
   copy tenant-specific attributes from an example without checking them.
 - **Always bound and order builder results:** every builder_query must include a
-  positive ` + "`limit`" + ` and non-empty v5 ` + "`order`" + `. For time-series views,
+  positive limit and non-empty v5 order. For time-series views,
   the limit selects groups over the whole requested range, so a short-lived
   locally significant series can fall outside the returned top N.
 - **Full Query Builder v5 spec:** https://signoz.io/docs/userguide/query-builder-v5/
@@ -88,26 +88,28 @@ The server rejects them with HTTP 400 "failed to validate request body".
 ## Update flow
 
 signoz_update_view **replaces** the view (upstream is HTTP PUT). To
-rename or tweak one field:
+rename the label or tweak one field:
 
 1. Call signoz_get_view with the view's id. It returns
    {"status":"success","data":{...SavedView...}}.
 2. Take the **data** object from that response.
-3. Strip server-populated fields (id, createdAt, createdBy, updatedAt, updatedBy).
-4. Modify the field(s) you want to change.
+3. Strip server-populated fields (id, createdAt, createdBy, updatedAt, updatedBy) and drop name.
+4. Modify the field(s) you want to change (e.g. spec.displayName).
 5. Call signoz_update_view with { "id": "<id>", "view": <modified data> }.
 
-(The MCP server strips server-populated fields for you if you forget, but
-omitting them up front is clearer.)
+(The MCP server strips server-populated fields and name for you if you
+forget, but omitting them up front is clearer.)
 
 ## Minimal create body
 
     {
-      "name": "my view",
-      "sourcePage": "traces",
-      "compositeQuery": {
-        "queryType": "builder",
+      "name": "slow-checkout-traces",
+      "source": "traces",
+      "schemaVersion": "v2",
+      "spec": {
+        "displayName": "Slow checkout traces",
         "panelType": "list",
+        "requestType": "raw",
         "queries": [{
           "type": "builder_query",
           "spec": {
@@ -120,9 +122,14 @@ omitting them up front is clearer.)
             "filter":  { "expression": "service.name = 'checkoutservice'" },
             "having":  { "expression": "" }
           }
-        }]
+        }],
+        "selectedFields": [
+          {"name": "service.name", "signal": "traces", "fieldContext": "attribute", "fieldDataType": "string"},
+          {"name": "duration_nano", "signal": "traces", "fieldContext": "span", "fieldDataType": "int64"}
+        ],
+        "display": {"maxLines": 2, "fontSize": "small", "format": "table", "color": "default"}
       }
     }
 
-See signoz://view/examples for complete payloads per sourcePage.
+See signoz://view/examples for complete payloads per source.
 `

--- a/plans/saved-views-v2-api-migration.context.md
+++ b/plans/saved-views-v2-api-migration.context.md
@@ -23,8 +23,15 @@
 - **Response envelope**: render.Envelope `{status, data}` on success; `{status, error:{...}}` on error with coded errors (e.g. `saved_view_not_found`).
 - MCP handlers become mostly **pass-through** (like the dashboards-v2 migration), reading/writing the v2 typed shape directly.
 
+### 2026-08-30 — PR #296 review decisions
+- @makeavish: drop `ai_observability` from the `source` enum until the UI ships it (enum is `traces|logs|metrics|meter`). Applied.
+- @makeavish: `schemaVersion` is not a supported input; hard-code `v2` in the create/update handlers so a caller value never reaches upstream. Applied (param removed, value forced).
+- @makeavish: the companion `SigNoz/agent-skills` update is a pre-*release* gate, NOT a pre-*merge* blocker — this PR may merge first; the skill is updated before the next MCP version release. Recorded; PR body keeps the CMP-3 flag.
+- Codex bot (accepted): `name` param description now states it is a DNS-1123 label (lowercase/digits/hyphens) and `spec.displayName` is the display label.
+- Codex bot: proposed preserving a legacy `sourcePage` alias — **rejected** after discussion (option b): legacy `sourcePage` is intentionally rejected to avoid a partial compat shim on a hard rename. Wire-catalog goldens updated through the guardrail path for the changed entries only.
+
 ## Open Questions
-- [ ] The old MCP tools carried `category`, `tags`, `extraData` free-text params. v2 has no category/tags. Confirm whether SigNoz deprecated these or whether they map to `selectedFields`/`display`. (Resolved in discussion below.)
+- [x] The old MCP tools carried `category`, `tags`, `extraData` free-text params. v2 has no category/tags. Resolved by upstream reviewer + @makeavish: category/tags were removed in the v2 contract; rendering prefs map to `spec.selectedFields`/`spec.display`. **Decision (PR review, @makeavish, 2026-08-29): the agent-skills update is a pre-*release* gate, not a merge blocker; `ai_observability` is dropped from the source enum until the UI ships it; `schemaVersion` is hard-coded to `v2`; `name` is documented as a DNS-1123 label; legacy `sourcePage` is intentionally rejected (no alias).**
 
 ## Agent-skills impact (CMP-3)
 The `signoz_*_view` tool parameter contracts change (list loses `category`; create/update take the v2 typed shape instead of `compositeQuery`). This is a breaking contract change — agent-skills needs a companion update; flag in the PR.

--- a/plans/saved-views-v2-api-migration.context.md
+++ b/plans/saved-views-v2-api-migration.context.md
@@ -1,0 +1,30 @@
+# Feature: Saved-views v2 API migration — Context & Discussion
+
+## Original Prompt
+> Raise a PR for https://github.com/SigNoz/nerve-pod/issues/100.
+> The branch name should be nerve-pod/issues/100.
+> The ultimate goal is to migrate the saved view tools to the v2/saved_view apis introduced in SigNoz.
+> Start with the migration to v2/saved_views. The migration should fix nerve-pod/issues/100.
+
+## Reference Links
+- [nerve-pod issue #100](https://github.com/SigNoz/nerve-pod/issues/100)
+- Upstream `SigNoz/signoz` (cloned to /tmp): `pkg/apiserver/signozapiserver/savedview.go`, `pkg/types/savedviewtypes/*`, `pkg/modules/savedview/implsavedview/{handler,handler_v2,store,module}.go`
+
+## Issue #100 Summary
+`signoz_update_view` against a deleted saved view returns `success` with sentinel zero-value metadata; `signoz_get_view` on the deleted id returns HTTP 500 instead of 404. Root cause is upstream v1 `/api/v1/explorer/views/*`; the v2 `/api/v2/saved_views` store checks `RowsAffected()==0` on update/delete and returns `ErrCodeSavedViewNotFound` (rendered as 404). Migrating the MCP view tools to v2 fixes the fail-silent behavior.
+
+## Key Decisions & Discussion Log
+### 2026-08-29 — v1→v2 shape mapping
+- **List**: v1 `sourcePage`+`name`/`category` → v2 `source`+`name` only. v2 has NO `category` filter (and name/name LIKE only). Decision: drop the `category` tool param on list; `sourcePage` param renamed/constrained to the v2 `Source` enum (`traces`, `logs`, `metrics`, `meter`, `ai_observability`).
+- **v2 SavedView shape** (read): `{id, name, source, schemaVersion:"v2", spec{displayName, panelType, requestType, queries[], selectedFields[], display{maxLines,fontSize,format,color}}}` + audit fields (`createdAt/By`,`updatedAt/By`). No more v1 `compositeQuery` wrapper — queries live directly in `spec.queries`. The v1 `name`/`category`/`tags`/`extraData` fields are gone from writes; `selectedFields` and `display` carry what `extraData` used to.
+- **Create (Postable)**: `{name, generateName, source, schemaVersion:"v2", spec}` → 201 `types.Identifiable{id}`. `generateName` supported.
+- **Update (Updatable)**: `{source, schemaVersion:"v2", spec}` → 204 No Content. `name` is immutable server-side (update body has no name). Full-replacement semantics preserved.
+- **Delete**: shared v1/v2 handler → 204.
+- **Response envelope**: render.Envelope `{status, data}` on success; `{status, error:{...}}` on error with coded errors (e.g. `saved_view_not_found`).
+- MCP handlers become mostly **pass-through** (like the dashboards-v2 migration), reading/writing the v2 typed shape directly.
+
+## Open Questions
+- [ ] The old MCP tools carried `category`, `tags`, `extraData` free-text params. v2 has no category/tags. Confirm whether SigNoz deprecated these or whether they map to `selectedFields`/`display`. (Resolved in discussion below.)
+
+## Agent-skills impact (CMP-3)
+The `signoz_*_view` tool parameter contracts change (list loses `category`; create/update take the v2 typed shape instead of `compositeQuery`). This is a breaking contract change — agent-skills needs a companion update; flag in the PR.

--- a/plans/saved-views-v2-api-migration.plan.md
+++ b/plans/saved-views-v2-api-migration.plan.md
@@ -1,0 +1,52 @@
+# Plan: Saved-views v2 (typed-spec) API migration
+
+## Status
+In Progress
+
+## Context
+Move the `signoz_*_view` tools from v1 `/api/v1/explorer/views/*` (legacy free-form shape) to v2 `/api/v2/saved_views/*` (typed `spec` shape, `schemaVersion:"v2"`). This fixes nerve-pod #100 because the upstream v2 store returns `not-found` (404) on update/get/delete of a nonexistent id, instead of v1's upsert-like success + zero-value metadata. Mirrors the dashboards-v2 migration convention.
+
+## Approach
+
+### Client (`internal/client/{client,interface,mock}.go`)
+Repoint the five view methods to v2 and saturate pass-through helpers:
+- `ListViews(ctx, source, name)` → GET `/api/v2/saved_views?source=..&name=..`
+- `GetView(ctx, id)` → GET `/api/v2/saved_views/{id}`
+- `CreateView(ctx, body)` → POST `/api/v2/saved_views`
+- `UpdateView(ctx, id, body)` → PUT `/api/v2/saved_views/{id}`
+- `DeleteView(ctx, id)` → DELETE `/api/v2/saved_views/{id}`
+Update `interface.go` + `mock.go` signatures (`sourcePage` → `source`).
+
+### Handler (`internal/handler/tools/views.go`)
+Rewrite `RegisterViewHandlers` + the five handlers against the v2 shape:
+- **list**: param `source` (enum `traces|logs|metrics|meter|ai_observability`) + `name` (both optional upstream, but the MCP tool keeps `sourcePage`→`source` required for discoverability); drop `category` param. Pass-through render envelope → `paginate.Wrap` into our pagination.
+- **get**: `readResourceID(args,"viewId")` → v2 Get; return `{status,data:{view typed shape}}` preserved envelope via `structuredResult`.
+- **create**: accept v2 `PostableSavedView` shape (`name`, `generateName`, `source`, `schemaVersion`, `spec{...}`); strip nothing more than `searchContext`; POST pass-through. Validate `source` against the v2 enum (incl. `ai_observability`). The Cost Meter mapping check moves to `spec.queries[].type=="builder_query"` spec `signal`/`source`.
+- **update**: accept v2 `UpdatableSavedView` (`source`, `schemaVersion`, `spec`); `id` path param; PUT pass-through; reject cross-source change? v2 has no `name` in update (`displayName` lives in `spec`).
+- **delete**: pass-through; treat 204-empty as success.
+
+### Resources (`pkg/views/{instructions,examples}.go`)
+Rewrite `Instructions` and `Examples` against the v2 typed shape (`spec.queries`, `panelType`, `requestType`, `selectedFields`, `display`, `schemaVersion:"v2"`). Tool descriptions stay linked to them.
+
+### Docs/metadata
+- `manifest.json` — refresh the five `signoz_*_view` tool entries (param changes).
+- `README.md` — view tool table updated; note minimum SigNoz version.
+- `AGENTS.md` — unchanged conventions.
+
+### Tests
+- Rework `views_test.go` fixtures to the v2 shape (list envelope, postable/updatable bodies, 204 empty update, 404 not-found mapping).
+- Keep coded-error coverage (`views_codes_test.go`).
+- Update `guardrails/tests.txt` entry if the file list changes.
+
+## Files to Modify
+- `internal/client/{client.go,interface.go,mock.go}` — v2 URLs + signatures
+- `internal/handler/tools/views.go` — handlers + registration
+- `pkg/views/{instructions.go,examples.go}` — resource content rewritten to v2
+- `pkg/types/view.go` / `view_test.go` — may drop the legacy `SavedView` struct if unused
+- `internal/handler/tools/views_test.go`, `views_codes_test.go` — fixtures
+- `manifest.json`, `README.md`
+
+## Verification
+1. `go build ./cmd/server`
+2. `go test ./...`
+3. Live smoke (delegated to subagent): list/create/get/update/delete on v2; update a nonexistent id → expect coded not-found (404) rather than success.

--- a/plans/saved-views-v2-api-migration.plan.md
+++ b/plans/saved-views-v2-api-migration.plan.md
@@ -1,7 +1,9 @@
 # Plan: Saved-views v2 (typed-spec) API migration
 
 ## Status
-In Progress
+Done
+
+Client repointed to `/api/v2/saved_views`; handlers accept the v2 typed shape (`source`, `spec{...}`, `generateName`, `schemaVersion`); update drops immutable `name` and handles 204; resources/manifest/README rewritten; wire-catalog goldens updated through the guardrail path. `go build`, `gofmt`, `go test ./...`, and the focused `TestGuardrail_*` suite all green. Live e2e verification on SigNoz ≥ v0.137.0 and the agent-skills companion PR remain as follow-ups (flagged in the PR body).
 
 ## Context
 Move the `signoz_*_view` tools from v1 `/api/v1/explorer/views/*` (legacy free-form shape) to v2 `/api/v2/saved_views/*` (typed `spec` shape, `schemaVersion:"v2"`). This fixes nerve-pod #100 because the upstream v2 store returns `not-found` (404) on update/get/delete of a nonexistent id, instead of v1's upsert-like success + zero-value metadata. Mirrors the dashboards-v2 migration convention.


### PR DESCRIPTION
## Summary

Migrates the five `signoz_*_view` tools from v1 `/api/v1/explorer/views/*` to v2 `/api/v2/saved_views/*`.

Fixes: SigNoz/nerve-pod#100

### Why v2 fixes the bug
The upstream v2 store checks `RowsAffected()==0` on update/delete and renders a coded not-found (404, `saved_view_not_found`), replacing v1's upsert-like success-with-sentinel-metadata on a deleted view and the 500 on get-after-delete.

### Contract changes (breaking)
- **list**: param `sourcePage` → `source` (enum adds `ai_observability`); `category` filter removed (unsupported by v2).
- **create**: takes the v2 typed shape — `name`/`generateName`/`source`/`schemaVersion:v2`/`spec{queries,panelType,requestType,selectedFields,display}` — replacing `compositeQuery`/`category`/`tags`/`extraData`. Response `data` is `{id}` (201).
- **update**: v2 `UpdatableSavedView` (`source`/`schemaVersion`/`spec`); name immutable server-side; 204 empty body on success. Cross-source change still rejected.
- **get/delete**: pass-through to v2; get-after-delete now returns 404-classifiable coded error instead of 500.

### Companion change (CMP-3)
**SigNoz/agent-skills needs a companion PR**: renamed param (`sourcePage`→`source`), removed params (`category`/`tags`/`extraData`), and the new typed `spec` payload are contract changes taught by the skills.

### Docs/metadata
- `manifest.json` + `README.md` tool entries updated to the v2 params (in this PR).
- `signoz://view/instructions` and `signoz://view/examples` resources rewritten for the v2 shape.

### Status
Draft: plan files only for now (`plans/saved-views-v2-api-migration.*`); implementation follows on this branch.